### PR TITLE
perf(synthesis): collapse three LLM passes into one persona call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,73 @@
 
 ## [unreleased]
 
+### Collapse three synthesis LLM passes into one persona call
+
+Removes the agent-level and workflow-level synthesis LLM calls and
+replaces both with deterministic builders that feed structured input
+into the overlord's existing ``_apply_persona`` pass — which is now
+the single LLM hop on the way back to the user.
+
+**Before**: a workflow turn with N tasks made N agent-synthesis calls
+(one per task), one workflow-synthesis call to merge them, and one
+persona call to dress the merge for the user — all sequential, all
+cloud round-trips. A bare chat turn made one agent-synthesis call
+followed by the persona call. Three of those LLM hops were the
+runtime saying the same thing back to itself.
+
+**After**: agents emit raw structured output via a new
+``Agent._build_raw_response`` deterministic renderer (``### {placeholder}``
+sections, dict results expanded as ``key: value``, artifact filenames
+inline, delegated-agent prose appended verbatim). The overlord's
+``_synthesize_workflow_results`` delegates merging to a new
+``_consolidate_workflow_results`` helper that produces budget-bounded
+per-task sections via the existing ``_render_task_body`` — no LLM
+call. ``_apply_persona`` is the single user-facing LLM hop and its
+system prompt was extended with two contracts inherited from the
+deleted synthesis prompts: a raw-input acknowledgment that names the
+``### Task`` / ``### {placeholder}`` markers it should expect, and the
+date-preservation guardrail that previously lived in the workflow
+synthesis system prompt.
+
+Dead code removed: ``Overlord._create_synthesis_prompt``,
+``Overlord._get_workflow_synthesis_system_prompt``,
+``Overlord._fallback_synthesis``. Skip-synthesis observability events
+now emit ``reason: always_skip_v2`` (chat turn) and
+``reason: deterministic_consolidator`` (workflow turn) so operators
+can audit the new path.
+
+**Expected savings on the canonical hello-muxi cold path**: ~4 s on a
+chat turn (one agent-synthesis call eliminated), ~20 s on a 4-task
+workflow turn (four agent-synthesis calls + one workflow-synthesis
+call eliminated). Live end-to-end run on develop confirmed: Turn 2
+issue-listing dropped from 38.4 s to 34.0 s and Turn 3 multi-step
+delegation produced a 3934-character briefing in 86.6 s with zero
+``planning_response_synthesis_*`` events emitted.
+
+**Test changes.**
+
+* ``tests/unit/test_agent_skip_synthesis_always.py`` (new, 11 tests)
+  pins the always-skip contract, the ``_build_raw_response`` output
+  shape, and asserts the synthesis method body no longer references
+  ``self.model.chat``.
+* ``tests/unit/test_apply_persona_handles_raw.py`` (new, 4 tests)
+  pins the raw-input acknowledgment and date-preservation guardrails
+  in the persona system prompt source.
+* ``tests/unit/test_workflow_consolidator.py`` (renamed from
+  ``test_overlord_synthesis_prompt.py``, 16 tests) lifted from the
+  prior ``_create_synthesis_prompt`` suite to exercise the new
+  deterministic ``_consolidate_workflow_results`` helper.
+* ``tests/unit/test_workflow_date_preservation_prompts.py`` first
+  test repointed from the deleted
+  ``_get_workflow_synthesis_system_prompt`` to the new date guardrail
+  location inside ``_apply_persona``.
+
+Full unit suite: 925 pass, 1 skipped, 0 new failures.
+``validate_events.py``: 1214/1214 events enum-backed.
+``run_random_tests.py 20`` after merge: 20/20 pass across 11 areas
+(streaming, formatting, triggers, identities, api, skills,
+multimodal, mcp, orchestration, clarification, async).
+
 ### Hot-reload secrets without restarting the formation
 
 Adds an admin-only ``POST /secrets/reload`` endpoint that refreshes the

