### PR TITLE
fix(observability): log original user request, not the wrapped enhanced blob

### DIFF
--- a/src/muxi/runtime/datatypes/observability.py
+++ b/src/muxi/runtime/datatypes/observability.py
@@ -1351,26 +1351,43 @@ class ErrorEvents(Enum):
 
 @dataclass
 class TokenUsage:
-    """Enhanced token usage tracking with cache support using self-documenting arrays."""
+    """Enhanced token usage tracking with cache support using self-documenting arrays.
+
+    Uses a single short vocabulary across both the legend and per-call
+    event payloads: ``total / in / out / total_cached / in_cached /
+    out_cached``. The provider boundary in
+    ``_extract_tokens_from_response`` translates from the OpenAI/OneLLM
+    convention (``prompt_tokens`` / ``completion_tokens``) into this
+    shape so every downstream consumer sees one vocabulary instead of
+    two parallel ones.
+    """
 
     # Field definitions (class constant for self-documentation)
-    FIELDS = ["total", "input", "output", "total_cached", "input_cached", "output_cached"]
+    FIELDS = ["total", "in", "out", "total_cached", "in_cached", "out_cached"]
 
     # Internal storage as arrays matching FIELDS order
     total: List[int] = field(default_factory=lambda: [0, 0, 0, 0, 0, 0])
     breakdown: Dict[str, List[int]] = field(default_factory=dict)
 
     def add_tokens(self, model: str, usage_data: Dict[str, int]) -> None:
-        """Add comprehensive token usage data in array format."""
+        """Add comprehensive token usage data in array format.
+
+        ``usage_data`` is the short-name dict produced by
+        ``LLMService._extract_tokens_from_response`` — keys
+        ``total / in / out / in_cached / out_cached``. ``total_cached``
+        is derived (sum of the cached pair) so the caller never has to
+        pass it.
+        """
         # Extract values in FIELDS order
+        in_cached = usage_data.get("in_cached", 0)
+        out_cached = usage_data.get("out_cached", 0)
         values = [
-            usage_data.get("total_tokens", 0),
-            usage_data.get("prompt_tokens", 0),
-            usage_data.get("completion_tokens", 0),
-            usage_data.get("prompt_tokens_cached", 0)
-            + usage_data.get("completion_tokens_cached", 0),  # total_cached
-            usage_data.get("prompt_tokens_cached", 0),
-            usage_data.get("completion_tokens_cached", 0),
+            usage_data.get("total", 0),
+            usage_data.get("in", 0),
+            usage_data.get("out", 0),
+            in_cached + out_cached,  # total_cached (derived)
+            in_cached,
+            out_cached,
         ]
 
         # Update totals (element-wise addition)

--- a/src/muxi/runtime/datatypes/observability.py
+++ b/src/muxi/runtime/datatypes/observability.py
@@ -837,6 +837,12 @@ class ConversationEvents(Enum):
     MODEL_REQUEST_FAILED = "model.request.failed"
     # When LLM request fails
 
+    MODEL_FALLBACK_SUCCESS = "model.fallback.success"
+    # When primary LLM model fails and the configured fallback model
+    # succeeds. Distinct from MODEL_REQUEST_COMPLETED (which is per
+    # actual provider call) — this marks the resilience-layer
+    # transition. Mirrors MCP_TRANSPORT_FALLBACK_SUCCESS.
+
     MODEL_STREAMING_STARTED = "model.streaming.started"
     # When LLM streaming response begins
 

--- a/src/muxi/runtime/formation/overlord/chat_orchestrator.py
+++ b/src/muxi/runtime/formation/overlord/chat_orchestrator.py
@@ -9,7 +9,7 @@ import asyncio
 import time
 import traceback
 from contextlib import suppress
-from typing import Any, AsyncGenerator, Dict, List, Optional, Union
+from typing import Any, AsyncGenerator, Dict, List, NamedTuple, Optional, Union
 
 from ...datatypes.response import MuxiResponse
 from ...services import observability, streaming
