### PR TITLE
ci: fix docker manifest creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,20 +180,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Create and push manifest
         run: |
           VERSION="v${{ needs.version.outputs.version }}"
           IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
 
-          docker manifest create ${IMAGE}:${VERSION} \
+          # Create multi-arch manifest using buildx imagetools
+          docker buildx imagetools create -t ${IMAGE}:${VERSION} \
             ${IMAGE}:${VERSION}-amd64 \
             ${IMAGE}:${VERSION}-arm64
-          docker manifest push ${IMAGE}:${VERSION}
 
-          docker manifest create ${IMAGE}:latest \
+          docker buildx imagetools create -t ${IMAGE}:latest \
             ${IMAGE}:${VERSION}-amd64 \
             ${IMAGE}:${VERSION}-arm64
-          docker manifest push ${IMAGE}:latest
+
+          echo "Created multi-arch manifests for ${VERSION} and latest"
 
   # ===== PyPI Publish =====
   pypi:


### PR DESCRIPTION
Use `docker buildx imagetools create` instead of `docker manifest create` to handle buildx-created images