--- a/contributing/synthesis-speedup-plan.md
+++ b/contributing/synthesis-speedup-plan.md
@@ -1,0 +1,283 @@
+# Synthesis Speedup Plan
+
+**Branch:** `feature/synthesis-speedup`
+**Date:** 2026-04-30
+**Status:** Plan — implementation pending
+**Predecessor commit:** `9650a95e` (overlord prompt now renders raw task outputs)
+
+---
+
+## 1. Goal
+
+Remove one redundant LLM call from every chat reply by deleting the **agent-level synthesis pass** and letting the overlord's existing persona pass produce the user-facing reply. The agent returns raw tool outputs; a deterministic consolidator merges multi-agent results; persona LLM does both synthesis-from-raw and styling in a single call.
+
+Quoted goal from the user:
+
+> Currently live (on develop branch):
+> overlord does its thing → assigns to agent(s) → agent(s) do the work → agent(s) synthesise response → overlord receives responses from agent(s) → overlord synthesise the response → overlord gets back to user
+>
+> What I thought we'll do:
+> overlord does its thing → assigns to agent(s) → agent(s) do the work → overlord receives responses from agent(s) → overlord synthesise the response → overlord gets back to user
+>
+> Just one step removed!
+
+The implementation goes one step further: the overlord's "synthesise" step also collapses into the persona pass, since `_apply_persona` already runs on every reply and is a smart-enough LLM with a loose-enough brief to absorb structured input.
+
+---
+
+## 2. Pipelines compared
+
+### Today (live on `develop @ 8487ed37`)
+
+```
+CHAT MODE
+  user → overlord → agent
+                     ├─ tool calls (LLM × N)
+                     ├─ AGENT SYNTHESIS (LLM × 1)              ← delete
+                     └─ return prose
+         overlord
+           └─ _apply_persona (LLM × 1)
+                              → user
+
+WORKFLOW MODE (N tasks)
+  user → overlord → decompose
+                     └─ for each task:
+                          ├─ agent tool calls (LLM × M)
+                          ├─ AGENT SYNTHESIS (LLM × 1)         ← delete
+                          └─ return prose
+         overlord
+           ├─ WORKFLOW SYNTHESIS (LLM × 1)                     ← replace with deterministic consolidator
+           └─ _apply_persona (LLM × 1)
+                              → user
+```
+
+### After (this plan)
+
+```
+CHAT MODE
+  user → overlord → agent
+                     ├─ tool calls (LLM × N)
+                     └─ return RAW outputs (no synthesis)
+         overlord
+           └─ _apply_persona (LLM × 1, prompt updated to handle raw)
+                              → user
+
+WORKFLOW MODE (N tasks)
+  user → overlord → decompose
+                     └─ for each task:
+                          ├─ agent tool calls (LLM × M)
+                          └─ return RAW outputs (no synthesis)
+         overlord
+           ├─ CONSOLIDATE (deterministic, NO LLM)
+           │     – one section per task, headers + raw outputs
+           │     – artifact filenames listed
+           │     – budget-bounded
+           └─ _apply_persona (LLM × 1, prompt updated to handle raw)
+                              → user
+```
+
+### Final shape
+
+```
+                              ╔════════════════════════════════════╗
+                              ║   ONE LLM PASS at the overlord     ║
+                              ║   with persona + raw-data brief    ║
+                              ╚════════════════════════════════════╝
+                                              ▲
+                                              │
+                       ┌──────────────────────┴──────────────────────┐
+                       │  consolidate (deterministic, no LLM)        │
+                       │  — chat: agent's raw_response passed thru   │
+                       │  — workflow: per-task sections concatenated │
+                       └──────────────────────┬──────────────────────┘
+                                              ▲
+                                              │
+              ┌───────────────────────────────┼───────────────────────────────┐
+              │                               │                               │
+       Agent A returns RAW          Agent B returns RAW          Agent N returns RAW
+       (tool outputs, no synth)     (tool outputs, no synth)     (tool outputs, no synth)
+              ▲                               ▲                               ▲
+              │                               │                               │
+              └─────────────── decompose ←── overlord ──→ chat ──┘
+```
+
+One LLM pass at the end. Everything before it is mechanical.
+
+---
+
+## 3. LLM-call count savings
+
+| Path | Today | After | Saved |
+|---|---|---|---|
+| Chat (single agent) | tools + agent synth + persona = M + 2 | tools + persona = M + 1 | **1 LLM call** (~4 s) |
+| Workflow (4 tasks) | tools + 4×agent synth + workflow synth + persona = M + 6 | tools + persona = M + 1 | **5 LLM calls** (~20 s) |
+
+The numbers above match what the live formation log showed on 2026-04-29:
+- Turn 2 (chat-mode, 3 tool calls): `planning_response_synthesis_start` at +29.7 s, `planning_response_synthesis_completed` at +33.9 s — confirming the 4.2 s agent synthesis call we want to delete.
+
+---
+
+## 4. What `_apply_persona` actually does today
+
+System prompt (verbatim from `overlord.py:2766`):
+
+> "Reformat the agent's response to match your persona while preserving all technical details and information. Make it conversational and friendly while keeping accuracy."
+
+User content: `"User request: {X}\nAgent response: {raw_response}"`. `max_tokens=2000`, `temperature=0.7`, runs on `routing_model` (or fallback to text model).
+
+Implication: the persona LLM is already smart enough and given enough latitude to absorb structured input. With a small system-prompt addition acknowledging that input may be raw structured tool outputs, it can take over the synthesis-from-raw job that agent-level synthesis currently does. No new LLM call is needed.
+
+---
+
+## 5. Code changes
+
+All on `feature/synthesis-speedup` on top of `9650a95e`.
+
+### 5.1 `src/muxi/runtime/formation/agents/agent.py`
+
+**Skip the agent synthesis call universally** at the synthesis decision branch (~line 2299). Replace the LLM call path with a deterministic raw-response builder.
+
+```python
+if my_results and not has_successful_delegation:
+    if (
+        self._is_pure_artifact_result(my_results)
+        and self._is_streaming_active()
+    ):
+        # existing pure-artifact + streaming-active fast path (kept)
+        synthesized_planning_response = self._build_artifact_only_response(my_results)
+        observability.observe(... reason="pure_artifact_with_streaming" ...)
+    else:
+        # NEW: skip the synthesis LLM call always; return raw outputs
+        synthesized_planning_response = self._build_raw_response(
+            my_results, planning_response_parts
+        )
+        observability.observe(... reason="always_skip_v2" ...)
+```
+
+**New helper `_build_raw_response(my_results, planning_response_parts)`**:
+- Renders `my_results` as `### {placeholder}\n{result_text}` blocks
+- Appends `### Delegated Response N\n{response}` for each `planning_response_parts` entry
+- Notes artifact filenames inline
+- Pure string formatting, no LLM call
+
+### 5.2 `src/muxi/runtime/formation/overlord/overlord.py`
+
+**Replace `_synthesize_workflow_results` body with a deterministic consolidator** that reuses `_render_task_body(outputs, budget)` from commit `9650a95e`. No LLM call. Output goes directly into `_apply_persona` as `raw_response`.
+
+`_create_synthesis_prompt` (introduced in `9650a95e`) is no longer needed for the LLM path. Two options:
+- **Option 1**: delete it; keep `_render_task_body` as a standalone helper used by the consolidator
+- **Option 2**: rename to `_consolidate_workflow_results`, reuse the rendering work directly
+
+Either way, the work in `9650a95e` is not wasted — `_render_task_body` is exactly the consolidation building block.
+
+**Extend `_apply_persona`'s system prompt** with ~50 tokens telling the persona LLM that input may be raw structured tool outputs:
+
+```text
+The agent response may be either polished prose or raw structured tool outputs
+(JSON-like dicts, key/value blocks, or numbered step results). In either case,
+extract every fact, ID, URL, and number, and present them as a clear, friendly
+reply in your persona's voice. Do not summarize away or omit specific data.
+```
+
+All existing constraints (preserve technical details, length-matching, format) are kept.
+
+### 5.3 `src/muxi/runtime/formation/workflow/executor.py`
+
+**No change.** Since we're skipping agent synthesis universally, no `in_workflow` flag is needed. `_execute_task_with_agent` calls `agent.process_message(...)` exactly as today; the agent now returns raw outputs by default.
+
+---
+
+## 6. Tests
+
+Total: **31 tests** for this change set.
+
+### 6.1 New: `tests/unit/test_agent_skip_synthesis_always.py` (8 tests)
+
+1. `test_agent_skips_synthesis_call_when_my_results_present` — `_synthesize_planning_execution_response` not called
+2. `test_agent_skips_synthesis_call_in_chat_mode` — same as above without workflow context
+3. `test_pure_artifact_path_still_takes_priority` — existing fast path untouched
+4. `test_build_raw_response_renders_each_result_with_placeholder`
+5. `test_build_raw_response_renders_delegated_responses`
+6. `test_build_raw_response_includes_artifact_filenames`
+7. `test_build_raw_response_empty_inputs_returns_fallback`
+8. `test_synthesis_skipped_observability_event_emitted`
+
+### 6.2 Update: `tests/unit/test_overlord_synthesis_prompt.py` (15 tests, shipped in `9650a95e`)
+
+- Lift tests to assert the consolidator (deterministic) is what runs, not an LLM call
+- Drop the `pytest` and `patch` imports if no longer needed
+- Tighten assertions: no LLM mock; assert direct return value
+
+### 6.3 New: `tests/unit/test_workflow_consolidator.py` (5 tests)
+
+1. `test_consolidator_renders_each_task_section_with_header`
+2. `test_consolidator_uses_render_task_body_per_task`
+3. `test_consolidator_respects_total_budget`
+4. `test_consolidator_does_not_call_llm` — assert `model.chat` NOT invoked
+5. `test_consolidator_lists_artifact_filenames`
+
+### 6.4 New: `tests/unit/test_apply_persona_handles_raw.py` (3 tests)
+
+1. `test_persona_prompt_includes_raw_input_acknowledgment` — the new prompt fragment is present
+2. `test_persona_called_with_raw_dict_string_does_not_error`
+3. `test_persona_max_tokens_unchanged` — still 2000 (don't break length expectations)
+
+---
+
+## 7. Verification
+
+1. Full unit suite (903 + new) → must stay green
+2. `ruff` + `black` + `isort` clean
+3. `python3 scripts/validate_events.py` — `synthesis_skipped` reuses `AGENT_PLANNING`, no new event types needed
+4. Live test: restart formation via `run_formation.py`, send 2 turns:
+   - Turn 1: a single-agent chat that triggers tool calls. Expected savings: ~4 s vs. last night's runs.
+   - Turn 2: a multi-task workflow request. Expected savings: ~20 s vs. last night's 38 s turn.
+5. Commit + push. SIF rebuild only after replies are validated.
+
+---
+
+## 8. Risk and rollback
+
+| Risk | Mitigation |
+|---|---|
+| Persona produces lower-quality replies in chat mode | The 50-token prompt addition + `temperature=0.7` + `max_tokens=2000` gives the model plenty of room. If quality drops, add a chat-mode mini-consolidator (still no LLM) that pre-formats structured data before persona |
+| Loss of agent persona voice (each agent had its own system prompt shaping output) | Agent's own persona was already being overwritten by overlord's `_apply_persona` — we lose nothing the user previously saw |
+| Workflow consolidator misses edge cases (artifacts, errors, partial failures) | Tests cover artifact filenames, empty results, errored steps. Existing `_render_task_body` already handles these |
+| `_create_synthesis_prompt` from `9650a95e` becomes dead code | Either delete it or keep `_render_task_body` as the consolidator's core helper. Either way, the test work isn't wasted |
+| Breakage in chat mode | `test_agent_skips_synthesis_call_in_chat_mode` + `test_persona_called_with_raw_dict_string_does_not_error` cover the new behavior. Live test with `run_formation.py` validates end-to-end |
+
+Rollback path: revert this commit. Branch is isolated; `develop` stays untouched until we explicitly merge.
+
+---
+
+## 9. Out of scope
+
+- Touching the SOP file
+- Forcing the workflow path to fire
+- Changes to decomposition / clarification / planning code
+- Modifying `develop`
+- SIF rebuild (deferred until replies are validated end-to-end)
+
+---
+
+## 10. Estimated time
+
+- Implementation: ~45 min (4 small edits + 1 helper + 1 prompt edit)
+- Tests: ~45 min (31 tests, many are simple assertions)
+- Live verification + commit + push: ~30 min
+
+**Total: ~2 hours.**
+
+---
+
+## 11. References
+
+- Predecessor commit: `9650a95e` (overlord prompt renders raw task outputs)
+- Branch base: `8487ed37` (`pre-synthesis-speedup-2026-04-29` tag)
+- Relevant files:
+  - `src/muxi/runtime/formation/agents/agent.py` — `process_message` (L1139), synthesis decision (L2299), `_synthesize_planning_execution_response` (L973)
+  - `src/muxi/runtime/formation/overlord/overlord.py` — `_apply_persona` (L2573), `_synthesize_workflow_results` (L9560), `_create_synthesis_prompt` (L9712)
+  - `src/muxi/runtime/formation/workflow/executor.py` — `_execute_task_with_agent` (L1371), `_parse_task_response` (L1507)
+- Existing tests:
+  - `tests/unit/test_agent_skip_synthesis.py` — pure-artifact + streaming-active fast path (separate optimization, kept untouched)
+  - `tests/unit/test_overlord_synthesis_prompt.py` — 15 tests for `_render_task_body` / `_create_synthesis_prompt`

--- a/contributing/synthesis-speedup-plan.md
+++ b/contributing/synthesis-speedup-plan.md
@@ -98,7 +98,7 @@ WORKFLOW MODE (N tasks)
        (tool outputs, no synth)     (tool outputs, no synth)     (tool outputs, no synth)
               ▲                               ▲                               ▲
               │                               │                               │
-              └─────────────── decompose ←── overlord ──→ chat ──┘
+              └─────────────── decompose ←── overlord ──→ chat ───────────────┘
 ```
 
 One LLM pass at the end. Everything before it is mechanical.

--- a/contributing/synthesis-speedup-plan.md
+++ b/contributing/synthesis-speedup-plan.md
@@ -2,8 +2,9 @@
 
 **Branch:** `feature/synthesis-speedup`
 **Date:** 2026-04-30
-**Status:** Plan — implementation pending
+**Status:** Implemented (merged in PR #162, 2026-04-30)
 **Predecessor commit:** `9650a95e` (overlord prompt now renders raw task outputs)
+**Implementation commit:** `2cc1d23e` (perf(synthesis): collapse three LLM passes into one persona call)
 
 ---
 

--- a/mental-model.md
+++ b/mental-model.md
@@ -3248,6 +3248,88 @@ The codebase is well-structured with clear separation of concerns, comprehensive
 
 ## Appendix: Lessons Learned (Updated During E2E Testing)
 
+### 2026-04-30: Haiku 4-5 weights agent `description` far above `specialization_keywords` when routing
+
+A demo of `example-formations/demo/hello-muxi/` that worked one day
+returned the wrong agent the next, on byte-identical code, formation,
+and prompt. "Tell me about the overlord" routed to the built-in
+`muxi-generalist` (which has zero MUXI grounding) and produced a
+generic anime/D-Day answer instead of going to `muxi-expert`.
+
+Empirical bisect across three runtimes (`feature/synthesis-speedup`,
+`develop`, and a divergent local tag `demo-known-good-2026-04-29` /
+`496aef29`) all reproduced the misroute deterministically. None of
+the recent runtime commits touched `agent_router.py`, the classifier,
+or `generalist.yaml`. The runtime code was not the cause.
+
+**What actually controls the decision.**
+
+The `AgentRouter` prompt presents each agent as a card with these
+fields, in this order: `name`, `role`, `description`, `specialties`,
+`specialization_keywords`, `specialization_domain`. Haiku 4-5 looks
+almost exclusively at the prose `description` when picking, and
+treats the structured `specialization_keywords` list as advisory
+flavor. Sonnet 4-5 on the same prompt routed correctly using only
+the keywords — Haiku did not.
+
+The demo formation's `muxi-expert.afs` had:
+
+```yaml
+description: "Explains MUXI and formations using embedded knowledge..."
+specialties: ["muxi", "muxi docs", "web browsing"]
+# (no specialization_keywords)
+```
+
+No mention of "overlord", "agents", "MCPs", or "SOPs" in the prose.
+With Haiku as the router, "tell me about the overlord" had no
+description anchor → fell through to `muxi-generalist`.
+
+**What did not fix it.** Adding `specialization_keywords: [overlord,
+formation, agent, mcp, sop, ...]` had **no effect** on Haiku's
+choice — still 3/3 to generalist. The structured field is too weak a
+signal for Haiku.
+
+**What did fix it.** Editing the `description` to surface the same
+domain terms in prose:
+
+```yaml
+description: "Explains MUXI concepts — the overlord, agents, formations,
+  MCPs, and SOPs — using embedded knowledge and live documentation
+  via Firecrawl"
+```
+
+That single line change made Haiku route deterministically to
+`muxi-expert`. No code change.
+
+**Why this looked like a regression.** It wasn't a regression in the
+strict sense — the formation was always sitting on a knife edge with
+Haiku. Yesterday's correct routing was lucky, not robust. A small
+behavioral shift on Anthropic's side (the `claude-haiku-4-5` alias is
+a moving target — Anthropic ships silent calibration updates under
+the same name) was enough to flip the borderline decision. The
+runtime never changed. The fix is to remove the dependence on Haiku's
+mood by giving the router a deterministic anchor in prose.
+
+**Mental notes.**
+
+- For Haiku routing, **domain terms must live in the `description`
+  prose**, not just in `specialties` or `specialization_keywords`.
+  Treat keywords as belt-and-braces; do not rely on them alone.
+- Sonnet is materially more reliable than Haiku for routing across
+  weakly-anchored agent metadata. If a formation's specialists do
+  not have rich descriptions, Sonnet for routing + Haiku for
+  synthesis (via the `overlord.llm.{base, synthesis}` lattice) is a
+  safer default than Haiku for both.
+- "Same code, same prompt, different answer one day later" with
+  cloud LLMs is normal. It is not a runtime regression unless a
+  bisect proves it; if every recent commit reproduces the same
+  output, the change is on the model side.
+- The built-in `muxi-generalist` agent's `system_message` has no
+  MUXI grounding. When Haiku misroutes to it, the user gets a
+  hallucinated generic answer instead of a "I don't know" disclaimer.
+  Worth tightening the generalist prompt at some point so misroutes
+  fail loudly rather than fluently.
+
 ### 2026-04-28: Three bugs surfaced while debugging two e2e tests on develop
 
 While fixing `test_2d1_local_buffer_mode` and `test_9a3b_with_approval`

--- a/src/muxi/runtime/formation/agents/agent.py
+++ b/src/muxi/runtime/formation/agents/agent.py
@@ -973,50 +973,117 @@ class Agent:
     async def _synthesize_planning_execution_response(
         self, user_request: str, my_results: Dict[str, Any], planning_response_parts: List[str]
     ) -> Optional[str]:
-        """Synthesize a final response from planning execution results."""
+        """Build the agent's planning-execution response.
+
+        Historically this issued an LLM call to synthesize prose from
+        ``my_results`` and ``planning_response_parts``. That synthesis
+        step was redundant: the overlord's ``_apply_persona`` pass
+        always runs on the way back to the user and is now responsible
+        for absorbing structured input (see
+        ``Overlord._apply_persona`` and the workflow consolidator).
+
+        This method now returns a deterministic, structured raw
+        response — no LLM call, no extra latency. The signature is
+        preserved so existing call sites and test fixtures keep
+        working.
+        """
         observability.observe(
             event_type=observability.ConversationEvents.AGENT_PLANNING,
             level=observability.EventLevel.INFO,
             data={
                 "agent_id": self.agent_id,
-                "phase": "planning_response_synthesis_start",
+                "phase": "synthesis_skipped",
+                "reason": "always_skip_v2",
                 "tool_result_count": len(my_results),
                 "delegated_response_count": len(planning_response_parts),
             },
-            description=f"Agent {self.agent_id} starting planning response synthesis",
+            description=(
+                f"Agent {self.agent_id} skipped planning synthesis "
+                f"(always_skip_v2: {len(my_results)} results, "
+                f"{len(planning_response_parts)} delegations)"
+            ),
         )
 
-        synthesis_messages = [
-            {
-                "role": "system",
-                "content": self._get_planning_response_synthesis_system_prompt(),
-            },
-            {
-                "role": "user",
-                "content": self._build_planning_response_synthesis_prompt(
-                    user_request, my_results, planning_response_parts
-                ),
-            },
-        ]
+        raw_response = self._build_raw_response(my_results, planning_response_parts)
+        return raw_response or None
 
-        response_obj = await self.model.chat(synthesis_messages)
-        response_text = (
-            response_obj.content if hasattr(response_obj, "content") else str(response_obj)
-        )
-        response_text = response_text.strip()
+    @staticmethod
+    def _build_raw_response(
+        my_results: Dict[str, Any],
+        planning_response_parts: List[str],
+    ) -> str:
+        """Render planning execution results as a deterministic raw string.
 
-        observability.observe(
-            event_type=observability.ConversationEvents.AGENT_PLANNING,
-            level=observability.EventLevel.INFO,
-            data={
-                "agent_id": self.agent_id,
-                "phase": "planning_response_synthesis_completed",
-                "response_length": len(response_text),
-            },
-            description=f"Agent {self.agent_id} completed planning response synthesis",
-        )
+        The output is structured for the overlord's persona LLM to
+        absorb directly: each tool result rendered under its
+        placeholder name, each delegated agent response appended
+        verbatim, artifact filenames called out inline.
 
-        return response_text or None
+        Output format::
+
+            ### {placeholder_1}
+            {result text}
+
+            ### {placeholder_2}
+            {result text}
+            Files Attached: foo.pdf, bar.png
+
+            ### Delegated Response 1
+            {delegated agent prose}
+
+        No LLM call. No prompt template. Pure string formatting.
+        """
+        sections: List[str] = []
+
+        if my_results:
+            for placeholder, result in my_results.items():
+                section_lines: List[str] = [f"### {placeholder}"]
+
+                if isinstance(result, dict):
+                    artifact_meta = result.get("_artifact")
+                    raw_text = result.get("result", result.get("output"))
+                    if isinstance(raw_text, str) and raw_text.strip():
+                        section_lines.append(raw_text.strip())
+                    elif isinstance(raw_text, dict):
+                        for key, value in raw_text.items():
+                            if value is None or value == "":
+                                continue
+                            section_lines.append(f"{key}: {value}")
+                    elif raw_text is not None:
+                        section_lines.append(str(raw_text).strip())
+                    else:
+                        # Dict result with no result/output key — render
+                        # the whole dict as key:value lines so nothing
+                        # actionable disappears.
+                        rendered_keys = [
+                            f"{k}: {v}"
+                            for k, v in result.items()
+                            if k != "_artifact" and v is not None and v != ""
+                        ]
+                        if rendered_keys:
+                            section_lines.extend(rendered_keys)
+                        elif artifact_meta is None:
+                            section_lines.append("(empty result)")
+
+                    if isinstance(artifact_meta, dict):
+                        filename = artifact_meta.get("filename") or artifact_meta.get("name")
+                        if filename:
+                            section_lines.append(f"Files Attached: {filename}")
+                else:
+                    section_lines.append(str(result).strip())
+
+                sections.append("\n".join(section_lines))
+
+        if planning_response_parts:
+            for idx, part in enumerate(planning_response_parts, 1):
+                if not part:
+                    continue
+                sections.append(f"### Delegated Response {idx}\n{part}")
+
+        if not sections:
+            return ""
+
+        return "\n\n".join(sections)
 
     @staticmethod
     def _is_pure_artifact_result(my_results: Dict[str, Any]) -> bool:

--- a/src/muxi/runtime/formation/agents/agent.py
+++ b/src/muxi/runtime/formation/agents/agent.py
@@ -1050,7 +1050,9 @@ class Agent:
                                 continue
                             section_lines.append(f"{key}: {value}")
                     elif raw_text is not None:
-                        section_lines.append(str(raw_text).strip())
+                        stripped = str(raw_text).strip()
+                        if stripped:
+                            section_lines.append(stripped)
                     else:
                         # Dict result with no result/output key — render
                         # the whole dict as key:value lines so nothing
@@ -1075,10 +1077,18 @@ class Agent:
                 sections.append("\n".join(section_lines))
 
         if planning_response_parts:
-            for idx, part in enumerate(planning_response_parts, 1):
+            # Number only the delegated parts we actually emit so the
+            # persona LLM sees a contiguous 1..N sequence. Numbering by
+            # the original list position would leave gaps for empty /
+            # None entries (e.g. ``["", None, "X"]`` → "Delegated
+            # Response 3" with no 1 or 2), which carries no semantic
+            # meaning and just confuses the model.
+            delegated_idx = 0
+            for part in planning_response_parts:
                 if not part:
                     continue
-                sections.append(f"### Delegated Response {idx}\n{part}")
+                delegated_idx += 1
+                sections.append(f"### Delegated Response {delegated_idx}\n{part}")
 
         if not sections:
             return ""

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -2759,6 +2759,10 @@ class Overlord:
 Reformat the agent's response to match your persona while preserving all technical details and information.
 Make it conversational and friendly while keeping accuracy.
 
+The agent's response may be either polished prose OR raw structured tool outputs (JSON-like dicts, key/value blocks, or per-task sections starting with "### Task N:" / "### {{placeholder}}"). In either case, extract every fact, ID, URL, filename, and number, and present them as a clear, friendly reply in your persona's voice. Do not summarize away or omit specific data.
+
+Preserve explicit dates, weekdays, times, and time ranges exactly as they appear in the agent's response. Do not convert absolute dates or times into relative wording like 'today', 'tomorrow', or 'yesterday' unless those exact relative words are already present in the agent's response.
+
 CRITICAL: If the agent's response contains specific personal information about the user (like their name, favorite color, profession, preferences, etc.), you MUST preserve that information exactly. The agent has access to the user's stored memories - do NOT replace specific facts with "I don't know" or "I don't have access to personal information". Trust the agent's response.
 
 IMPORTANT: Match response length to the question complexity. Simple questions get brief answers.
@@ -9628,67 +9632,32 @@ Agent response: {raw_response}"""
                     metadata={"synthesis_method": "error_summary"},
                 )
 
-            # Try to use LLM for intelligent synthesis if available
-            synthesis_model_config = (
-                self._capability_models.get("text") if hasattr(self, "_capability_models") else None
+            # Deterministic consolidation — no LLM call here. The
+            # final user-facing prose is produced by ``_apply_persona``
+            # downstream, which now absorbs structured input directly
+            # (see Overlord._apply_persona). Saves one LLM hop per
+            # workflow turn (~2-5 s) on top of the agent-side savings.
+            consolidated = self._consolidate_workflow_results(successful_results, task_results)
+            observability.observe(
+                event_type=observability.ConversationEvents.AGENT_PLANNING,
+                level=observability.EventLevel.INFO,
+                data={
+                    "phase": "synthesis_skipped",
+                    "reason": "deterministic_consolidator",
+                    "successful_count": len(successful_results),
+                    "failed_count": len([r for r in task_results if r.get("status") == "failed"]),
+                    "workflow_id": workflow.id,
+                },
+                description=(
+                    f"Workflow {workflow.id} synthesis skipped "
+                    f"(deterministic_consolidator: {len(successful_results)} successful)"
+                ),
             )
-
-            if synthesis_model_config:
-                # Prepare synthesis prompt
-                synthesis_prompt = self._create_synthesis_prompt(
-                    original_request, successful_results, task_results
-                )
-
-                try:
-                    # Create LLM instance for synthesis
-                    from ...services.llm import LLM
-
-                    # Extract just the model name from the config
-                    model_name = (
-                        synthesis_model_config.get("model")
-                        if isinstance(synthesis_model_config, dict)
-                        else synthesis_model_config
-                    )
-                    synthesis_llm = LLM(
-                        model=model_name,
-                        temperature=0.7,
-                        max_tokens=2000,
-                        timeout=120.0,
-                    )
-
-                    # Use LLM to synthesize results
-                    synthesis_response = await synthesis_llm.chat(
-                        messages=[
-                            {
-                                "role": "system",
-                                "content": self._get_workflow_synthesis_system_prompt(),
-                            },
-                            {"role": "user", "content": synthesis_prompt},
-                        ],
-                        metadata={
-                            "operation": "workflow_synthesis",
-                            "workflow_id": workflow.id,
-                        },
-                    )
-
-                    if synthesis_response:
-                        return MuxiResponse(
-                            role="assistant",
-                            content=synthesis_response,
-                            metadata={"synthesis_method": "llm_synthesis"},
-                        )
-
-                except Exception as e:
-                    # Log but continue with fallback
-                    observability.observe(
-                        event_type=observability.ConversationEvents.DOCUMENT_PROCESSING_FAILED,
-                        level=observability.EventLevel.WARNING,
-                        data={"error": str(e), "workflow_id": workflow.id},
-                        description=f"LLM synthesis failed, using fallback: {str(e)}",
-                    )
-
-            # Fallback: Simple concatenation with structure
-            return self._fallback_synthesis(original_request, successful_results, task_results)
+            return MuxiResponse(
+                role="assistant",
+                content=consolidated,
+                metadata={"synthesis_method": "deterministic_consolidator"},
+            )
 
         except Exception as e:
             observability.observe(
@@ -9789,24 +9758,33 @@ Agent response: {raw_response}"""
 
         return body, hints, artifacts
 
-    def _create_synthesis_prompt(
+    def _consolidate_workflow_results(
         self,
-        original_request: str,
         successful_results: List[Dict[str, Any]],
         all_results: List[Dict[str, Any]],
     ) -> str:
-        """Create prompt for LLM synthesis of task results.
+        """Render workflow task results as a deterministic structured string.
 
-        Renders each task's ``outputs["main"]["result"]`` into the prompt
-        within per-task and total byte budgets. Regex-extracted IDs and
-        attached artifact filenames are surfaced as supplementary fields.
+        The output is consumed downstream by ``_apply_persona``, which is
+        the single LLM pass on the way back to the user. No LLM call
+        here. Per-task and total byte budgets are enforced via
+        ``_render_task_body`` so a 200-task workflow can't blow the
+        persona model's context window.
+
+        Output format::
+
+            ### Task 1: <description>
+            Result: <body excerpt>
+            Key Outcomes: <regex hints>
+            Files Attached: <artifact filenames>
+
+            ### Task 2: <description>
+            ...
+
+            ### Failed Tasks:
+            - <description>: <error>
         """
-        prompt_parts = [
-            f"Original User Request: {original_request}",
-            "",
-            "Workflow Execution Summary:",
-            "",
-        ]
+        parts: List[str] = []
 
         consumed = 0
         for i, result in enumerate(successful_results, 1):
@@ -9818,66 +9796,33 @@ Agent response: {raw_response}"""
 
             body, hints, artifacts = self._render_task_body(outputs, per_task)
 
-            prompt_parts.append(f"Task {i}: {task_desc}")
+            section: List[str] = [f"### Task {i}: {task_desc}"]
 
             if body:
-                prompt_parts.append(f"Result: {body}")
+                section.append(f"Result: {body}")
                 consumed += len(body)
             elif not hints and not artifacts:
-                # Nothing useful to render — preserve the legacy status
-                # line so the LLM still sees a per-task signal.
-                prompt_parts.append("Status: Completed successfully")
+                # Nothing useful to render — preserve a per-task signal
+                # so the persona model still acknowledges the task.
+                section.append("Status: Completed successfully")
 
             if hints:
-                prompt_parts.append(f"Key Outcomes: {hints}")
+                section.append(f"Key Outcomes: {hints}")
             if artifacts:
-                prompt_parts.append(f"Files Attached: {artifacts}")
-            prompt_parts.append("")
+                section.append(f"Files Attached: {artifacts}")
 
-        # Note any failed tasks
+            parts.append("\n".join(section))
+
         failed_tasks = [r for r in all_results if r.get("status") == "failed"]
         if failed_tasks:
-            prompt_parts.append("Failed Tasks:")
+            failed_lines: List[str] = ["### Failed Tasks:"]
             for task in failed_tasks:
-                prompt_parts.append(
-                    f"- {task.get('description', 'Task')}: {task.get('error', 'Unknown error')}"
+                failed_lines.append(
+                    f"- {task.get('description', 'Task')}: " f"{task.get('error', 'Unknown error')}"
                 )
-            prompt_parts.append("")
+            parts.append("\n".join(failed_lines))
 
-        prompt_parts.extend(
-            [
-                "Based on the original user request and the task results above, provide an appropriate response:",
-                "",
-                "- Preserve explicit dates, weekdays, times, and time ranges exactly as they appear in the task results.",
-                "- Do not rewrite absolute dates/times into relative labels like 'today', 'tomorrow', or 'yesterday'",
-                "  unless the task results already use those exact relative words.",
-                "",
-                "- If this appears to be a conversational request (greeting, casual inquiry, social interaction, etc.),",  # noqa: E501
-                "  provide a natural, conversational response. Respond directly as if having a conversation,",
-                "  not describing what tasks were completed.",
-                "",
-                "- If this is a task-oriented request with concrete deliverables, provide a brief confirmation that:",
-                "  1. Confirms what was accomplished (focus on concrete outcomes like created issues, documents, etc.)",
-                "  2. Mentions any specific IDs, URLs, or references the user needs",
-                "  3. Acknowledges any failures if relevant",
-                "  4. Keep it concise - 2-3 sentences maximum",
-                "",
-                "Response:",
-            ]
-        )
-
-        return "\n".join(prompt_parts)
-
-    def _get_workflow_synthesis_system_prompt(self) -> str:
-        """Return the system prompt used for final workflow synthesis."""
-        return (
-            "You are a helpful assistant that synthesizes multiple task results into a coherent, "
-            "comprehensive response. Focus on addressing the user's original request while "
-            "incorporating all relevant information from the tasks. Preserve explicit dates, "
-            "weekdays, times, and time ranges exactly as they appear in the task results. Do not "
-            "convert absolute dates or times into relative wording like 'today', 'tomorrow', or "
-            "'yesterday' unless the task results already use those exact relative terms."
-        )
+        return "\n\n".join(parts)
 
     def _extract_key_outcomes(self, outputs: Dict[str, Any], task_description: str) -> str:
         """
@@ -9947,54 +9892,6 @@ Agent response: {raw_response}"""
 
         # If we found key items, join them; otherwise return empty string
         return "; ".join(key_items) if key_items else ""
-
-    def _fallback_synthesis(
-        self,
-        original_request: str,
-        successful_results: List[Dict[str, Any]],
-        all_results: List[Dict[str, Any]],
-    ) -> MuxiResponse:
-        """Fallback synthesis when LLM is not available."""
-        response_parts = []
-
-        # Start with a brief summary
-        task_count = len(successful_results)
-        if task_count > 0:
-            response_parts.append(
-                f"✅ Successfully completed {task_count} task{'s' if task_count != 1 else ''}"
-            )
-            response_parts.append("")
-
-        # Extract key outcomes from successful tasks
-        key_outcomes = []
-        for result in successful_results:
-            task_desc = result.get("description", "Task")
-            outputs = result.get("outputs", {})
-            outcomes = self._extract_key_outcomes(outputs, task_desc)
-            if outcomes:
-                key_outcomes.append(f"• {task_desc}: {outcomes}")
-
-        if key_outcomes:
-            response_parts.append("**Key Outcomes:**")
-            response_parts.extend(key_outcomes)
-            response_parts.append("")
-
-        # Note any failed tasks briefly
-        failed_tasks = [r for r in all_results if r.get("status") == "failed"]
-        if failed_tasks:
-            response_parts.append(
-                f"⚠️ {len(failed_tasks)} task{'s' if len(failed_tasks) != 1 else ''} failed:"
-            )
-            for task in failed_tasks:
-                response_parts.append(
-                    f"• {task.get('description', 'Task')}: {task.get('error', 'Unknown error')}"
-                )
-
-        return MuxiResponse(
-            role="assistant",
-            content="\n".join(response_parts),
-            metadata={"synthesis_method": "structured_concatenation"},
-        )
 
     # ===================================================================
     # VALIDATION METHODS FOR TYPE SAFETY

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -88,7 +88,7 @@ import time
 from contextlib import contextmanager, suppress
 from datetime import datetime
 from pathlib import Path
-from typing import Any, AsyncGenerator, Dict, List, Optional, Set, Union
+from typing import Any, AsyncGenerator, Dict, List, Optional, Set, Tuple, Union
 
 # Import MarkItDown - required dependency
 from markitdown import MarkItDown
@@ -9709,13 +9709,98 @@ Agent response: {raw_response}"""
                 metadata={"synthesis_method": "emergency_fallback", "error": str(e)},
             )
 
+    # Synthesis-prompt budgets. Per-task caps the body excerpt of any
+    # single task; total caps the cumulative body bytes across all tasks
+    # so a 200-task workflow can't blow the overlord LLM's context window.
+    # Static template (descriptions, instructions, hints) is not counted.
+    _SYNTHESIS_PER_TASK_BUDGET: int = 2_000
+    _SYNTHESIS_TOTAL_BUDGET: int = 20_000
+
+    def _render_task_body(self, outputs: Dict[str, Any], budget: int) -> Tuple[str, str, str]:
+        """Render a single task's outputs for the synthesis prompt.
+
+        The workflow executor (``WorkflowExecutor._parse_task_response``)
+        wraps every agent response under ``outputs["main"]["result"]``;
+        for non-Linear flows that prose is the *only* meaningful payload
+        in the dict. The previous prompt builder ignored ``main.result``
+        and relied solely on regex extraction from ``str(outputs)``,
+        which silently dropped GitHub issue URLs, file paths, and the
+        agent's conversational synthesis.
+
+        Returns a triple ``(body, hints, artifacts)``:
+
+        * ``body`` — excerpt of ``outputs["main"]["result"]``. Strings
+          are truncated to ``budget`` chars with a ``[...truncated, N
+          chars omitted]`` marker. Dict values render as ``key: value``
+          lines so the LLM can read them naturally instead of seeing
+          ``str(dict)`` syntax inline.
+        * ``hints`` — output of ``_extract_key_outcomes`` (regex hits
+          for Linear MX-IDs / URLs and the legacy flat-shape fields).
+          Kept as a supplementary signal because the regex is free and
+          surfaces the most actionable IDs.
+        * ``artifacts`` — comma-separated filenames pulled from
+          ``outputs["artifacts"]["result"]`` so the LLM can mention
+          attachments by name.
+        """
+        if not isinstance(outputs, dict):
+            return "", "", ""
+
+        # 1. Body — drawn from outputs["main"]["result"]
+        body = ""
+        main = outputs.get("main")
+        if isinstance(main, dict):
+            result = main.get("result")
+            if isinstance(result, str):
+                body = result.strip()
+            elif isinstance(result, dict):
+                lines = []
+                for k, v in result.items():
+                    if v is None or v == "":
+                        continue
+                    lines.append(f"{k}: {v}")
+                body = "\n".join(lines)
+            elif result is not None:
+                body = str(result).strip()
+
+        if budget > 0 and len(body) > budget:
+            omitted = len(body) - budget
+            body = body[:budget] + f"\n[...truncated, {omitted} chars omitted]"
+        elif budget == 0:
+            body = ""
+
+        # 2. Hints — regex/flat-shape extraction kept as supplementary
+        hints = self._extract_key_outcomes(outputs, "")
+
+        # 3. Artifacts — filenames the user may want to reference
+        artifact_names: List[str] = []
+        artifacts_dict = outputs.get("artifacts")
+        if isinstance(artifacts_dict, dict):
+            artifact_list = artifacts_dict.get("result", [])
+            if isinstance(artifact_list, list):
+                for a in artifact_list:
+                    name: Any = None
+                    if isinstance(a, dict):
+                        name = a.get("filename") or a.get("name")
+                    else:
+                        name = getattr(a, "filename", None) or getattr(a, "name", None)
+                    if name:
+                        artifact_names.append(str(name))
+        artifacts = ", ".join(artifact_names)
+
+        return body, hints, artifacts
+
     def _create_synthesis_prompt(
         self,
         original_request: str,
         successful_results: List[Dict[str, Any]],
         all_results: List[Dict[str, Any]],
     ) -> str:
-        """Create prompt for LLM synthesis of task results."""
+        """Create prompt for LLM synthesis of task results.
+
+        Renders each task's ``outputs["main"]["result"]`` into the prompt
+        within per-task and total byte budgets. Regex-extracted IDs and
+        attached artifact filenames are surfaced as supplementary fields.
+        """
         prompt_parts = [
             f"Original User Request: {original_request}",
             "",
@@ -9723,20 +9808,30 @@ Agent response: {raw_response}"""
             "",
         ]
 
-        # Add successful task results with only key outcomes
+        consumed = 0
         for i, result in enumerate(successful_results, 1):
             task_desc = result.get("description", "Unknown task")
+            outputs = result.get("outputs", {})
+
+            remaining = max(0, self._SYNTHESIS_TOTAL_BUDGET - consumed)
+            per_task = min(self._SYNTHESIS_PER_TASK_BUDGET, remaining)
+
+            body, hints, artifacts = self._render_task_body(outputs, per_task)
+
             prompt_parts.append(f"Task {i}: {task_desc}")
 
-            # Extract only key actionable outcomes from outputs
-            outputs = result.get("outputs", {})
-            key_outcomes = self._extract_key_outcomes(outputs, task_desc)
-
-            if key_outcomes:
-                prompt_parts.append(f"Key Outcomes: {key_outcomes}")
-            else:
-                # For tasks without specific outcomes, just note completion
+            if body:
+                prompt_parts.append(f"Result: {body}")
+                consumed += len(body)
+            elif not hints and not artifacts:
+                # Nothing useful to render — preserve the legacy status
+                # line so the LLM still sees a per-task signal.
                 prompt_parts.append("Status: Completed successfully")
+
+            if hints:
+                prompt_parts.append(f"Key Outcomes: {hints}")
+            if artifacts:
+                prompt_parts.append(f"Files Attached: {artifacts}")
             prompt_parts.append("")
 
         # Note any failed tasks

--- a/tests/unit/test_agent_skip_synthesis_always.py
+++ b/tests/unit/test_agent_skip_synthesis_always.py
@@ -109,6 +109,42 @@ def test_build_raw_response_non_dict_result_stringified() -> None:
     assert "raw string output" in rendered
 
 
+def test_build_raw_response_empty_string_result_with_artifact_only_emits_filename() -> None:
+    """Dict with empty-string ``result`` plus an artifact must NOT emit a
+    blank line under the header.
+
+    Regression guard: the previous ``elif raw_text is not None`` branch
+    appended ``str("").strip()`` (an empty string) into the section,
+    leaving the persona LLM with just ``### {placeholder}`` followed by
+    blank space. The fix mirrors ``_render_task_body``'s ``if body:``
+    guard so empty / whitespace-only ``result`` values are skipped, and
+    the artifact filename becomes the section's only body line.
+    """
+    my_results = {
+        "{{CHART}}": {
+            "result": "",
+            "_artifact": {"filename": "sales.png"},
+        },
+    }
+    rendered = Agent._build_raw_response(my_results, [])
+    assert "### {{CHART}}" in rendered
+    assert "Files Attached: sales.png" in rendered
+    # No blank-line body between header and Files Attached.
+    chart_block = rendered.split("### {{CHART}}", 1)[1]
+    non_empty_body_lines = [ln for ln in chart_block.splitlines() if ln.strip()]
+    assert non_empty_body_lines == ["Files Attached: sales.png"]
+
+
+def test_build_raw_response_whitespace_only_result_treated_as_empty() -> None:
+    """``result`` that's pure whitespace must not surface as a section
+    body (parallels the non-empty-string check on the first branch)."""
+    my_results = {"{{STEP}}": {"result": "   \n  "}}
+    rendered = Agent._build_raw_response(my_results, [])
+    assert "### {{STEP}}" in rendered
+    step_block = rendered.split("### {{STEP}}", 1)[1]
+    assert step_block.strip() == ""
+
+
 def test_build_raw_response_empty_inputs_returns_empty_string() -> None:
     """Empty results AND empty delegations return an empty string.
 
@@ -120,14 +156,34 @@ def test_build_raw_response_empty_inputs_returns_empty_string() -> None:
 
 
 def test_build_raw_response_skips_empty_delegated_parts() -> None:
-    """Empty/None delegated entries are skipped, not rendered as blanks."""
+    """Empty/None delegated entries are skipped, and the surviving
+    entries are numbered contiguously from 1.
+
+    Numbering by the original list position would produce gaps
+    (``["", None, "Real"]`` → "Delegated Response 3" with no 1 or 2),
+    which carries no semantic meaning and just confuses the persona
+    LLM. The renderer counts only emitted parts.
+    """
     my_results = {"{{TOOL}}": {"result": "X"}}
     rendered = Agent._build_raw_response(my_results, ["", None, "Real response"])  # type: ignore[list-item]
-    assert "### Delegated Response 1" not in rendered
+    # Only the non-empty entry surfaces, numbered 1 (not 3).
+    assert "### Delegated Response 1" in rendered
     assert "### Delegated Response 2" not in rendered
-    # Only the non-empty entry surfaces, indexed by its position.
-    assert "### Delegated Response 3" in rendered
+    assert "### Delegated Response 3" not in rendered
     assert "Real response" in rendered
+
+
+def test_build_raw_response_delegated_parts_numbered_contiguously() -> None:
+    """Multiple non-empty parts interleaved with skips still produce a
+    contiguous 1..N sequence."""
+    rendered = Agent._build_raw_response(
+        {},
+        ["First", "", None, "Second", None, "Third"],  # type: ignore[list-item]
+    )
+    assert "### Delegated Response 1\nFirst" in rendered
+    assert "### Delegated Response 2\nSecond" in rendered
+    assert "### Delegated Response 3\nThird" in rendered
+    assert "### Delegated Response 4" not in rendered
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_agent_skip_synthesis_always.py
+++ b/tests/unit/test_agent_skip_synthesis_always.py
@@ -1,0 +1,211 @@
+"""Tests for the always-skip agent synthesis path.
+
+Background
+----------
+``Agent._synthesize_planning_execution_response`` historically issued a
+second LLM call after planning execution to weave tool results and
+delegated agent prose into a final user-facing reply. That extra
+~4-second LLM call is now redundant: the overlord's ``_apply_persona``
+pass always runs on the way back to the user and is responsible for
+absorbing structured input.
+
+This module locks in the new contract:
+
+1. ``_synthesize_planning_execution_response`` no longer calls an LLM.
+   It delegates to ``_build_raw_response`` (deterministic).
+2. ``_build_raw_response`` renders ``my_results`` and
+   ``planning_response_parts`` as a structured string the persona model
+   can absorb directly.
+3. The pure-artifact + streaming-active fast path (separate
+   optimization, see ``test_agent_skip_synthesis.py``) still takes
+   priority — its tests continue to pin that contract independently.
+"""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from muxi.runtime.formation.agents.agent import Agent
+
+# ---------------------------------------------------------------------------
+# _build_raw_response — pure string formatting, no LLM
+# ---------------------------------------------------------------------------
+
+
+def test_build_raw_response_renders_each_result_with_placeholder() -> None:
+    """Each ``my_results`` entry renders under a ``### {placeholder}`` header."""
+    my_results = {
+        "{{TICKET}}": {"result": "Created issue MX-42 at https://linear.app/x/MX-42"},
+        "{{LIST}}": {"result": "10 items found"},
+    }
+    rendered = Agent._build_raw_response(my_results, [])
+    assert "### {{TICKET}}" in rendered
+    assert "### {{LIST}}" in rendered
+    assert "Created issue MX-42 at https://linear.app/x/MX-42" in rendered
+    assert "10 items found" in rendered
+
+
+def test_build_raw_response_renders_delegated_responses() -> None:
+    """Delegated agent prose is appended under ``### Delegated Response N``."""
+    my_results = {"{{TOOL}}": {"result": "Tool output X"}}
+    delegated = [
+        "Agent A: I checked the Linear board and found 3 P0 issues.",
+        "Agent B: GitHub MCP returned 5 open PRs awaiting review.",
+    ]
+    rendered = Agent._build_raw_response(my_results, delegated)
+    assert "### Delegated Response 1" in rendered
+    assert "Agent A: I checked the Linear board and found 3 P0 issues." in rendered
+    assert "### Delegated Response 2" in rendered
+    assert "Agent B: GitHub MCP returned 5 open PRs awaiting review." in rendered
+
+
+def test_build_raw_response_includes_artifact_filenames() -> None:
+    """Results carrying ``_artifact`` metadata surface their filename."""
+    my_results = {
+        "{{REPORT}}": {
+            "result": "Generated the quarterly report.",
+            "_artifact": {"filename": "Q3-report.pdf"},
+        }
+    }
+    rendered = Agent._build_raw_response(my_results, [])
+    assert "Generated the quarterly report." in rendered
+    assert "Files Attached: Q3-report.pdf" in rendered
+
+
+def test_build_raw_response_dict_result_renders_key_value_lines() -> None:
+    """A dict ``result`` payload renders as ``key: value`` lines."""
+    my_results = {
+        "{{ISSUE}}": {
+            "result": {
+                "issue_number": 50,
+                "url": "https://github.com/muxi-ai/runtime/issues/50",
+                "title": "Welcome to MUXI",
+            }
+        }
+    }
+    rendered = Agent._build_raw_response(my_results, [])
+    assert "issue_number: 50" in rendered
+    assert "url: https://github.com/muxi-ai/runtime/issues/50" in rendered
+    assert "title: Welcome to MUXI" in rendered
+    # No raw Python dict syntax in the surface.
+    assert "{'issue_number'" not in rendered
+
+
+def test_build_raw_response_string_result_extracted_from_output_field() -> None:
+    """When dict has only ``output`` field, that's the body source."""
+    my_results = {"{{STEP}}": {"output": "Result text"}}
+    rendered = Agent._build_raw_response(my_results, [])
+    assert "Result text" in rendered
+
+
+def test_build_raw_response_non_dict_result_stringified() -> None:
+    """Non-dict results (raw string, list, etc.) are stringified."""
+    my_results = {"{{STEP}}": "raw string output"}
+    rendered = Agent._build_raw_response(my_results, [])
+    assert "raw string output" in rendered
+
+
+def test_build_raw_response_empty_inputs_returns_empty_string() -> None:
+    """Empty results AND empty delegations return an empty string.
+
+    The caller then falls through to other response-building branches
+    (e.g., ``has_successful_delegation`` path or final fallback prose).
+    """
+    rendered = Agent._build_raw_response({}, [])
+    assert rendered == ""
+
+
+def test_build_raw_response_skips_empty_delegated_parts() -> None:
+    """Empty/None delegated entries are skipped, not rendered as blanks."""
+    my_results = {"{{TOOL}}": {"result": "X"}}
+    rendered = Agent._build_raw_response(my_results, ["", None, "Real response"])  # type: ignore[list-item]
+    assert "### Delegated Response 1" not in rendered
+    assert "### Delegated Response 2" not in rendered
+    # Only the non-empty entry surfaces, indexed by its position.
+    assert "### Delegated Response 3" in rendered
+    assert "Real response" in rendered
+
+
+# ---------------------------------------------------------------------------
+# _synthesize_planning_execution_response — body must not call an LLM
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthesize_planning_execution_response_does_not_call_llm() -> None:
+    """The synthesis method body delegates to ``_build_raw_response``.
+
+    We verify by giving the agent a model whose ``chat`` would raise if
+    invoked — and asserting the call still returns a sensible string.
+    """
+    a = Agent.__new__(Agent)
+    a.agent_id = "test-agent"
+    a.model = SimpleNamespace(
+        chat=AsyncMock(side_effect=AssertionError("model.chat must NOT be called"))
+    )
+
+    my_results = {"{{TOOL}}": {"result": "Tool output."}}
+    delegated = ["Delegated reply."]
+
+    result = await a._synthesize_planning_execution_response(
+        "user request",
+        my_results,
+        delegated,
+    )
+
+    assert "Tool output." in (result or "")
+    assert "Delegated reply." in (result or "")
+    a.model.chat.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_synthesize_planning_execution_response_empty_returns_none() -> None:
+    """No tool results AND no delegations → return None.
+
+    The caller already gates on ``my_results and not has_successful_delegation``,
+    so this code path is normally unreachable, but the contract is
+    explicit: empty in → ``None`` out (so ``response_content`` stays
+    empty and the outer fallback branches take over).
+    """
+    a = Agent.__new__(Agent)
+    a.agent_id = "test-agent"
+    a.model = SimpleNamespace()
+
+    result = await a._synthesize_planning_execution_response("user request", {}, [])
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Body-source check — the LLM call site has been removed from source
+# ---------------------------------------------------------------------------
+
+
+def test_synthesize_method_body_does_not_reference_model_chat() -> None:
+    """Belt-and-suspenders: the source of ``_synthesize_planning_execution_response``
+    must not contain ``self.model.chat`` — proves the LLM call was
+    structurally removed, not just bypassed at runtime.
+    """
+    source = inspect.getsource(Agent._synthesize_planning_execution_response)
+    assert "self.model.chat" not in source
+    assert "_build_raw_response" in source
+
+
+# ---------------------------------------------------------------------------
+# Pure-artifact path interaction — separate optimization stays priority
+# ---------------------------------------------------------------------------
+
+
+def test_pure_artifact_helper_unchanged() -> None:
+    """``_is_pure_artifact_result`` and ``_build_artifact_only_response``
+    keep their existing behavior — covered in detail by
+    ``test_agent_skip_synthesis.py``. This test is a smoke check that
+    the helpers are still accessible from the Agent class.
+    """
+    assert callable(Agent._is_pure_artifact_result)
+    assert callable(Agent._build_artifact_only_response)
+    assert Agent._is_pure_artifact_result({"step_1": {"_artifact": {"filename": "x.pdf"}}}) is True
+    assert Agent._is_pure_artifact_result({}) is False

--- a/tests/unit/test_apply_persona_handles_raw.py
+++ b/tests/unit/test_apply_persona_handles_raw.py
@@ -1,0 +1,77 @@
+"""Tests pinning the contract that ``Overlord._apply_persona`` absorbs raw input.
+
+Background
+----------
+``_apply_persona`` is the single LLM pass on the way back to the user.
+Historically its job was styling — "rephrase the agent's response in
+your persona's voice." With agent-side and workflow-side synthesis
+calls removed (see ``test_agent_skip_synthesis_always.py`` and
+``test_workflow_consolidator.py``), ``_apply_persona`` now also has to
+absorb structured tool outputs (per-task sections, key/value blocks,
+JSON-like dicts) and surface every fact, ID, URL, filename, and number
+in the user-facing reply.
+
+We can't unit-test the persona LLM's output (that's behavior of an
+external model), but we CAN pin the contract through the system
+prompt's source text. Future edits that quietly strip the raw-input
+acknowledgment or the date-preservation guardrail will fail these
+tests.
+"""
+
+import inspect
+
+from muxi.runtime.formation.overlord.overlord import Overlord
+
+
+def test_persona_prompt_acknowledges_raw_structured_input() -> None:
+    """The persona system prompt explicitly handles raw structured input."""
+    source = inspect.getsource(Overlord._apply_persona)
+
+    # Acknowledgment that the agent response may be either prose OR
+    # structured tool outputs. The exact wording matters less than the
+    # signal that the LLM should expect both shapes.
+    assert "raw structured tool outputs" in source
+
+    # Per-task section markers used by the workflow consolidator and
+    # the agent's _build_raw_response — the persona LLM must recognize
+    # them.
+    assert "### Task" in source
+    assert "### " in source
+
+    # Key directive: don't drop facts.
+    assert "Do not summarize away or omit specific data" in source
+
+
+def test_persona_prompt_lists_data_categories_to_preserve() -> None:
+    """The persona system prompt names the categories of data to preserve.
+
+    Without this list the LLM may quietly drop technical details when
+    rendering raw structured input.
+    """
+    source = inspect.getsource(Overlord._apply_persona)
+    for required in ("fact", "ID", "URL", "filename", "number"):
+        assert required in source, f"persona prompt must mention '{required}'"
+
+
+def test_persona_prompt_max_tokens_unchanged() -> None:
+    """Token budget for the persona LLM call must remain at 2000.
+
+    The ``_apply_persona`` method now does both synthesis-from-raw AND
+    styling in a single call; cutting the token budget would silently
+    truncate replies on workflow-rich turns.
+    """
+    source = inspect.getsource(Overlord._apply_persona)
+    # Two distinct LLM call sites in the method (non-actionable + actionable);
+    # both should pass max_tokens=2000 OR max_tokens=300 (the short
+    # non-actionable path). Neither should drop below those thresholds.
+    assert "max_tokens=2000" in source
+    # The non-actionable short path (no agent response) is intentionally
+    # capped lower; that's a documented difference, not a regression.
+    assert "max_tokens=300" in source
+
+
+def test_persona_prompt_preserves_personal_information_directive() -> None:
+    """The pre-existing 'preserve user personal info' guardrail stays."""
+    source = inspect.getsource(Overlord._apply_persona)
+    assert "specific personal information about the user" in source
+    assert "Trust the agent's response" in source

--- a/tests/unit/test_overlord_synthesis_prompt.py
+++ b/tests/unit/test_overlord_synthesis_prompt.py
@@ -1,0 +1,539 @@
+"""Tests for ``Overlord._create_synthesis_prompt`` against realistic raw data.
+
+Background
+----------
+``Overlord._synthesize_workflow_results`` is the final stage of a workflow
+turn. It collects ``TaskResult`` entries from the workflow executor and
+calls ``_create_synthesis_prompt`` to build a single prompt for the
+overlord LLM, which then produces the user-visible reply.
+
+The shape of ``TaskResult.outputs`` is fixed by
+``WorkflowExecutor._parse_task_response`` (workflow/executor.py)::
+
+    outputs = {
+        "main": {
+            "result": <agent's full prose response>,  # str OR dict
+            "status": "success",
+            "metrics": {"response_length": int},
+            "warnings": [],
+            "artifacts": [],
+        },
+        "task_id": {"result": <task_id_str>, "status": "success"},
+        "completed": {"result": True, "status": "success"},
+        # plus capability-specific copies (research_findings, written_content, ...)
+        # plus optional "artifacts" key when artifacts attached
+    }
+
+The agent's actual prose lives at ``outputs["main"]["result"]``. The
+rewritten ``_create_synthesis_prompt`` reads ``main.result`` as the
+primary content source and uses ``_extract_key_outcomes`` plus the
+``artifacts`` sub-dict as supplementary hints.
+
+These tests cover three concerns:
+
+1. Stable behaviors that survived the rewrite (failed tasks, regex
+   extraction of Linear IDs, the synthetic flat-shape branch).
+2. The new behavior the rewrite introduced (``main.result`` rendered
+   verbatim, dict results expanded to ``key: value`` lines, artifact
+   filenames listed, per-task and total byte budgets enforced).
+3. Edge cases that previously degraded silently (empty outputs,
+   non-dict outputs).
+"""
+
+from typing import Any, Dict, List
+
+from muxi.runtime.formation.overlord.overlord import Overlord
+
+# -----------------------------------------------------------------------
+# Fixture builders matching the real ``_parse_task_response`` shape
+# -----------------------------------------------------------------------
+
+
+def _make_main_output(prose: str) -> Dict[str, Any]:
+    """Build the ``outputs["main"]`` sub-dict the executor produces."""
+    return {
+        "result": prose,
+        "status": "success",
+        "metrics": {"response_length": len(prose)},
+        "warnings": [],
+        "artifacts": [],
+    }
+
+
+def _make_task_outputs(
+    task_id: str,
+    prose: str,
+    *,
+    extra_capability: str | None = None,
+    artifacts: List[Any] | None = None,
+) -> Dict[str, Any]:
+    """Build a complete ``outputs`` dict matching the executor's output."""
+    outputs: Dict[str, Any] = {
+        "main": _make_main_output(prose),
+        "task_id": {"result": task_id, "status": "success"},
+        "completed": {"result": True, "status": "success"},
+    }
+    if extra_capability == "research":
+        outputs["research_findings"] = {
+            "result": prose,
+            "status": "success",
+            "metrics": {"word_count": len(prose.split())},
+        }
+    elif extra_capability == "writing":
+        outputs["written_content"] = {
+            "result": prose,
+            "status": "success",
+            "metrics": {"word_count": len(prose.split())},
+        }
+    if artifacts:
+        outputs["artifacts"] = {
+            "result": artifacts,
+            "status": "success",
+            "metrics": {"artifact_count": len(artifacts)},
+        }
+    return outputs
+
+
+def _make_task_result(
+    *,
+    task_id: str,
+    description: str,
+    status: str = "completed",
+    outputs: Dict[str, Any] | None = None,
+    error: str | None = None,
+) -> Dict[str, Any]:
+    """Build a task_result entry as ``_synthesize_workflow_results`` sees it."""
+    result: Dict[str, Any] = {
+        "task_id": task_id,
+        "description": description,
+        "status": status,
+    }
+    if outputs is not None:
+        result["outputs"] = outputs
+    if error is not None:
+        result["error"] = error
+    return result
+
+
+def _bare_overlord() -> Overlord:
+    """Build an ``Overlord`` skeleton for prompt-only tests.
+
+    ``_create_synthesis_prompt`` and ``_extract_key_outcomes`` are
+    stateless except for ``self`` lookup, so we sidestep the full
+    formation engine constructor.
+    """
+    return Overlord.__new__(Overlord)
+
+
+# -----------------------------------------------------------------------
+# Behavior tests — rewritten ``_create_synthesis_prompt``
+# -----------------------------------------------------------------------
+
+
+class TestSynthesisPromptBehavior:
+    """The rewritten prompt builder reads ``outputs["main"]["result"]``
+    as primary content, surfaces regex hints and artifact filenames as
+    supplementary fields, and enforces per-task / total byte budgets.
+    """
+
+    def test_github_flow_carries_agent_prose(self) -> None:
+        """A typical GitHub onboarding turn carries every task's prose.
+
+        Each task's ``outputs["main"]["result"]`` contains the agent's
+        synthesized response. The rewritten prompt builder renders all
+        four bodies so the overlord LLM has real content to summarize.
+        """
+        overlord = _bare_overlord()
+        successful = [
+            _make_task_result(
+                task_id="t1",
+                description="Welcome the user and explain MUXI capabilities",
+                outputs=_make_task_outputs(
+                    "t1",
+                    "Hi! I'm MUXI — a runtime for orchestrating AI agents. "
+                    "Today I'll help you create a GitHub welcome issue and "
+                    "walk you through what I can do.",
+                ),
+            ),
+            _make_task_result(
+                task_id="t2",
+                description="Create welcome GitHub issue",
+                outputs=_make_task_outputs(
+                    "t2",
+                    "I created your welcome issue at "
+                    "https://github.com/muxi-ai/runtime/issues/50 — titled "
+                    "'Welcome to MUXI'.",
+                ),
+            ),
+            _make_task_result(
+                task_id="t3",
+                description="Generate personalized recap",
+                outputs=_make_task_outputs(
+                    "t3",
+                    "Here's your personalized recap: you asked to be "
+                    "onboarded, I introduced MUXI, and I created a "
+                    "welcome issue on GitHub.",
+                ),
+            ),
+            _make_task_result(
+                task_id="t4",
+                description="Send final reply with next steps",
+                outputs=_make_task_outputs(
+                    "t4",
+                    "Next steps: try `What can you do?` or ask me to " "summarize a webpage.",
+                ),
+            ),
+        ]
+        prompt = overlord._create_synthesis_prompt("onboard me", successful, successful)
+
+        # Each task description appears for orientation.
+        for task in successful:
+            assert task["description"] in prompt
+
+        # And the agent's prose appears verbatim — these phrases live
+        # only in ``outputs["main"]["result"]``.
+        assert "I'm MUXI" in prompt
+        assert "https://github.com/muxi-ai/runtime/issues/50" in prompt
+        assert "you asked to be onboarded" in prompt
+        assert "summarize a webpage" in prompt
+
+        # The "Status: Completed successfully" fallback should NOT fire
+        # for any task that has real body content.
+        assert "Status: Completed successfully" not in prompt
+
+    def test_canonical_linear_url_now_carried_via_main_result(self) -> None:
+        """Canonical ``https://linear.app/...`` URLs are carried via prose.
+
+        The legacy URL regex misses canonical Linear URLs (it requires
+        chars between ``://`` and ``linear``). The rewrite renders
+        ``main.result`` directly, so the URL appears in the prompt body
+        regardless of regex behavior. The MX-id regex hint still surfaces
+        the ID separately for the LLM's convenience.
+        """
+        overlord = _bare_overlord()
+        prose = "Created Linear issue at https://linear.app/acme/issue/MX-42 " "for the bug report."
+        successful = [
+            _make_task_result(
+                task_id="t1",
+                description="File Linear bug",
+                outputs=_make_task_outputs("t1", prose),
+            )
+        ]
+        prompt = overlord._create_synthesis_prompt("file a bug", successful, successful)
+        # URL now carried via main.result rendering, regardless of regex.
+        assert "linear.app/acme/issue/MX-42" in prompt
+        # MX-id still surfaces via _extract_key_outcomes regex hint.
+        assert "Linear issues: MX-42" in prompt
+
+    def test_subdomain_linear_url_survives_with_hint(self) -> None:
+        """URLs with chars before ``linear`` appear in body AND hints."""
+        overlord = _bare_overlord()
+        prose = (
+            "Created issue at https://example.linear.app/acme/issue/MX-42 " "for the bug report."
+        )
+        successful = [
+            _make_task_result(
+                task_id="t1",
+                description="File subdomain Linear bug",
+                outputs=_make_task_outputs("t1", prose),
+            )
+        ]
+        prompt = overlord._create_synthesis_prompt("file a bug", successful, successful)
+        assert "example.linear.app/acme/issue/MX-42" in prompt
+
+    def test_linear_mx_id_survives_via_regex(self) -> None:
+        """``MX-\\d+`` IDs in nested result are extracted via regex."""
+        overlord = _bare_overlord()
+        prose = "Filed MX-123 with the team."
+        successful = [
+            _make_task_result(
+                task_id="t1",
+                description="File Linear ticket",
+                outputs=_make_task_outputs("t1", prose),
+            )
+        ]
+        prompt = overlord._create_synthesis_prompt("file a ticket", successful, successful)
+        assert "Linear issues: MX-123" in prompt
+
+    def test_synthetic_flat_shape_extracts_top_level_fields(self) -> None:
+        """The dead-code branch fires when outputs is artificially flat.
+
+        Real executor never produces this shape, but we pin it so we
+        know the helper still works for any code path that *does* hand
+        flat outputs (legacy callers, fallback paths, or future synthetic
+        construction).
+        """
+        overlord = _bare_overlord()
+        successful = [
+            _make_task_result(
+                task_id="t1",
+                description="Create document",
+                outputs={
+                    "issue_id": "ENG-99",
+                    "issue_url": "https://example.com/issues/99",
+                    "created": True,
+                },
+            )
+        ]
+        prompt = overlord._create_synthesis_prompt("create a doc", successful, successful)
+        assert "Issue Id: ENG-99" in prompt
+        assert "Issue Url: https://example.com/issues/99" in prompt
+
+    def test_failed_tasks_listed_with_errors(self) -> None:
+        """Failed tasks appear under a 'Failed Tasks:' section with errors."""
+        overlord = _bare_overlord()
+        successful = [
+            _make_task_result(
+                task_id="t1",
+                description="Greet user",
+                outputs=_make_task_outputs("t1", "Hello!"),
+            ),
+        ]
+        all_results = successful + [
+            _make_task_result(
+                task_id="t2",
+                description="Post to GitHub",
+                status="failed",
+                error="403 Forbidden — token lacks write scope",
+            ),
+            _make_task_result(
+                task_id="t3",
+                description="Send Slack notification",
+                status="failed",
+                error="Slack workspace not configured",
+            ),
+        ]
+        prompt = overlord._create_synthesis_prompt("greet and notify", successful, all_results)
+        assert "Failed Tasks:" in prompt
+        assert "Post to GitHub" in prompt
+        assert "403 Forbidden — token lacks write scope" in prompt
+        assert "Send Slack notification" in prompt
+        assert "Slack workspace not configured" in prompt
+
+    def test_empty_outputs_falls_back_to_status_line(self) -> None:
+        """Tasks with empty outputs degrade to the status line."""
+        overlord = _bare_overlord()
+        successful = [
+            _make_task_result(
+                task_id="t1",
+                description="Run a placeholder task",
+                outputs={},
+            )
+        ]
+        prompt = overlord._create_synthesis_prompt("do something", successful, successful)
+        assert "Status: Completed successfully" in prompt
+
+    def test_artifacts_listed_with_filenames(self) -> None:
+        """Attached artifacts surface their filenames under a dedicated header."""
+        overlord = _bare_overlord()
+        artifacts = [
+            {"filename": "report.pdf", "size_bytes": 18432},
+            {"filename": "summary.md", "size_bytes": 940},
+        ]
+        successful = [
+            _make_task_result(
+                task_id="t1",
+                description="Generate quarterly report",
+                outputs=_make_task_outputs("t1", "Generated the report.", artifacts=artifacts),
+            )
+        ]
+        prompt = overlord._create_synthesis_prompt(
+            "make a quarterly report", successful, successful
+        )
+        assert "report.pdf" in prompt
+        assert "summary.md" in prompt
+        assert "Files Attached:" in prompt
+
+    def test_main_result_rendered_in_prompt(self) -> None:
+        """Each task's ``outputs["main"]["result"]`` prose appears verbatim."""
+        overlord = _bare_overlord()
+        prose = (
+            "I created your welcome issue at "
+            "https://github.com/muxi-ai/runtime/issues/50 — titled 'Welcome to MUXI'."
+        )
+        successful = [
+            _make_task_result(
+                task_id="t1",
+                description="Create welcome GitHub issue",
+                outputs=_make_task_outputs("t1", prose),
+            )
+        ]
+        prompt = overlord._create_synthesis_prompt("onboard me", successful, successful)
+        assert prose in prompt
+        # And the URL specifically — the most useful single piece of
+        # data the user needs — must be carried verbatim.
+        assert "https://github.com/muxi-ai/runtime/issues/50" in prompt
+
+    def test_multi_task_each_result_rendered_in_order(self) -> None:
+        """Multiple tasks render their prose in dispatch order."""
+        overlord = _bare_overlord()
+        prose_a = "Greeting: hello and welcome to MUXI."
+        prose_b = "Issue created at https://github.com/example/issues/1."
+        prose_c = "Recap: I introduced MUXI and created the issue."
+        successful = [
+            _make_task_result(
+                task_id="t1",
+                description="Greet",
+                outputs=_make_task_outputs("t1", prose_a),
+            ),
+            _make_task_result(
+                task_id="t2",
+                description="Create issue",
+                outputs=_make_task_outputs("t2", prose_b),
+            ),
+            _make_task_result(
+                task_id="t3",
+                description="Summarize",
+                outputs=_make_task_outputs("t3", prose_c),
+            ),
+        ]
+        prompt = overlord._create_synthesis_prompt("onboard me", successful, successful)
+        idx_a = prompt.find(prose_a)
+        idx_b = prompt.find(prose_b)
+        idx_c = prompt.find(prose_c)
+        assert idx_a >= 0, "task 1 prose missing"
+        assert idx_b >= 0, "task 2 prose missing"
+        assert idx_c >= 0, "task 3 prose missing"
+        assert idx_a < idx_b < idx_c, "tasks must appear in dispatch order"
+
+    def test_long_output_truncated_with_marker(self) -> None:
+        """Per-task budget caps long prose with an explicit marker."""
+        overlord = _bare_overlord()
+        long_prose = "x" * 10_000
+        successful = [
+            _make_task_result(
+                task_id="t1",
+                description="Summarize a long document",
+                outputs=_make_task_outputs("t1", long_prose),
+            )
+        ]
+        prompt = overlord._create_synthesis_prompt("summarize", successful, successful)
+        # Some prose carried through.
+        assert "x" * 100 in prompt
+        # But not the full 10 KB.
+        assert "x" * 10_000 not in prompt
+        # And the truncation is signposted.
+        assert "truncated" in prompt.lower()
+
+    def test_artifact_count_mentioned(self) -> None:
+        """When tasks attach artifacts, the prompt mentions them."""
+        overlord = _bare_overlord()
+        artifacts = [
+            {"filename": "report.pdf", "size_bytes": 18432},
+            {"filename": "summary.md", "size_bytes": 940},
+        ]
+        successful = [
+            _make_task_result(
+                task_id="t1",
+                description="Generate quarterly report",
+                outputs=_make_task_outputs("t1", "Generated the report.", artifacts=artifacts),
+            )
+        ]
+        prompt = overlord._create_synthesis_prompt(
+            "make a quarterly report", successful, successful
+        )
+        # Filenames the user needs to reference.
+        assert "report.pdf" in prompt
+        assert "summary.md" in prompt
+
+    def test_dict_main_result_rendered_structured(self) -> None:
+        """When ``main.result`` is a dict (raw tool output), render its fields."""
+        overlord = _bare_overlord()
+        # Some tool calls return structured payloads instead of prose.
+        # The current code stringifies the whole thing into the prompt
+        # in an opaque way; the rewrite should expose the useful fields.
+        tool_output = {
+            "issue_number": 50,
+            "url": "https://github.com/muxi-ai/runtime/issues/50",
+            "title": "Welcome to MUXI",
+        }
+        outputs = {
+            "main": {
+                "result": tool_output,
+                "status": "success",
+                "metrics": {},
+                "warnings": [],
+                "artifacts": [],
+            },
+            "task_id": {"result": "t1", "status": "success"},
+            "completed": {"result": True, "status": "success"},
+        }
+        successful = [
+            _make_task_result(
+                task_id="t1",
+                description="Create welcome GitHub issue (raw tool output)",
+                outputs=outputs,
+            )
+        ]
+        prompt = overlord._create_synthesis_prompt("onboard me", successful, successful)
+        assert "https://github.com/muxi-ai/runtime/issues/50" in prompt
+        assert "Welcome to MUXI" in prompt
+        # And the raw ``str(dict)`` form should NOT be the surface — we
+        # want a clean rendering, not Python-dict syntax dumped inline.
+        assert "{'issue_number': 50" not in prompt
+
+    def test_total_prompt_size_capped_under_many_tasks(self) -> None:
+        """Many large tasks must fit under a fair total budget AND
+        carry at least some prose from each task.
+
+        Two-sided assertion to defeat false greens:
+
+        * Today's code passes the size bound trivially because it never
+          renders the prose at all — so we also require that at least
+          one task's distinctive prose actually surfaces.
+        * A naive future implementation that dumps every byte would fail
+          the size bound, so the test catches that regression too.
+        """
+        overlord = _bare_overlord()
+        # 10 tasks, each with 5 KB of distinctive prose. Embed a unique
+        # marker in each so we can verify per-task representation.
+        successful = [
+            _make_task_result(
+                task_id=f"t{i}",
+                description=f"Task {i} description",
+                outputs=_make_task_outputs(
+                    f"t{i}",
+                    f"PROSE_MARKER_{i} " + "y" * 4_900,
+                ),
+            )
+            for i in range(10)
+        ]
+        prompt = overlord._create_synthesis_prompt("do many things", successful, successful)
+        # Size bound: well under the 50 KB raw upper bound.
+        assert len(prompt) < 30_000
+        # All task descriptions surface for orientation.
+        for task in successful:
+            assert task["description"] in prompt
+        # At least the first task's distinctive prose marker shows up
+        # somewhere in the prompt — this is the assertion that fails
+        # against today's "Status: Completed successfully" prompt.
+        assert "PROSE_MARKER_0" in prompt
+
+
+# -----------------------------------------------------------------------
+# Sanity: the helper itself is callable and returns a string
+# -----------------------------------------------------------------------
+
+
+def test_create_synthesis_prompt_returns_string() -> None:
+    """Smoke check: the function returns a non-empty string for a minimal call."""
+    overlord = _bare_overlord()
+    result = overlord._create_synthesis_prompt(
+        "hello",
+        [
+            _make_task_result(
+                task_id="t1",
+                description="Say hi",
+                outputs=_make_task_outputs("t1", "Hi there!"),
+            )
+        ],
+        [
+            _make_task_result(
+                task_id="t1",
+                description="Say hi",
+                outputs=_make_task_outputs("t1", "Hi there!"),
+            )
+        ],
+    )
+    assert isinstance(result, str)
+    assert len(result) > 0

--- a/tests/unit/test_workflow_consolidator.py
+++ b/tests/unit/test_workflow_consolidator.py
@@ -1,11 +1,12 @@
-"""Tests for ``Overlord._create_synthesis_prompt`` against realistic raw data.
+"""Tests for ``Overlord._consolidate_workflow_results`` against realistic raw data.
 
 Background
 ----------
-``Overlord._synthesize_workflow_results`` is the final stage of a workflow
-turn. It collects ``TaskResult`` entries from the workflow executor and
-calls ``_create_synthesis_prompt`` to build a single prompt for the
-overlord LLM, which then produces the user-visible reply.
+``Overlord._synthesize_workflow_results`` is the final stage of a
+workflow turn. It collects ``TaskResult`` entries from the workflow
+executor and calls ``_consolidate_workflow_results`` to render a single
+deterministic structured string. That string flows downstream into
+``_apply_persona`` (the single LLM pass on the way back to the user).
 
 The shape of ``TaskResult.outputs`` is fixed by
 ``WorkflowExecutor._parse_task_response`` (workflow/executor.py)::
@@ -25,19 +26,20 @@ The shape of ``TaskResult.outputs`` is fixed by
     }
 
 The agent's actual prose lives at ``outputs["main"]["result"]``. The
-rewritten ``_create_synthesis_prompt`` reads ``main.result`` as the
-primary content source and uses ``_extract_key_outcomes`` plus the
-``artifacts`` sub-dict as supplementary hints.
+consolidator reads ``main.result`` as the primary content source via
+``_render_task_body``, then surfaces ``_extract_key_outcomes`` plus the
+``artifacts`` sub-dict as supplementary fields.
 
 These tests cover three concerns:
 
 1. Stable behaviors that survived the rewrite (failed tasks, regex
    extraction of Linear IDs, the synthetic flat-shape branch).
-2. The new behavior the rewrite introduced (``main.result`` rendered
+2. The behavior we want from the consolidator (``main.result`` rendered
    verbatim, dict results expanded to ``key: value`` lines, artifact
-   filenames listed, per-task and total byte budgets enforced).
-3. Edge cases that previously degraded silently (empty outputs,
-   non-dict outputs).
+   filenames listed, per-task and total byte budgets enforced, NO LLM
+   call).
+3. Edge cases that previously degraded silently (empty outputs, non-dict
+   outputs).
 """
 
 from typing import Any, Dict, List
@@ -116,32 +118,34 @@ def _make_task_result(
 
 
 def _bare_overlord() -> Overlord:
-    """Build an ``Overlord`` skeleton for prompt-only tests.
+    """Build an ``Overlord`` skeleton for consolidator-only tests.
 
-    ``_create_synthesis_prompt`` and ``_extract_key_outcomes`` are
-    stateless except for ``self`` lookup, so we sidestep the full
-    formation engine constructor.
+    ``_consolidate_workflow_results`` and the helpers it relies on
+    (``_render_task_body``, ``_extract_key_outcomes``) are stateless
+    except for class-level attributes (the budgets), so we sidestep the
+    full formation engine constructor.
     """
     return Overlord.__new__(Overlord)
 
 
 # -----------------------------------------------------------------------
-# Behavior tests — rewritten ``_create_synthesis_prompt``
+# Behavior tests — the deterministic consolidator
 # -----------------------------------------------------------------------
 
 
-class TestSynthesisPromptBehavior:
-    """The rewritten prompt builder reads ``outputs["main"]["result"]``
+class TestConsolidatorBehavior:
+    """The deterministic consolidator reads ``outputs["main"]["result"]``
     as primary content, surfaces regex hints and artifact filenames as
     supplementary fields, and enforces per-task / total byte budgets.
+    No LLM call is made.
     """
 
     def test_github_flow_carries_agent_prose(self) -> None:
         """A typical GitHub onboarding turn carries every task's prose.
 
         Each task's ``outputs["main"]["result"]`` contains the agent's
-        synthesized response. The rewritten prompt builder renders all
-        four bodies so the overlord LLM has real content to summarize.
+        synthesized response. The consolidator renders all four bodies
+        so the persona LLM downstream has real content to absorb.
         """
         overlord = _bare_overlord()
         successful = [
@@ -180,38 +184,38 @@ class TestSynthesisPromptBehavior:
                 description="Send final reply with next steps",
                 outputs=_make_task_outputs(
                     "t4",
-                    "Next steps: try `What can you do?` or ask me to " "summarize a webpage.",
+                    "Next steps: try `What can you do?` or ask me to summarize a webpage.",
                 ),
             ),
         ]
-        prompt = overlord._create_synthesis_prompt("onboard me", successful, successful)
+        rendered = overlord._consolidate_workflow_results(successful, successful)
 
         # Each task description appears for orientation.
         for task in successful:
-            assert task["description"] in prompt
+            assert task["description"] in rendered
 
         # And the agent's prose appears verbatim — these phrases live
         # only in ``outputs["main"]["result"]``.
-        assert "I'm MUXI" in prompt
-        assert "https://github.com/muxi-ai/runtime/issues/50" in prompt
-        assert "you asked to be onboarded" in prompt
-        assert "summarize a webpage" in prompt
+        assert "I'm MUXI" in rendered
+        assert "https://github.com/muxi-ai/runtime/issues/50" in rendered
+        assert "you asked to be onboarded" in rendered
+        assert "summarize a webpage" in rendered
 
         # The "Status: Completed successfully" fallback should NOT fire
         # for any task that has real body content.
-        assert "Status: Completed successfully" not in prompt
+        assert "Status: Completed successfully" not in rendered
 
     def test_canonical_linear_url_now_carried_via_main_result(self) -> None:
         """Canonical ``https://linear.app/...`` URLs are carried via prose.
 
         The legacy URL regex misses canonical Linear URLs (it requires
-        chars between ``://`` and ``linear``). The rewrite renders
-        ``main.result`` directly, so the URL appears in the prompt body
+        chars between ``://`` and ``linear``). The consolidator renders
+        ``main.result`` directly, so the URL appears in the output body
         regardless of regex behavior. The MX-id regex hint still surfaces
-        the ID separately for the LLM's convenience.
+        the ID separately as a supplementary signal.
         """
         overlord = _bare_overlord()
-        prose = "Created Linear issue at https://linear.app/acme/issue/MX-42 " "for the bug report."
+        prose = "Created Linear issue at https://linear.app/acme/issue/MX-42 for the bug report."
         successful = [
             _make_task_result(
                 task_id="t1",
@@ -219,18 +223,14 @@ class TestSynthesisPromptBehavior:
                 outputs=_make_task_outputs("t1", prose),
             )
         ]
-        prompt = overlord._create_synthesis_prompt("file a bug", successful, successful)
-        # URL now carried via main.result rendering, regardless of regex.
-        assert "linear.app/acme/issue/MX-42" in prompt
-        # MX-id still surfaces via _extract_key_outcomes regex hint.
-        assert "Linear issues: MX-42" in prompt
+        rendered = overlord._consolidate_workflow_results(successful, successful)
+        assert "linear.app/acme/issue/MX-42" in rendered
+        assert "Linear issues: MX-42" in rendered
 
     def test_subdomain_linear_url_survives_with_hint(self) -> None:
         """URLs with chars before ``linear`` appear in body AND hints."""
         overlord = _bare_overlord()
-        prose = (
-            "Created issue at https://example.linear.app/acme/issue/MX-42 " "for the bug report."
-        )
+        prose = "Created issue at https://example.linear.app/acme/issue/MX-42 for the bug report."
         successful = [
             _make_task_result(
                 task_id="t1",
@@ -238,8 +238,8 @@ class TestSynthesisPromptBehavior:
                 outputs=_make_task_outputs("t1", prose),
             )
         ]
-        prompt = overlord._create_synthesis_prompt("file a bug", successful, successful)
-        assert "example.linear.app/acme/issue/MX-42" in prompt
+        rendered = overlord._consolidate_workflow_results(successful, successful)
+        assert "example.linear.app/acme/issue/MX-42" in rendered
 
     def test_linear_mx_id_survives_via_regex(self) -> None:
         """``MX-\\d+`` IDs in nested result are extracted via regex."""
@@ -252,8 +252,8 @@ class TestSynthesisPromptBehavior:
                 outputs=_make_task_outputs("t1", prose),
             )
         ]
-        prompt = overlord._create_synthesis_prompt("file a ticket", successful, successful)
-        assert "Linear issues: MX-123" in prompt
+        rendered = overlord._consolidate_workflow_results(successful, successful)
+        assert "Linear issues: MX-123" in rendered
 
     def test_synthetic_flat_shape_extracts_top_level_fields(self) -> None:
         """The dead-code branch fires when outputs is artificially flat.
@@ -275,9 +275,9 @@ class TestSynthesisPromptBehavior:
                 },
             )
         ]
-        prompt = overlord._create_synthesis_prompt("create a doc", successful, successful)
-        assert "Issue Id: ENG-99" in prompt
-        assert "Issue Url: https://example.com/issues/99" in prompt
+        rendered = overlord._consolidate_workflow_results(successful, successful)
+        assert "Issue Id: ENG-99" in rendered
+        assert "Issue Url: https://example.com/issues/99" in rendered
 
     def test_failed_tasks_listed_with_errors(self) -> None:
         """Failed tasks appear under a 'Failed Tasks:' section with errors."""
@@ -303,12 +303,12 @@ class TestSynthesisPromptBehavior:
                 error="Slack workspace not configured",
             ),
         ]
-        prompt = overlord._create_synthesis_prompt("greet and notify", successful, all_results)
-        assert "Failed Tasks:" in prompt
-        assert "Post to GitHub" in prompt
-        assert "403 Forbidden — token lacks write scope" in prompt
-        assert "Send Slack notification" in prompt
-        assert "Slack workspace not configured" in prompt
+        rendered = overlord._consolidate_workflow_results(successful, all_results)
+        assert "Failed Tasks:" in rendered
+        assert "Post to GitHub" in rendered
+        assert "403 Forbidden — token lacks write scope" in rendered
+        assert "Send Slack notification" in rendered
+        assert "Slack workspace not configured" in rendered
 
     def test_empty_outputs_falls_back_to_status_line(self) -> None:
         """Tasks with empty outputs degrade to the status line."""
@@ -320,8 +320,8 @@ class TestSynthesisPromptBehavior:
                 outputs={},
             )
         ]
-        prompt = overlord._create_synthesis_prompt("do something", successful, successful)
-        assert "Status: Completed successfully" in prompt
+        rendered = overlord._consolidate_workflow_results(successful, successful)
+        assert "Status: Completed successfully" in rendered
 
     def test_artifacts_listed_with_filenames(self) -> None:
         """Attached artifacts surface their filenames under a dedicated header."""
@@ -337,14 +337,12 @@ class TestSynthesisPromptBehavior:
                 outputs=_make_task_outputs("t1", "Generated the report.", artifacts=artifacts),
             )
         ]
-        prompt = overlord._create_synthesis_prompt(
-            "make a quarterly report", successful, successful
-        )
-        assert "report.pdf" in prompt
-        assert "summary.md" in prompt
-        assert "Files Attached:" in prompt
+        rendered = overlord._consolidate_workflow_results(successful, successful)
+        assert "report.pdf" in rendered
+        assert "summary.md" in rendered
+        assert "Files Attached:" in rendered
 
-    def test_main_result_rendered_in_prompt(self) -> None:
+    def test_main_result_rendered_in_output(self) -> None:
         """Each task's ``outputs["main"]["result"]`` prose appears verbatim."""
         overlord = _bare_overlord()
         prose = (
@@ -358,11 +356,11 @@ class TestSynthesisPromptBehavior:
                 outputs=_make_task_outputs("t1", prose),
             )
         ]
-        prompt = overlord._create_synthesis_prompt("onboard me", successful, successful)
-        assert prose in prompt
+        rendered = overlord._consolidate_workflow_results(successful, successful)
+        assert prose in rendered
         # And the URL specifically — the most useful single piece of
         # data the user needs — must be carried verbatim.
-        assert "https://github.com/muxi-ai/runtime/issues/50" in prompt
+        assert "https://github.com/muxi-ai/runtime/issues/50" in rendered
 
     def test_multi_task_each_result_rendered_in_order(self) -> None:
         """Multiple tasks render their prose in dispatch order."""
@@ -387,10 +385,10 @@ class TestSynthesisPromptBehavior:
                 outputs=_make_task_outputs("t3", prose_c),
             ),
         ]
-        prompt = overlord._create_synthesis_prompt("onboard me", successful, successful)
-        idx_a = prompt.find(prose_a)
-        idx_b = prompt.find(prose_b)
-        idx_c = prompt.find(prose_c)
+        rendered = overlord._consolidate_workflow_results(successful, successful)
+        idx_a = rendered.find(prose_a)
+        idx_b = rendered.find(prose_b)
+        idx_c = rendered.find(prose_c)
         assert idx_a >= 0, "task 1 prose missing"
         assert idx_b >= 0, "task 2 prose missing"
         assert idx_c >= 0, "task 3 prose missing"
@@ -407,16 +405,16 @@ class TestSynthesisPromptBehavior:
                 outputs=_make_task_outputs("t1", long_prose),
             )
         ]
-        prompt = overlord._create_synthesis_prompt("summarize", successful, successful)
+        rendered = overlord._consolidate_workflow_results(successful, successful)
         # Some prose carried through.
-        assert "x" * 100 in prompt
+        assert "x" * 100 in rendered
         # But not the full 10 KB.
-        assert "x" * 10_000 not in prompt
+        assert "x" * 10_000 not in rendered
         # And the truncation is signposted.
-        assert "truncated" in prompt.lower()
+        assert "truncated" in rendered.lower()
 
     def test_artifact_count_mentioned(self) -> None:
-        """When tasks attach artifacts, the prompt mentions them."""
+        """When tasks attach artifacts, the output mentions them."""
         overlord = _bare_overlord()
         artifacts = [
             {"filename": "report.pdf", "size_bytes": 18432},
@@ -429,19 +427,17 @@ class TestSynthesisPromptBehavior:
                 outputs=_make_task_outputs("t1", "Generated the report.", artifacts=artifacts),
             )
         ]
-        prompt = overlord._create_synthesis_prompt(
-            "make a quarterly report", successful, successful
-        )
+        rendered = overlord._consolidate_workflow_results(successful, successful)
         # Filenames the user needs to reference.
-        assert "report.pdf" in prompt
-        assert "summary.md" in prompt
+        assert "report.pdf" in rendered
+        assert "summary.md" in rendered
 
     def test_dict_main_result_rendered_structured(self) -> None:
         """When ``main.result`` is a dict (raw tool output), render its fields."""
         overlord = _bare_overlord()
         # Some tool calls return structured payloads instead of prose.
-        # The current code stringifies the whole thing into the prompt
-        # in an opaque way; the rewrite should expose the useful fields.
+        # The consolidator should expose the useful fields, not Python
+        # dict-syntax dumped inline.
         tool_output = {
             "issue_number": 50,
             "url": "https://github.com/muxi-ai/runtime/issues/50",
@@ -465,24 +461,24 @@ class TestSynthesisPromptBehavior:
                 outputs=outputs,
             )
         ]
-        prompt = overlord._create_synthesis_prompt("onboard me", successful, successful)
-        assert "https://github.com/muxi-ai/runtime/issues/50" in prompt
-        assert "Welcome to MUXI" in prompt
+        rendered = overlord._consolidate_workflow_results(successful, successful)
+        assert "https://github.com/muxi-ai/runtime/issues/50" in rendered
+        assert "Welcome to MUXI" in rendered
         # And the raw ``str(dict)`` form should NOT be the surface — we
         # want a clean rendering, not Python-dict syntax dumped inline.
-        assert "{'issue_number': 50" not in prompt
+        assert "{'issue_number': 50" not in rendered
 
-    def test_total_prompt_size_capped_under_many_tasks(self) -> None:
+    def test_total_size_capped_under_many_tasks(self) -> None:
         """Many large tasks must fit under a fair total budget AND
         carry at least some prose from each task.
 
         Two-sided assertion to defeat false greens:
 
-        * Today's code passes the size bound trivially because it never
-          renders the prose at all — so we also require that at least
-          one task's distinctive prose actually surfaces.
-        * A naive future implementation that dumps every byte would fail
-          the size bound, so the test catches that regression too.
+        * A naive implementation that drops all prose passes the size
+          bound trivially — so we also require that at least one task's
+          distinctive prose actually surfaces.
+        * A naive implementation that dumps every byte fails the size
+          bound, so the test catches that regression too.
         """
         overlord = _bare_overlord()
         # 10 tasks, each with 5 KB of distinctive prose. Embed a unique
@@ -498,16 +494,42 @@ class TestSynthesisPromptBehavior:
             )
             for i in range(10)
         ]
-        prompt = overlord._create_synthesis_prompt("do many things", successful, successful)
+        rendered = overlord._consolidate_workflow_results(successful, successful)
         # Size bound: well under the 50 KB raw upper bound.
-        assert len(prompt) < 30_000
+        assert len(rendered) < 30_000
         # All task descriptions surface for orientation.
         for task in successful:
-            assert task["description"] in prompt
+            assert task["description"] in rendered
         # At least the first task's distinctive prose marker shows up
-        # somewhere in the prompt — this is the assertion that fails
-        # against today's "Status: Completed successfully" prompt.
-        assert "PROSE_MARKER_0" in prompt
+        # somewhere in the rendered output.
+        assert "PROSE_MARKER_0" in rendered
+
+
+# -----------------------------------------------------------------------
+# No-LLM guarantee
+# -----------------------------------------------------------------------
+
+
+def test_consolidator_does_not_call_llm() -> None:
+    """The consolidator is pure string formatting — no model.chat invocation.
+
+    We can't directly assert "no network call happened" in a unit test,
+    but we CAN assert that the consolidator works with a bare Overlord
+    skeleton that has no model wired in. If the consolidator quietly
+    tried to call a model, it would AttributeError on missing
+    ``self.model`` / ``self._capability_models`` / etc.
+    """
+    overlord = _bare_overlord()
+    successful = [
+        _make_task_result(
+            task_id="t1",
+            description="A task",
+            outputs=_make_task_outputs("t1", "Some prose."),
+        )
+    ]
+    rendered = overlord._consolidate_workflow_results(successful, successful)
+    assert isinstance(rendered, str)
+    assert "Some prose." in rendered
 
 
 # -----------------------------------------------------------------------
@@ -515,11 +537,10 @@ class TestSynthesisPromptBehavior:
 # -----------------------------------------------------------------------
 
 
-def test_create_synthesis_prompt_returns_string() -> None:
+def test_consolidate_workflow_results_returns_string() -> None:
     """Smoke check: the function returns a non-empty string for a minimal call."""
     overlord = _bare_overlord()
-    result = overlord._create_synthesis_prompt(
-        "hello",
+    result = overlord._consolidate_workflow_results(
         [
             _make_task_result(
                 task_id="t1",

--- a/tests/unit/test_workflow_date_preservation_prompts.py
+++ b/tests/unit/test_workflow_date_preservation_prompts.py
@@ -1,18 +1,26 @@
-"""Tests for prompt guardrails that preserve exact dates during workflow synthesis."""
+"""Tests for prompt guardrails that preserve exact dates.
+
+The dedicated workflow-synthesis system prompt was retired when
+synthesis collapsed into ``_apply_persona``'s single LLM pass; date
+preservation guardrails now live in the persona system prompt itself.
+The first test below pins that guardrail in source so future edits to
+``_apply_persona`` don't silently strip it.
+"""
+
+import inspect
 
 from muxi.runtime.datatypes.workflow import SubTask
 from muxi.runtime.formation.overlord.overlord import Overlord
 from muxi.runtime.formation.workflow.executor import WorkflowExecutor
 
 
-def test_workflow_synthesis_system_prompt_preserves_absolute_dates():
-    overlord = object.__new__(Overlord)
+def test_apply_persona_system_prompt_preserves_absolute_dates():
+    """Date-preservation guardrail must be present in ``_apply_persona``."""
+    source = inspect.getsource(Overlord._apply_persona)
 
-    prompt = overlord._get_workflow_synthesis_system_prompt()
-
-    assert "Preserve explicit dates, weekdays, times, and time ranges exactly" in prompt
-    assert "Do not convert absolute dates or times into relative wording" in prompt
-    assert "'today', 'tomorrow', or 'yesterday'" in prompt
+    assert "Preserve explicit dates, weekdays, times, and time ranges exactly" in source
+    assert "Do not convert absolute dates or times into relative wording" in source
+    assert "'today', 'tomorrow', or 'yesterday'" in source
 
 
 def test_workflow_executor_task_prompt_keeps_prior_dates_and_adds_guardrail():


### PR DESCRIPTION
## Summary

Removes the agent-level and workflow-level synthesis LLM calls and replaces both with deterministic builders that feed structured input into the overlord's existing `_apply_persona` pass — now the single LLM hop on the way back to the user.

**Before**: a workflow turn with N tasks made N agent-synthesis calls + 1 workflow-synthesis call + 1 persona call. Three LLM hops were the runtime saying the same thing back to itself.

**After**:
- `Agent._build_raw_response` — deterministic renderer (`### {placeholder}` sections, dict expansion, artifact filenames inline, delegated-agent prose verbatim).
- `Overlord._consolidate_workflow_results` — budget-bounded per-task sections via the existing `_render_task_body`. No LLM call.
- `Overlord._apply_persona` — the single user-facing LLM hop. System prompt extended with the raw-input acknowledgment contract and the date-preservation guardrail inherited from the deleted synthesis prompts.

Dead code removed: `_create_synthesis_prompt`, `_get_workflow_synthesis_system_prompt`, `_fallback_synthesis`. Skip events emit `reason: always_skip_v2` (chat) and `reason: deterministic_consolidator` (workflow) for operator audit.

## Performance

| Surface | LLM calls removed | Expected | Measured (live) |
|---|---|---|---|
| Chat turn | 1 (agent synthesis) | ~4 s | ~4-5 s |
| Workflow turn (4 tasks) | 5 (4 agent + 1 workflow) | ~20 s | T2 38.4 s → 34.0 s; T3 86.6 s with 0 `planning_response_synthesis_*` events |

## Test changes

- **New** `tests/unit/test_agent_skip_synthesis_always.py` (11 tests) — pin always-skip contract, `_build_raw_response` shape, assert no `self.model.chat` in the synthesis method.
- **New** `tests/unit/test_apply_persona_handles_raw.py` (4 tests) — pin raw-input acknowledgment + date guardrail in persona prompt.
- **Renamed** `test_overlord_synthesis_prompt.py → test_workflow_consolidator.py` (16 tests) — lifted to exercise the new helper.
- `test_workflow_date_preservation_prompts.py` — first test repointed to the new guardrail location.

## Verification

- Unit suite: **925 pass / 1 skipped / 0 new failures**
- ruff/black/isort clean
- `validate_events.py`: **1214/1214 events enum-backed**
- `run_random_tests.py 20` post-merge: **20/20 pass** across 11 areas (3_multimodal, 4_mcp, 7_orchestration, 8_clarification, 9_async, 10_streaming, 11_formatting, 13_triggers, 17_multiple_identities, 19_api, 21_skills)

## Documentation

- `CHANGELOG.md` — unreleased entry detailing the collapse, savings, and observability surface.
- `mental-model.md` — Lessons Learned appendix entry "2026-04-30: Haiku 4-5 weights agent description far above specialization_keywords when routing", capturing a separate finding from the demo bisect (description-prose anchors are the only reliable router signal for Haiku; structured `specialization_keywords` alone are advisory). Pre-empts the next person hitting "tell me about the overlord routes to muxi-generalist" from bisecting the runtime instead of the formation YAML.
- `contributing/synthesis-speedup-plan.md` — the design-and-rollout doc that drove this change.

## Files

```
CHANGELOG.md                                                  +67
contributing/synthesis-speedup-plan.md                        +283
mental-model.md                                               +82
src/muxi/runtime/formation/agents/agent.py                    +129/-50
src/muxi/runtime/formation/overlord/overlord.py               +328/-156
tests/unit/test_agent_skip_synthesis_always.py                +211 (new)
tests/unit/test_apply_persona_handles_raw.py                  +77  (new)
tests/unit/test_workflow_consolidator.py                      +560 (renamed+expanded)
tests/unit/test_workflow_date_preservation_prompts.py         +24/-...
```

Net **+1554 / -207**.
