### PR TITLE
fix(scheduler): restore job stat persistence + collapse doubled session_id + preserve delivery framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,139 @@
 
 ## [unreleased]
 
+### Scheduler: restore job stat persistence + collapse doubled session_id + preserve delivery framing
+
+Three independent scheduler bugs surfaced by user testing on a recurring
+``*/3 * * * *`` reminder job. After two confirmed successful runs the
+``scheduled_jobs`` row showed ``last_run_at NULL``, ``total_runs 0``,
+``last_run_status`` empty — yet the user's external webhook receiver
+*had* recorded the result text in their ``job_results`` table. From the
+outside the scheduler looked broken; from the inside it looked like the
+job had never run.
+
+**1. Job stats never persisted (the root cause).**
+
+``Overlord._execute_async_request`` referenced ``self._scheduler`` (with
+a leading underscore) at four sites — but the scheduler is stored as
+``self.scheduler_service``. ``hasattr(self, "_scheduler")`` returned
+False on every scheduled run, so the entire completion-handler block
+was silently skipped:
+
+```python
+if (
+    hasattr(self, "_scheduler")   # ← always False
+    and self._scheduler           # ← never evaluated
+    and session_id
+    and session_id.startswith("job_")
+):
+    handled = await self._scheduler.complete_job_from_webhook(...)
+```
+
+Effect on every successful scheduled run:
+
+* ``mark_job_execution_success`` never called → ``total_runs`` stayed 0
+* ``scheduled.job.completed`` event never emitted
+* ``last_run_at`` / ``last_run_status`` never updated
+* External webhook *was* delivered (control fell through to the
+  standard delivery branch once the inner ``if`` was skipped) — which
+  is why the user's external receiver had the result and made it look
+  like the job worked
+
+The four references were renamed to ``self.scheduler_service``
+(``getattr(self, "scheduler_service", None)`` to keep the original
+defensive shape during early init). The accompanying silent
+``except Exception: pass`` blocks — which were how this typo hid for
+months — were replaced with logged ``ERROR.INTERNAL_ERROR`` warnings,
+so any future breakage on this path surfaces in observability instead
+of vanishing.
+
+**2. Doubled ``job_`` prefix in ``session_id`` (cosmetic).**
+
+``_execute_single_job`` constructed
+``session_id = f"job_{job_id}"`` — but job IDs are already prefixed by
+the manager, producing ``job_job_<id>`` in every observability event:
+
+```json
+{
+  "event": "scheduled.job.started",
+  "data": {
+    "job_id":     "job_JmYB5QuDisCdBpLU",
+    "session_id": "job_job_JmYB5QuDisCdBpLU"
+  }
+}
+```
+
+``complete_job_from_webhook`` papered over the doubling with
+``job_id = session_id[4:]`` (strips the first ``job_`` and recovers
+the real job_id), so the lookup *worked* and the dev-reported
+hypothesis that this caused the missing stat updates was incorrect —
+both ends used the same doubled string. But the relationship between
+session_id and job_id was no longer obvious to anyone reading code or
+logs. Now: ``session_id = job_id`` directly, and the strip in
+``complete_job_from_webhook`` becomes ``job_id = session_id`` (the
+``startswith("job_")`` namespace guard stays).
+
+**3. Prompt rewriter strips delivery framing (behavioral).**
+
+The scheduler's prompt rewriter over-compresses scheduled prompts.
+A user scheduling
+
+> ``remind me to drink water every 3 minutes``
+
+ended up with an execution prompt of bare ``drink water``. The agent,
+receiving that as a fresh user message with no scheduling context,
+interpreted it as a confirmation and replied:
+
+> "Got it. Drinking water now? Want me to set up a daily reminder?"
+
+— a recursive offer to schedule the exact reminder it was already
+executing. Reminders, notifications, and "send me a summary of"
+scheduled tasks were silently non-functional whenever their intent
+lived in the framing.
+
+Root cause: the rewriter prompt told the model to "Strip away ALL
+scheduling patterns" but never explicitly told it to *preserve*
+delivery framing (``remind me``, ``notify me``, ``send me``,
+``tell me``, ``show me``, ``alert me``). A 12B model interprets "all
+scheduling patterns" generously and treats ``remind me to`` as
+metadata.
+
+The rewriter prompt was rewritten to:
+
+* Frame the rewrite for the agent's perspective: "the agent will
+  receive your output as a fresh user message — with NO knowledge
+  that it was scheduled" — drives home why framing matters.
+* Explicitly call out delivery-framing words as part of the action,
+  NOT scheduling.
+* Provide a side-by-side correct/wrong table including the exact
+  failure case (``remind me to drink water`` → keep, NOT strip).
+* Spell out the recipient pronoun (``remind ME``, ``tell US``).
+
+**Test changes.**
+
+Three new test classes added to
+``tests/unit/test_bugfix_verification.py`` (mirroring the existing
+source-shape testing pattern in that file):
+
+* ``TestSchedulerOverlordCompletionAttribute`` — asserts no live code
+  references ``self._scheduler`` (with comment / docstring stripping
+  so historical regression notes don't trip the test); asserts
+  ``_execute_async_request`` calls
+  ``scheduler_service.complete_job_from_webhook`` on both the success
+  and failure branches.
+* ``TestSchedulerSessionIdNotDoubled`` — asserts ``_execute_single_job``
+  uses ``session_id = job_id`` directly; asserts
+  ``complete_job_from_webhook`` does not slice with ``session_id[4:]``
+  (the strip was only correct for the doubled prefix and would now
+  strip the legitimate ``job_`` prefix).
+* ``TestSchedulerPromptRewriterPreservesFraming`` — asserts the
+  rewriter prompt mentions ``remind me``, carries ``drink water`` as a
+  guard example, and explicitly warns against stripping framing.
+
+22/22 tests in test_bugfix_verification pass. Full unit suite:
+999 passed, 1 skipped (the one pre-existing RCE auth failure unchanged
+on develop).
+
 ### MCP tool filtering via ``tools.{whitelist|blacklist}``
 
 Adds an optional ``tools`` block on any MCP server config that lets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [unreleased]
 
-### Scheduler: restore job stat persistence + collapse doubled session_id + preserve delivery framing
+### Scheduler: restore job stat persistence + collapse doubled session_id + preserve delivery framing + disambiguate scheduled execution at agent boundary
 
 Three independent scheduler bugs surfaced by user testing on a recurring
 ``*/3 * * * *`` reminder job. After two confirmed successful runs the
@@ -110,9 +110,89 @@ The rewriter prompt was rewritten to:
   failure case (``remind me to drink water`` → keep, NOT strip).
 * Spell out the recipient pronoun (``remind ME``, ``tell US``).
 
+**4. Disambiguate scheduled execution at the agent boundary
+(behavioral, second-order).**
+
+Live-testing the rewriter fix surfaced a second-order problem.
+Rewriter output for ``remind me to drink water every hour`` is now
+correctly ``remind me to drink water`` — but when the cron fires and
+that string lands in the agent as a fresh user message with no
+context, Claude Sonnet 4.6 treats it as a chat request to *configure*
+a reminder and politely declines:
+
+> "Can't set reminders directly — no access to your clock or
+> notification system. Quickest fix: just tell your phone's
+> assistant 'Remind me to drink water every hour' and you're done."
+
+A recursive offer to schedule the exact reminder it was already
+executing. The rewriter is correct; the agent is missing the
+context that this is a *firing*, not a *configuration request*.
+
+Live-tested four marker variants on hello-muxi. The minimum form
+
+```
+[SCHEDULED] remind me to drink water
+```
+
+worked perfectly with no system-prompt change required. The agent
+produced direct reminder content (``💧 Water break! Hey, time to grab
+a glass of water``) and even self-tagged the response with
+``Scheduled reminder ✓``. Longer preambles accidentally triggered
+SOP routing (variant C posted to GitHub), so the marker has to stay
+minimal.
+
+Implemented as a single-source-of-truth helper in
+``chat_orchestrator.py``:
+
+```python
+SCHEDULED_EXECUTION_MARKER = "[SCHEDULED] "
+
+def _apply_scheduled_marker(message: str, session_id: Optional[str]) -> str:
+    if session_id and session_id.startswith("job_"):
+        return f"{SCHEDULED_EXECUTION_MARKER}{message}"
+    return message
+```
+
+Wired into both message-rendering paths: the analyzer-pipeline
+``=== CURRENT REQUEST ===`` rendering inside
+``_enhance_message_with_context``, and the agent-LLM
+``current_user_message`` field returned by
+``_build_clean_chat_context``. ``buffer_turns`` (history rendered
+from buffer memory) is intentionally left untouched — past
+scheduled invocations appear in history as the original user text,
+since the assistant's prior responses already encode the
+scheduled-execution behavior.
+
+**Memory and observability stay clean.** PR #165's
+``EnhancedMessage(original, enhanced)`` threading pays off here: the
+``original`` field is the raw user text the marker is applied *on
+top of*, so:
+
+* Buffer memory stores the unprefixed message (``remind me to drink
+  water``) — no marker pollution in conversation history.
+* Observability events emit ``message_preview`` from the original,
+  not the enhanced/marked form — the
+  ``clarification.request.sent`` and
+  ``overlord.agent.selection_started`` events on a scheduled run
+  show ``"message_preview": "remind me to drink water"`` (verified
+  live).
+* Only the agent's view at inference time gets the marker — visible
+  in the ``agent.planning`` event's ``request`` field, which is the
+  correct place since that event records what the agent is planning
+  *against*.
+
+**Live verification matrix on hello-muxi (Claude Sonnet 4.6):**
+
+| Scenario | session_id | Expected | Result |
+|---|---|---|---|
+| Scheduled job firing | ``job_test1`` | reminder content | ✓ ``💧 Water break!`` |
+| Normal chat | ``normal-chat`` | no regression | ✓ same as pre-fix |
+| Streaming scheduled | ``job_stream_test`` | reminder content via stream | ✓ ``💧 Water check!`` |
+| Adversarial — user types ``[SCHEDULED]`` in normal chat | ``user-typed-bracket`` | agent ignores marker, answers normally | ✓ answered the question, no exploit surface |
+
 **Test changes.**
 
-Three new test classes added to
+Four new test classes added to
 ``tests/unit/test_bugfix_verification.py`` (mirroring the existing
 source-shape testing pattern in that file):
 
@@ -130,10 +210,18 @@ source-shape testing pattern in that file):
 * ``TestSchedulerPromptRewriterPreservesFraming`` — asserts the
   rewriter prompt mentions ``remind me``, carries ``drink water`` as a
   guard example, and explicitly warns against stripping framing.
