### PR TITLE
ci: parallel Docker builds with native ARM runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,8 +81,8 @@ jobs:
             git push origin "$TAG"
           fi
 
-  # ===== Docker Build & Push (Multi-platform with QEMU) =====
-  docker:
+  # ===== Docker Build (AMD64) - Native =====
+  docker-amd64:
     runs-on: ubuntu-latest
     needs: version
     permissions:
@@ -104,10 +104,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: v${{ needs.version.outputs.version }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -119,18 +115,85 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push (amd64)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ needs.version.outputs.version }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ needs.version.outputs.version }}-amd64
+          platforms: linux/amd64
+          cache-from: type=gha,scope=amd64
+          cache-to: type=gha,mode=max,scope=amd64
+
+  # ===== Docker Build (ARM64) - Native =====
+  docker-arm64:
+    runs-on: ubuntu-24.04-arm
+    needs: version
+    permissions:
+      packages: write
+
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost
+          df -h
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.version.outputs.version }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (arm64)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ needs.version.outputs.version }}-arm64
+          platforms: linux/arm64
+          cache-from: type=gha,scope=arm64
+          cache-to: type=gha,mode=max,scope=arm64
+
+  # ===== Create Multi-Arch Manifest =====
+  docker-manifest:
+    runs-on: ubuntu-latest
+    needs: [version, docker-amd64, docker-arm64]
+    permissions:
+      packages: write
+
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest
+        run: |
+          VERSION="v${{ needs.version.outputs.version }}"
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+
+          docker manifest create ${IMAGE}:${VERSION} \
+            ${IMAGE}:${VERSION}-amd64 \
+            ${IMAGE}:${VERSION}-arm64
+          docker manifest push ${IMAGE}:${VERSION}
+
+          docker manifest create ${IMAGE}:latest \
+            ${IMAGE}:${VERSION}-amd64 \
+            ${IMAGE}:${VERSION}-arm64
+          docker manifest push ${IMAGE}:latest
 
   # ===== PyPI Publish =====
   pypi:
@@ -144,7 +207,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: v${{ needs.version.outputs.version }}
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -162,39 +224,22 @@ jobs:
   # ===== GitHub Release =====
   github-release:
     runs-on: ubuntu-latest
-    needs: [version, docker, pypi]
+    needs: [version, docker-manifest, pypi]
     permissions:
       contents: write
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ needs.version.outputs.version }}
           name: v${{ needs.version.outputs.version }}
-          draft: false
-          prerelease: false
           body: |
             ## MUXI Runtime v${{ needs.version.outputs.version }}
 
-            ### Installation
+            **PyPI:** `pip install muxi-runtime==${{ needs.version.outputs.version }}`
 
-            **PyPI:**
-            ```bash
-            pip install muxi-runtime==${{ needs.version.outputs.version }}
-            ```
-
-            **Docker:**
-            ```bash
-            docker pull ghcr.io/muxi-ai/runtime:v${{ needs.version.outputs.version }}
-            ```
-
-            ### Changes
-
-            See [CHANGELOG.md](https://github.com/muxi-ai/runtime/blob/main/CHANGELOG.md) for details.
+            **Docker:** `docker pull ghcr.io/muxi-ai/runtime:v${{ needs.version.outputs.version }}`
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -216,7 +261,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
           git fetch origin develop
           git checkout develop
           git merge --no-ff main -m "chore: merge main back to develop (v${{ needs.version.outputs.version }})"


### PR DESCRIPTION
- Split Docker build into parallel amd64 + arm64 jobs
- Uses native ARM runner (ubuntu-24.04-arm) for faster builds
- Expected time: ~15-20min instead of ~50min