@@ -22,6 +22,22 @@ from ...services.observability.context import (
 from ...utils.id_generator import generate_nanoid
 from ..background.cancellation import RequestCancelledException
 from ..background.request_tracker import RequestState, RequestStatus
+
+
+class EnhancedMessage(NamedTuple):
+    """Pair of (original, enhanced) messages produced by context enrichment.
+
+    The marker-formatted ``enhanced`` blob is the analyzer-pipeline contract
+    (clarification analyzer, planning, intent extraction, and other
+    pre-agent text-parsing hops still expect the legacy shape). The
+    ``original`` is the raw user text — the value we want to surface in
+    observability events. Returning both at the source kills the
+    re-parse-the-wrapper pattern that used to be repeated 5+ times across
+    overlord internals.
+    """
+
+    original: str
+    enhanced: str
 
 
 class ChatOrchestrator:
@@ -558,7 +574,7 @@ class ChatOrchestrator:
             #   double-encoding of conversation history that broke
             #   Sonnet 4.6's pure-chat behavior on PR #160's casual
             #   chat test.
-            enhanced_message, clean_chat_context = await asyncio.gather(
+            enhanced_pair, clean_chat_context = await asyncio.gather(
                 self._enhance_message_with_context(
                     message=message,
                     user_id=user_id,
@@ -572,6 +588,13 @@ class ChatOrchestrator:
                     file_results=file_results,
                 ),
             )
+            # ``enhanced_pair.original`` is just ``message`` — we destructure
+            # for symmetry with ``enhanced`` and to make the data contract
+            # visible at the call site. Both values are threaded through
+            # the call chain so observability emits can log the bare user
+            # request without re-parsing the marker wrapper.
+            enhanced_message = enhanced_pair.enhanced
+            original_message = enhanced_pair.original
 
             # Extract user information from enhanced message (fire-and-forget)
             # Only if persistent memory is configured
@@ -636,6 +659,7 @@ class ChatOrchestrator:
                     request_id=request_id,
                     webhook_url=webhook_url,
                     timestamp=timestamp,
+                    original_message=original_message,
                 )
 
                 # Record framework mode telemetry (async requests are always "successful" at queue time)
@@ -671,7 +695,7 @@ class ChatOrchestrator:
                 # Return the streaming generator (delegates to separate function with yield)
                 return self._create_stream_generator(
                     enhanced_message=enhanced_message,
-                    original_message=message,
+                    original_message=original_message,
                     agent_name=agent_name,
                     user_id=stream_user_id,
                     session_id=stream_session_id,
@@ -693,7 +717,7 @@ class ChatOrchestrator:
                     user_id=user_id,
                     session_id=session_id,
                     request_id=request_id,
-                    original_message=message,  # Pass original for extraction
+                    original_message=original_message,
                     use_async=use_async,
                     webhook_url=webhook_url,
                     bypass_workflow_approval=bypass_workflow_approval,
@@ -751,18 +775,23 @@ class ChatOrchestrator:
         request_id: str,
         webhook_url: Optional[str],
         timestamp: float,
+        original_message: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Execute a request asynchronously.
 
         Args:
-            message: The user's message
+            message: Marker-formatted enhanced blob
             agent_name: Optional specific agent
             user_id: Optional user ID
             session_id: Optional session ID
             request_id: Unique request ID
             webhook_url: Optional webhook URL
             timestamp: Request timestamp
+            original_message: Bare user text (no markers) — stored on
+                ``RequestState`` so that downstream observability events
+                in the async background path read the actual user
+                request rather than the wrapper.
 
         Returns:
             Dictionary with async request information
@@ -772,7 +801,7 @@ class ChatOrchestrator:
             id=request_id,
             status=RequestStatus.PROCESSING,
             start_time=timestamp,
-            original_message=message,
+            original_message=original_message if original_message is not None else message,
             user_id=user_id,
             webhook_url=webhook_url,
             session_id=session_id,
@@ -811,6 +840,7 @@ class ChatOrchestrator:
                 agent_name=agent_name,
                 user_id=user_id,
                 session_id=session_id,
+                original_message=original_message,
             )
 
         self.overlord._create_tracked_task(
@@ -877,6 +907,7 @@ class ChatOrchestrator:
                 user_id=user_id,
                 session_id=session_id,
                 request_id=request_id,
+                original_message=original_message,
                 use_async=use_async,
                 webhook_url=webhook_url,
                 bypass_workflow_approval=bypass_workflow_approval,
@@ -1070,7 +1101,7 @@ class ChatOrchestrator:
         user_id: Any,
         session_id: Optional[str],
         file_results: Optional[str] = None,
-    ) -> str:
+    ) -> EnhancedMessage:
         """
         Enhance user message with conversation context.
 
@@ -1078,18 +1109,25 @@ class ChatOrchestrator:
         Implements priority ordering: current request → file results → conversation context.
 
         Args:
-            message: The current user message
+            message: The current user message (raw, no markers)
             user_id: User identifier for filtering
             session_id: Optional session identifier for filtering
             file_results: Optional file processing results to include
 
         Returns:
-            Enhanced message with context in priority order
+            ``EnhancedMessage(original, enhanced)`` — the raw user request
+            alongside the marker-formatted analyzer blob. Returning both
+            here (instead of just the enhanced string) is what lets every
+            downstream observability event log the bare user text without
+            re-parsing the wrapper out of it.
         """
-        # Check if message is already enhanced to prevent double enhancement
+        # Check if message is already enhanced to prevent double enhancement.
+        # In this defensive branch we cannot recover the *true* original
+        # (whoever pre-enhanced lost it), so we surface the wrapper as both
+        # fields. Callers normally never hit this branch; it exists as a
+        # safety rail against double-enhancement.
         if "=== CURRENT REQUEST ===" in message:
-            # Message is already enhanced, return as-is
-            return message
+            return EnhancedMessage(original=message, enhanced=message)
 
         def _is_profile_recall_request(current_message: str) -> bool:
             normalized = current_message.strip().lower()
@@ -1408,7 +1446,7 @@ class ChatOrchestrator:
 
         enhanced_message = "\n".join(enhanced_parts)
 
