### PR TITLE
feat(secrets): hot reload secrets without restarting the formation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 ## [unreleased]
 
+### Hot-reload secrets without restarting the formation
+
+Adds an admin-only ``POST /secrets/reload`` endpoint that refreshes the
+running formation's in-memory secret cache from ``secrets.enc`` without
+restarting the process. Useful when secrets are rotated externally
+(e.g. CI redeploys the encrypted file) and you don't want to bounce a
+live formation just to pick up the new values.
+
+**Non-destructive merge semantics**
+Reload does not replace the cache wholesale. It performs an
+add-or-override merge:
+- secrets present on disk but missing in memory are added
+- secrets present in both places are overwritten with the disk value
+- secrets present only in memory are preserved and are NOT deleted
+
+The preservation rule is intentional: an in-memory-only secret may
+have been added through the API or be in active use by a running
+agent / MCP integration, and silently dropping it on reload would
+break those consumers.
+
+**Failure isolation**
+If decrypting or parsing ``secrets.enc`` fails, the existing
+in-memory cache is left untouched and the endpoint returns 500. The
+reload is performed under the existing ``SecretsManager`` async lock,
+so concurrent readers never see a partially-built cache.
+
+**Scope of effect**
+Reload affects future secret lookups that read from the live cache
+(e.g. ``get_secret``, ``interpolate_secrets``, skill env resolution,
+runtime user-credential resolution). It does NOT retroactively
+rewrite values that were already interpolated into formation config
+during initialization or into MCP auth at registration time — those
+remain fixed until a normal reload of the affected component.
+
+New pieces:
+- ``SecretsManager.reload()`` returning ``{added, overwritten,
+  preserved, count}``
+- ``Formation.reload_secrets()`` wrapper
+- ``APIEventType.SECRET_RELOADED`` (``secret.reloaded``)
+- ``POST /secrets/reload`` admin route emitting the merge summary
+
+Five new unit tests in
+``tests/unit/test_secrets_reload.py`` cover add, overwrite, preserve,
+failure-leaves-cache-intact, and missing-file behaviour.
+
 ### Cold-path latency cuts: classifier preload + SOP-template analyzer skip
 
 Two complementary changes that together shave ~16-18 s off the cold

--- a/src/muxi/runtime/datatypes/api.py
+++ b/src/muxi/runtime/datatypes/api.py
@@ -34,6 +34,7 @@ class APIEventType(str, Enum):
     SECRET_UPDATED = "secret.updated"
     SECRET_DELETED = "secret.deleted"
     SECRET_LIST = "secret.list"
+    SECRET_RELOADED = "secret.reloaded"
 
     MEMORY_CREATED = "memory.created"
     MEMORY_RETRIEVED = "memory.retrieved"

--- a/src/muxi/runtime/formation/formation.py
+++ b/src/muxi/runtime/formation/formation.py
@@ -2082,6 +2082,25 @@ class Formation:
             print(f"Warning: Unexpected error deleting secret '{name}': {e}")
             return False
 