+* ``TestScheduledExecutionMarker`` — asserts the centralized helper
+  exists with the expected ``[SCHEDULED] `` literal; asserts the
+  helper applies / does not apply correctly across job and
+  non-job session IDs (including ``None``, empty string, and
+  arbitrary non-prefixed IDs); asserts both rendering paths call
+  the helper rather than re-implementing the rule inline; locks the
+  ``buffer_turns left untouched`` invariant via a comment-shape
+  assertion.
 
-22/22 tests in test_bugfix_verification pass. Full unit suite:
-999 passed, 1 skipped (the one pre-existing RCE auth failure unchanged
-on develop).
+28/28 tests in test_bugfix_verification pass. Full unit suite:
+1005 passed, 1 skipped (the one pre-existing RCE auth failure
+unchanged on develop).
 
 ### MCP tool filtering via ``tools.{whitelist|blacklist}``
 

--- a/src/muxi/runtime/formation/overlord/chat_orchestrator.py
+++ b/src/muxi/runtime/formation/overlord/chat_orchestrator.py
@@ -40,6 +40,29 @@ class EnhancedMessage(NamedTuple):
     enhanced: str
 
 
+# Marker prefix the agent sees in front of a scheduled-execution message.
+# Resolves the ambiguity where ``remind me to X`` reads as a chat request
+# to *configure* a reminder rather than as the reminder firing right now.
+# Applied only at the agent's view of the message — buffer memory and
+# observability still see the raw user text. See
+# ``_apply_scheduled_marker`` for the single-place rule.
+SCHEDULED_EXECUTION_MARKER = "[SCHEDULED] "
+
+
+def _apply_scheduled_marker(message: str, session_id: Optional[str]) -> str:
+    """Return ``message`` with the scheduled-execution marker if and only
+    if ``session_id`` belongs to the scheduler namespace.
+
+    Centralized so both message-rendering paths
+    (``_enhance_message_with_context`` and ``_build_clean_chat_context``)
+    apply the same rule, and so a single source-shape assertion can lock
+    the policy.
+    """
+    if session_id and session_id.startswith("job_"):
+        return f"{SCHEDULED_EXECUTION_MARKER}{message}"
+    return message
+
+
 class ChatOrchestrator:
     """
     Handles chat orchestration for the Overlord.
@@ -1384,9 +1407,14 @@ class ChatOrchestrator:
         # Build enhanced message with priority ordering (most important first)
         enhanced_parts = []
 
-        # 1. Current request (highest priority - always preserved)
+        # 1. Current request (highest priority - always preserved).
+        # Apply the scheduled-execution marker only at the rendering
+        # layer — the ``message`` variable (and the EnhancedMessage
+        # ``original`` field returned below) stays unchanged so memory
+        # storage and observability emits keep the raw user text.
+        display_message = _apply_scheduled_marker(message, session_id)
         enhanced_parts.append("=== CURRENT REQUEST ===")
-        enhanced_parts.append(f"User: {message}")
+        enhanced_parts.append(f"User: {display_message}")
         enhanced_parts.append("")
 
         # 2. User profile (high priority - provides context about the user)
@@ -1602,9 +1630,17 @@ class ChatOrchestrator:
             _fetch_buffer_role_turns(),
         )
 
+        # Apply the scheduled-execution marker only at the agent's
+        # view of the current message. ``buffer_turns`` is left
+        # untouched — those rows came from buffer memory which stores
+        # the original user text, so prior scheduled invocations
+        # appear in history without the marker (correct: only the
+        # *current* turn needs the marker to disambiguate intent;
+        # past turns' assistant responses already encode the
+        # scheduled-execution behavior).
         return {
             "buffer_turns": buffer_turns,
-            "current_user_message": current_user_message,
+            "current_user_message": _apply_scheduled_marker(current_user_message, session_id),
             "user_profile_text": user_profile_text,
             "long_term_memories": long_term_memories,
             "file_results": file_results or "",

--- a/src/muxi/runtime/formation/overlord/chat_orchestrator.py
+++ b/src/muxi/runtime/formation/overlord/chat_orchestrator.py
@@ -57,9 +57,17 @@ def _apply_scheduled_marker(message: str, session_id: Optional[str]) -> str:
     (``_enhance_message_with_context`` and ``_build_clean_chat_context``)
     apply the same rule, and so a single source-shape assertion can lock
     the policy.
+
+    Idempotent: if ``message`` already starts with the marker (e.g. a
+    user copy-pasted a prior scheduled-firing transcript into a new
+    scheduled job, or two render paths chain the helper through the
+    same string), the marker is not doubled. Double-prefixing is
+    harmless for well-behaved models but still a silent edge case
+    worth guarding against.
     """
     if session_id and session_id.startswith("job_"):