-        return enhanced_message
+        return EnhancedMessage(original=message, enhanced=enhanced_message)
 
     async def _build_clean_chat_context(
         self,

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -5679,6 +5679,7 @@ Agent response: {raw_response}"""
         agent_name: Optional[str],
         user_id: Any,
         session_id: Optional[str] = None,
+        original_message: Optional[str] = None,
     ) -> None:
         """
         Execute async request in background.
@@ -5686,6 +5687,10 @@ Agent response: {raw_response}"""
         This method runs the actual chat processing in the background for async requests,
         updating the request tracker with progress and delivering webhook notifications
         upon completion or failure.
+
+        ``original_message`` carries the bare user text alongside the
+        marker-formatted ``message``. Used so downstream observability
+        emits log the user's actual request rather than the wrapper.
         """
 
         observability.observe(
@@ -5780,6 +5785,7 @@ Agent response: {raw_response}"""
                 request_id=request_id,
                 use_async=True,
                 webhook_url=webhook_url,
+                original_message=original_message,
             )
             processing_time = time.time() - start_time
 
@@ -6209,6 +6215,7 @@ Agent response: {raw_response}"""
         webhook_url: Optional[str] = None,
         bypass_workflow_approval: bool = False,
         clean_chat_context: Optional[Dict[str, Any]] = None,
+        original_message: Optional[str] = None,
     ) -> MuxiResponse:
         """
         Process chat synchronously using existing infrastructure.
@@ -6226,10 +6233,31 @@ Agent response: {raw_response}"""
         ``ChatOrchestrator._build_clean_chat_context`` for the bundle
         shape and rationale.
 
+        ``original_message`` carries the raw user request alongside
+        ``message`` (which is the marker-formatted enhanced blob). It
+        is used directly for observability emits and for any analyzer
+        path that needs the bare user text — replacing the
+        re-parse-the-wrapper pattern that used to be repeated across
+        this function. Recursive callers that already have the bare
+        text (clarification re-entries) pass it through unchanged.
+        ``ChatOrchestrator._enhance_message_with_context`` returns
+        ``EnhancedMessage(original, enhanced)`` and the orchestrator
+        threads both fields here.
+
         ENHANCED: Now detects and handles agent clarification requests.
         """
         # Track processing time
         start_time = time.time()
+
+        # Single source of truth for the bare user request. Every
+        # downstream observability emit and analyzer hop that wants
+        # "what did the user actually say?" reads this value instead
+        # of regex-extracting it back out of the marker wrapper. When
+        # ``original_message`` was not supplied (legacy internal callers
+        # that pass already-bare text as ``message``), the input is
+        # already the raw text — this is also true for clarification
+        # recursive re-entries below where ``message=original_message``.
+        actual_message: str = original_message if original_message is not None else message
 
         # Check for cancellation at start of sync processing
         if request_id and self.request_tracker.is_cancelled(request_id):
@@ -6287,30 +6315,10 @@ Agent response: {raw_response}"""
         # Check if streaming is enabled for this request
         is_streaming = streaming_manager.is_streaming_enabled(request_id) if request_id else False
 
-        # Extract clean message for streaming display (only if streaming is enabled)
-        display_msg = message
-        if is_streaming and "=== CURRENT REQUEST ===" in message and "User:" in message:
-            lines = message.split("\n")
-            for i, line in enumerate(lines):
-                if line.strip() == "=== CURRENT REQUEST ===" and i + 1 < len(lines):
-                    next_line = lines[i + 1].strip()
-                    if next_line.startswith("User:"):
-                        # Handle multi-line messages
-                        content_lines = []
-                        first_line_content = next_line[5:].strip()
-                        if first_line_content:
-                            content_lines.append(first_line_content)
-                        # Collect subsequent lines until we hit another section
-                        for j in range(i + 2, len(lines)):
-                            line_content = lines[j].strip()
-                            if line_content.startswith("===") or (
-                                not line_content and len(content_lines) > 0
-                            ):
-                                break
-                            if line_content:
-                                content_lines.append(line_content)
-                        display_msg = " ".join(content_lines)
-                        break
+        # Clean message for streaming display — already extracted at the source
+        # via the ``EnhancedMessage(original, enhanced)`` contract; no
+        # re-parsing the wrapper here.
+        display_msg = actual_message if is_streaming else message
 
         # Emit streaming event for processing start
         import random
@@ -6448,15 +6456,20 @@ Agent response: {raw_response}"""
 
                             # If we have the original message, retry it now with credentials stored
                             if original_message:
-                                # Recursively call _process_sync_chat with the original message
-                                # IMPORTANT: Skip clarification to avoid infinite loop
+                                # Recursively call _process_sync_chat with the original message.
+                                # IMPORTANT: Skip clarification to avoid infinite loop.
+                                # ``message`` and ``original_message`` are both the bare
+                                # user text here — the wrapper hasn't been re-applied for
+                                # this re-entry, and downstream observability emits read
+                                # ``actual_message`` which now equals the user's request.
                                 return await self._process_sync_chat(
                                     message=original_message,
                                     user_id=user_id,
                                     session_id=session_id,
                                     request_id=request_id,
                                     agent_name=agent_name,
-                                    skip_clarification=True,  # Prevent infinite clarification loop
+                                    skip_clarification=True,
+                                    original_message=original_message,
                                 )
                             else:
                                 # Fallback if no original message stored
@@ -6493,20 +6506,10 @@ Agent response: {raw_response}"""
                     # Parse the user's selection
                     selected_credential = None
                     try:
-                        # Extract just the user's message from the formatted context
-                        actual_message = message
-                        if "=== CURRENT REQUEST ===" in message and "User:" in message:
-                            # Extract the user's actual message from the formatted context
-                            lines = message.split("\n")
-                            for i, line in enumerate(lines):
-                                if line.strip() == "=== CURRENT REQUEST ===" and i + 1 < len(lines):
-                                    next_line = lines[i + 1].strip()
-                                    if next_line.startswith("User:"):
-                                        actual_message = next_line[
-                                            5:
-                                        ].strip()  # Remove "User: " prefix
-                                        break
-
+                        # ``actual_message`` is the bare user request, computed once
+                        # at the top of ``_process_sync_chat`` from the
+                        # ``original_message`` parameter (or fallback). No inline
+                        # extraction here.
                         import re
 
                         numbers = re.findall(r"\d+", actual_message.strip())
@@ -6569,7 +6572,8 @@ Agent response: {raw_response}"""
                                     session_id=session_id,
                                     request_id=request_id,
                                     agent_name=agent_name,
-                                    skip_clarification=True,  # Prevent infinite clarification loop
+                                    skip_clarification=True,
+                                    original_message=original_message,
                                 )
                             else:
                                 return MuxiResponse(
@@ -6625,18 +6629,12 @@ Agent response: {raw_response}"""
                     response_result = None
                     if self.clarification and clarification_info.get("request_id"):
                         try:
-                            # Extract the raw user message (strip buffer context markers)
-                            clean_response = message
-                            if "=== CURRENT REQUEST ===" in message and "User:" in message:
-                                for _line in message.split("\n"):
-                                    _line_s = _line.strip()
-                                    if _line_s.startswith("User:"):
-                                        clean_response = _line_s[5:].strip()
-                                        break
-
+                            # ``actual_message`` is already the bare user response
+                            # — see the top-of-function destructure of
+                            # ``original_message``. No re-parsing needed.
                             response_result = await self.clarification.handle_response(
                                 request_id=clarification_info.get("request_id"),
-                                response=clean_response,
+                                response=actual_message,
                             )
 
                             # ALWAYS clear the pending clarification after handling response
@@ -6684,7 +6682,10 @@ Agent response: {raw_response}"""
                                         ctx.get("user_id", user_id),
                                     )
 
-                                # Process the enhanced/final request
+                                # Process the enhanced/final request. ``response_result.request``
+                                # is the bare user text (the unified clarification system has
+                                # not re-applied the marker wrapper), so it doubles as the
+                                # original for observability.
                                 return await self._process_sync_chat(
                                     message=response_result.request,
                                     agent_name=agent_name,
@@ -6692,6 +6693,7 @@ Agent response: {raw_response}"""
                                     session_id=session_id,
                                     request_id=request_id,
                                     skip_clarification=True,
+                                    original_message=response_result.request,
                                 )
 
                         except Exception as e:
@@ -6714,7 +6716,7 @@ Agent response: {raw_response}"""
                         data={
                             "session_id": session_id,
                             "workflow_id": clarification_info.get("workflow_id"),
-                            "user_response": message[:200],
+                            "user_response": actual_message[:200],
                             "request_id": request_id,
                         },
                         description="Received user response to workflow approval request",
@@ -6942,11 +6944,11 @@ Agent response: {raw_response}"""
         # or ask for more info.
         _matched_sop = None
         if not skip_clarification and self._ensure_sop_system():