+    async def reload_secrets(self) -> Optional[Dict[str, Any]]:
+        """
+        Reload secrets from disk into the formation's in-memory cache.
+
+        Uses non-destructive merge semantics:
+        - new keys on disk are added to the cache
+        - existing keys are overwritten with disk values
+        - keys only present in memory are preserved (not deleted), since they
+          may still be in active use by the running formation
+
+        Returns:
+            Summary dict from SecretsManager.reload() on success, or None if the
+            secrets manager is unavailable.
+        """
+        if not await self.ensure_secrets_manager():
+            return None
+
+        return await self.secrets_manager.reload()
+
     async def interpolate_secrets(self, config: Dict[str, Any]) -> Dict[str, Any]:
         """
         Interpolate secrets in a configuration dictionary.

--- a/src/muxi/runtime/formation/server/routes/admin/secrets.py
+++ b/src/muxi/runtime/formation/server/routes/admin/secrets.py
@@ -173,17 +173,8 @@ async def reload_secrets(request: Request) -> JSONResponse:
         )
         return JSONResponse(content=response.model_dump(), status_code=500)
 
-    observability.observe(
-        event_type=observability.SystemEvents.SECRET_OPERATION_COMPLETED,
-        level=observability.EventLevel.INFO,
-        data={"operation": "reload", **summary},
-        description=(
-            f"Secrets reloaded: {len(summary['added'])} added, "
-            f"{len(summary['overwritten'])} overwritten, "
-            f"{len(summary['preserved'])} preserved"
-        ),
-    )
-
+    # Success observability is already emitted by SecretsManager.reload()
+    # (SECRET_OPERATION_COMPLETED) — avoid double-counting in dashboards.
     response = create_success_response(
         APIObjectType.SECRET,
         APIEventType.SECRET_RELOADED,

--- a/src/muxi/runtime/formation/server/routes/admin/secrets.py
+++ b/src/muxi/runtime/formation/server/routes/admin/secrets.py
@@ -163,12 +163,8 @@ async def reload_secrets(request: Request) -> JSONResponse:
             )
             return JSONResponse(content=response.model_dump(), status_code=503)
     except Exception as e:
-        observability.observe(
-            event_type=observability.SystemEvents.SECRET_OPERATION_FAILED,
-            level=observability.EventLevel.ERROR,
-            data={"operation": "reload", "error": str(e), "error_type": type(e).__name__},
-            description=f"Secrets reload failed: {str(e)}",
-        )
+        # Failure observability is already emitted by SecretsManager.reload()
+        # before re-raising; avoid double-counting in dashboards/alerting.
         response = create_error_response(
             "SECRETS_RELOAD_FAILED",
             f"Failed to reload secrets: {str(e)}",
@@ -178,7 +174,7 @@ async def reload_secrets(request: Request) -> JSONResponse:
         return JSONResponse(content=response.model_dump(), status_code=500)
 
     observability.observe(
-        event_type=observability.SystemEvents.CONFIG_FORMATION_LOADED,
+        event_type=observability.SystemEvents.SECRET_OPERATION_COMPLETED,
         level=observability.EventLevel.INFO,
         data={"operation": "reload", **summary},
         description=(

--- a/src/muxi/runtime/formation/server/routes/admin/secrets.py
+++ b/src/muxi/runtime/formation/server/routes/admin/secrets.py
@@ -127,6 +127,79 @@ async def create_secret(request: Request, secret: SecretCreate) -> JSONResponse:
     return JSONResponse(content=response.model_dump(), status_code=201)
 
 
+@router.post("/secrets/reload", response_model=APIResponse)
+async def reload_secrets(request: Request) -> JSONResponse:
+    """
+    Reload the in-memory secrets cache from secrets.enc using non-destructive merge.
+
+    Merge semantics:
+    - secrets present on disk but missing in memory are added
+    - secrets present in both places are overwritten with disk values
+    - secrets present only in memory are preserved (not deleted), since they may
+      still be in active use by the running formation
+
+    On failure, the existing in-memory cache is left untouched.
+
+    Returns:
+        Success response with merge summary (added / overwritten / preserved / count).
+    """
+    formation = request.app.state.formation
+    request_id = getattr(request.state, "request_id", None)
+
+    if not hasattr(formation, "secrets_manager") or not formation.secrets_manager:
+        response = create_error_response(
+            "SERVICE_UNAVAILABLE", "Secrets manager not available", None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=503)
+
+    try:
+        summary = await formation.reload_secrets()
+        if summary is None:
+            response = create_error_response(
+                "SERVICE_UNAVAILABLE",
+                "Secrets manager not available",
+                None,
+                request_id,
+            )
+            return JSONResponse(content=response.model_dump(), status_code=503)
+    except Exception as e:
+        observability.observe(
+            event_type=observability.SystemEvents.SECRET_OPERATION_FAILED,
+            level=observability.EventLevel.ERROR,
+            data={"operation": "reload", "error": str(e), "error_type": type(e).__name__},
+            description=f"Secrets reload failed: {str(e)}",
+        )
+        response = create_error_response(
+            "SECRETS_RELOAD_FAILED",
+            f"Failed to reload secrets: {str(e)}",
+            None,
+            request_id,
+        )
+        return JSONResponse(content=response.model_dump(), status_code=500)
+
+    observability.observe(
+        event_type=observability.SystemEvents.CONFIG_FORMATION_LOADED,
+        level=observability.EventLevel.INFO,
+        data={"operation": "reload", **summary},
+        description=(
+            f"Secrets reloaded: {len(summary['added'])} added, "
+            f"{len(summary['overwritten'])} overwritten, "
+            f"{len(summary['preserved'])} preserved"
+        ),
+    )
+
+    response = create_success_response(
+        APIObjectType.SECRET,
+        APIEventType.SECRET_RELOADED,
+        {
+            "message": "Secrets reloaded successfully using add-or-override merge semantics",
+            **summary,
+        },
+        request_id,
+    )
+    return JSONResponse(content=response.model_dump(), status_code=200)
+
+
 @router.put("/secrets/{key}", response_model=APIResponse)
 async def update_secret(request: Request, key: str, secret: SecretUpdate) -> JSONResponse:
     """