-        return f"{SCHEDULED_EXECUTION_MARKER}{message}"
+        if not message.startswith(SCHEDULED_EXECUTION_MARKER):
+            return f"{SCHEDULED_EXECUTION_MARKER}{message}"
     return message
 
 

--- a/src/muxi/runtime/formation/overlord/chat_orchestrator.py
+++ b/src/muxi/runtime/formation/overlord/chat_orchestrator.py
@@ -1491,11 +1491,19 @@ class ChatOrchestrator:
 
             {
               "buffer_turns": [{"role": "user"|"assistant", "content": "..."}],
-              "current_user_message": "<raw text, no markers>",
+              "current_user_message": "<user text, optionally prefixed
+                                       with '[SCHEDULED] ' when
+                                       session_id belongs to the
+                                       scheduler namespace>",
               "user_profile_text": "...",
               "long_term_memories": "...",
               "file_results": "...",
             }
+
+        ``current_user_message`` is the only field the marker is applied
+        to — ``buffer_turns`` mirrors buffer memory's stored shape (the
+        original user text, no marker) and the remaining fields carry
+        no user input. See ``_apply_scheduled_marker`` for the rule.
 
         in contrast to ``_enhance_message_with_context`` which produces a
         single flat string with ``=== CURRENT REQUEST ===`` /

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -5860,20 +5860,37 @@ Agent response: {raw_response}"""
             # Check if this is a scheduled job completion (wrap in try-except to prevent errors)
             try:
                 if (
-                    hasattr(self, "_scheduler")
-                    and self._scheduler
+                    getattr(self, "scheduler_service", None)
                     and session_id
                     and session_id.startswith("job_")
                 ):
                     # This is a scheduled job - handle completion through scheduler
-                    handled = await self._scheduler.complete_job_from_webhook(
+                    handled = await self.scheduler_service.complete_job_from_webhook(
                         session_id, success=True, result=result_content, error=None
                     )
                     if handled:
                         return  # Don't send normal webhook for scheduled jobs
-            except Exception:
-                # If scheduler handling fails, continue with normal webhook
-                pass
+            except Exception as scheduler_completion_error:
+                # If scheduler handling fails, log and continue with normal
+                # webhook delivery — but make the failure visible. Silently
+                # swallowing was how the original ``self._scheduler`` typo
+                # hid for so long.
+                observability.observe(
+                    event_type=observability.ErrorEvents.INTERNAL_ERROR,
+                    level=observability.EventLevel.WARNING,
+                    data={
+                        "request_id": request_id,
+                        "session_id": session_id,
+                        "error": str(scheduler_completion_error),
+                        "error_type": type(scheduler_completion_error).__name__,
+                        "operation": "scheduler_complete_job_from_webhook_success",
+                    },
+                    description=(
+                        "Scheduler completion (success path) raised; "
+                        "falling back to normal webhook delivery: "
+                        f"{scheduler_completion_error}"
+                    ),
+                )
 
             webhook_url = await self._get_webhook_url_for_request(request_id)
             if webhook_url:
@@ -5957,8 +5974,7 @@ Agent response: {raw_response}"""
             # Check if this is a scheduled job failure (wrap in try-except to prevent secondary errors)
             try:
                 if (
-                    hasattr(self, "_scheduler")
-                    and self._scheduler
+                    getattr(self, "scheduler_service", None)
                     and session_id
                     and session_id.startswith("job_")
                 ):
@@ -5966,14 +5982,30 @@ Agent response: {raw_response}"""
                     formatted_error = await self._apply_persona(
                         f"An error occurred: {str(e)}", message
                     )
-                    handled = await self._scheduler.complete_job_from_webhook(
+                    handled = await self.scheduler_service.complete_job_from_webhook(
                         session_id, success=False, result=None, error=formatted_error
                     )
                     if handled:
                         return  # Don't send normal webhook for scheduled jobs
-            except Exception:
-                # If scheduler handling fails, continue with normal webhook
-                pass
+            except Exception as scheduler_completion_error:
+                # If scheduler handling fails, log and continue with normal
+                # webhook delivery — but make the failure visible.
+                observability.observe(
+                    event_type=observability.ErrorEvents.INTERNAL_ERROR,
+                    level=observability.EventLevel.WARNING,
+                    data={
+                        "request_id": request_id,
+                        "session_id": session_id,
+                        "error": str(scheduler_completion_error),
+                        "error_type": type(scheduler_completion_error).__name__,
+                        "operation": "scheduler_complete_job_from_webhook_failure",
+                    },
+                    description=(
+                        "Scheduler completion (failure path) raised; "
+                        "falling back to normal webhook delivery: "
+                        f"{scheduler_completion_error}"
+                    ),
+                )
 
             # Send failure webhook if URL is configured
             # NOTE: Must get webhook URL BEFORE removing request from tracker

--- a/src/muxi/runtime/formation/prompts/scheduler_prompt_rewriter.md
+++ b/src/muxi/runtime/formation/prompts/scheduler_prompt_rewriter.md
@@ -1,22 +1,38 @@
-Extract and rewrite the core action from this scheduling request, removing all scheduling/timing instructions.
+Rewrite this scheduling request into the prompt that will actually execute on schedule. Strip the timing, keep everything else.
 
 Original Request: "{original_prompt}"{context_info}
 
-IMPORTANT: The user has requested a scheduled task. Strip away ALL scheduling patterns
-(like "every minute", "daily at", "every hour", etc.) and return ONLY the action to be performed.
+The user has scheduled a task. When the schedule fires, an agent will receive your output as a fresh user message — with NO knowledge that it was scheduled. Your output must read like a complete, standalone instruction the agent can act on.
 
-Guidelines:
-1. Remove all scheduling/timing words (every, daily, hourly, minute, at, recurring, etc.)
-2. Keep ONLY the core action/task to be executed
-3. Make it self-contained and clear
-4. If the request is just an action with timing (e.g., "check my email every minute"), return just the action (e.g., "check my email")
-5. Do NOT add words like "update", "reminder", or "notification" unless they were in the original action
+WHAT TO REMOVE
+Remove ONLY the timing/recurrence words and phrases:
+- "every minute", "every 3 minutes", "every hour", "hourly", "daily", "weekly", "monthly"
+- "at 9am", "at noon", "on Monday", "on the first of each month"
+- "recurring", "scheduled", "regularly", "periodically"
 
-Examples:
-- "check my email every hour" → "check my email"
-- "tell me a dad joke every minute" → "tell me a dad joke"
-- "send weather report daily at 9am" → "send weather report"
-- "remind me about the meeting every Monday" → "remind me about the meeting"
-- "generate sales report on the first of each month" → "generate sales report"
+WHAT TO KEEP — CRITICAL
+Keep EVERY other word in the request, especially:
+- The verb and its object: "drink water", "send the report", "check email"
+- The DELIVERY FRAMING: "remind me to ...", "notify me when ...", "send me ...", "tell me ...", "show me ...", "alert me about ..."
+- The recipient: "remind ME", "tell US", "notify the team"
+- The subject/topic that gives the action meaning
 
-Return only the extracted action, no scheduling instructions, no explanation.
+Delivery framing is NOT scheduling — it's the action itself. The agent needs to know it's supposed to send a reminder, deliver a notification, etc. Stripping "remind me to" turns a reminder into a confused statement of fact.
+
+Examples — what to keep, what to drop:
+
+| Original                                              | Correct rewrite                          | Wrong (strips framing)        |
+|-------------------------------------------------------|------------------------------------------|-------------------------------|
+| remind me to drink water every 3 minutes              | remind me to drink water                 | drink water                   |
+| notify me when the build finishes every morning       | notify me when the build finishes        | the build finishes            |
+| send me the sales summary every Friday at 5pm         | send me the sales summary                | sales summary                 |
+| tell me a dad joke every minute                       | tell me a dad joke                       | dad joke                      |
+| check my email every hour                             | check my email                           | email                         |
+| generate the monthly report on the first of each month| generate the monthly report              | monthly report                |
+| alert me if disk usage exceeds 90% every 5 minutes    | alert me if disk usage exceeds 90%       | disk usage exceeds 90%        |
+
+If the original prompt is already self-contained without scheduling words (e.g., "send the daily standup summary"), return it unchanged.
+
+DO NOT add words that were not in the original ("update", "reminder", "notification") unless they appeared in the user's framing already.
+
+Return ONLY the rewritten action. No quotes, no explanation, no scheduling instructions.

--- a/src/muxi/runtime/services/scheduler/service.py
+++ b/src/muxi/runtime/services/scheduler/service.py
@@ -730,7 +730,11 @@ class SchedulerService:
             job: Job data dict
         """
         job_id = job["id"]
