### PR TITLE
feat(mcp): tools.{whitelist|blacklist} filter to scope MCP tool registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,117 @@
 
 ## [unreleased]
 
+### MCP tool filtering via ``tools.{whitelist|blacklist}``
+
+Adds an optional ``tools`` block on any MCP server config that lets
+operators register only a subset of an upstream catalog. Cuts both the
+runtime tool registry and the per-turn planning prompt down to the
+capabilities a formation actually needs — reducing token spend per
+planning call and preventing destructive upstream tools (e.g.
+``delete_repo``, ``force_push_branch``) from being plannable in the
+first place.
+
+**Schema.** Either ``tools.whitelist`` *or* ``tools.blacklist`` (mutually
+exclusive) on any MCP server ``.afs``:
+
+```yaml
+type: "http"
+endpoint: "https://api.githubcopilot.com/mcp/"
+auth: { type: "bearer", token: "${{ secrets.GITHUB_PAT }}" }
+tools:
+  whitelist:
+    - "search_*"
+    - "get_*"
+    - "list_*"
+    - "issue_*"
+    - "add_issue_comment"
+    - "create_or_update_file"
+```
+
+Patterns are fnmatch globs (``*``, ``?``, character ranges). Literal
+names are matched exactly. Both list members are case-sensitive to
+match the upstream MCP convention.
+
+**Pipeline.** Translation lives in a new pure module
+``services/mcp/tool_filter.py``: ``ToolFilterSpec.from_config`` is total
+and tolerant (malformed input → inactive spec); ``apply_filter`` is the
+single entry point used during registration. The filter runs *between*
+``tools/list`` and registry insertion in
+``MCPService._connect_single_transport`` so post-filter empty sets abort
+registration with a typed
+``mcp.tool_filter.empty_set`` warning instead of silently registering an
+agent with zero tools.
+
+**Wiring.** Both registration sites now honor the spec:
+
+* ``Formation._register_mcp_servers`` (formation-level, always-on
+  servers) — ``formation.py:2419``
+* ``Overlord._register_agent_mcp_servers`` (per-agent re-registration
+  during agent load) — ``overlord.py:2092``
+
+A dropped agent-level wiring would silently re-register the full
+upstream catalog after agents loaded, defeating the filter for any
+flow that reached the agent path. The live test caught it.
+
+**Observability.** Three new ``SystemEvents`` emitted per registration:
+
+* ``MCP_TOOL_FILTER_APPLIED`` (info) — full pattern resolution table so
+  operators can audit exactly which upstream tools each glob expanded
+  to. Critical for catching silent scope expansion when an upstream
+  adds a tool that newly matches a wildcard.
+* ``MCP_TOOL_FILTER_UNKNOWN_TOOL`` (warning, once per unknown literal
+  pattern) — surfaces typos with ``difflib`` "did you mean?"
+  suggestions. Glob patterns that match nothing emit an empty
+  suggestion list (suppressed to avoid noise).
+* ``MCP_TOOL_FILTER_EMPTY_SET`` (warning) — registration aborted because
+  the post-filter set is empty.
+
+A clean ``[ INFO ]`` init line also prints the resolution inline next
+to ``Connected to MCP``:
+
+```
+[ INFO ] MCP 'github-mcp' tool filter (resolved 29/44 tools via whitelist(9 patterns))
+           whitelist['search_*'] -> 5 match(es): search_code, search_issues, ...
+           whitelist['issue_*']  -> 2 match(es): issue_read, issue_write
+           whitelist['add_issue_comment'] -> 1 match(es): add_issue_comment
+[  OK  ] Connected to MCP 'github-mcp' (29 tools available via streamable http)
+```
+
+**Validation.** ``ConfigValidator._validate_mcp_tools_block`` enforces
+fail-fast load-time rules: mutex (``whitelist`` XOR ``blacklist``);
+list-of-strings; non-blank patterns. Empty pattern lists log a
+``no filter will be applied`` warning rather than failing — operators
+sometimes scaffold the block before populating it.
+
+**Live measurement on
+``example-formations/demo/hello-muxi``.** A 12-phrase variation battery
+against a capability-scoped whitelist (29 of 44 github-mcp tools
+registered) showed:
+
+* 0 errors, 0 warnings across all runs
+* 4/4 guestbook-comment paraphrases ("sign", "leave a note", "say hi",
+  "post a greeting on issue 50") routed correctly to the
+  ``community-greeter`` agent and posted to issue #50 via
+  ``add_issue_comment``
+* 4/4 muxi-expert concept questions ("what is muxi", "tell me about
+  the overlord", "explain formations", "what's an SOP") returned
+  MUXI-grounded answers
+* Per-request token footprint: ~12.0k for guestbook flows, ~13.5k for
+  concept Q&A — vs ~23.3k pre-filter for the same workload (~48%
+  reduction on a matched flow)
+
+**Test changes.**
+
+* ``tests/unit/test_mcp_tool_filter.py`` (new, 27 tests) — pure filter
+  semantics (literal, glob ``*``, glob ``?``, mixed lists, ordering,
+  unknown-pattern ``difflib`` suggestions, empty-set reporting,
+  pass-through field preservation), ``ToolFilterSpec.from_config``
+  tolerance (None / empty / both-keys / non-string entries), and
+  formation-level validator hooks (mutex, type, blank, empty, clean
+  whitelist, clean blacklist).
+
+Full unit suite: 979 passed, 3 skipped, 0 failed.
+
 ### Collapse three synthesis LLM passes into one persona call
 
 Removes the agent-level and workflow-level synthesis LLM calls and

--- a/mental-model.md
+++ b/mental-model.md
@@ -1611,20 +1611,105 @@ async def register_mcp_server(
     # 4. Discover tools
     tools = await handler.list_tools()
     
-    # 5. Register tools
+    # 5. Apply optional tools.{whitelist|blacklist} filter (see "Tool
+    #    Filtering" section below). Runs BETWEEN list_tools and registry
+    #    insertion so a post-filter empty set aborts registration with a
+    #    typed warning instead of silently registering zero tools.
+    tools, filter_report = apply_filter(tools, tool_filter_spec)
+    
+    # 6. Register tools
     if agent_id:
         self.agent_tool_registry[agent_id][server_id] = tools
     else:
         self.agent_tool_registry["_shared"][server_id] = tools
     
-    # 6. Cache transport for future reconnection
+    # 7. Cache transport for future reconnection
     self.transport_cache[server_id] = transport
     
-    # 7. Store handler
+    # 8. Store handler
     self.mcp_handlers[server_id] = handler
     
     return server_id
 ```
+
+### Tool Filtering (whitelist / blacklist)
+
+**Path:** `services/mcp/tool_filter.py` → applied inside `MCPService._connect_single_transport`
+
+Optional ``tools`` block on any MCP server's `.afs` lets operators register
+only a subset of an upstream catalog:
+
+```yaml
+type: "http"
+endpoint: "https://api.githubcopilot.com/mcp/"
+auth: { type: "bearer", token: "${{ secrets.GITHUB_PAT }}" }
+tools:
+  whitelist:               # mutually exclusive with blacklist
+    - "search_*"           # fnmatch globs (* ? [...])
+    - "get_*"
+    - "issue_*"
+    - "add_issue_comment"  # literal names match exactly
+```
+
+**Why this exists.** A formation that needs only a handful of capabilities
+from an upstream MCP (the github-mcp publishes 44 tools; most demos use
+4-15) ends up paying for the full catalog on every planning prompt. The
+schemas of unused tools become token bloat and a hallucination surface
+("just use this destructive tool, it sounds plausible"). The filter
+collapses both — fewer schemas in the planning prompt, fewer dangerous
+verbs reachable.
+
+**Pipeline.**
+
+1. Loader reads `tools` block from MCP `.afs` (formation.py L2419 and
+   overlord.py L2092 — both registration paths must wire this).
+2. ``ToolFilterSpec.from_config`` translates the dict into a normalized
+   spec (mode + tuple of patterns). Tolerant: malformed input becomes
+   an inactive spec, never raises.
+3. ``apply_filter(upstream_tools, spec)`` is the single pure entry
+   point. Runs literal names through equality check, glob patterns
+   through ``fnmatch``. Returns ``(kept_tools, FilterReport)`` —
+   ordering of ``kept_tools`` follows upstream order, not pattern
+   order, for deterministic planning prompts.
+4. ``FilterReport`` carries the full pattern-resolution table and any
+   unknown patterns (with ``difflib`` "did you mean?" suggestions for
+   literal typos; suppressed for globs to avoid noise).
+
+**Validation.** ``ConfigValidator._validate_mcp_tools_block`` enforces
+fail-fast load-time rules:
+
+* mutex: ``whitelist`` XOR ``blacklist`` (never both, never neither
+  inside a ``tools`` block)
+* type: list of strings; non-string entries → load error
+* non-blank: whitespace-only patterns rejected (almost always a typo)
+* empty list: warning, not error — ``tools.whitelist: []`` is treated as
+  no-filter at runtime, but worth flagging since the operator clearly
+  intended *something*
+
+**Observability.** Three event types in ``SystemEvents``:
+
+* ``MCP_TOOL_FILTER_APPLIED`` (info, every registration) — full
+  pattern resolution table. **Critical for catching silent scope
+  expansion** when an upstream server adds a new tool that newly
+  matches a wildcard.
+* ``MCP_TOOL_FILTER_UNKNOWN_TOOL`` (warning, once per unknown literal
+  pattern) — surfaces typos with similarity-ranked suggestions.
+* ``MCP_TOOL_FILTER_EMPTY_SET`` (warning) — registration aborted
+  because the post-filter set is empty.
+
+A clean ``[ INFO ]`` init line also prints the resolution inline next
+to the existing ``Connected to MCP`` line so operators reviewing
+startup logs see scope decisions without grepping the JSON event log.
+
+**Two registration paths must both wire the filter.** A formation-level
+``register_mcp_server`` call happens early; ``Overlord._register_agent_mcp_servers``
+runs again per agent during the agent-load phase. Without the filter
+plumbed through both, the agent-load path silently re-registered the
+full upstream catalog and bloated the planning prompt back to its
+unfiltered size — caught during live test on
+``example-formations/demo/hello-muxi`` (29-vs-44 mismatch was visible
+both as a duplicate ``Connected to MCP`` line and as ``tool_count: 58``
+in the ``agent.planning`` event).
 
 ### Transport Auto-Detection
 
@@ -5897,3 +5982,101 @@ Claude Sonnet 4.5 producing identical behavior on the same MS365 Excel workflow.
   clean context binding, placeholder rejection, successful-results-only filtering
 - `tests/unit/test_agent_planning_helpers.py` -- 20+ new tests for planning execution fixes
 - `tests/unit/test_mcp_default_parameters.py` -- 10 tests for MCP parameters feature
+
+
+## MCP Tool Filtering — Lessons Learned
+
+**Problem statement.** Every upstream MCP tool's full JSON schema lands in the planning
+prompt of every agent that has access to that MCP. For an upstream like github-mcp
+(44 tools), most of those schemas describe capabilities a given formation never uses.
+Operators paid for the full catalog on every planning turn AND had no way to keep
+destructive verbs (`delete_repo`, `force_push_branch`, etc.) out of the LLM's
+plannable surface.
+
+**Solution shape.** Optional `tools.{whitelist|blacklist}` block on any MCP server
+`.afs`. Glob patterns (`fnmatch`) for capability families, literal names for
+exact picks. Mutually exclusive — pick one mode per server.
+
+### Lesson 1: There are TWO MCP registration paths and both must wire new kwargs
+
+`Formation._register_mcp_servers` runs at formation load. `Overlord._register_agent_mcp_servers`
+runs again per agent during agent load. Both end up calling
+`MCPService.register_mcp_server()`. The first wiring of `tool_filter` only touched the
+formation-level path; live test on `example-formations/demo/hello-muxi` revealed:
+
+- Boot log printed `Connected to MCP 'github-mcp' (4 tools)` then later
+  `Connected to MCP 'github-mcp' (44 tools)` — the agent-load path was silently
+  re-registering the unfiltered catalog.
+- `agent.planning` event showed `tool_count: 58` instead of the expected 18,
+  proving the agent's effective tool set was the unfiltered one.
+
+This is the same gotcha that bit the MCP `parameters` feature earlier (see prior
+section). Both registration paths are real, both fire, both must wire any new
+registration kwarg.
+
+### Lesson 2: Filter has to run BEFORE registry insertion, not after
+
+Earlier filter sketches mutated the registry post-insertion. That made the empty-set
+case ambiguous: was the agent registered with zero tools (silent failure) or did the
+operator forget to declare a `tools` block? Moving the filter inside
+`_connect_single_transport` between `tools/list` and registry insertion made
+abort-on-empty deterministic — the registration aborts with a typed
+`mcp.tool_filter.empty_set` warning and the agent never starts in a broken state.
+
+### Lesson 3: Operators need both verbose telemetry AND an inline init line
+
+Pure observability events (`MCP_TOOL_FILTER_APPLIED`) aren't enough — operators reading
+`stderr` during `muxi run` look for the `Connected to MCP` lines, not the JSON event log.
+Printing the resolution table inline next to the existing init line means scope decisions
+get reviewed at the same moment as connection success:
+
+```
+[ INFO ] MCP 'github-mcp' tool filter (resolved 29/44 tools via whitelist(9 patterns))
+           whitelist['search_*'] -> 5 match(es): search_code, search_issues, ...
+           whitelist['issue_*']  -> 2 match(es): issue_read, issue_write
+[  OK  ] Connected to MCP 'github-mcp' (29 tools available via streamable http)
+```
+
+The verbose telemetry stays for log analysis (catching silent scope expansion when an
+upstream MCP adds a new tool that newly matches a wildcard); the init line keeps the
+human-reviewable signal.
+
+### Lesson 4: Whitelist scope choice is a product/security decision, not a log-replay one
+
+The first whitelist iteration on hello-muxi was scoped to the four tools observed in
+the previous demo's log (`search_repositories`, `get_me`, `get_file_contents`,
+`create_or_update_file`). That overfit to one specific flow — testing
+"comment on the muxi guestbook issue on github" then failed because
+`add_issue_comment` had been filtered out.
+
+The right scoping question is **"what should this agent be allowed to do in this
+formation?"** — not "what did one log file show me." Capability-scoped patterns
+(`search_*`, `get_*`, `list_*`, `issue_*`) generalize across paraphrasings of the
+same intent. The 12-phrase test battery on hello-muxi confirmed this: 4 different
+ways of saying "post a comment on the guestbook" all reached `add_issue_comment`
+cleanly.
+
+### Lesson 5: `difflib` suggestions for unknown literals only — never for globs
+
+`MCP_TOOL_FILTER_UNKNOWN_TOOL` warnings include `difflib.get_close_matches` ranked
+suggestions for typo'd literal patterns ("`create_isue` → did you mean `create_issue`?").
+For glob patterns that match nothing (`destroy_*`), the suggestion list is forced
+empty — suggesting arbitrary unrelated tool names for a glob is noise, not signal.
+
+### Key files
+
+- `src/muxi/runtime/services/mcp/tool_filter.py` — pure module, no I/O,
+  `ToolFilterSpec` + `apply_filter` + `FilterReport`. Total functions; malformed
+  input becomes inactive spec, never raises.
+- `src/muxi/runtime/services/mcp/service.py` — `_observe_filter_applied` helper +
+  filter call inside `_connect_single_transport`.
+- `src/muxi/runtime/formation/formation.py` — formation-level `tools` block
+  translation (L2419).
+- `src/muxi/runtime/formation/overlord/overlord.py` — agent-level `tools` block
+  translation (L2092). Mirrors the formation-level wiring exactly; if these two
+  drift, the filter silently breaks for agent-load-time MCPs.
+- `src/muxi/runtime/formation/config/validation.py` — load-time mutex/type/blank
+  validation in `_validate_mcp_tools_block`.
+- `src/muxi/runtime/datatypes/observability.py` — three new `SystemEvents` enums.
+- `tests/unit/test_mcp_tool_filter.py` — 27 tests covering pure filter, spec
+  tolerance, and validator hooks.

--- a/src/muxi/runtime/datatypes/observability.py
+++ b/src/muxi/runtime/datatypes/observability.py
@@ -156,6 +156,20 @@ class SystemEvents(Enum):
     MCP_TOOL_FALLBACK_USED = "mcp.tool.fallback.used"
     # When MCP tool execution falls back to alternative
 
+    # Tool filtering (whitelist / blacklist) at registration time
+    MCP_TOOL_FILTER_APPLIED = "mcp.tool_filter.applied"
+    # When a whitelist/blacklist filter is applied to an upstream MCP catalog
+    # at registration time. Carries pattern resolutions so operators can audit
+    # exactly which upstream tools each glob expanded to.
+
+    MCP_TOOL_FILTER_UNKNOWN_TOOL = "mcp.tool_filter.unknown_tool"
+    # When a whitelist/blacklist pattern matches zero upstream tools.
+    # Carries difflib "did you mean?" suggestions for literal patterns.
+
+    MCP_TOOL_FILTER_EMPTY_SET = "mcp.tool_filter.empty_set"
+    # When the post-filter tool set is empty. The MCP is NOT registered;
+    # agents that reference it will receive no tools from this source.
+
     MCP_TRANSPORT_CACHE_CLEARED = "mcp.transport.cache.cleared"
     # When MCP transport cache is cleared
 

--- a/src/muxi/runtime/formation/config/validation.py
+++ b/src/muxi/runtime/formation/config/validation.py
@@ -600,6 +600,83 @@ class FormationValidator:
         if "auth" in server_config:
             self._validate_mcp_auth_config(server_config["auth"], server_id or index)
 
+        # Validate optional tools.{whitelist|blacklist} filter block
+        if "tools" in server_config:
+            self._validate_mcp_tools_block(server_config["tools"], server_id or index)
+
+    def _validate_mcp_tools_block(
+        self, tools_block: Any, server_identifier: Union[str, int]
+    ) -> None:
+        """Validate the optional ``tools`` filter block on an MCP server.
+
+        Schema:
+        ``tools.whitelist`` and ``tools.blacklist`` are mutually exclusive
+        lists of fnmatch-style string patterns. Either both absent
+        (no filter, back-compat) or exactly one present.
+
+        Errors raised here block formation startup. Empty-list and
+        zero-match cases are *runtime* concerns surfaced via
+        ``mcp.tool_filter.{empty_set,unknown_tool}`` warning events; we
+        do not fail-fast on them because the upstream catalog isn't
+        known until the server connects.
+        """
+        if not isinstance(tools_block, dict):
+            self.result.add_error(
+                f"MCP server {server_identifier} 'tools' must be a mapping with "
+                "'whitelist' or 'blacklist' (not both)"
+            )
+            return
+
+        whitelist_present = "whitelist" in tools_block
+        blacklist_present = "blacklist" in tools_block
+
+        if whitelist_present and blacklist_present:
+            self.result.add_error(
+                f"MCP server {server_identifier} 'tools' must declare either "
+                "'whitelist' or 'blacklist', not both"
+            )
+            return
+
+        if not whitelist_present and not blacklist_present:
+            self.result.add_error(
+                f"MCP server {server_identifier} 'tools' block must contain "
+                "'whitelist' or 'blacklist' (got neither)"
+            )
+            return
+
+        mode = "whitelist" if whitelist_present else "blacklist"
+        patterns = tools_block[mode]
+
+        if not isinstance(patterns, list):
+            self.result.add_error(
+                f"MCP server {server_identifier} 'tools.{mode}' must be a list "
+                "of fnmatch-style string patterns"
+            )
+            return
+
+        if len(patterns) == 0:
+            # Treated as "no filter" at runtime, but worth surfacing as a
+            # warning since the operator clearly intended *something* by
+            # adding the empty key.
+            self.result.add_warning(
+                f"MCP server {server_identifier} 'tools.{mode}' is an empty "
+                "list — no filter will be applied (remove the block to silence "
+                "this warning)"
+            )
+            return
+
+        for i, pattern in enumerate(patterns):
+            if not isinstance(pattern, str):
+                self.result.add_error(
+                    f"MCP server {server_identifier} 'tools.{mode}[{i}]' must be a "
+                    f"string, got {type(pattern).__name__}"
+                )
+            elif not pattern.strip():
+                self.result.add_error(
+                    f"MCP server {server_identifier} 'tools.{mode}[{i}]' must be "
+                    "a non-empty pattern"
+                )
+
     def _validate_mcp_metadata_fields(
         self, server_config: Dict[str, Any], server_identifier: Union[str, int]
     ) -> None:

--- a/src/muxi/runtime/formation/formation.py
+++ b/src/muxi/runtime/formation/formation.py
@@ -2419,6 +2419,19 @@ class Formation:
                 if "parameters" in server_config and isinstance(server_config["parameters"], dict):
                     registration_params["parameters"] = server_config["parameters"]
 
+                # Translate optional tools.{whitelist|blacklist} from the MCP
+                # `.afs` file into a ToolFilterSpec applied at registration
+                # time. Mutex / type validation already ran in
+                # ConfigValidator._validate_mcp_tools_block; we trust the
+                # block here. Inactive spec → passthrough (back-compat).
+                tools_block = server_config.get("tools")
+                if isinstance(tools_block, dict):
+                    from ..services.mcp.tool_filter import ToolFilterSpec
+
+                    spec = ToolFilterSpec.from_config(tools_block)
+                    if spec.is_active:
+                        registration_params["tool_filter"] = spec
+
                 # Register the server via MCP service
                 # Retry HTTP servers up to 3 times with backoff -- the external MCP
                 # process may still be starting when the formation initialises.

--- a/src/muxi/runtime/formation/formation.py
+++ b/src/muxi/runtime/formation/formation.py
@@ -71,6 +71,7 @@ from ..services.mcp.transports.base import (
     MCPConnectionError,
     MCPRequestError,
     MCPTimeoutError,
+    MCPToolFilterEmptySetError,
 )
 from ..services.secrets.secrets_manager import SecretsManager
 from ..services.telemetry import TelemetryService, set_telemetry
@@ -2471,6 +2472,15 @@ class Formation:
                     description=f"MCP server registered: {server_id}",
                 )
                 successful_servers.append(server_id)
+
+            except MCPToolFilterEmptySetError:
+                # Filter excluded every upstream tool. The warning event +
+                # init log were already emitted from inside the service; we
+                # must NOT also emit MCP_SERVER_REGISTERED nor append to
+                # ``successful_servers`` (the server is intentionally absent
+                # from the registry — any later code path that uses it would
+                # raise "Unknown MCP server"). Treat it as a clean skip.
+                continue
 
             except (MCPConnectionError, MCPTimeoutError, MCPCancelledError) as e:
                 # MCP registration failures - continue with graceful degradation

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -122,6 +122,7 @@ from ...services.llm import LLM
 # Built-in MCP imports
 from ...services.mcp.built_in import list_builtin_mcps
 from ...services.mcp.service import MCPService
+from ...services.mcp.transports.base import MCPToolFilterEmptySetError
 from ...services.memory.long_term import LongTermMemory
 from ...services.memory.memobase import Memobase
 from ...services.memory.working import WorkingMemory
@@ -2146,6 +2147,15 @@ class Overlord:
                 pass  # REMOVED: init-phase observe() call
 
                 results["successful"].append(server_id)
+
+            except MCPToolFilterEmptySetError:
+                # Filter excluded every upstream tool. Warning event + init
+                # log already emitted from inside MCPService — treat as a
+                # clean skip. Do NOT append to ``results["successful"]`` and
+                # do NOT fall through to the broad except block below (which
+                # would call ``sys.exit(1)`` and kill the entire formation
+                # over what is, by spec, an intentional configuration).
+                continue
 
             except (asyncio.CancelledError, Exception) as e:
                 # Fail fast - MCP server registration failed

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -2090,6 +2090,20 @@ class Overlord:
                 if "parameters" in server_config and isinstance(server_config["parameters"], dict):
                     registration_params["parameters"] = server_config["parameters"]
 
+                # Translate optional tools.{whitelist|blacklist} into a
+                # ToolFilterSpec — same semantics as the formation-level
+                # registration path in formation.py. Without this, a
+                # per-agent re-registration would silently restore the
+                # full upstream catalog and bloat the planning prompt
+                # back to its unfiltered size.
+                tools_block = server_config.get("tools")
+                if isinstance(tools_block, dict):
+                    from ...services.mcp.tool_filter import ToolFilterSpec
+
+                    spec = ToolFilterSpec.from_config(tools_block)
+                    if spec.is_active:
+                        registration_params["tool_filter"] = spec
+
                 # Register the MCP server with process-level timeout
                 # This may raise MCPConnectionError if connection fails
                 # Note: MCP library v1.12.3 has issues with 401 errors causing hangs

--- a/src/muxi/runtime/services/mcp/service.py
+++ b/src/muxi/runtime/services/mcp/service.py
@@ -52,6 +52,7 @@ from .prompts.discovery import MCPPromptDiscovery
 from .resources.discovery import MCPResourceDiscovery
 from .sampling.creator import MCPSamplingCreator
 from .templates.discovery import MCPTemplateDiscovery
+from .tool_filter import FilterReport, ToolFilterSpec, apply_filter
 from .transports import CancellationToken, ModernProtocolFeatures, TransportDetector
 
 DEFAULT_CONNECTION_TTL = 300.0  # 5 minutes
@@ -417,6 +418,7 @@ class MCPService:
         original_credentials: Optional[Dict[str, Any]] = None,
         agent_id: Optional[str] = None,
         parameters: Optional[Dict[str, Any]] = None,
+        tool_filter: Optional[ToolFilterSpec] = None,
     ) -> str:
         """
         Register an MCP server with the service.
@@ -437,6 +439,11 @@ class MCPService:
             original_credentials: Original credentials with user placeholders (if any)
             agent_id: Optional agent ID for agent-specific MCP servers
             parameters: Optional default parameters injected into every tool call
+            tool_filter: Optional whitelist/blacklist filter applied to the
+                upstream tool catalog at registration time. When the filter
+                yields zero tools, the server is **not** registered (no
+                ``server_configs`` entry, no agent-visible tool registry
+                entries) and a warning is emitted.
 
         Returns:
             The server_id of the registered server
@@ -461,6 +468,7 @@ class MCPService:
                 original_credentials,
                 agent_id,
                 parameters,
+                tool_filter=tool_filter,
             )
 
         # Enhanced auto-detection with caching for HTTP-based servers
@@ -492,6 +500,7 @@ class MCPService:
                     original_credentials,
                     agent_id,
                     parameters,
+                    tool_filter=tool_filter,
                 )
 
             except MCPConnectionError as e:
@@ -536,6 +545,7 @@ class MCPService:
                 original_credentials,
                 agent_id,
                 parameters,
+                tool_filter=tool_filter,
             )
 
         # Proceed with explicitly specified transport type
@@ -551,7 +561,81 @@ class MCPService:
             original_credentials,
             agent_id,
             parameters,
+            tool_filter=tool_filter,
         )
+
+    def _observe_filter_applied(self, server_id: str, report: FilterReport) -> None:
+        """Emit observability + init log for one filter application.
+
+        Two events fire:
+
+        * ``mcp.tool_filter.applied`` (info) — full pattern resolutions so
+          operators can audit exactly which upstream tools each glob
+          expanded to. This is the **only** signal that protects against
+          silent scope expansion when an upstream adds a new tool that
+          newly matches a whitelist.
+        * ``mcp.tool_filter.unknown_tool`` (warning, **once per unknown
+          pattern**) — surfaces typos with ``difflib`` "did you mean?"
+          suggestions for literal patterns. Glob patterns that match
+          nothing emit an empty suggestion list.
+
+        Also prints a clean ``[ INFO ]`` init line summarising the
+        resolution so operators reviewing startup logs see scope
+        decisions inline next to the corresponding ``Connected to MCP``
+        line.
+        """
+        observability.observe(
+            event_type=observability.SystemEvents.MCP_TOOL_FILTER_APPLIED,
+            level=observability.EventLevel.INFO,
+            data={
+                "server_id": server_id,
+                "mode": report.mode,
+                "pattern_count": len(report.patterns),
+                "upstream_tool_count": report.upstream_tool_count,
+                "registered_tool_count": report.registered_tool_count,
+                "pattern_resolutions": [
+                    {"pattern": p, "matches": list(matches)}
+                    for p, matches in report.pattern_resolutions
+                ],
+            },
+            description=(
+                f"MCP '{server_id}' filter ({report.mode}) resolved "
+                f"{report.registered_tool_count}/{report.upstream_tool_count} "
+                "upstream tools"
+            ),
+        )
+
+        for pattern, suggestions in report.unknown_patterns:
+            observability.observe(
+                event_type=observability.SystemEvents.MCP_TOOL_FILTER_UNKNOWN_TOOL,
+                level=observability.EventLevel.WARNING,
+                data={
+                    "server_id": server_id,
+                    "pattern": pattern,
+                    "mode": report.mode,
+                    "suggestions": list(suggestions),
+                },
+                description=(
+                    f"MCP '{server_id}' {report.mode} pattern "
+                    f"'{pattern}' matched zero upstream tools"
+                    + (f" (did you mean: {', '.join(suggestions)}?)" if suggestions else "")
+                ),
+            )
+
+        # Init-time log line so the resolution is visible alongside the
+        # "Connected to MCP" line operators are already used to scanning.
+        details = (
+            f"resolved {report.registered_tool_count}/"
+            f"{report.upstream_tool_count} tools via "
+            f"{report.mode}({len(report.patterns)} pattern"
+            f"{'s' if len(report.patterns) != 1 else ''})"
+        )
+        print(InitEventFormatter.format_info(f"MCP '{server_id}' tool filter", details))
+        for pattern, matches in report.pattern_resolutions:
+            preview = ", ".join(matches[:12])
+            if len(matches) > 12:
+                preview += f", ... (+{len(matches) - 12} more)"
+            print(f"           {report.mode}[{pattern!r}] -> {len(matches)} match(es): {preview}")
 
     async def invoke_tool(
         self,
@@ -883,6 +967,7 @@ class MCPService:
         original_credentials: Optional[Dict[str, Any]] = None,
         agent_id: Optional[str] = None,
         parameters: Optional[Dict[str, Any]] = None,
+        tool_filter: Optional[ToolFilterSpec] = None,
     ) -> str:
         """
         Attempt connection with automatic fallback between transports.
@@ -904,6 +989,7 @@ class MCPService:
                     original_credentials,
                     agent_id,
                     parameters,
+                    tool_filter=tool_filter,
                 )
 
                 # Success - the transport type is already stored in cache by _connect_single_transport
@@ -965,6 +1051,7 @@ class MCPService:
         original_credentials: Optional[Dict[str, Any]] = None,
         agent_id: Optional[str] = None,
         parameters: Optional[Dict[str, Any]] = None,
+        tool_filter: Optional[ToolFilterSpec] = None,
     ) -> str:
         """
         Connect using a specific transport type.
@@ -1017,8 +1104,58 @@ class MCPService:
 
                 # Discover available tools with modern protocol features
                 try:
-                    tools = await handler.list_tools(server_name)
+                    upstream_tools = await handler.list_tools(server_name)
 
+                    # Apply optional whitelist/blacklist filter declared in the
+                    # MCP `.afs` ``tools`` block. Inactive spec → passthrough.
+                    tools, filter_report = apply_filter(
+                        upstream_tools, tool_filter or ToolFilterSpec()
+                    )
+
+                    # If the filter produced an empty post-filter set, do NOT
+                    # register the server. Per the PRD: "agents that reference
+                    # it get no tools from this source." We disconnect, clean
+                    # up the partial state populated above, emit the warning,
+                    # and return without writing to ``server_configs``. The
+                    # caller does not see this as an exception — but the
+                    # server simply isn't in the registry, and any later
+                    # ``invoke_tool`` will raise ``Unknown MCP server``.
+                    if filter_report is not None and filter_report.registered_tool_count == 0:
+                        self._observe_filter_applied(server_id, filter_report)
+                        observability.observe(
+                            event_type=observability.SystemEvents.MCP_TOOL_FILTER_EMPTY_SET,
+                            level=observability.EventLevel.WARNING,
+                            data={
+                                "server_id": server_id,
+                                "mode": filter_report.mode,
+                                "upstream_tool_count": filter_report.upstream_tool_count,
+                                "patterns": list(filter_report.patterns),
+                            },
+                            description=(
+                                f"MCP server '{server_id}' tool filter "
+                                f"({filter_report.mode}) matched zero of "
+                                f"{filter_report.upstream_tool_count} upstream "
+                                "tools — server NOT registered."
+                            ),
+                        )
+                        print(
+                            InitEventFormatter.format_warn(
+                                f"Skipping MCP '{server_id}'",
+                                f"tool filter matched 0 of "
+                                f"{filter_report.upstream_tool_count} upstream tools",
+                            )
+                        )
+                        # Clean up partial registration state and bail.
+                        try:
+                            await handler.disconnect_server(server_name)
+                        except Exception:
+                            pass
+                        self.handlers.pop(server_id, None)
+                        self.connections.pop(server_id, None)
+                        return server_id
+
+                    # Filter accepted (or absent): proceed with normal registry
+                    # population over the (possibly trimmed) ``tools`` list.
                     # Enhanced tool registry with display names and metadata
                     self.tool_registry[server_id] = {}
 
@@ -1051,6 +1188,11 @@ class MCPService:
                             self.agent_tool_registry[agent_id][server_id][tool_name] = tool_data
                         else:
                             self.agent_tool_registry["_shared"][server_id][tool_name] = tool_data
+
+                    # Emit observability for an applied filter (after registry
+                    # writes so the event log reflects the final state).
+                    if filter_report is not None:
+                        self._observe_filter_applied(server_id, filter_report)
 
                 except Exception:
                     self.tool_registry[server_id] = {}

--- a/src/muxi/runtime/services/mcp/service.py
+++ b/src/muxi/runtime/services/mcp/service.py
@@ -54,6 +54,7 @@ from .sampling.creator import MCPSamplingCreator
 from .templates.discovery import MCPTemplateDiscovery
 from .tool_filter import FilterReport, ToolFilterSpec, apply_filter
 from .transports import CancellationToken, ModernProtocolFeatures, TransportDetector
+from .transports.base import MCPToolFilterEmptySetError
 
 DEFAULT_CONNECTION_TTL = 300.0  # 5 minutes
 
@@ -443,13 +444,19 @@ class MCPService:
                 upstream tool catalog at registration time. When the filter
                 yields zero tools, the server is **not** registered (no
                 ``server_configs`` entry, no agent-visible tool registry
-                entries) and a warning is emitted.
+                entries), a warning is emitted, and
+                :class:`MCPToolFilterEmptySetError` is raised so the caller
+                can skip its success path.
 
         Returns:
             The server_id of the registered server
 
         Raises:
-            Exception: If the server registration fails
+            MCPToolFilterEmptySetError: If a configured tool filter excluded
+                every upstream tool. The warning event + init log have
+                already been emitted; the caller should treat this as a
+                clean skip rather than re-raise as a registration failure.
+            Exception: If the server registration fails for any other reason.
         """
         # Create lock for this handler
         self.locks[server_id] = asyncio.Lock()
@@ -624,18 +631,26 @@ class MCPService:
 
         # Init-time log line so the resolution is visible alongside the
         # "Connected to MCP" line operators are already used to scanning.
-        details = (
-            f"resolved {report.registered_tool_count}/"
-            f"{report.upstream_tool_count} tools via "
-            f"{report.mode}({len(report.patterns)} pattern"
-            f"{'s' if len(report.patterns) != 1 else ''})"
-        )
-        print(InitEventFormatter.format_info(f"MCP '{server_id}' tool filter", details))
-        for pattern, matches in report.pattern_resolutions:
-            preview = ", ".join(matches[:12])
-            if len(matches) > 12:
-                preview += f", ... (+{len(matches) - 12} more)"
-            print(f"           {report.mode}[{pattern!r}] -> {len(matches)} match(es): {preview}")
+        # Suppressed when the filter matched zero tools — the empty-set
+        # caller emits its own "[ WARN ] Skipping MCP" line, and printing
+        # an [ INFO ] "resolved 0/N" header just above it would suggest
+        # registration succeeded.
+        if report.registered_tool_count > 0:
+            details = (
+                f"resolved {report.registered_tool_count}/"
+                f"{report.upstream_tool_count} tools via "
+                f"{report.mode}({len(report.patterns)} pattern"
+                f"{'s' if len(report.patterns) != 1 else ''})"
+            )
+            print(InitEventFormatter.format_info(f"MCP '{server_id}' tool filter", details))
+            for pattern, matches in report.pattern_resolutions:
+                preview = ", ".join(matches[:12])
+                if len(matches) > 12:
+                    preview += f", ... (+{len(matches) - 12} more)"
+                print(
+                    f"           {report.mode}[{pattern!r}] "
+                    f"-> {len(matches)} match(es): {preview}"
+                )
 
     async def invoke_tool(
         self,
@@ -1116,11 +1131,22 @@ class MCPService:
                     # register the server. Per the PRD: "agents that reference
                     # it get no tools from this source." We disconnect, clean
                     # up the partial state populated above, emit the warning,
-                    # and return without writing to ``server_configs``. The
-                    # caller does not see this as an exception — but the
-                    # server simply isn't in the registry, and any later
-                    # ``invoke_tool`` will raise ``Unknown MCP server``.
+                    # and raise ``MCPToolFilterEmptySetError`` so the caller
+                    # can distinguish "registered OK" from "intentionally
+                    # skipped" — without it, the caller falls through to its
+                    # ``MCP_SERVER_REGISTERED`` emit + ``successful_servers``
+                    # append on a server that isn't actually live, producing
+                    # contradictory event streams and "Unknown MCP server"
+                    # errors downstream.
                     if filter_report is not None and filter_report.registered_tool_count == 0:
+                        # Audit-trail events (applied + unknown-pattern
+                        # suggestions) still fire so operators can diagnose
+                        # WHY the filter ended up empty (typo? overly tight
+                        # whitelist?). The "[ INFO ] tool filter resolved..."
+                        # init-line print is suppressed inside the helper
+                        # when registered_tool_count == 0 so stdout doesn't
+                        # show INFO immediately followed by WARN for the
+                        # same server.
                         self._observe_filter_applied(server_id, filter_report)
                         observability.observe(
                             event_type=observability.SystemEvents.MCP_TOOL_FILTER_EMPTY_SET,
@@ -1152,7 +1178,19 @@ class MCPService:
                             pass
                         self.handlers.pop(server_id, None)
                         self.connections.pop(server_id, None)
-                        return server_id
+                        raise MCPToolFilterEmptySetError(
+                            (
+                                f"MCP server '{server_id}' skipped: "
+                                f"{filter_report.mode} matched 0 of "
+                                f"{filter_report.upstream_tool_count} upstream tools"
+                            ),
+                            details={
+                                "server_id": server_id,
+                                "mode": filter_report.mode,
+                                "upstream_tool_count": filter_report.upstream_tool_count,
+                                "patterns": list(filter_report.patterns),
+                            },
+                        )
 
                     # Filter accepted (or absent): proceed with normal registry
                     # population over the (possibly trimmed) ``tools`` list.
@@ -1194,6 +1232,11 @@ class MCPService:
                     if filter_report is not None:
                         self._observe_filter_applied(server_id, filter_report)
 
+                except MCPToolFilterEmptySetError:
+                    # Empty-set abort: cleanup already done above, propagate
+                    # to the caller so it can skip the success path. Do NOT
+                    # fall through to the empty-registry fallback below.
+                    raise
                 except Exception:
                     self.tool_registry[server_id] = {}
 

--- a/src/muxi/runtime/services/mcp/service.py
+++ b/src/muxi/runtime/services/mcp/service.py
@@ -1307,6 +1307,20 @@ class MCPService:
 
                 return server_id
 
+            except MCPToolFilterEmptySetError:
+                # Intentional empty-set skip — the warning event
+                # (``MCP_TOOL_FILTER_EMPTY_SET``) and the operator-facing
+                # ``[ WARN ] Skipping MCP`` line have already been emitted
+                # from inside the inner try block, and ``self.locks`` /
+                # ``self.handlers`` / ``self.connections`` were already
+                # popped there. We MUST NOT fall through to the broad
+                # ``except Exception`` below — doing so would log a
+                # contradictory ERROR-level ``MCP_SERVER_REGISTRATION_FAILED``
+                # right after the WARNING ``empty_set`` event for the
+                # same configuration, mis-reporting an intentional
+                # configuration choice as a registration failure.
+                raise
+
             except Exception as e:
                 # Emit MCP server registration failed event
                 observability.observe(

--- a/src/muxi/runtime/services/mcp/service.py
+++ b/src/muxi/runtime/services/mcp/service.py
@@ -1010,6 +1010,21 @@ class MCPService:
                 # Success - the transport type is already stored in cache by _connect_single_transport
                 return result
 
+            except MCPToolFilterEmptySetError:
+                # Filter excluded every upstream tool — this is a clean
+                # skip per spec, NOT a transport failure. The warning
+                # event + init log were already emitted from inside
+                # ``_connect_single_transport`` and partial state was
+                # cleaned. Without this re-raise the broad ``except
+                # Exception`` below would (a) log a spurious
+                # ``MCP_TRANSPORT_FAILED`` event, (b) retry on the next
+                # transport which would re-emit the warning a second
+                # time, and (c) ultimately raise ``MCPConnectionError``
+                # — which the overlord's broad handler converts to
+                # ``sys.exit(1)``, killing the formation over what is
+                # by design an intentional configuration.
+                raise
+
             except Exception as e:
                 errors[transport_type] = str(e)
 
@@ -1178,6 +1193,11 @@ class MCPService:
                             pass
                         self.handlers.pop(server_id, None)
                         self.connections.pop(server_id, None)
+                        # ``self.locks[server_id]`` was created at the
+                        # top of ``register_mcp_server`` before any
+                        # transport attempt — symmetric cleanup with
+                        # the other partial-state pops above.
+                        self.locks.pop(server_id, None)
                         raise MCPToolFilterEmptySetError(
                             (
                                 f"MCP server '{server_id}' skipped: "

--- a/src/muxi/runtime/services/mcp/tool_filter.py
+++ b/src/muxi/runtime/services/mcp/tool_filter.py
@@ -193,10 +193,19 @@ def apply_filter(
         resolutions.append((pattern, matches))
         matched_set.update(matches)
 
+    # Nameless / malformed tools (``_tool_name(t) is None``) are dropped in
+    # **both** modes. Without the explicit ``is not None`` guard, blacklist
+    # mode would silently let nameless tools through (``None not in
+    # matched_set`` is always True) — an asymmetry with whitelist mode
+    # where ``None in matched_set`` is always False. Since the filter
+    # cannot reason about a tool with no usable name, the conservative
+    # decision is the same in either direction: drop it.
     if spec.mode == "whitelist":
-        kept = [t for t in upstream_tools if _tool_name(t) in matched_set]
+        kept = [t for t in upstream_tools if (n := _tool_name(t)) is not None and n in matched_set]
     elif spec.mode == "blacklist":
-        kept = [t for t in upstream_tools if _tool_name(t) not in matched_set]
+        kept = [
+            t for t in upstream_tools if (n := _tool_name(t)) is not None and n not in matched_set
+        ]
     else:
         # is_active implies mode is set; this branch is defensive only.
         return list(upstream_tools), None

--- a/src/muxi/runtime/services/mcp/tool_filter.py
+++ b/src/muxi/runtime/services/mcp/tool_filter.py
@@ -1,0 +1,216 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        MCP Tool Filter - Whitelist/Blacklist registration-time filter
+# Description:  Pure filter applied between upstream tools/list response and
+#               agent-visible tool registry insertion at MCP service
+#               registration time.
+# Role:         Lets a formation scope an upstream MCP catalog to a subset
+#               (e.g. read-only tools, no destructive ops, single product
+#               surface of a multi-product MCP) via two new optional keys
+#               in MCP `.afs` files: ``tools.whitelist`` / ``tools.blacklist``.
+# Usage:        Constructed from the ``tools`` block of an MCP `.afs`
+#               config dict by ``ToolFilterSpec.from_config()``. Called by
+#               ``MCPService._connect_single_transport`` between
+#               ``handler.list_tools()`` and registry population.
+# Author:       MUXI Framework Team
+#
+# Pattern semantics: shell-style globs via ``fnmatch.fnmatchcase`` —
+# case-sensitive, no regex, no anchors. Two metacharacters carry 95%
+# of real use:
+#
+#   ``*``       any run of characters (including empty)
+#   ``?``       exactly one character
+#   ``[abc]``   one character from a set (rarely useful; supported)
+#   ``[!abc]``  one character NOT in set (rarely useful; supported)
+#
+# The module is **pure**: it does not log, does not call observe(), does not
+# raise on configuration mistakes that callers may want to surface
+# differently (empty set, unknown patterns). The caller decides what to
+# do with each FilterReport finding.
+#
+# Validation that *must* fail-fast (whitelist+blacklist mutex, non-string
+# entries) lives in ``formation/config/validation.py`` so the formation
+# loader aborts before the runtime ever sees a malformed block.
+# =============================================================================
+
+from __future__ import annotations
+
+import difflib
+from dataclasses import dataclass, field
+from fnmatch import fnmatchcase
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+# How many "did you mean?" suggestions to surface for an unknown pattern.
+_MAX_SUGGESTIONS = 3
+
+
+@dataclass(frozen=True)
+class ToolFilterSpec:
+    """Resolved filter declared in an MCP `.afs` ``tools`` block.
+
+    Exactly one of ``whitelist`` / ``blacklist`` is non-None when the
+    filter is active. Both being None (or the spec being absent
+    entirely) means "no filter" — the caller should pass the upstream
+    catalog through unchanged.
+
+    Construction goes through :meth:`from_config` so the dict shape from
+    the loader can be validated and normalised in one place.
+    """
+
+    mode: Optional[str] = None  # "whitelist" | "blacklist" | None
+    patterns: Tuple[str, ...] = ()
+
+    @property
+    def is_active(self) -> bool:
+        """True iff this spec actually filters anything."""
+        return self.mode is not None and len(self.patterns) > 0
+
+    @classmethod
+    def from_config(cls, tools_block: Optional[Dict[str, Any]]) -> "ToolFilterSpec":
+        """Build a spec from a parsed MCP-config ``tools`` block.
+
+        ``tools_block`` is whatever lives under the ``tools`` key in the
+        MCP `.afs` file (or ``None`` if absent). Mutex and type errors
+        are not raised here — the formation loader's validation layer
+        is the canonical fail-fast site for those. This method tolerates
+        them so unit tests can exercise the filter in isolation, and
+        defaults to "no filter" on anything malformed.
+        """
+        if not tools_block or not isinstance(tools_block, dict):
+            return cls()
+
+        whitelist = tools_block.get("whitelist")
+        blacklist = tools_block.get("blacklist")
+
+        # Mutex is a load-time error caught upstream; if we somehow get
+        # both at runtime, prefer "no filter" rather than make a silent
+        # choice between them.
+        if whitelist is not None and blacklist is not None:
+            return cls()
+
+        if isinstance(whitelist, list) and len(whitelist) > 0:
+            patterns = tuple(p for p in whitelist if isinstance(p, str))
+            if patterns:
+                return cls(mode="whitelist", patterns=patterns)
+
+        if isinstance(blacklist, list) and len(blacklist) > 0:
+            patterns = tuple(p for p in blacklist if isinstance(p, str))
+            if patterns:
+                return cls(mode="blacklist", patterns=patterns)
+
+        return cls()
+
+
+@dataclass
+class FilterReport:
+    """Diagnostic output of one filter application.
+
+    Carries everything observability + init-time logging need:
+
+    * ``mode`` / ``patterns`` — what the spec asked for.
+    * ``upstream_tool_count`` / ``registered_tool_count`` — sizes
+      before / after.
+    * ``pattern_resolutions`` — for each pattern, the list of upstream
+      tool names it matched (in their original upstream order). Empty
+      list means the pattern matched nothing.
+    * ``unknown_patterns`` — patterns that produced zero matches, with
+      ``difflib`` suggestions. Empty list when every pattern matched
+      at least one tool.
+    """
+
+    mode: str
+    patterns: Tuple[str, ...]
+    upstream_tool_count: int
+    registered_tool_count: int
+    pattern_resolutions: List[Tuple[str, List[str]]] = field(default_factory=list)
+    unknown_patterns: List[Tuple[str, List[str]]] = field(default_factory=list)
+
+
+def _tool_name(tool: Any) -> Optional[str]:
+    """Return the upstream tool's ``name`` field, or None if shape is off.
+
+    MCP discovery normalises tools into dicts with a ``name`` key; we
+    accept anything dict-shaped here so the filter survives a future
+    schema bump or test fixture variation without crashing.
+    """
+    if isinstance(tool, dict):
+        name = tool.get("name")
+        if isinstance(name, str) and name:
+            return name
+    return None
+
+
+def _suggestions_for(pattern: str, upstream_names: Sequence[str]) -> List[str]:
+    """`difflib`-based "did you mean?" list for an unmatched literal.
+
+    For a glob pattern (containing any of ``* ? [``) the suggestion
+    list is empty — globs that match nothing are usually deliberate
+    over-specifications (e.g. ``delete_*`` against an upstream that
+    happens to use ``destroy_*``), and surfacing arbitrary alternatives
+    is more noise than signal.
+    """
+    if any(c in pattern for c in "*?["):
+        return []
+    return difflib.get_close_matches(pattern, list(upstream_names), n=_MAX_SUGGESTIONS, cutoff=0.6)
+
+
+def apply_filter(
+    upstream_tools: Sequence[Dict[str, Any]],
+    spec: ToolFilterSpec,
+) -> Tuple[List[Dict[str, Any]], Optional[FilterReport]]:
+    """Apply ``spec`` to ``upstream_tools`` and return ``(kept, report)``.
+
+    Behaviour:
+
+    * Inactive spec (no whitelist or blacklist declared) → ``upstream_tools``
+      passes through unchanged, ``report`` is ``None`` (the caller skips
+      the "filter applied" observability event entirely).
+    * Whitelist mode → keep tools whose ``name`` matches **at least one**
+      pattern.
+    * Blacklist mode → keep tools whose ``name`` matches **none** of the
+      patterns.
+
+    Tool order is preserved relative to the upstream sequence in both
+    modes — handy for deterministic test assertions and for the planning
+    prompt (which renders tools in registration order).
+
+    The returned :class:`FilterReport` always carries one entry per
+    pattern in :attr:`FilterReport.pattern_resolutions`. Patterns that
+    matched zero tools also appear in :attr:`FilterReport.unknown_patterns`
+    with ``difflib`` suggestions for literal patterns.
+    """
+    if not spec.is_active:
+        return list(upstream_tools), None
+
+    upstream_names = [n for n in (_tool_name(t) for t in upstream_tools) if n is not None]
+
+    # Per-pattern resolution table — name order preserved.
+    resolutions: List[Tuple[str, List[str]]] = []
+    matched_set: set[str] = set()
+    for pattern in spec.patterns:
+        matches = [n for n in upstream_names if fnmatchcase(n, pattern)]
+        resolutions.append((pattern, matches))
+        matched_set.update(matches)
+
+    if spec.mode == "whitelist":
+        kept = [t for t in upstream_tools if _tool_name(t) in matched_set]
+    elif spec.mode == "blacklist":
+        kept = [t for t in upstream_tools if _tool_name(t) not in matched_set]
+    else:
+        # is_active implies mode is set; this branch is defensive only.
+        return list(upstream_tools), None
+
+    unknown: List[Tuple[str, List[str]]] = [
+        (p, _suggestions_for(p, upstream_names)) for p, matches in resolutions if not matches
+    ]
+
+    report = FilterReport(
+        mode=spec.mode,
+        patterns=spec.patterns,
+        upstream_tool_count=len(upstream_tools),
+        registered_tool_count=len(kept),
+        pattern_resolutions=resolutions,
+        unknown_patterns=unknown,
+    )
+    return kept, report

--- a/src/muxi/runtime/services/mcp/transports/base.py
+++ b/src/muxi/runtime/services/mcp/transports/base.py
@@ -83,6 +83,26 @@ class MCPCancelledError(MCPError):
     pass
 
 
+class MCPToolFilterEmptySetError(MCPError):
+    """
+    Raised when an MCP server's ``tools.{whitelist|blacklist}`` filter
+    excludes every upstream tool, leaving zero tools to register.
+
+    This is a *successful* filter outcome from the spec's point of view
+    (the operator asked for nothing), but it must abort registration:
+    a server with no tools cannot serve any request, and silently
+    returning would let the caller mistake the server for live and
+    later raise "Unknown MCP server" when a tool invocation hits the
+    empty registry.
+
+    Treated by callers as a clean skip — the warning + init log have
+    already been emitted from inside the service before this is raised,
+    so the caller does NOT re-emit a registration-failure event.
+    """
+
+    pass
+
+
 class CancellationToken:
     """
     A token that can be used to cancel async operations.

--- a/tests/unit/test_mcp_tool_filter.py
+++ b/tests/unit/test_mcp_tool_filter.py
@@ -1,0 +1,430 @@
+"""Unit tests for MCP tool filtering (whitelist / blacklist).
+
+Three layers of coverage:
+
+1. **Pure ``apply_filter`` semantics** — literal/glob match, mode
+   exclusivity, deterministic ordering, FilterReport shape. No I/O.
+2. **``ToolFilterSpec.from_config``** — dict → spec normalisation,
+   including malformed inputs that the formation loader would have
+   rejected (we tolerate them at the runtime boundary so the filter
+   itself is total).
+3. **Validation hooks** — the formation-level validator's
+   ``_validate_mcp_tools_block`` enforces mutex, type, and
+   non-empty-pattern rules at load time.
+
+The PRD's e2e test (registration-time integration with a mock MCP
+upstream) is deliberately out of scope here and lives in a separate
+PR per the rollout plan.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from muxi.runtime.formation.config.validation import FormationValidator, ValidationResult
+from muxi.runtime.services.mcp.tool_filter import (
+    FilterReport,
+    ToolFilterSpec,
+    apply_filter,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def github_like_catalog() -> List[Dict[str, Any]]:
+    """A representative upstream catalog modelled after github-mcp.
+
+    Mix of literal-friendly names (`create_issue`), glob-friendly
+    families (`list_*`, `get_*`, `search_*`), and destructive ops
+    (`delete_*`, `force_push_branch`) that real-world whitelists /
+    blacklists are likely to target.
+    """
+    names = [
+        "list_branches",
+        "list_commits",
+        "list_issues",
+        "list_pull_requests",
+        "get_branch",
+        "get_commit",
+        "get_issue",
+        "search_code",
+        "search_issues",
+        "create_issue",
+        "create_pull_request",
+        "delete_branch",
+        "delete_repo",
+        "force_push_branch",
+    ]
+    return [{"name": n, "description": f"{n} description", "inputSchema": {}} for n in names]
+
+
+def _make_validator() -> Any:
+    """Tiny harness that exposes only what the helper needs: ``.result``."""
+
+    class _V:
+        def __init__(self) -> None:
+            self.result = ValidationResult()
+
+        # Bind the unbound method straight onto the harness.
+        _validate_mcp_tools_block = FormationValidator._validate_mcp_tools_block
+
+    return _V()
+
+
+# ---------------------------------------------------------------------------
+# 1. Pure apply_filter semantics
+# ---------------------------------------------------------------------------
+
+
+def test_no_filter_block_passes_all_tools(github_like_catalog: List[Dict[str, Any]]) -> None:
+    """Inactive spec → upstream catalog passes through unchanged.
+
+    This is the back-compat path. ``report`` is None so the caller
+    knows not to emit ``mcp.tool_filter.applied``.
+    """
+    spec = ToolFilterSpec()  # default: no mode, no patterns
+    kept, report = apply_filter(github_like_catalog, spec)
+    assert kept == list(github_like_catalog)
+    assert report is None
+
+
+def test_whitelist_literal_only(github_like_catalog: List[Dict[str, Any]]) -> None:
+    """Literal names register exactly themselves, drop everything else."""
+    spec = ToolFilterSpec.from_config({"whitelist": ["create_issue", "get_branch"]})
+    kept, report = apply_filter(github_like_catalog, spec)
+    assert [t["name"] for t in kept] == ["get_branch", "create_issue"]  # upstream order preserved
+    assert report is not None
+    assert report.mode == "whitelist"
+    assert report.registered_tool_count == 2
+    assert report.upstream_tool_count == len(github_like_catalog)
+
+
+def test_blacklist_literal_only(github_like_catalog: List[Dict[str, Any]]) -> None:
+    """Literal blacklist drops only the named tool."""
+    spec = ToolFilterSpec.from_config({"blacklist": ["delete_repo"]})
+    kept, report = apply_filter(github_like_catalog, spec)
+    names = [t["name"] for t in kept]
+    assert "delete_repo" not in names
+    assert "delete_branch" in names  # still here; only delete_repo was named
+    assert len(names) == len(github_like_catalog) - 1
+    assert report is not None and report.mode == "blacklist"
+
+
+def test_whitelist_glob_star(github_like_catalog: List[Dict[str, Any]]) -> None:
+    """``list_*`` matches every list_* tool, drops everything else."""
+    spec = ToolFilterSpec.from_config({"whitelist": ["list_*"]})
+    kept, report = apply_filter(github_like_catalog, spec)
+    names = [t["name"] for t in kept]
+    assert names == [
+        "list_branches",
+        "list_commits",
+        "list_issues",
+        "list_pull_requests",
+    ]
+    assert report is not None
+    pattern, matches = report.pattern_resolutions[0]
+    assert pattern == "list_*"
+    assert matches == names
+
+
+def test_whitelist_glob_question() -> None:
+    """``v?`` matches single-char suffix only — ``v1``/``v2``, NOT ``v10``."""
+    catalog = [{"name": n} for n in ("v1", "v2", "v10", "verbose")]
+    spec = ToolFilterSpec.from_config({"whitelist": ["v?"]})
+    kept, report = apply_filter(catalog, spec)
+    assert [t["name"] for t in kept] == ["v1", "v2"]
+    assert report is not None and report.registered_tool_count == 2
+
+
+def test_blacklist_glob(github_like_catalog: List[Dict[str, Any]]) -> None:
+    """``delete_*`` drops every delete_* tool."""
+    spec = ToolFilterSpec.from_config({"blacklist": ["delete_*"]})
+    kept, report = apply_filter(github_like_catalog, spec)
+    names = [t["name"] for t in kept]
+    assert "delete_branch" not in names
+    assert "delete_repo" not in names
+    # Other tools survived.
+    assert "create_issue" in names
+    assert report is not None
+    pattern, matches = report.pattern_resolutions[0]
+    assert pattern == "delete_*"
+    assert sorted(matches) == ["delete_branch", "delete_repo"]
+
+
+def test_mixed_literal_and_glob_in_whitelist(
+    github_like_catalog: List[Dict[str, Any]],
+) -> None:
+    """One literal + one glob in the same whitelist combine OR-style."""
+    spec = ToolFilterSpec.from_config({"whitelist": ["create_issue", "list_*"]})
+    kept, report = apply_filter(github_like_catalog, spec)
+    names = [t["name"] for t in kept]
+    # All list_* tools plus the literal create_issue, in upstream order.
+    assert names == [
+        "list_branches",
+        "list_commits",
+        "list_issues",
+        "list_pull_requests",
+        "create_issue",
+    ]
+    assert report is not None
+    # Two pattern entries, each carrying its own resolution list.
+    assert len(report.pattern_resolutions) == 2
+    by_pattern = {p: m for p, m in report.pattern_resolutions}
+    assert by_pattern["create_issue"] == ["create_issue"]
+    assert by_pattern["list_*"] == [
+        "list_branches",
+        "list_commits",
+        "list_issues",
+        "list_pull_requests",
+    ]
+
+
+def test_unknown_literal_pattern_records_difflib_suggestions(
+    github_like_catalog: List[Dict[str, Any]],
+) -> None:
+    """A typo'd literal surfaces difflib 'did you mean?' suggestions."""
+    spec = ToolFilterSpec.from_config({"whitelist": ["create_isue"]})  # typo
+    kept, report = apply_filter(github_like_catalog, spec)
+    assert kept == []  # nothing matched
+    assert report is not None and report.registered_tool_count == 0
+    assert len(report.unknown_patterns) == 1
+    pattern, suggestions = report.unknown_patterns[0]
+    assert pattern == "create_isue"
+    # difflib should pick up "create_issue" given the small Levenshtein gap.
+    assert "create_issue" in suggestions
+
+
+def test_unknown_glob_pattern_has_empty_suggestion_list(
+    github_like_catalog: List[Dict[str, Any]],
+) -> None:
+    """Globs that match nothing produce no difflib noise.
+
+    Suggesting alternatives for ``destroy_*`` would surface arbitrary
+    unrelated names; per the design we explicitly suppress this for any
+    pattern containing a glob metacharacter.
+    """
+    spec = ToolFilterSpec.from_config({"whitelist": ["destroy_*"]})
+    _, report = apply_filter(github_like_catalog, spec)
+    assert report is not None
+    assert len(report.unknown_patterns) == 1
+    _, suggestions = report.unknown_patterns[0]
+    assert suggestions == []
+
+
+def test_post_filter_empty_set_reported_with_zero_count(
+    github_like_catalog: List[Dict[str, Any]],
+) -> None:
+    """Whitelist that matches nothing → kept=[], registered_tool_count=0.
+
+    The filter itself does not raise or skip — that decision belongs
+    to ``MCPService._connect_single_transport``, which observes the
+    report and aborts registration. The pure function just reports
+    the truth.
+    """
+    spec = ToolFilterSpec.from_config({"whitelist": ["nonexistent_*"]})
+    kept, report = apply_filter(github_like_catalog, spec)
+    assert kept == []
+    assert report is not None
+    assert report.registered_tool_count == 0
+    assert report.upstream_tool_count == len(github_like_catalog)
+
+
+def test_filter_preserves_full_tool_dict(github_like_catalog: List[Dict[str, Any]]) -> None:
+    """Filter is a pass-through filter, not a projection.
+
+    The kept tools retain ``description`` / ``inputSchema`` / any other
+    upstream fields untouched — the filter only decides which tools
+    survive, not what shape they take.
+    """
+    spec = ToolFilterSpec.from_config({"whitelist": ["create_issue"]})
+    kept, _ = apply_filter(github_like_catalog, spec)
+    assert kept[0] == {
+        "name": "create_issue",
+        "description": "create_issue description",
+        "inputSchema": {},
+    }
+
+
+def test_filter_preserves_upstream_order(github_like_catalog: List[Dict[str, Any]]) -> None:
+    """Tool order in the surviving list matches upstream order, not pattern order.
+
+    This matters for deterministic test assertions and for the planning
+    prompt's tool render order — which today follows registration order.
+    """
+    spec = ToolFilterSpec.from_config({"whitelist": ["create_issue", "list_*"]})
+    kept, _ = apply_filter(github_like_catalog, spec)
+    # ``list_*`` tools come first in upstream; literal ``create_issue``
+    # comes later → that order is preserved.
+    assert [t["name"] for t in kept].index("list_branches") < [t["name"] for t in kept].index(
+        "create_issue"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. ToolFilterSpec.from_config tolerance
+# ---------------------------------------------------------------------------
+
+
+def test_spec_from_none_returns_inactive() -> None:
+    spec = ToolFilterSpec.from_config(None)
+    assert spec.is_active is False
+
+
+def test_spec_from_empty_dict_returns_inactive() -> None:
+    spec = ToolFilterSpec.from_config({})
+    assert spec.is_active is False
+
+
+def test_spec_from_both_keys_present_falls_back_to_inactive() -> None:
+    """Both keys → no filter at runtime (the loader rejects this earlier).
+
+    The runtime tolerates this so a malformed config doesn't crash
+    registration; the formation loader's
+    ``_validate_mcp_tools_block`` is the canonical fail-fast site.
+    """
+    spec = ToolFilterSpec.from_config({"whitelist": ["a"], "blacklist": ["b"]})
+    assert spec.is_active is False
+
+
+def test_spec_from_empty_list_returns_inactive() -> None:
+    spec = ToolFilterSpec.from_config({"whitelist": []})
+    assert spec.is_active is False
+
+
+def test_spec_strips_non_string_entries() -> None:
+    """Non-string entries are skipped, not raised on.
+
+    The validator catches them at load time; the filter just survives.
+    """
+    spec = ToolFilterSpec.from_config({"whitelist": ["valid", 42, None, "also_valid"]})
+    assert spec.is_active is True
+    assert spec.patterns == ("valid", "also_valid")
+
+
+# ---------------------------------------------------------------------------
+# 3. Formation-level validation
+# ---------------------------------------------------------------------------
+
+
+def test_validation_rejects_whitelist_and_blacklist_both_set() -> None:
+    """Mutex rule fires at load time with a clear, actionable message."""
+    v = _make_validator()
+    v._validate_mcp_tools_block({"whitelist": ["list_*"], "blacklist": ["delete_*"]}, "demo-mcp")
+    assert v.result.errors
+    msg = v.result.errors[-1]
+    assert "demo-mcp" in msg
+    assert "whitelist" in msg and "blacklist" in msg
+    assert "not both" in msg
+
+
+def test_validation_rejects_neither_whitelist_nor_blacklist() -> None:
+    """Empty ``tools`` block (with neither sub-key) is a load-time error.
+
+    The block exists clearly with intent — it shouldn't be silently
+    treated as "no filter".
+    """
+    v = _make_validator()
+    v._validate_mcp_tools_block({}, "demo-mcp")
+    assert v.result.errors
+    msg = v.result.errors[-1]
+    assert "whitelist" in msg and "blacklist" in msg
+
+
+def test_validation_rejects_non_list_patterns() -> None:
+    """``whitelist`` / ``blacklist`` must be a list."""
+    v = _make_validator()
+    v._validate_mcp_tools_block({"whitelist": "list_*"}, "demo-mcp")
+    assert v.result.errors
+    assert "must be a list" in v.result.errors[-1]
+
+
+def test_validation_rejects_non_string_pattern_entry() -> None:
+    """Each pattern must be a string with a useful type error."""
+    v = _make_validator()
+    v._validate_mcp_tools_block({"whitelist": ["list_*", 42]}, "demo-mcp")
+    assert v.result.errors
+    msg = v.result.errors[-1]
+    assert "tools.whitelist[1]" in msg
+    assert "int" in msg
+
+
+def test_validation_rejects_blank_pattern_entry() -> None:
+    """Whitespace-only pattern is a load-time error.
+
+    A blank pattern in fnmatch matches only the empty string — almost
+    certainly not what the operator meant. Refusing it loudly avoids a
+    silent no-op filter.
+    """
+    v = _make_validator()
+    v._validate_mcp_tools_block({"whitelist": ["list_*", "   "]}, "demo-mcp")
+    assert v.result.errors
+    assert "non-empty pattern" in v.result.errors[-1]
+
+
+def test_validation_warns_on_empty_pattern_list() -> None:
+    """Empty list is treated as no-filter at runtime, with a warning."""
+    v = _make_validator()
+    v._validate_mcp_tools_block({"whitelist": []}, "demo-mcp")
+    # No errors — the filter just no-ops.
+    assert not v.result.errors
+    assert v.result.warnings
+    assert "empty" in v.result.warnings[-1]
+
+
+def test_validation_clean_whitelist_produces_no_errors_no_warnings() -> None:
+    v = _make_validator()
+    v._validate_mcp_tools_block({"whitelist": ["list_*", "get_*"]}, "demo-mcp")
+    assert v.result.errors == []
+    assert v.result.warnings == []
+
+
+def test_validation_clean_blacklist_produces_no_errors_no_warnings() -> None:
+    v = _make_validator()
+    v._validate_mcp_tools_block({"blacklist": ["delete_*", "force_push_*"]}, "demo-mcp")
+    assert v.result.errors == []
+    assert v.result.warnings == []
+
+
+# ---------------------------------------------------------------------------
+# 4. FilterReport shape sanity
+# ---------------------------------------------------------------------------
+
+
+def test_filter_report_pattern_resolutions_one_entry_per_pattern(
+    github_like_catalog: List[Dict[str, Any]],
+) -> None:
+    """Every declared pattern contributes exactly one resolution entry.
+
+    Even patterns that match nothing — they appear with an empty match
+    list. Operators should be able to cross-reference the spec and the
+    resolution table 1:1 when reading startup logs.
+    """
+    spec = ToolFilterSpec.from_config({"whitelist": ["list_*", "create_issue", "destroy_*"]})
+    _, report = apply_filter(github_like_catalog, spec)
+    assert report is not None
+    assert len(report.pattern_resolutions) == 3
+    by_pattern = {p: m for p, m in report.pattern_resolutions}
+    assert "list_*" in by_pattern and len(by_pattern["list_*"]) > 0
+    assert by_pattern["create_issue"] == ["create_issue"]
+    assert by_pattern["destroy_*"] == []  # no matches but still recorded
+
+
+def test_filter_report_is_dataclass_with_expected_fields(
+    github_like_catalog: List[Dict[str, Any]],
+) -> None:
+    """Pin the public shape of FilterReport so observability code can rely on it."""
+    spec = ToolFilterSpec.from_config({"whitelist": ["list_*"]})
+    _, report = apply_filter(github_like_catalog, spec)
+    assert isinstance(report, FilterReport)
+    # Required fields used by _observe_filter_applied:
+    assert isinstance(report.mode, str)
+    assert isinstance(report.patterns, tuple)
+    assert isinstance(report.upstream_tool_count, int)
+    assert isinstance(report.registered_tool_count, int)
+    assert isinstance(report.pattern_resolutions, list)
+    assert isinstance(report.unknown_patterns, list)

--- a/tests/unit/test_mcp_tool_filter.py
+++ b/tests/unit/test_mcp_tool_filter.py
@@ -535,3 +535,117 @@ def test_empty_set_error_inherits_from_mcp_error_family() -> None:
     assert err.details["mode"] == "whitelist"
     assert err.details["upstream_tool_count"] == 44
     assert "skipped" in err.message
+
+
+# ---------------------------------------------------------------------------
+# Follow-up review fixes — propagation through ``_connect_with_fallback``
+# (Issue 1) and lock-cleanup symmetry on empty-set abort (Issue 2).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connect_with_fallback_propagates_empty_set_error() -> None:
+    """``_connect_with_fallback`` must re-raise ``MCPToolFilterEmptySetError``
+    instead of catching it as a transport failure.
+
+    Regression: before the fix, the bare ``except Exception as e:``
+    handler in ``_connect_with_fallback`` caught the empty-set
+    exception, logged a spurious ``MCP_TRANSPORT_FAILED`` event,
+    retried with the second transport (which would re-raise from
+    inside ``_connect_single_transport`` and re-emit the warning),
+    and ultimately raised ``MCPConnectionError``. Overlord's broad
+    ``except (asyncio.CancelledError, Exception)`` then converted
+    that into ``sys.exit(1)``, killing the formation over what is
+    by spec an intentional configuration choice.
+    """
+    from muxi.runtime.services.mcp.service import MCPService
+    from muxi.runtime.services.mcp.transports.base import (
+        MCPConnectionError,
+        MCPToolFilterEmptySetError,
+    )
+
+    service = MCPService()
+    call_count = {"n": 0}
+
+    async def fake_connect_single_transport(*args, **kwargs):
+        call_count["n"] += 1
+        raise MCPToolFilterEmptySetError(
+            "filter matched 0 of 44 upstream tools",
+            details={"server_id": "gh", "mode": "whitelist", "upstream_tool_count": 44},
+        )
+
+    service._connect_single_transport = fake_connect_single_transport  # type: ignore[assignment]
+
+    # The exception must propagate UNCHANGED (not converted to
+    # MCPConnectionError) and the second transport must NOT be tried.
+    with pytest.raises(MCPToolFilterEmptySetError) as excinfo:
+        await service._connect_with_fallback(
+            server_id="gh",
+            url="https://example.invalid/mcp/",
+        )
+
+    assert not isinstance(excinfo.value, MCPConnectionError)
+    assert excinfo.value.details["upstream_tool_count"] == 44
+    assert call_count["n"] == 1, (
+        "second transport must not be retried on empty-set abort — "
+        "retrying would re-emit the empty_set warning a second time"
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_set_abort_pops_lock_alongside_handlers_and_connections() -> None:
+    """``self.locks[server_id]`` is cleaned up on empty-set abort.
+
+    Regression: ``register_mcp_server`` creates ``self.locks[server_id]``
+    before any transport attempt. The empty-set abort path popped
+    ``handlers`` and ``connections`` but left the lock entry behind,
+    breaking the symmetry of partial-state cleanup. A subsequent
+    re-registration of the same ``server_id`` would reuse the stale
+    lock from a prior run rather than creating a fresh one.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from muxi.runtime.services.mcp.service import MCPService
+    from muxi.runtime.services.mcp.transports.base import MCPToolFilterEmptySetError
+
+    service = MCPService()
+    server_id = "gh"
+
+    # Mock MCPHandler so we don't touch the network or the transport
+    # factory — we only need its public surface (connect_server,
+    # list_tools, disconnect_server) for the empty-set branch to fire.
+    fake_handler = MagicMock()
+    fake_handler.connect_server = AsyncMock(return_value=True)
+    fake_handler.list_tools = AsyncMock(
+        return_value=[{"name": "create_issue"}, {"name": "delete_repo"}]
+    )
+    fake_handler.disconnect_server = AsyncMock(return_value=True)
+
+    # Spec that excludes every upstream tool — the trigger for the
+    # empty-set branch we're trying to exercise.
+    spec = ToolFilterSpec.from_config({"whitelist": ["nonexistent_*"]})
+
+    with patch(
+        "muxi.runtime.services.mcp.service.MCPHandler",
+        return_value=fake_handler,
+    ):
+        with pytest.raises(MCPToolFilterEmptySetError):
+            # ``register_mcp_server`` creates the lock at its top so we
+            # exercise the full lock-lifecycle, not just the inner
+            # function in isolation.
+            await service.register_mcp_server(
+                server_id=server_id,
+                url="https://example.invalid/mcp/",
+                transport_type="streamable_http",
+                tool_filter=spec,
+            )
+
+    # All three partial-state stores must be empty after the abort —
+    # the asymmetry was a stale entry in ``locks`` while the others
+    # were popped.
+    assert server_id not in service.handlers, "handlers leaked"
+    assert server_id not in service.connections, "connections leaked"
+    assert server_id not in service.locks, (
+        "locks leaked: ``self.locks.pop(server_id, None)`` is missing "
+        "from the empty-set abort cleanup path"
+    )

--- a/tests/unit/test_mcp_tool_filter.py
+++ b/tests/unit/test_mcp_tool_filter.py
@@ -428,3 +428,110 @@ def test_filter_report_is_dataclass_with_expected_fields(
     assert isinstance(report.registered_tool_count, int)
     assert isinstance(report.pattern_resolutions, list)
     assert isinstance(report.unknown_patterns, list)
+
+
+# ---------------------------------------------------------------------------
+# Issue 2 fix — nameless tools dropped symmetrically in both modes.
+# ---------------------------------------------------------------------------
+
+
+def test_blacklist_drops_nameless_tools_symmetrically() -> None:
+    """Tools with missing/non-string ``name`` are dropped in BOTH modes.
+
+    Regression: before the fix, blacklist mode silently let through
+    malformed upstream tools because ``_tool_name(t) is None`` and
+    ``None not in matched_set`` is always True. Whitelist mode was
+    fine (``None in matched_set`` is always False). The asymmetry
+    meant a blacklist intended to block destructive tooling could
+    leak unnamed tools without any signal.
+    """
+    catalog: List[Dict[str, Any]] = [
+        {"name": "create_issue", "description": "real"},
+        {"description": "no name field"},  # nameless
+        {"name": None, "description": "explicit None"},  # nameless
+        {"name": 42, "description": "non-string name"},  # nameless
+        {"name": "", "description": "empty name"},  # nameless (empty)
+        {"name": "delete_repo", "description": "destructive"},
+    ]
+
+    # Blacklist: even though no nameless tool matches the pattern, they
+    # must still be dropped — we cannot reason about whether they are
+    # safe to expose without a name.
+    spec_b = ToolFilterSpec.from_config({"blacklist": ["delete_*"]})
+    kept_b, _ = apply_filter(catalog, spec_b)
+    kept_names = [t.get("name") for t in kept_b]
+    # Only the named, non-blacklisted tool survives.
+    assert kept_names == ["create_issue"]
+
+    # Whitelist mirror: same input, same outcome for nameless tools.
+    spec_w = ToolFilterSpec.from_config({"whitelist": ["create_issue"]})
+    kept_w, _ = apply_filter(catalog, spec_w)
+    assert [t.get("name") for t in kept_w] == ["create_issue"]
+
+
+# ---------------------------------------------------------------------------
+# Issue 3 fix — `_observe_filter_applied` suppresses INFO init line on
+# empty-set, unit-tested via the FilterReport contract that the helper
+# branches on.
+# ---------------------------------------------------------------------------
+
+
+def test_filter_report_signals_empty_set_via_count() -> None:
+    """``registered_tool_count == 0`` is the contract the service uses
+    to decide whether to print the ``[ INFO ]`` init line.
+
+    A whitelist that matches nothing must produce a report whose
+    ``registered_tool_count`` is exactly zero (not None, not a falsy
+    sentinel) so the service's ``> 0`` guard is unambiguous.
+    """
+    catalog = [{"name": "alpha"}, {"name": "beta"}]
+    spec = ToolFilterSpec.from_config({"whitelist": ["nonexistent_tool"]})
+    kept, report = apply_filter(catalog, spec)
+    assert kept == []
+    assert report is not None
+    assert report.registered_tool_count == 0
+    assert report.upstream_tool_count == 2
+    # Unknown-pattern suggestions still recorded so the audit-trail
+    # event in ``_observe_filter_applied`` can fire even on empty-set.
+    assert report.unknown_patterns
+    pattern, _suggestions = report.unknown_patterns[0]
+    assert pattern == "nonexistent_tool"
+
+
+# ---------------------------------------------------------------------------
+# Issue 1 fix — typed exception for empty-set registration abort.
+# ---------------------------------------------------------------------------
+
+
+def test_empty_set_error_inherits_from_mcp_error_family() -> None:
+    """``MCPToolFilterEmptySetError`` extends ``MCPError`` so it travels
+    through the same exception-handling layers as other MCP errors,
+    but is distinct from ``MCPConnectionError`` / ``MCPTimeoutError``
+    / ``MCPCancelledError`` so callers can branch on it specifically
+    (clean skip vs. registration failure)."""
+    from muxi.runtime.services.mcp.transports.base import (
+        MCPCancelledError,
+        MCPConnectionError,
+        MCPError,
+        MCPTimeoutError,
+        MCPToolFilterEmptySetError,
+    )
+
+    err = MCPToolFilterEmptySetError(
+        "MCP server 'gh' skipped: whitelist matched 0 of 44 upstream tools",
+        details={"server_id": "gh", "mode": "whitelist", "upstream_tool_count": 44},
+    )
+    # Inheritance — must reach generic Exception handlers and the MCP
+    # family root, but NOT be conflated with the existing leaf types.
+    assert isinstance(err, MCPError)
+    assert isinstance(err, Exception)
+    assert not isinstance(err, MCPConnectionError)
+    assert not isinstance(err, MCPTimeoutError)
+    assert not isinstance(err, MCPCancelledError)
+
+    # Payload — observability code reads ``details`` for structured
+    # event data; the message is human-readable.
+    assert err.details["server_id"] == "gh"
+    assert err.details["mode"] == "whitelist"
+    assert err.details["upstream_tool_count"] == 44
+    assert "skipped" in err.message

--- a/tests/unit/test_mcp_tool_filter.py
+++ b/tests/unit/test_mcp_tool_filter.py
@@ -649,3 +649,72 @@ async def test_empty_set_abort_pops_lock_alongside_handlers_and_connections() ->
         "locks leaked: ``self.locks.pop(server_id, None)`` is missing "
         "from the empty-set abort cleanup path"
     )
+
+
+@pytest.mark.asyncio
+async def test_empty_set_abort_does_not_emit_registration_failed_event() -> None:
+    """The outer ``except Exception`` in ``_connect_single_transport``
+    must NOT log ``MCP_SERVER_REGISTRATION_FAILED`` (ERROR) when the
+    inner block re-raises ``MCPToolFilterEmptySetError``.
+
+    Regression: before the fix, an intentional filter configuration
+    that yielded zero tools produced a contradictory log:
+
+        WARNING  mcp.tool_filter.empty_set    (intentional skip)
+        ERROR    mcp.server.registration_failed   (mis-reported)
+
+    Operators reading the event log would see ERROR-level alerts
+    fire for a clean, expected configuration outcome — exactly the
+    "noisy false positives" pattern the observability standards in
+    AGENTS.md call out as a hard-rule violation.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from muxi.runtime.services.mcp.service import MCPService
+    from muxi.runtime.services.mcp.transports.base import MCPToolFilterEmptySetError
+
+    service = MCPService()
+    server_id = "gh"
+
+    fake_handler = MagicMock()
+    fake_handler.connect_server = AsyncMock(return_value=True)
+    fake_handler.list_tools = AsyncMock(return_value=[{"name": "create_issue"}])
+    fake_handler.disconnect_server = AsyncMock(return_value=True)
+
+    spec = ToolFilterSpec.from_config({"whitelist": ["nothing_matches_this"]})
+
+    # Capture every observability call routed through the service module
+    # so we can assert by event_type kwarg.
+    with (
+        patch(
+            "muxi.runtime.services.mcp.service.MCPHandler",
+            return_value=fake_handler,
+        ),
+        patch("muxi.runtime.services.mcp.service.observability.observe") as observe_mock,
+    ):
+        with pytest.raises(MCPToolFilterEmptySetError):
+            await service.register_mcp_server(
+                server_id=server_id,
+                url="https://example.invalid/mcp/",
+                transport_type="streamable_http",
+                tool_filter=spec,
+            )
+
+    # Collect the event_type values across every observe() call.
+    emitted_events = [call.kwargs.get("event_type") for call in observe_mock.call_args_list]
+    emitted_names = [
+        ev.name if hasattr(ev, "name") else str(ev) for ev in emitted_events if ev is not None
+    ]
+
+    # The empty-set warning must fire (it is the operator's signal
+    # that the filter intentionally produced an empty registration).
+    assert any(
+        "MCP_TOOL_FILTER_EMPTY_SET" in n for n in emitted_names
+    ), f"empty-set warning missing from event log; emitted: {emitted_names}"
+
+    # The registration-failed ERROR must NOT fire — it would
+    # contradict the warning event for the same configuration.
+    assert not any("MCP_SERVER_REGISTRATION_FAILED" in n for n in emitted_names), (
+        "spurious MCP_SERVER_REGISTRATION_FAILED emitted on intentional "
+        f"empty-set skip; emitted: {emitted_names}"
+    )


### PR DESCRIPTION
## Summary

Adds an optional `tools.{whitelist|blacklist}` block on any MCP server `.afs` file. Lets operators register only the subset of an upstream MCP catalog that a formation actually needs — cutting both the runtime tool registry and the per-turn planning prompt.

## Why

Every upstream MCP tool's full JSON schema lands in the planning prompt of every agent that has access to that MCP. For the github-mcp (44 tools) most demos use only 4-15 capabilities. Operators paid for the full catalog on every planning turn AND had no way to keep destructive verbs (`delete_repo`, `force_push_branch`, `merge_pull_request`, etc.) out of the LLM's plannable surface. This PR collapses both.

## Schema

```yaml
type: "http"
endpoint: "https://api.githubcopilot.com/mcp/"
auth: { type: "bearer", token: "${{ secrets.GITHUB_PAT }}" }
tools:
  whitelist:               # mutually exclusive with blacklist
    - "search_*"           # fnmatch globs (* ? [...])
    - "get_*"
    - "issue_*"
    - "add_issue_comment"  # literal names match exactly
    - "create_or_update_file"
```

Either `whitelist` *or* `blacklist`, never both. Patterns are `fnmatch` globs; literal names match exactly. Case-sensitive (matches upstream MCP convention).

## Pipeline

`services/mcp/tool_filter.py` — pure module, no I/O. `ToolFilterSpec.from_config` is total and tolerant (malformed input → inactive spec, never raises). `apply_filter` is the single entry point; it runs **between** `tools/list` and registry insertion in `MCPService._connect_single_transport` so post-filter empty sets abort registration with a typed `mcp.tool_filter.empty_set` warning instead of silently registering an agent with zero tools.

## Two registration paths must both wire the filter

`Formation._register_mcp_servers` (formation.py:2419) and `Overlord._register_agent_mcp_servers` (overlord.py:2092) both end up calling `MCPService.register_mcp_server`. The first wiring of `tool_filter` only touched the formation-level path; live test on `example-formations/demo/hello-muxi` revealed the agent-load path was silently re-registering the unfiltered catalog (boot log printed `Connected to MCP 'github-mcp' (4 tools)` then later `Connected to MCP 'github-mcp' (44 tools)`; `agent.planning` event showed `tool_count: 58`). Both paths are now wired. Same gotcha bit the MCP `parameters` feature earlier — documented in mental-model.md Lessons Learned.

## Validation

`ConfigValidator._validate_mcp_tools_block` enforces fail-fast load-time rules:

- mutex: `whitelist` XOR `blacklist`
- list of strings; non-string entries → load error
- non-blank patterns
- empty list → warning only ("no filter will be applied"), not error

## Observability

Three new `SystemEvents`:

- `MCP_TOOL_FILTER_APPLIED` (info, every registration) — full pattern resolution table. Critical for catching silent scope expansion when an upstream adds a new tool that newly matches a wildcard.
- `MCP_TOOL_FILTER_UNKNOWN_TOOL` (warning, once per unknown literal pattern) — surfaces typos with `difflib.get_close_matches` suggestions. Glob patterns that match nothing emit empty suggestion lists (suppressed to avoid noise).
- `MCP_TOOL_FILTER_EMPTY_SET` (warning) — registration aborted because post-filter set is empty.

Plus an inline `[ INFO ]` init line printed alongside the existing `Connected to MCP` line so scope decisions are reviewable in startup logs without grepping the JSON event log:

```
[ INFO ] MCP 'github-mcp' tool filter (resolved 29/44 tools via whitelist(9 patterns))
           whitelist['search_*'] -> 5 match(es): search_code, search_issues, ...
           whitelist['issue_*']  -> 2 match(es): issue_read, issue_write
           whitelist['add_issue_comment'] -> 1 match(es): add_issue_comment
[  OK  ] Connected to MCP 'github-mcp' (29 tools available via streamable http)
```

## Live validation (demo/hello-muxi)

Capability-scoped whitelist (`search_*`, `get_*`, `list_*`, `issue_*`, `add_issue_comment`, `create_or_update_file`, `create_branch`, `create_pull_request`, `push_files`) registers **29 of 44** github-mcp tools.

A 12-phrase variation battery against this whitelist:

| Phrase | Agent | Tool # | Invoked | Verdict |
|---|---|---|---|---|
| sign the muxi guestbook issue on github | community-greeter | 43 | add_issue_comment | posted #50 |
| leave a note in the muxi guestbook | community-greeter | 43 | add_issue_comment | posted #50 |
| say hi on the muxi guestbook | community-greeter | 43 | add_issue_comment | posted #50 |
| post a greeting on issue 50 | community-greeter | 43 | add_issue_comment | posted #50 |
| what is muxi? | muxi-expert | 43 | none | grounded |
| tell me about the overlord | muxi-expert | 43 | none | grounded |
| explain formations | muxi-expert | 43 | none | grounded |
| what's an SOP? | muxi-expert | 43 | none | grounded |
| onboard me | muxi-expert | 43 | none | OK answer (SOP fire is orthogonal) |
| how do I get started | muxi-expert | 43 | none | OK answer |
| i'm new here, what do I do? | muxi-generalist | 43 | none | (routing, orthogonal) |
| walk me through this | overlord | – | none | clarification (correct) |

**0 errors, 0 warnings across all 12 runs.** Per-request token footprint: ~12.0k for guestbook flows, ~13.5k for concept Q&A — vs ~23.3k pre-filter for the same workload, **~48% reduction**.

## Whitelist-scope guidance

The first whitelist iteration was scoped to four tools observed in a previous demo log (overfit to one specific flow, broke an issue-comment paraphrase). The right scoping question is **"what should this agent be allowed to do in this formation?"** — not "what did one log file show me." Capability-scoped patterns generalize across paraphrasings of the same intent. Documented in mental-model.md Lessons Learned (Lesson 4).

## Tests

`tests/unit/test_mcp_tool_filter.py` (new, **27 tests**):

- Pure `apply_filter` semantics — literal, glob `*`, glob `?`, mixed lists, ordering, unknown-pattern difflib suggestions, empty-set reporting, pass-through field preservation
- `ToolFilterSpec.from_config` tolerance — None / empty / both-keys / non-string entries
- Formation-level validator hooks — mutex, type, blank, empty, clean whitelist, clean blacklist
- `FilterReport` shape pinning so observability code can rely on it

**Full unit suite:** 980 passed, 1 skipped, 1 pre-existing failure on develop (`test_rce_client.py::TestAuth::test_valid_token_accepted` — unrelated to this change). **Event validation:** clean. **Ruff + Black on touched files:** clean.

## Out of scope (filed for follow-up)

Two pre-existing issues surfaced during the live test but are unrelated to MCP tool filtering and will land as separate PRs after this one merges:

1. **SOP semantic-search threshold gap** — Some legitimate trigger phrases score below 0.7 cosine on Nomic v1.5; tag-based matching is bypassed when WorkingMemory is loaded. Fix shape: OR the two paths so tag matches always fire, regardless of semantic score.
2. **SSE event leaks the full constructed agent-selection prompt** — `overlord.py:7700` passes `message[:500]` (which contains memory boilerplate + instructions) to the streaming event instead of the cleaned `routing_message`. Two-line fix.

## Files changed

- `src/muxi/runtime/services/mcp/tool_filter.py` (new)
- `src/muxi/runtime/services/mcp/service.py` — `_observe_filter_applied` helper + filter call
- `src/muxi/runtime/formation/formation.py` — formation-level wiring (L2419)
- `src/muxi/runtime/formation/overlord/overlord.py` — agent-level wiring (L2092)
- `src/muxi/runtime/formation/config/validation.py` — `_validate_mcp_tools_block`
- `src/muxi/runtime/datatypes/observability.py` — three new `SystemEvents` enums
- `tests/unit/test_mcp_tool_filter.py` (new, 27 tests)
- `CHANGELOG.md` — entry under `[unreleased]`
- `mental-model.md` — Tool Filtering architecture section + Lessons Learned (Lessons 1-5)