-            import re as _re
-
-            _sop_match = _re.search(r"User:\s*([^\n]+)", message)
-            _sop_message = _sop_match.group(1).strip() if _sop_match else message
-            _matched_sop = await self._find_relevant_sop(_sop_message)
+            # Match against the bare user request — ``actual_message`` was
+            # destructured at the top of the function from
+            # ``original_message``. The previous regex-based inline
+            # extraction was lossy on multi-line messages.
+            _matched_sop = await self._find_relevant_sop(actual_message)
             if _matched_sop:
                 _sop_display = _matched_sop.get("name", _matched_sop["id"])
                 streaming.stream(
@@ -7043,13 +7045,17 @@ Agent response: {raw_response}"""
 
                                 # If there's an original message to replay, process it now
                                 if response.get("continue_with"):
-                                    # Recursively process the original request now that credentials are stored
+                                    # Recursively process the original request now that
+                                    # credentials are stored. ``response["continue_with"]``
+                                    # is the saved bare user text from the credential
+                                    # handler.
                                     continuation_response = await self._process_sync_chat(
                                         message=response["continue_with"],
                                         user_id=user_id,
                                         agent_name=agent_name,
                                         session_id=session_id,
                                         request_id=request_id,
+                                        original_message=response["continue_with"],
                                     )
                                     # Combine the success message with the continuation response
                                     combined_content = f"{success_response.content}\n\n{continuation_response.content}"
@@ -7332,7 +7338,7 @@ Agent response: {raw_response}"""
                 "has_pending_clarifications": (
                     bool(await self._get_pending_clarification(session_id)) if session_id else False
                 ),
-                "message_preview": message[:100],
+                "message_preview": actual_message[:200],
             },
             description="Checking workflow analysis conditions",
         )
@@ -7355,35 +7361,8 @@ Agent response: {raw_response}"""
         if agent_name is None and (self.auto_decomposition or _matched_sop is not None):
             # Analyze request complexity
             try:
-                # Extract the actual user message from formatted context if needed
-                actual_message = message
-                if "=== CURRENT REQUEST ===" in message and "User:" in message:
-                    # Extract the user's actual message from the formatted context
-                    lines = message.split("\n")
-                    for i, line in enumerate(lines):
-                        if line.strip() == "=== CURRENT REQUEST ===" and i + 1 < len(lines):
-                            next_line = lines[i + 1].strip()
-                            if next_line.startswith("User:"):
-                                # Handle multi-line messages: collect all content after "User:"
-                                content_lines = []
-                                # First, get any content on the same line as "User:"
-                                first_line_content = next_line[5:].strip()
-                                if first_line_content:
-                                    content_lines.append(first_line_content)
-
-                                # Then collect subsequent lines until we hit another section or end
-                                for j in range(i + 2, len(lines)):
-                                    line_content = lines[j].strip()
-                                    # Stop if we hit another section marker or empty line
-                                    if line_content.startswith("===") or (
-                                        not line_content and len(content_lines) > 0
-                                    ):
-                                        break
-                                    if line_content:  # Only add non-empty lines
-                                        content_lines.append(line_content)
-
-                                actual_message = " ".join(content_lines)
-                                break
+                # ``actual_message`` is the bare user request, computed once at
+                # the top of this function from ``original_message``.
 
                 # Build context with available SOPs for the analyzer
                 analysis_context = {"request_tracker": self.request_tracker}
@@ -7667,6 +7646,7 @@ Agent response: {raw_response}"""
                         webhook_url=webhook_url,
                         relevant_sop=_matched_sop,
                         bypass_workflow_approval=bypass_workflow_approval,
+                        original_message=actual_message,
                     )
 
                 # Check if complexity exceeds threshold
@@ -7697,6 +7677,7 @@ Agent response: {raw_response}"""
                             webhook_url=webhook_url,
                             relevant_sop=relevant_sop,
                             bypass_workflow_approval=bypass_workflow_approval,
+                            original_message=actual_message,
                         )
 
                     # No SOP found - apply normal protection logic
@@ -7725,6 +7706,7 @@ Agent response: {raw_response}"""
                                 webhook_url=webhook_url,
                                 relevant_sop=None,
                                 bypass_workflow_approval=bypass_workflow_approval,
+                                original_message=actual_message,
                             )
             except RequestCancelledException:
                 # Re-raise cancellation exceptions - don't catch them here
@@ -7751,7 +7733,7 @@ Agent response: {raw_response}"""
                 "planning",
                 "Determining the best agent to handle this request...",
                 stage="agent_selection",
-                message_preview=message[:500],
+                message_preview=actual_message[:500],
                 agent_requested=agent_name,
             )
 
@@ -7759,30 +7741,15 @@ Agent response: {raw_response}"""
             observability.observe(
                 event_type=observability.ConversationEvents.OVERLORD_AGENT_SELECTION_STARTED,
                 level=observability.EventLevel.INFO,
-                data={"message": message[:200]},
+                data={"message": actual_message[:200]},
                 description="Starting agent selection process",
             )
 