-        session_id = f"job_{job_id}"
+        # Job IDs are already prefixed with ``job_`` by the manager,
+        # so the session_id is just the job_id verbatim. (Previously
+        # this was ``f"job_{job_id}"`` which produced double-prefixed
+        # ``job_job_<id>`` strings in observability events.)
+        session_id = job_id
         self._active_executions.add(session_id)  # Track by session_id, not job_id
 
         try:
@@ -991,7 +995,8 @@ class SchedulerService:
         Called by webhook handler to complete a job execution.
 
         Args:
-            session_id: Session ID (format: "job_{job_id}")
+            session_id: Session ID — this is the job_id verbatim
+                (already prefixed with ``job_`` by the job manager).
             success: Whether the execution was successful
             result: Result text if successful
             error: Error message if failed
@@ -1002,11 +1007,13 @@ class SchedulerService:
         if session_id not in self._active_executions:
             return False
 
-        # Extract job_id from session_id (format: "job_{job_id}")
+        # Sanity check the namespace; non-job sessions are not ours.
         if not session_id.startswith("job_"):
             return False
 
-        job_id = session_id[4:]  # Remove "job_" prefix
+        # session_id IS the job_id (no slicing required since the
+        # scheduler stopped double-prefixing in _execute_single_job).
+        job_id = session_id
         self._active_executions.discard(session_id)
 
         # Get job details for logging

--- a/tests/unit/test_bugfix_verification.py
+++ b/tests/unit/test_bugfix_verification.py
@@ -13,6 +13,51 @@ from unittest.mock import MagicMock
 SRC_ROOT = Path(__file__).parent.parent.parent / "src"
 
 
+def _strip_comments_and_docstrings(source: str) -> str:
+    """Drop docstring blocks and comment-only / trailing-comment text so
+    regression *documentation* mentioning an old form does not trip
+    code-shape assertions.
+
+    Tracks multi-line docstring state via a triple-quote toggle: any
+    line whose stripped form starts with ``\"\"\"`` or ``'''`` flips
+    the toggle, and interior lines of an open docstring are dropped
+    entirely. This catches the case where a multi-line docstring
+    mentions the historical typo for context — a ``startswith('\"\"\"')``
+    check alone would miss the interior lines and treat them as live
+    code.
+
+    Module-level so every test class can share the same toggle logic
+    rather than each re-implementing it (the ad-hoc reimplementations
+    have historically been fragile)."""
+    out: list[str] = []
+    in_doc = False
+    for line in source.splitlines():
+        stripped = line.strip()
+        # Toggle on a triple-quote at the start of the stripped line.
+        # ``""" ... """`` on a single line flips and re-flips, ending
+        # in the same state — handled implicitly because we ``continue``
+        # without appending.
+        if stripped.startswith('"""') or stripped.startswith("'''"):
+            # A line that opens AND closes on the same line (``""" foo """``)
+            # is a one-line docstring; the toggle still ends balanced
+            # because we don't increment, we flip — flip-flip = no-op.
+            triple = '"""' if stripped.startswith('"""') else "'''"
+            opens_and_closes = (
+                len(stripped) >= 6 and stripped.endswith(triple) and stripped.count(triple) >= 2
+            )
+            if not opens_and_closes:
+                in_doc = not in_doc
+            continue
+        if in_doc:
+            continue
+        if stripped.startswith("#"):
+            continue
+        if "#" in line:
+            line = line.split("#", 1)[0]
+        out.append(line)
+    return "\n".join(out)
+
+
 class TestSchedulerRoutesFix:
     """Verify scheduler routes no longer reference formation._scheduler."""
 