--- a/src/muxi/runtime/services/secrets/secrets_manager.py
+++ b/src/muxi/runtime/services/secrets/secrets_manager.py
@@ -558,6 +558,99 @@ class SecretsManager:
             )
             raise
 
+    async def reload(self) -> Dict[str, Any]:
+        """
+        Reload secrets from disk into the in-memory cache using non-destructive merge.
+
+        Merge semantics:
+        - Secrets present on disk but missing in memory are added.
+        - Secrets present in both places are overwritten with the disk value.
+        - Secrets present in memory but missing on disk are preserved (NOT deleted),
+          since they may still be in active use by the running formation.
+
+        On failure, the existing in-memory cache is left untouched.
+
+        Returns:
+            Summary dict with keys:
+              - "added": list of normalized secret names newly added from disk
+              - "overwritten": list of normalized secret names whose values changed
+              - "preserved": list of normalized secret names kept in memory only
+              - "count": total number of secrets in cache after reload
+        """
+        try:
+            if not self._fernet:
+                await self.initialize_encryption()
+
+            async with self._lock:
+                # Load fresh secrets from disk (raises on decrypt/parse failure,
+                # leaving the existing cache intact).
+                disk_secrets = (
+                    await self._load_secrets_from_file()
+                    if self.secrets_file_path.exists()
+                    else {}
+                )
+
+                current_cache = self._secrets_cache or {}
+
+                added: List[str] = []
+                overwritten: List[str] = []
+
+                # Build merged cache: start from current in-memory state,
+                # then add or overwrite from disk. Never delete.
+                merged: Dict[str, Any] = dict(current_cache)
+                for name, value in disk_secrets.items():
+                    if name not in current_cache:
+                        added.append(name)
+                    elif current_cache.get(name) != value:
+                        overwritten.append(name)
+                    merged[name] = value
+
+                preserved = sorted(set(current_cache.keys()) - set(disk_secrets.keys()))
+
+                # Atomically swap cache reference
+                self._secrets_cache = merged
+
+                summary = {
+                    "added": sorted(added),
+                    "overwritten": sorted(overwritten),
+                    "preserved": preserved,
+                    "count": len(merged),
+                }
+
+            observability.observe(
+                event_type=observability.SystemEvents.SECRET_OPERATION_COMPLETED,
+                level=observability.EventLevel.INFO,
+                description=(
+                    f"Secrets reloaded: {len(summary['added'])} added, "
+                    f"{len(summary['overwritten'])} overwritten, "
+                    f"{len(summary['preserved'])} preserved"
+                ),
+                data={
+                    "operation_type": "reload",
+                    "added_count": len(summary["added"]),
+                    "overwritten_count": len(summary["overwritten"]),
+                    "preserved_count": len(summary["preserved"]),
+                    "total_count": summary["count"],
+                    "success": True,
+                },
+            )
+
+            return summary
+
+        except Exception as e:
+            observability.observe(
+                event_type=observability.SystemEvents.SECRET_OPERATION_FAILED,
+                level=observability.EventLevel.ERROR,
+                description=f"Secret reload failed: {str(e)}",
+                data={
+                    "operation_type": "reload",
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                    "success": False,
+                },
+            )
+            raise
+
     async def import_secrets(self, secrets: Dict[str, Any], overwrite: bool = False) -> None:
         """
         Import multiple secrets from a dictionary.

--- a/src/muxi/runtime/services/secrets/secrets_manager.py
+++ b/src/muxi/runtime/services/secrets/secrets_manager.py
@@ -585,9 +585,7 @@ class SecretsManager:
                 # Load fresh secrets from disk (raises on decrypt/parse failure,
                 # leaving the existing cache intact).
                 disk_secrets = (
-                    await self._load_secrets_from_file()
-                    if self.secrets_file_path.exists()
-                    else {}
+                    await self._load_secrets_from_file() if self.secrets_file_path.exists() else {}
                 )
 
                 current_cache = self._secrets_cache or {}

--- a/tests/unit/test_secrets_reload.py
+++ b/tests/unit/test_secrets_reload.py
@@ -1,0 +1,111 @@
+"""Unit tests for SecretsManager.reload() non-destructive merge semantics."""
+
+import pytest
+from cryptography.fernet import InvalidToken
+
+from muxi.runtime.services.secrets.secrets_manager import SecretsManager
+
+
+@pytest.mark.asyncio
+async def test_reload_adds_new_disk_secrets(tmp_path):
+    """Secrets present on disk but missing in memory are added to the cache."""
+    sm = SecretsManager(tmp_path)
+    await sm.initialize_encryption()
+
+    # Initial state on disk: A=1
+    await sm.store_secret("A", "1")
+
+    # Simulate external update: write B=2 directly via a sibling manager
+    # (same .key file, so encryption is compatible)
+    sm2 = SecretsManager(tmp_path)
+    await sm2.initialize_encryption()
+    await sm2.store_secret("B", "2")
+
+    # First manager doesn't know about B yet
+    assert await sm.get_secret("B") is None
+
+    summary = await sm.reload()
+
+    assert "B" in summary["added"]
+    assert summary["overwritten"] == []
+    assert summary["preserved"] == []
+    assert summary["count"] == 2
+    assert await sm.get_secret("B") == "2"
+    assert await sm.get_secret("A") == "1"
+
+
+@pytest.mark.asyncio
+async def test_reload_overwrites_changed_disk_secrets(tmp_path):
+    """Secrets present in both places are overwritten with the disk value."""
+    sm = SecretsManager(tmp_path)
+    await sm.initialize_encryption()
+    await sm.store_secret("A", "old")
+
+    sm2 = SecretsManager(tmp_path)
+    await sm2.initialize_encryption()
+    await sm2.store_secret("A", "new", overwrite=True)
+
+    # Cache in sm still has old value
+    assert await sm.get_secret("A") == "old"
+
+    summary = await sm.reload()
+
+    assert summary["added"] == []
+    assert "A" in summary["overwritten"]
+    assert summary["preserved"] == []
+    assert await sm.get_secret("A") == "new"
+
+
+@pytest.mark.asyncio
+async def test_reload_preserves_in_memory_only_secrets(tmp_path):
+    """Secrets only in memory must NOT be deleted on reload."""
+    sm = SecretsManager(tmp_path)
+    await sm.initialize_encryption()
+    await sm.store_secret("DISK_KEY", "disk_value")
+
+    # Inject an in-memory-only secret directly into the cache, bypassing disk
+    sm._secrets_cache["MEMORY_ONLY"] = "memory_value"
+
+    summary = await sm.reload()
+
+    # MEMORY_ONLY is not on disk, must be preserved
+    assert "MEMORY_ONLY" in summary["preserved"]
+    assert await sm.get_secret("MEMORY_ONLY") == "memory_value"
+    # DISK_KEY remains accessible
+    assert await sm.get_secret("DISK_KEY") == "disk_value"
+
+
+@pytest.mark.asyncio
+async def test_reload_failure_leaves_cache_intact(tmp_path):
+    """If decrypting secrets.enc fails, the existing cache must remain untouched."""
+    sm = SecretsManager(tmp_path)
+    await sm.initialize_encryption()
+    await sm.store_secret("A", "1")
+
+    # Corrupt the secrets file
+    sm.secrets_file_path.write_bytes(b"not-valid-fernet-payload")
+
+    with pytest.raises(InvalidToken):
+        await sm.reload()
+
+    # Cache still intact
+    assert await sm.get_secret("A") == "1"
+
+
+@pytest.mark.asyncio
+async def test_reload_with_no_secrets_file(tmp_path):
+    """Reload should succeed when secrets.enc does not exist; treat as empty disk."""
+    sm = SecretsManager(tmp_path)
+    await sm.initialize_encryption()
+    sm._secrets_cache["MEMORY_ONLY"] = "v"
+
+    # Ensure no secrets.enc exists
+    if sm.secrets_file_path.exists():
+        sm.secrets_file_path.unlink()
+
+    summary = await sm.reload()
+
+    assert summary["added"] == []
+    assert summary["overwritten"] == []
+    assert "MEMORY_ONLY" in summary["preserved"]
+    assert await sm.get_secret("MEMORY_ONLY") == "v"


### PR DESCRIPTION
## Summary

Adds an admin-only `POST /secrets/reload` endpoint that refreshes the running formation's in-memory secret cache from `secrets.enc` without restarting the process. Useful when secrets are rotated externally and you don't want to bounce a live formation just to pick up the new values.

## Non-destructive merge semantics

Reload does **not** replace the cache wholesale. It performs an add-or-override merge:

- secrets present on disk but missing in memory are **added**
- secrets present in both places are **overwritten** with the disk value
- secrets present only in memory are **preserved** and are NOT deleted

The preservation rule is intentional: an in-memory-only secret may have been added through the API or be in active use by a running agent / MCP integration. Silently dropping it on reload would break those consumers.

## Failure isolation

If decrypting or parsing `secrets.enc` fails, the existing in-memory cache is left untouched and the endpoint returns 500. The reload runs under the existing `SecretsManager` async lock, so concurrent readers never see a partially-built cache.

## Scope of effect

Reload affects future secret lookups that read from the live cache (`get_secret`, `interpolate_secrets`, skill env resolution, runtime user-credential resolution).

It does **not** retroactively rewrite values already interpolated into formation config at init time or into MCP auth at registration time. Those remain fixed until the affected component is reloaded.

## Changes

- `SecretsManager.reload()` returning `{added, overwritten, preserved, count}`
- `Formation.reload_secrets()` wrapper
- `APIEventType.SECRET_RELOADED` (`secret.reloaded`)
- `POST /secrets/reload` admin route emitting the merge summary
- 5 new unit tests in `tests/unit/test_secrets_reload.py`
- CHANGELOG entry under `[unreleased]`

## Verification

- `ruff check` clean on all touched files
- 5/5 new unit tests pass
- `scripts/validate_events.py`: 1217/1217 (100%) events valid

## Related spec

Companion OpenAPI spec change lives in the website repo: `muxi-formation-api-v1.yaml` documents `POST /secrets/reload` with the same merge semantics.