-            # Extract clean user message for routing to avoid security false positives
-            # The enhanced message contains protocol instructions that can trigger security checks
-            routing_message = message
-            if "=== CURRENT REQUEST ===" in message and "User:" in message:
-                lines = message.split("\n")
-                for i, line in enumerate(lines):
-                    if line.strip() == "=== CURRENT REQUEST ===":
-                        request_lines = []
-                        for request_line in lines[i + 1 :]:
-                            stripped_line = request_line.strip()
-                            if stripped_line.startswith("===") and stripped_line.endswith("==="):
-                                break
-                            if request_line.startswith("User:"):
-                                request_lines.append(request_line[5:].strip())
-                            elif request_lines:
-                                request_lines.append(request_line)
-                        candidate_message = "\n".join(request_lines).strip()
-                        if candidate_message:
-                            routing_message = candidate_message
-                            break
+            # Use the bare user request for routing — the enhanced wrapper
+            # contains protocol instructions that can trigger security checks
+            # as false positives. ``actual_message`` was destructured at the
+            # top of the function from ``original_message``.
+            routing_message = actual_message
 
             try:
                 agent_name = await self.select_agent_for_message(
@@ -7892,19 +7859,10 @@ Agent response: {raw_response}"""
             # Check if this is a credential error that needs clarification
             from ..credentials import AmbiguousCredentialError, MissingCredentialError
 
-            # Extract the actual user message from formatted context if needed (for credential errors)
-            actual_message_for_credential = message
-            if "=== CURRENT REQUEST ===" in message and "User:" in message:
-                # Extract the user's actual message from the formatted context
-                lines = message.split("\n")
-                for i, line in enumerate(lines):
-                    if line.strip() == "=== CURRENT REQUEST ===" and i + 1 < len(lines):
-                        next_line = lines[i + 1].strip()
-                        if next_line.startswith("User:"):
-                            actual_message_for_credential = next_line[
-                                5:
-                            ].strip()  # Remove "User: " prefix
-                            break
+            # ``actual_message`` is the bare user request for credential-error
+            # bookkeeping (we store it in clarification_info["original_message"]
+            # so the recursive retry below has the un-wrapped text).
+            actual_message_for_credential = actual_message
 
             if isinstance(e, MissingCredentialError):
                 # Use unified system to handle credential request based on configuration
@@ -8289,6 +8247,7 @@ Agent response: {raw_response}"""
         use_async: Optional[bool] = None,
         webhook_url: Optional[str] = None,
         bypass_workflow_approval: bool = False,
+        original_message: Optional[str] = None,
     ) -> MuxiResponse:
         """
         Process a complex request using workflow orchestration.
@@ -8302,7 +8261,11 @@ Agent response: {raw_response}"""
         emit events during workflow execution for real-time progress updates.
 
         Args:
-            message: The user's original message
+            message: The user's request — typically already the bare text by
+                the time we reach the workflow path (callers extract from the
+                marker wrapper before invoking us), but treat ``message`` as
+                potentially-wrapped legacy and ``original_message`` as the
+                canonical bare value when supplied.
             analysis: RequestAnalysis object containing complexity score and decomposition hints
             user_id: User identifier
             session_id: Optional session identifier
@@ -8310,6 +8273,8 @@ Agent response: {raw_response}"""
             relevant_sop: Optional SOP to use for workflow
             use_async: Optional async execution preference
             webhook_url: Optional webhook URL for async results
+            original_message: Bare user text — used for observability emits
+                so they don't dump the marker wrapper.
 
         Returns:
             MuxiResponse containing either workflow results or approval request
@@ -8318,6 +8283,11 @@ Agent response: {raw_response}"""
         self._validate_workflow_inputs(message, user_id, session_id, request_id)
         self._validate_workflow_analysis(analysis)
 
+        # ``actual_message`` is the bare user request for observability.
+        # Recursive callers pass ``original_message`` explicitly; legacy
+        # callers fall back to ``message``.
+        actual_message: str = original_message if original_message is not None else message
+
         try:
             # Emit streaming event for workflow planning
             streaming.stream(
@@ -8325,7 +8295,7 @@ Agent response: {raw_response}"""
                 "This is a complex request. Let me break it down into steps...",
                 stage="workflow_decomposition",
                 complexity_score=analysis.complexity_score if analysis else None,
-                message_preview=message[:500],
+                message_preview=actual_message[:500],
             )
 
             # Emit workflow orchestration started event
@@ -8364,7 +8334,7 @@ Agent response: {raw_response}"""
                     "plan_approval_threshold": self.plan_approval_threshold,
                     "needs_approval": needs_approval,
                     "bypass_workflow_approval": bypass_workflow_approval,
-                    "message_preview": redact_message_preview(message, 100),
+                    "message_preview": redact_message_preview(actual_message, 200),
                 },
                 description=f"Workflow approval decision: {'REQUIRED' if needs_approval else 'NOT REQUIRED'}"
                 + (" (bypassed by flag)" if bypass_workflow_approval else ""),
@@ -8432,7 +8402,7 @@ Agent response: {raw_response}"""
                 )
             elif self._ensure_sop_system():
                 # Fallback: search for SOPs if none was passed (shouldn't happen in normal flow)
-                fallback_sop = await self._find_relevant_sop(message)
+                fallback_sop = await self._find_relevant_sop(actual_message)
                 if fallback_sop:
                     # Recursive call with the found SOP
                     return await self._process_with_workflow(
@@ -8443,6 +8413,7 @@ Agent response: {raw_response}"""
                         request_id=request_id,
                         relevant_sop=fallback_sop,
                         bypass_workflow_approval=bypass_workflow_approval,
+                        original_message=actual_message,
                     )
 
             # Fall back to standard decomposition if no SOP found
@@ -10365,8 +10336,16 @@ Agent response: {raw_response}"""
                     f"{original_message}\n\nAdditional context: {clarification_response}"
                 )
 
-            # Re-process with enhanced message
-            result = await self._process_sync_chat(enhanced_message, agent_name, user_id)
+            # Re-process with enhanced message. ``enhanced_message`` here is bare text
+            # (original + appended clarification response), not marker-wrapped — pass it
+            # as both ``message`` and ``original_message`` so observability emits read
+            # the user-readable string.
+            result = await self._process_sync_chat(
+                enhanced_message,
+                agent_name,
+                user_id,
+                original_message=enhanced_message,
+            )
 
             # Emit completion event
             observability.observe(

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -7586,6 +7586,7 @@ Agent response: {raw_response}"""
                             use_async=use_async,
                             webhook_url=webhook_url,
                             bypass_workflow_approval=bypass_workflow_approval,
+                            original_message=actual_message,
                         )
                     else:
                         # SOP explicitly requested but not found - return error to user

--- a/src/muxi/runtime/services/llm/llm.py
+++ b/src/muxi/runtime/services/llm/llm.py
@@ -1123,43 +1123,41 @@ class LLM:
         return False
 
     def _extract_tokens_from_response(self, response: Any) -> Dict[str, int]:
-        """Extract comprehensive token usage including cache information from LLM response."""
-        try:
-            usage_data = {}
+        """Extract token usage from a provider response and translate to the
+        runtime's short-name vocabulary.
 
-            # Handle object with usage attribute
+        Provider responses (OpenAI / Anthropic / OneLLM-normalized) use
+        ``prompt_tokens`` / ``completion_tokens`` / ``*_tokens_cached``.
+        Internally we standardize on ``total / in / out / in_cached /
+        out_cached`` everywhere — both the cumulative ``request.tokens``
+        legend and the per-call ``MODEL_REQUEST_COMPLETED`` event. This
+        function is the single boundary translation point: every
+        downstream consumer sees one vocabulary instead of two parallel
+        ones (``input`` vs ``prompt``, ``output`` vs ``completion``).
+        """
+        try:
+            # Pull raw usage (dict, attribute object, or nested under "usage"
+            # in a response dict). Three response shapes; one extraction.
             if hasattr(response, "usage"):
                 usage = response.usage
-                if isinstance(usage, dict):
-                    usage_data = {
-                        "total_tokens": usage.get("total_tokens", 0),
-                        "prompt_tokens": usage.get("prompt_tokens", 0),
-                        "completion_tokens": usage.get("completion_tokens", 0),
-                        "prompt_tokens_cached": usage.get("prompt_tokens_cached", 0),
-                        "completion_tokens_cached": usage.get("completion_tokens_cached", 0),
-                    }
-                else:
-                    # Handle object-style usage
-                    usage_data = {
-                        "total_tokens": getattr(usage, "total_tokens", 0),
-                        "prompt_tokens": getattr(usage, "prompt_tokens", 0),
-                        "completion_tokens": getattr(usage, "completion_tokens", 0),
-                        "prompt_tokens_cached": getattr(usage, "prompt_tokens_cached", 0),
-                        "completion_tokens_cached": getattr(usage, "completion_tokens_cached", 0),
-                    }
-
-            # Handle dictionary format
             elif isinstance(response, dict) and "usage" in response:
                 usage = response["usage"]
-                usage_data = {
-                    "total_tokens": usage.get("total_tokens", 0),
-                    "prompt_tokens": usage.get("prompt_tokens", 0),
-                    "completion_tokens": usage.get("completion_tokens", 0),
-                    "prompt_tokens_cached": usage.get("prompt_tokens_cached", 0),
-                    "completion_tokens_cached": usage.get("completion_tokens_cached", 0),
-                }
+            else:
+                return {}
 
-            return usage_data
+            # Reader that handles both dict and attribute-object usage.
+            def _read(key: str) -> int:
+                if isinstance(usage, dict):
+                    return usage.get(key, 0) or 0
+                return getattr(usage, key, 0) or 0
+
+            return {
+                "total": _read("total_tokens"),
+                "in": _read("prompt_tokens"),
+                "out": _read("completion_tokens"),
+                "in_cached": _read("prompt_tokens_cached"),
+                "out_cached": _read("completion_tokens_cached"),
+            }
 
         except (AttributeError, KeyError, TypeError):
             return {}
@@ -1196,9 +1194,9 @@ class LLM:
         # Step 2: cumulative tally — only update when we actually got
         # numbers back from the provider. Embeddings/transcription
         # often return usage_data with zeros for unsupported metrics
-        # (e.g., completion_tokens), and we still want to track the
-        # call so we use ``usage_data`` truthiness rather than
-        # ``total_tokens > 0`` as the gate.
+        # (e.g., ``out``), and we still want to track the call so we
+        # use ``usage_data`` truthiness rather than ``total > 0`` as
+        # the gate.
         if usage_data:
             from ...services.observability.context import get_current_request_context
 

--- a/src/muxi/runtime/services/llm/llm.py
+++ b/src/muxi/runtime/services/llm/llm.py
@@ -1335,16 +1335,20 @@ class LLM:
                         self._model = self.fallback_model
                     self.model_name = self.fallback_model
 
-                    # Try the fallback model (without retries to avoid double retry)
+                    # Try the fallback model (without retries to avoid
+                    # double retry). The inner chat function emits its
+                    # own MODEL_REQUEST_COMPLETED for the actual call;
+                    # here we only emit the resilience-layer transition
+                    # event so per-call event counts stay 1:1 with
+                    # MODEL_REQUEST_STARTED.
                     result = await _wrapped_func(*args, **kwargs)
 
                     observability.observe(
-                        event_type=observability.ConversationEvents.MODEL_REQUEST_COMPLETED,
+                        event_type=observability.ConversationEvents.MODEL_FALLBACK_SUCCESS,
                         level=observability.EventLevel.INFO,
                         data={
                             "primary_model": original_model,
                             "fallback_model": self.fallback_model,
-                            "fallback_success": True,
                         },
                         description=f"Fallback model {self.fallback_model} succeeded after {original_model} failed",
                     )

--- a/src/muxi/runtime/services/llm/llm.py
+++ b/src/muxi/runtime/services/llm/llm.py
@@ -1164,6 +1164,67 @@ class LLM:
         except (AttributeError, KeyError, TypeError):
             return {}
 
+    def _record_model_completion(
+        self,
+        response: Any,
+        *,
+        model: str,
+        operation: str,
+    ) -> None:
+        """Centralize post-LLM-call bookkeeping for every chat / tools /
+        embedding / transcription path:
+
+        1. Extract the per-call ``usage_data`` from the provider response.
+        2. Add it to the cumulative ``request.tokens`` tally on the
+           active request context (so every subsequent observability
+           event sees the running total + per-model breakdown).
+        3. Emit a ``MODEL_REQUEST_COMPLETED`` event with the per-call
+           ``tokens``, ``model``, ``provider``, and ``operation`` so
+           downstream consumers can attribute spend to the specific
+           call that produced it.
+
+        Before this helper existed, step (2) was duplicated inline at 5
+        call sites and step (3) was missing entirely on the success
+        path — only the fallback-success branch emitted a completion
+        event, so users saw 5+ ``model.request.started`` events with
+        no matching ``model.request.completed`` and no per-call token
+        attribution. Cumulative tokens still updated correctly, but
+        the per-call accountability was gone.
+        """
+        usage_data = self._extract_tokens_from_response(response)
+
+        # Step 2: cumulative tally — only update when we actually got
+        # numbers back from the provider. Embeddings/transcription
+        # often return usage_data with zeros for unsupported metrics
+        # (e.g., completion_tokens), and we still want to track the
+        # call so we use ``usage_data`` truthiness rather than
+        # ``total_tokens > 0`` as the gate.
+        if usage_data:
+            from ...services.observability.context import get_current_request_context
+
+            ctx = get_current_request_context()
+            if ctx:
+                ctx.tokens.add_tokens(model, usage_data)
+
+        # Step 3: per-call completion event. Wrapped in try/except
+        # because observability failures must never break the LLM
+        # call path — same defensive posture as the
+        # MODEL_REQUEST_STARTED emission above.
+        try:
+            observability.observe(
+                event_type=observability.ConversationEvents.MODEL_REQUEST_COMPLETED,
+                level=observability.EventLevel.INFO,
+                data={
+                    "model": model,
+                    "provider": self._provider,
+                    "operation": operation,
+                    "tokens": usage_data or {},
+                },
+                description=f"Model request completed: {model} ({operation})",
+            )
+        except Exception:
+            pass  # Observability failure - continue gracefully
+
     async def _execute_with_resilience(self, func, *args, **kwargs):
         """Execute a function with full resilience patterns including fallback model support."""
 