@@ -185,15 +230,19 @@ class TestSchedulerOverlordCompletionAttribute:
 
     def test_no_underscore_scheduler_attribute_lookup(self):
         """Overlord must not reference ``self._scheduler`` — the
-        attribute is ``self.scheduler_service``."""
+        attribute is ``self.scheduler_service``. Historical mentions
+        inside docstrings or comments are allowed (the typo is
+        documented in regression notes), so we strip those before the
+        check via the module-level helper."""
         source = self._get_overlord_source()
-        # Attribute access (with optional whitespace), not comments.
-        # We allow it inside docstrings/comments (the historical typo
-        # is documented), so we look for live code references.
-        for line in source.splitlines():
-            stripped = line.strip()
-            if stripped.startswith("#") or stripped.startswith('"""'):
-                continue
+        # The previous inline strip only matched lines whose stripped
+        # form *starts* with ``\"\"\"``, which fails the moment a
+        # multi-line docstring contains the historical attribute on
+        # an interior line. ``_strip_comments_and_docstrings`` tracks
+        # docstring state via a triple-quote toggle and drops interior
+        # lines correctly.
+        live_code = _strip_comments_and_docstrings(source)
+        for line in live_code.splitlines():
             assert "self._scheduler" not in line, (
                 "Live code references ``self._scheduler`` (missing). "
                 "Use ``self.scheduler_service`` instead. Line: " + line.strip()
@@ -225,27 +274,9 @@ class TestSchedulerSessionIdNotDoubled:
 
     @staticmethod
     def _strip_comments_and_docstrings(method_body: str) -> str:
-        """Drop docstring blocks and comment-only / trailing-comment
-        text so regression *documentation* mentioning the old form
-        does not trip code-shape assertions."""
-        out: list[str] = []
-        in_doc = False
-        for line in method_body.splitlines():
-            stripped = line.strip()
-            # Toggle docstring state on triple-quote markers (handles
-            # the simple case of ``"""`` on its own line, which is
-            # what this codebase uses).
-            if stripped.startswith('"""') or stripped.startswith("'''"):
-                in_doc = not in_doc
-                continue
-            if in_doc:
-                continue
-            if stripped.startswith("#"):
-                continue
-            if "#" in line:
-                line = line.split("#", 1)[0]
-            out.append(line)
-        return "\n".join(out)
+        """Delegate to the module-level helper so all test classes
+        share a single toggle-based stripping implementation."""
+        return _strip_comments_and_docstrings(method_body)
 
     def test_no_double_prefix_in_execute_single_job(self):
         """``_execute_single_job`` must not construct

--- a/tests/unit/test_bugfix_verification.py
+++ b/tests/unit/test_bugfix_verification.py
@@ -166,3 +166,149 @@ class TestMemobaseInitializationFix:
         param_names = list(sig.parameters.keys())
         assert "connection_string" not in param_names
         assert "long_term_memory" in param_names
+
+
+class TestSchedulerOverlordCompletionAttribute:
+    """Verify the overlord references the scheduler via the correct
+    attribute name (``scheduler_service``) when completing scheduled
+    jobs from the async webhook path. Regression for the typo where
+    ``self._scheduler`` (which never existed) was used in
+    ``_execute_async_request``, causing every scheduled job's
+    completion handler to be silently skipped — ``mark_job_execution_success``
+    never ran, ``total_runs`` stayed 0, and ``last_run_at`` stayed NULL
+    even after confirmed successful executions."""
+
+    def _get_overlord_source(self):
+        path = SRC_ROOT / "muxi/runtime/formation/overlord/overlord.py"
+        return path.read_text()
+
+    def test_no_underscore_scheduler_attribute_lookup(self):
+        """Overlord must not reference ``self._scheduler`` — the
+        attribute is ``self.scheduler_service``."""
+        source = self._get_overlord_source()
+        # Attribute access (with optional whitespace), not comments.
+        # We allow it inside docstrings/comments (the historical typo
+        # is documented), so we look for live code references.
+        for line in source.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#") or stripped.startswith('"""'):
+                continue
+            assert "self._scheduler" not in line, (
+                "Live code references ``self._scheduler`` (missing). "
+                "Use ``self.scheduler_service`` instead. Line: " + line.strip()
+            )
+
+    def test_async_request_completion_uses_scheduler_service(self):
+        """``_execute_async_request`` must call
+        ``scheduler_service.complete_job_from_webhook`` on both the
+        success and failure branches."""
+        source = self._get_overlord_source()
+        method_start = source.index("async def _execute_async_request")
+        # Slice generously — there are two completion call sites.
+        method_body = source[method_start : method_start + 30000]
+        assert method_body.count("self.scheduler_service.complete_job_from_webhook") >= 2, (
+            "Expected at least two ``scheduler_service.complete_job_from_webhook`` "
+            "calls in _execute_async_request (success + failure branches)."
+        )
+
+
+class TestSchedulerSessionIdNotDoubled:
+    """Verify the scheduler does not double-prefix ``job_`` when
+    constructing ``session_id`` for job execution. Regression for the
+    cosmetic bug where ``session_id = f\"job_{job_id}\"`` produced
+    ``job_job_<id>`` because job IDs already begin with ``job_``."""
+
+    def _get_service_source(self):
+        path = SRC_ROOT / "muxi/runtime/services/scheduler/service.py"
+        return path.read_text()
+
+    @staticmethod
+    def _strip_comments_and_docstrings(method_body: str) -> str:
+        """Drop docstring blocks and comment-only / trailing-comment
+        text so regression *documentation* mentioning the old form
+        does not trip code-shape assertions."""
+        out: list[str] = []
+        in_doc = False
+        for line in method_body.splitlines():
+            stripped = line.strip()
+            # Toggle docstring state on triple-quote markers (handles
+            # the simple case of ``"""`` on its own line, which is
+            # what this codebase uses).
+            if stripped.startswith('"""') or stripped.startswith("'''"):
+                in_doc = not in_doc
+                continue
+            if in_doc:
+                continue
+            if stripped.startswith("#"):
+                continue
+            if "#" in line:
+                line = line.split("#", 1)[0]
+            out.append(line)
+        return "\n".join(out)
+
+    def test_no_double_prefix_in_execute_single_job(self):
+        """``_execute_single_job`` must not construct
+        ``f\"job_{job_id}\"`` — that produces ``job_job_<id>``."""
+        source = self._get_service_source()
+        method_start = source.index("async def _execute_single_job")
+        method_end = source.index("async def complete_job_from_webhook")
+        live_code = self._strip_comments_and_docstrings(source[method_start:method_end])
+        assert 'f"job_{job_id}"' not in live_code, (
+            "Found live-code double-prefix construction ``f'job_{job_id}'`` — "
+            "use ``session_id = job_id`` instead since job IDs are "
+            "already prefixed."
+        )
+        assert "session_id = job_id" in live_code
+
+    def test_complete_job_from_webhook_does_not_strip_prefix(self):
+        """``complete_job_from_webhook`` must not slice the session_id
+        with ``[4:]`` — that strip was only correct for the doubled
+        prefix and would now strip the legitimate ``job_`` prefix."""
+        source = self._get_service_source()
+        method_start = source.index("async def complete_job_from_webhook")
+        method_end = source.index("async def", method_start + 1)
+        method_body = source[method_start:method_end]
+        assert "session_id[4:]" not in method_body, (
+            "Found ``session_id[4:]`` strip — session_id IS the job_id "
+            "now that the doubled prefix is gone, so just use it directly."
+        )
+
+
+class TestSchedulerPromptRewriterPreservesFraming:
+    """Verify the scheduler prompt rewriter prompt explicitly preserves
+    delivery framing words (``remind me``, ``notify me``, ``send me``,
+    etc). Regression for the bug where ``"remind me to drink water
+    every 3 minutes"`` was rewritten to bare ``"drink water"`` —
+    stripping the entire reminder semantics — and the agent
+    interpreted it as a confirmation rather than a delivery
+    instruction."""
+
+    def _get_rewriter_prompt(self):
+        path = SRC_ROOT / "muxi/runtime/formation/prompts/scheduler_prompt_rewriter.md"
+        return path.read_text()
+
+    def test_prompt_preserves_remind_me_framing(self):
+        """The prompt must explicitly call out preserving ``remind
+        me`` (and similar delivery framing)."""
+        prompt = self._get_rewriter_prompt()
+        assert "remind me" in prompt.lower()
+        assert "notify me" in prompt.lower() or "notify" in prompt.lower()
+
+    def test_prompt_has_drink_water_guard_example(self):
+        """The exact failure mode (``remind me to drink water`` →
+        bare ``drink water``) must appear as a guard example so future
+        prompt edits don't silently regress this."""
+        prompt = self._get_rewriter_prompt()
+        assert "drink water" in prompt.lower()
+
+    def test_prompt_warns_against_stripping_framing(self):
+        """The prompt must warn against stripping the framing."""
+        prompt = self._get_rewriter_prompt().lower()
+        # Either an explicit "do not strip" instruction or a
+        # "wrong: strips framing" example column.
+        signals = ("delivery framing", "strips framing", "do not strip")
+        assert any(s in prompt for s in signals), (
+            "Prompt must explicitly warn against stripping delivery "
+            "framing — otherwise the LLM treats ``remind me`` as "
+            "schedule words and drops them."
+        )

--- a/tests/unit/test_bugfix_verification.py
+++ b/tests/unit/test_bugfix_verification.py
@@ -6,7 +6,6 @@ Verification tests for bugfixes:
 """
 
 import inspect
-import re
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -253,9 +252,16 @@ class TestSchedulerOverlordCompletionAttribute:
         ``scheduler_service.complete_job_from_webhook`` on both the
         success and failure branches."""
         source = self._get_overlord_source()
+        # Bound the slice to the actual method instead of an arbitrary
+        # 30 KB window: if ``_execute_async_request`` ever grew past
+        # the magic number, the failure-branch call at the tail would
+        # silently drop out of the count and turn a regression into a
+        # silent pass. ``_execute_async_request`` has no inner ``async
+        # def`` closures, so the generic boundary lookup lands on the
+        # next outer method.
         method_start = source.index("async def _execute_async_request")
-        # Slice generously — there are two completion call sites.
-        method_body = source[method_start : method_start + 30000]
+        method_end = source.index("async def ", method_start + 1)
+        method_body = source[method_start:method_end]
         assert method_body.count("self.scheduler_service.complete_job_from_webhook") >= 2, (
             "Expected at least two ``scheduler_service.complete_job_from_webhook`` "
             "calls in _execute_async_request (success + failure branches)."
@@ -466,30 +472,44 @@ class TestScheduledExecutionMarker:
     def test_marker_not_applied_inside_buffer_turns(self):
         """Buffer turns (history) come from buffer memory which stores
         original user text, so they must NOT be re-marked. Lock the
-        comment that documents this so the policy is visible."""
+        invariant *behaviorally* — the previous comment-text check
+        could pass while the call-site enforcement was removed."""
         source = self._get_orchestrator_source()
         # Same boundary discipline as ``test_clean_chat_context_uses_helper``.
         method_start = source.index("async def _build_clean_chat_context")
         method_end = source.index("async def _extract_user_information_async")
         method_body = source[method_start:method_end]
 
-        # Normalize comment-marker noise + whitespace so phrases that
-        # straddle line breaks become continuous substrings. Required
-        # because Python's source layout splits e.g. ``is left\n
-        # # untouched`` across two lines, and a literal substring
-        # check on the raw body would never see ``"left untouched"`` —
-        # which is exactly the precedence/empty-substring bug this
-        # rewrite replaces.
-        flat = re.sub(r"\s*#\s*", " ", method_body)
-        flat = re.sub(r"\s+", " ", flat)
+        # Strip docstrings and comments first. Without this step the
+        # method's docstring (which legitimately mentions both
+        # ``_apply_scheduled_marker`` and ``"buffer_turns"``) would
+        # fool the behavioral slice — ``index('"buffer_turns"')``
+        # would land at the docstring's schema example rather than at
+        # the return-dict construction site.
+        live_code = _strip_comments_and_docstrings(method_body)
 
-        # Each clause is asserted independently — no boolean glue, so
-        # operator precedence cannot make any single check vacuous.
-        # All three phrases must appear in the documenting comment for
-        # the invariant to be considered locked in.
-        for phrase in ("buffer_turns", "left untouched", "without the marker"):
-            assert phrase in flat, (
-                "The buffer-turns-not-marked invariant must be documented "
-                "in the rendering function so a future edit can't quietly "
-                f"start double-marking history. Missing phrase: {phrase!r}."
-            )
+        # The first ``"buffer_turns"`` literal in *live code* is the
+        # return-dict key. Everything before that point is the
+        # buffer_turns build path: the inner ``_fetch_buffer_role_turns``
+        # closure plus the ``asyncio.gather(..., _fetch_buffer_role_turns())``
+        # call that produces the value. The marker helper must not be
+        # called anywhere on that path — it is only legitimately
+        # applied to ``current_user_message`` on the line after.
+        buffer_slice_end = live_code.index('"buffer_turns"')
+        assert "_apply_scheduled_marker" not in live_code[:buffer_slice_end], (
+            "_apply_scheduled_marker must not be called on the "
+            "buffer_turns build path. Buffer memory stores the "
+            "original user text, so prior scheduled invocations must "
+            "appear in history without the marker — re-marking would "
+            "double-stamp messages on every replay."
+        )
+
+        # Sanity: the marker IS expected to be applied to
+        # ``current_user_message`` in the return dict (i.e., somewhere
+        # *after* the slice end). This catches the symmetric mistake
+        # where a refactor strips the call entirely.
+        assert "_apply_scheduled_marker" in live_code[buffer_slice_end:], (
+            "_apply_scheduled_marker must still be called on "
+            "current_user_message in the return dict — see "
+            "test_clean_chat_context_uses_helper for the positive guard."
+        )

--- a/tests/unit/test_bugfix_verification.py
+++ b/tests/unit/test_bugfix_verification.py
@@ -391,8 +391,18 @@ class TestScheduledExecutionMarker:
         ``current_user_message`` before returning the bundle the agent
         consumes."""
         source = self._get_orchestrator_source()
+        # Bound the slice to the next outer method so the assertion is
+        # scoped to ``_build_clean_chat_context`` only — without this,
+        # any later method that happens to call the helper would
+        # satisfy the substring check and the policy guard could
+        # silently rotate away under a refactor. Named-boundary
+        # (matching ``test_enhance_message_uses_helper``) is preferred
+        # over the generic ``async def `` lookup, which would land on
+        # an inner closure (``_fetch_user_synopsis``) rather than the
+        # next outer method and exclude the actual call site.
         method_start = source.index("async def _build_clean_chat_context")
-        method_body = source[method_start:]
+        method_end = source.index("async def _extract_user_information_async")
+        method_body = source[method_start:method_end]
         assert (
             "_apply_scheduled_marker" in method_body
         ), "_build_clean_chat_context must call _apply_scheduled_marker."
@@ -402,8 +412,10 @@ class TestScheduledExecutionMarker:
         original user text, so they must NOT be re-marked. Lock the
         comment that documents this so the policy is visible."""
         source = self._get_orchestrator_source()
+        # Same boundary discipline as ``test_clean_chat_context_uses_helper``.
         method_start = source.index("async def _build_clean_chat_context")
-        method_body = source[method_start:]
+        method_end = source.index("async def _extract_user_information_async")
+        method_body = source[method_start:method_end]
 
         # Normalize comment-marker noise + whitespace so phrases that
         # straddle line breaks become continuous substrings. Required

--- a/tests/unit/test_bugfix_verification.py
+++ b/tests/unit/test_bugfix_verification.py
@@ -367,6 +367,31 @@ class TestScheduledExecutionMarker:
                 == "remind me to drink water"
             ), f"Marker leaked into non-scheduler session: {session_id!r}"
 
+    def test_marker_application_is_idempotent(self):
+        """If a message already carries the marker (e.g. a user
+        copy-pasted a prior scheduled-firing transcript into a new
+        scheduled job, or both render paths chain through the same
+        string), the helper must not double-stamp it."""
+        from muxi.runtime.formation.overlord.chat_orchestrator import (
+            SCHEDULED_EXECUTION_MARKER,
+            _apply_scheduled_marker,
+        )
+
+        already_marked = f"{SCHEDULED_EXECUTION_MARKER}remind me to drink water"
+
+        # Single application on a marked message: unchanged.
+        assert _apply_scheduled_marker(already_marked, "job_abc123") == already_marked
+
+        # Two applications in series: still single-marked (chained-call
+        # safety).
+        once = _apply_scheduled_marker("remind me to drink water", "job_abc123")
+        twice = _apply_scheduled_marker(once, "job_abc123")
+        assert once == twice == already_marked
+
+        # Idempotence does not unmark non-scheduler sessions: a marked
+        # message in a normal session is left alone (no implicit strip).
+        assert _apply_scheduled_marker(already_marked, "normal-session") == already_marked
+
     def test_enhance_message_uses_helper(self):
         """``_enhance_message_with_context`` must apply the marker via
         the centralized helper at the ``=== CURRENT REQUEST ===``

--- a/tests/unit/test_bugfix_verification.py
+++ b/tests/unit/test_bugfix_verification.py
@@ -312,3 +312,105 @@ class TestSchedulerPromptRewriterPreservesFraming:
             "framing — otherwise the LLM treats ``remind me`` as "
             "schedule words and drops them."
         )
+
+
+class TestScheduledExecutionMarker:
+    """Verify the scheduler injects a ``[SCHEDULED]`` marker into the
+    agent's view of the message (only) when ``session_id`` is in the
+    scheduler namespace. Without this marker, an LLM receiving
+    ``remind me to drink water`` cold reads it as a chat request to
+    *configure* a reminder, then politely declines (\"I can't set
+    reminders, use your phone\") — the rewriter fix alone wasn't
+    enough to disambiguate intent for all model classes.
+
+    Memory and observability stay clean: only the agent's view at
+    inference time gets the marker. The original message is preserved
+    via PR #165's ``EnhancedMessage(original, enhanced)`` threading."""
+
+    def _get_orchestrator_source(self):
+        path = SRC_ROOT / "muxi/runtime/formation/overlord/chat_orchestrator.py"
+        return path.read_text()
+
+    def test_marker_helper_exists(self):
+        """A single-source-of-truth helper must exist so both
+        rendering paths apply identical rules."""
+        from muxi.runtime.formation.overlord.chat_orchestrator import (
+            SCHEDULED_EXECUTION_MARKER,
+            _apply_scheduled_marker,
+        )
+
+        assert SCHEDULED_EXECUTION_MARKER == "[SCHEDULED] "
+        assert callable(_apply_scheduled_marker)
+
+    def test_marker_applied_for_job_session(self):
+        """Session IDs starting with ``job_`` get the marker."""
+        from muxi.runtime.formation.overlord.chat_orchestrator import (
+            _apply_scheduled_marker,
+        )
+
+        assert (
+            _apply_scheduled_marker("remind me to drink water", "job_abc123")
+            == "[SCHEDULED] remind me to drink water"
+        )
+
+    def test_marker_not_applied_for_normal_session(self):
+        """Non-scheduler sessions stay unchanged — must not regress
+        normal chat."""
+        from muxi.runtime.formation.overlord.chat_orchestrator import (
+            _apply_scheduled_marker,
+        )
+
+        for session_id in (None, "", "user-typed-bracket", "session_123", "abc"):
+            assert (
+                _apply_scheduled_marker("remind me to drink water", session_id)
+                == "remind me to drink water"
+            ), f"Marker leaked into non-scheduler session: {session_id!r}"
+
+    def test_enhance_message_uses_helper(self):
+        """``_enhance_message_with_context`` must apply the marker via
+        the centralized helper at the ``=== CURRENT REQUEST ===``
+        rendering site (not by re-implementing the rule inline)."""
+        source = self._get_orchestrator_source()
+        method_start = source.index("async def _enhance_message_with_context")
+        method_end = source.index("async def _build_clean_chat_context")
+        method_body = source[method_start:method_end]
+        assert (
+            "_apply_scheduled_marker" in method_body
+        ), "_enhance_message_with_context must call _apply_scheduled_marker."
+        # The marker should be applied to the rendered ``User: ...``
+        # line, not to the raw ``message`` (which feeds the
+        # EnhancedMessage.original field — must stay clean).
+        assert (
+            "EnhancedMessage(original=message, enhanced=enhanced_message)" in method_body
+            or "original=message" in method_body
+        ), "EnhancedMessage.original must remain the unprefixed input."
+
+    def test_clean_chat_context_uses_helper(self):
+        """``_build_clean_chat_context`` must apply the marker to
+        ``current_user_message`` before returning the bundle the agent
+        consumes."""
+        source = self._get_orchestrator_source()
+        method_start = source.index("async def _build_clean_chat_context")
+        method_body = source[method_start:]
+        assert (
+            "_apply_scheduled_marker" in method_body
+        ), "_build_clean_chat_context must call _apply_scheduled_marker."
+
+    def test_marker_not_applied_inside_buffer_turns(self):
+        """Buffer turns (history) come from buffer memory which stores
+        original user text, so they must NOT be re-marked. Lock the
+        comment that documents this so the policy is visible."""
+        source = self._get_orchestrator_source()
+        method_start = source.index("async def _build_clean_chat_context")
+        method_body = source[method_start:]
+        # The documented invariant lives in the ``return`` block comment.
+        assert "buffer_turns" in method_body
+        assert (
+            "buffer_turns" in method_body
+            and "left untouched" in method_body
+            or "without the marker" in method_body
+        ), (
+            "The buffer-turns-not-marked invariant must be documented in "
+            "the rendering function so a future edit can't quietly start "
+            "double-marking history."
+        )

--- a/tests/unit/test_bugfix_verification.py
+++ b/tests/unit/test_bugfix_verification.py
@@ -6,6 +6,7 @@ Verification tests for bugfixes:
 """
 
 import inspect
+import re
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -403,14 +404,24 @@ class TestScheduledExecutionMarker:
         source = self._get_orchestrator_source()
         method_start = source.index("async def _build_clean_chat_context")
         method_body = source[method_start:]
-        # The documented invariant lives in the ``return`` block comment.
-        assert "buffer_turns" in method_body
-        assert (
-            "buffer_turns" in method_body
-            and "left untouched" in method_body
-            or "without the marker" in method_body
-        ), (
-            "The buffer-turns-not-marked invariant must be documented in "
-            "the rendering function so a future edit can't quietly start "
-            "double-marking history."
-        )
+
+        # Normalize comment-marker noise + whitespace so phrases that
+        # straddle line breaks become continuous substrings. Required
+        # because Python's source layout splits e.g. ``is left\n
+        # # untouched`` across two lines, and a literal substring
+        # check on the raw body would never see ``"left untouched"`` —
+        # which is exactly the precedence/empty-substring bug this
+        # rewrite replaces.
+        flat = re.sub(r"\s*#\s*", " ", method_body)
+        flat = re.sub(r"\s+", " ", flat)
+
+        # Each clause is asserted independently — no boolean glue, so
+        # operator precedence cannot make any single check vacuous.
+        # All three phrases must appear in the documenting comment for
+        # the invariant to be considered locked in.
+        for phrase in ("buffer_turns", "left untouched", "without the marker"):
+            assert phrase in flat, (
+                "The buffer-turns-not-marked invariant must be documented "
+                "in the rendering function so a future edit can't quietly "
+                f"start double-marking history. Missing phrase: {phrase!r}."
+            )


### PR DESCRIPTION
## Three independent scheduler bugs

Surfaced by user testing on a recurring `*/3 * * * *` reminder job. After two confirmed successful runs the `scheduled_jobs` row showed `last_run_at NULL`, `total_runs 0`, `last_run_status` empty — yet the user's external webhook receiver *had* recorded the result text in their `job_results` table. From the outside the scheduler looked broken; from the inside it looked like the job had never run.

### 1. Job stats never persisted (the root cause) — `15802a05`

`Overlord._execute_async_request` referenced `self._scheduler` (with a leading underscore) at four sites — but the scheduler is stored as `self.scheduler_service`. `hasattr(self, "_scheduler")` returned False on every scheduled run, so the entire completion-handler block was silently skipped:

```python
if (
    hasattr(self, "_scheduler")   # ← always False
    and self._scheduler           # ← never evaluated
    and session_id
    and session_id.startswith("job_")
):
    handled = await self._scheduler.complete_job_from_webhook(...)
```

Effect on every successful scheduled run:

* `mark_job_execution_success` never called → `total_runs` stayed 0
* `scheduled.job.completed` event never emitted
* `last_run_at` / `last_run_status` never updated
* External webhook *was* delivered (control fell through to the standard delivery branch once the inner `if` was skipped) — which is why the user's external receiver had the result and made it look like the job had worked

The four references were renamed to `self.scheduler_service` (`getattr(self, "scheduler_service", None)` to keep the original defensive shape during early init). The accompanying silent `except Exception: pass` blocks — which were how this typo hid for months — were replaced with logged `ERROR.INTERNAL_ERROR` warnings, so any future breakage on this path surfaces in observability instead of vanishing.

### 2. Doubled `job_` prefix in `session_id` (cosmetic) — `26f2829b`

`_execute_single_job` constructed `session_id = f"job_{job_id}"` — but job IDs are already prefixed by the manager, producing `job_job_<id>` in every observability event:

```json
{
  "event": "scheduled.job.started",
  "data": {
    "job_id":     "job_JmYB5QuDisCdBpLU",
    "session_id": "job_job_JmYB5QuDisCdBpLU"
  }
}
```

`complete_job_from_webhook` papered over the doubling with `job_id = session_id[4:]` (strips the first `job_` and recovers the real job_id), so the lookup *worked* and the dev-reported hypothesis that this caused the missing stat updates was incorrect — both ends used the same doubled string. But the relationship between session_id and job_id was no longer obvious to anyone reading code or logs. Now: `session_id = job_id` directly, and the strip in `complete_job_from_webhook` becomes `job_id = session_id` (the `startswith("job_")` namespace guard stays).

### 3. Prompt rewriter strips delivery framing (behavioral) — `b7ef05cd`

The scheduler's prompt rewriter over-compresses scheduled prompts. A user scheduling

> `remind me to drink water every 3 minutes`

ended up with an execution prompt of bare `drink water`. The agent, receiving that as a fresh user message with no scheduling context, interpreted it as a confirmation and replied:

> "Got it. Drinking water now? Want me to set up a daily reminder?"

— a recursive offer to schedule the exact reminder it was already executing. Reminders, notifications, and "send me a summary of" scheduled tasks were silently non-functional whenever their intent lived in the framing.

Root cause: the rewriter prompt told the model to "Strip away ALL scheduling patterns" but never explicitly told it to *preserve* delivery framing (`remind me`, `notify me`, `send me`, `tell me`, `show me`, `alert me`). A 12B model interprets "all scheduling patterns" generously and treats `remind me to` as metadata.

The rewriter prompt was rewritten to:

* Frame the rewrite for the agent's perspective: "the agent will receive your output as a fresh user message — with NO knowledge that it was scheduled" — drives home why framing matters
* Explicitly call out delivery-framing words as part of the action, NOT scheduling
* Provide a side-by-side correct/wrong table including the exact failure case (`remind me to drink water` → keep, NOT strip)
* Spell out the recipient pronoun (`remind ME`, `tell US`)

## Test changes — `a2b066d8`

Three new test classes added to `tests/unit/test_bugfix_verification.py` (mirroring the existing source-shape testing pattern in that file):

* **`TestSchedulerOverlordCompletionAttribute`** — asserts no live code references `self._scheduler` (with comment / docstring stripping so historical regression notes don't trip the test); asserts `_execute_async_request` calls `scheduler_service.complete_job_from_webhook` on both the success and failure branches.
* **`TestSchedulerSessionIdNotDoubled`** — asserts `_execute_single_job` uses `session_id = job_id` directly; asserts `complete_job_from_webhook` does not slice with `session_id[4:]` (the strip was only correct for the doubled prefix and would now strip the legitimate `job_` prefix).
* **`TestSchedulerPromptRewriterPreservesFraming`** — asserts the rewriter prompt mentions `remind me`, carries `drink water` as a guard example, and explicitly warns against stripping framing.

22/22 tests in `test_bugfix_verification` pass. Full unit suite: 999 passed, 1 skipped (the one pre-existing RCE auth failure unchanged on develop).

## Diagnostic correction for the original report

The dev's `findings.md` flagged Bugs 1 and 2 as related — hypothesizing the doubled `job_` prefix as the cause of the missing `mark_job_execution_success` calls. They were not related. Both ends of that path used the same doubled string and the `session_id[4:]` strip recovered the real job_id correctly. The actual cause was the `self._scheduler` typo on the overlord side, one frame earlier. The doubled prefix is real but cosmetic; both fixes ship in this PR but for different reasons.

## Quality gates

* `ruff check` — clean
* `black --line-length 100 --target-version py311` — clean
* `scripts/validate_events.py` — 1218/1218 events enum-backed
* `pytest tests/unit/` — 999 passed, 1 skipped (one pre-existing RCE auth failure on develop, unchanged)

## Out of scope

Findings 4-7 from the dev report are not addressed here:

* **#4 / #6** — agent passes a folder `driveItemId` to Excel tools; misleading WAC 403. Agent-routing / MCP fix.
* **#5** — embedding model (`local/all-MiniLM-L6-v2` / `nomic-embed-text-v1.5`) not available in the SIF runtime; falls back to recency retrieval. Docker / SIF packaging fix.
* **#7** — local Ollama models (gemma3:12b, mistral:latest) can't reliably plan against 118-tool MS365 catalog. Capability triage; documentation rather than code fix.

Happy to tackle any of those next on a separate branch.

## Commits

| Commit | |
|---|---|
| `15802a05` | fix(scheduler): restore job stat persistence — typo silently skipped completion |
| `26f2829b` | refactor(scheduler): collapse doubled job_ prefix in session_id |
| `b7ef05cd` | fix(scheduler): preserve delivery framing in prompt rewriter |
| `a2b066d8` | test(scheduler): regression tests for the three scheduler bugs |
| `f0686141` | docs(changelog): unreleased entry for the three scheduler bug fixes |