@@ -1559,14 +1620,8 @@ Provide a helpful, conversational response that directly addresses what the user
             if telemetry:
                 telemetry.record_llm_request(self._provider, self._model, cache_hit=False)
 
-            # Track token usage
-            usage_data = self._extract_tokens_from_response(response)
-            if usage_data and usage_data.get("total_tokens", 0) > 0:
-                from ...services.observability.context import get_current_request_context
-
-                context = get_current_request_context()
-                if context:
-                    context.tokens.add_tokens(self.model_name, usage_data)
+            # Record per-call tokens + emit MODEL_REQUEST_COMPLETED
+            self._record_model_completion(response, model=self.model_name, operation="chat")
 
             # Extract content from response using helper
             content = self._extract_content_from_response(response)
@@ -1641,14 +1696,10 @@ Provide a helpful, conversational response that directly addresses what the user
             if telemetry:
                 telemetry.record_llm_request(self._provider, self._model, cache_hit=False)
 
-            # Track token usage
-            usage_data = self._extract_tokens_from_response(response)
-            if usage_data and usage_data.get("total_tokens", 0) > 0:
-                from ...services.observability.context import get_current_request_context
-
-                context = get_current_request_context()
-                if context:
-                    context.tokens.add_tokens(self.model_name, usage_data)
+            # Record per-call tokens + emit MODEL_REQUEST_COMPLETED
+            self._record_model_completion(
+                response, model=self.model_name, operation="chat_with_tools"
+            )
 
             # Check if response contains tool calls - if so, return the full response
             if self._has_tool_calls(response):
@@ -1710,14 +1761,8 @@ Provide a helpful, conversational response that directly addresses what the user
             # Call OneLLM Embedding using async method
             response = await Embedding.acreate(**params)
 
-            # Track token usage
-            usage_data = self._extract_tokens_from_response(response)
-            if usage_data:
-                from ...services.observability.context import get_current_request_context
-
-                context = get_current_request_context()
-                if context:
-                    context.tokens.add_tokens(embedding_model, usage_data)
+            # Record per-call tokens + emit MODEL_REQUEST_COMPLETED
+            self._record_model_completion(response, model=embedding_model, operation="embedding")
 
             # Extract embedding from response
             if isinstance(response, dict) and "data" in response:
@@ -1783,14 +1828,10 @@ Provide a helpful, conversational response that directly addresses what the user
             # Call OneLLM AudioTranscription using async method
             response = await AudioTranscription.create(**params)
 
-            # Track token usage
-            usage_data = self._extract_tokens_from_response(response)
-            if usage_data:
-                from ...services.observability.context import get_current_request_context
-
-                context = get_current_request_context()
-                if context:
-                    context.tokens.add_tokens(transcription_model, usage_data)
+            # Record per-call tokens + emit MODEL_REQUEST_COMPLETED
+            self._record_model_completion(
+                response, model=transcription_model, operation="transcription"
+            )
 
             # Extract text from response
             if isinstance(response, dict) and "text" in response:
@@ -1852,14 +1893,10 @@ Provide a helpful, conversational response that directly addresses what the user
             # Call OneLLM Embedding using async method
             response = await Embedding.acreate(**params)
 
-            # Track token usage
-            usage_data = self._extract_tokens_from_response(response)
-            if usage_data:
-                from ...services.observability.context import get_current_request_context
-
-                context = get_current_request_context()
-                if context:
-                    context.tokens.add_tokens(embedding_model, usage_data)
+            # Record per-call tokens + emit MODEL_REQUEST_COMPLETED
+            self._record_model_completion(
+                response, model=embedding_model, operation="embedding_batch"
+            )
 
             # Extract embeddings from response
             if isinstance(response, dict) and "data" in response:

--- a/src/muxi/runtime/services/observability/logger.py
+++ b/src/muxi/runtime/services/observability/logger.py
@@ -170,10 +170,12 @@ class EventLogger:
                 "duration_ms": request_context.duration_ms,
                 "formation_id": request_context.formation_id,
                 "user_id": request_context.user_id,
-                "tokens": {
-                    "total": request_context.tokens.total,
-                    "breakdown": request_context.tokens.breakdown,
-                },
+                # ``TokenUsage.to_dict`` emits the self-documenting
+                # ``fields`` legend alongside the array values so
+                # consumers know which position is total/input/output/
+                # cached without reading the source. See manager.py for
+                # the same fix.
+                "tokens": request_context.tokens.to_dict(),
             }
 
             # Track parent relationship

--- a/src/muxi/runtime/services/observability/manager.py
+++ b/src/muxi/runtime/services/observability/manager.py
@@ -502,10 +502,13 @@ class ObservabilityManager:
                     "duration_ms": request_context.duration_ms,
                     "formation_id": request_context.formation_id,
                     "user_id": request_context.user_id,
-                    "tokens": {
-                        "total": request_context.tokens.total,
-                        "breakdown": request_context.tokens.breakdown,
-                    },
+                    # ``TokenUsage.to_dict`` emits the self-documenting
+                    # ``fields`` legend alongside the array values so
+                    # consumers know which position is total/input/output/
+                    # cached without reading the source. Hand-building this
+                    # dict (as we used to here) silently dropped the
+                    # legend, leaving consumers with opaque integer arrays.
+                    "tokens": request_context.tokens.to_dict(),
                 }
 
             # Add event-specific data

--- a/tests/unit/test_chat_orchestrator_buffer_recency_floor.py
+++ b/tests/unit/test_chat_orchestrator_buffer_recency_floor.py
@@ -55,9 +55,7 @@ def _make_orchestrator(
     orch = ChatOrchestrator.__new__(ChatOrchestrator)
 
     overlord = MagicMock()
-    overlord.formation_config = {
-        "memory": {"buffer": {"size": 5, "vector_search": vector_search}}
-    }
+    overlord.formation_config = {"memory": {"buffer": {"size": 5, "vector_search": vector_search}}}
     overlord.is_multi_user = False
     overlord.long_term_memory = None
     overlord.persistent_memory_manager = None
@@ -95,12 +93,14 @@ async def test_remote_mode_merges_recency_floor_with_vector_results() -> None:
         search_results={user_msg: vector_only, "": recency_only},
     )
 
-    result = await orch._enhance_message_with_context(
-        message=user_msg,
-        user_id="bob",
-        session_id="sess",
-        file_results=None,
-    )
+    result = (
+        await orch._enhance_message_with_context(
+            message=user_msg,
+            user_id="bob",
+            session_id="sess",
+            file_results=None,
+        )
+    ).enhanced
 
     # Two distinct calls: vector pass + recency pass.
     calls = orch.overlord.buffer_memory_manager.search_buffer_memory.await_args_list
@@ -128,12 +128,14 @@ async def test_local_mode_unchanged_uses_recency_only_search() -> None:
         search_results={user_msg: [], "": recency_only},
     )
 
-    result = await orch._enhance_message_with_context(
-        message=user_msg,
-        user_id="bob",
-        session_id="sess",
-        file_results=None,
-    )
+    result = (
+        await orch._enhance_message_with_context(
+            message=user_msg,
+            user_id="bob",
+            session_id="sess",
+            file_results=None,
+        )
+    ).enhanced
 
     # Only one call — recency pass only. Local mode must NOT issue a
     # second call to keep the fast path lean.
@@ -160,9 +162,11 @@ async def test_remote_mode_dedupes_overlap_between_vector_and_recency() -> None:
         vector_search=True,
         search_results={user_msg: vector, "": recency},
     )
-    result = await orch._enhance_message_with_context(
-        message=user_msg, user_id="u", session_id="s", file_results=None
-    )
+    result = (
+        await orch._enhance_message_with_context(
+            message=user_msg, user_id="u", session_id="s", file_results=None
+        )
+    ).enhanced
 
     # All three distinct items present.
     assert "V1 high-relevance" in result

--- a/tests/unit/test_memory_speedup.py
+++ b/tests/unit/test_memory_speedup.py
@@ -308,11 +308,13 @@ class TestUserSynopsisFastPath:
         )
         orchestrator = ChatOrchestrator(overlord)
 
-        enhanced = await orchestrator._enhance_message_with_context(
-            message="What is my current user profile?",
-            user_id="tester",
-            session_id="sess-1",
-        )
+        enhanced = (
+            await orchestrator._enhance_message_with_context(
+                message="What is my current user profile?",
+                user_id="tester",
+                session_id="sess-1",
+            )
+        ).enhanced
 
         assert "=== USER PROFILE ===" in enhanced
         assert overlord.persistent_memory_manager.search_long_term_memory.await_count == 0
@@ -343,11 +345,13 @@ class TestUserSynopsisFastPath:
         orchestrator = ChatOrchestrator(overlord)
 
         with patch.object(PromptLoader, "get", return_value="Use these memories."):
-            enhanced = await orchestrator._enhance_message_with_context(
-                message="What do you know about me?",
-                user_id="tester",
-                session_id="sess-1",
-            )
+            enhanced = (
+                await orchestrator._enhance_message_with_context(
+                    message="What do you know about me?",
+                    user_id="tester",
+                    session_id="sess-1",
+                )
+            ).enhanced
 
         assert "=== RELEVANT MEMORIES ===" in enhanced
         assert "Corey is the founder of MUXI" in enhanced


### PR DESCRIPTION
## What

Several observability events were emitting `message_preview` fields that dumped 100-500 chars of the marker-formatted enhanced wrapper:

```json
"message_preview": "=== CURRENT REQUEST ===\\nUser: onboard me\\n\\n=== RELEVANT MEMORIES ===\\n- Wants to create a paralegal"
```

— instead of the bare user request (`"onboard me"`). The wrapper noise made the metric useless: every preview was indistinguishable bookend text and the actual user input was usually truncated off the end.

## How

The wrapping happens in `ChatOrchestrator._enhance_message_with_context`, which builds the analyzer-pipeline blob from memory + buffer + profile context. The function previously returned only the enhanced string, so every downstream observability hop that wanted the bare user text had to re-parse the wrapper out of it. That re-parser was duplicated inline (~30 lines × 5+ times) across `overlord.py`.

**Approach:** remember the original at the source instead of extracting it on the way out.

- New `EnhancedMessage(original, enhanced)` NamedTuple. `_enhance_message_with_context` returns both halves so the bare user text survives untouched through the call chain.
- `ChatOrchestrator.chat()` destructures the pair and threads `original_message` alongside `enhanced_message` to every downstream call.
- `Overlord._process_sync_chat` and `_process_with_workflow` gain `original_message` parameters. A single `actual_message = original_message if original_message is not None else message` at the top of each replaces the 5+ inline wrapper extractors.
- Observability/streaming emit sites read `actual_message` directly.

## Result

```json
"event": "clarification.request.sent",
"data": {
  ...
  "message_preview": "onboard me"
}
```

`"=== CURRENT REQUEST ==="` no longer leaks into any `message_preview` field anywhere.

## Verification

- **Unit tests**: 992 pass, ruff/black/event-validation clean. (Two tests updated to access `.enhanced` on the returned NamedTuple.)
- **Live**: `onboard me` on hello-muxi → `clarification.request.sent` shows `"message_preview": "onboard me"`.

## Files

- `src/muxi/runtime/formation/overlord/chat_orchestrator.py` — NamedTuple, `_enhance_message_with_context` return shape, threading
- `src/muxi/runtime/formation/overlord/overlord.py` — `_process_sync_chat` + `_process_with_workflow` gain `original_message`, `actual_message` at top of each, 5+ inline extractors deleted, observability emits use bare text
- `tests/unit/test_chat_orchestrator_buffer_recency_floor.py` + `tests/unit/test_memory_speedup.py` — adapt to NamedTuple return