### PR TITLE
feat(mcp): translate misleading upstream errors into agent-actionable hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,125 @@
 
 ## [unreleased]
 
+### MCP: translate misleading upstream errors into agent-actionable hints
+
+Findings 4 and 6 from the 2026-04-29 MS365 testing run both surfaced
+the same defect from the agent's perspective: an Excel tool call
+(``list-excel-worksheets`` and ``excel-write-range`` respectively)
+received a ``driveItemId`` / ``file_id`` that pointed to a folder
+rather than a workbook. Microsoft Graph returned 403 with the
+message ``"Could not obtain a WAC access token."`` — a WAC-token
+error that, read at face value, looks like an auth failure. The
+agent surfaced it to the user as a permissions problem rather than
+re-resolving the file ID.
+
+The runtime's parameter-funnel work in 0.20260410.0 already covers
+the *common* failure modes for this flow: ``parameters`` defaults
+on MCP server declarations remove the LLM's need to infer org-level
+constants like ``driveId``, and
+``_validate_inferred_parameters_against_results()`` rejects
+LLM-fabricated IDs not found in any prior successful result.
+
+But the WAC case sits in a fourth class the funnel doesn't catch:
+the agent picks a *real* ID from a *real* prior tool result — it's
+just the **wrong type** for the next tool's contract. The Attachments
+folder ID does appear in ``list-folder-files`` output, so it isn't
+fabricated; the required param isn't missing; clean-context binding
+is irrelevant. The runtime can't disambiguate folder-vs-file inside
+a generic list response without per-MCP semantics — that line stays
+on the model side. But the runtime *can* spot the misleading error
+pattern after the fact and tell the agent what likely happened, so
+the next turn carries an actionable correction instead of a
+confusing auth-flavored error.
+
+**Implementation.** New module ``services/mcp/tools/error_translator.py``
+with a small registry of ``_ErrorPattern`` declarations. Each pattern
+gates on three signals — content regex (case-insensitive search of
+the upstream error text), required arg keys (at least one of these
+must be in the tool call's arguments — prevents matching unrelated
+tools), and an optional server_id regex (for server-specific
+patterns; default ``None`` means server-agnostic). First-match-wins
+on overlap. The single shipped pattern catches the WAC-token case
+gated on ``driveItemId`` or ``file_id`` being present:
+
+```
+category:           excel_wac_token_folder_id
+content_regex:      r"could not obtain a wac access token" (IGNORECASE)
+required_arg_keys:  ("driveItemId", "file_id")
+hint:               "Likely cause: the supplied driveItemId/file_id
+                     refers to a folder rather than a workbook (.xlsx)
+                     file. […] Re-resolve the workbook ID via
+                     list-folder-files (or the equivalent listing tool)
+                     and select the item whose name ends in '.xlsx' —
+                     not a folder such as 'Attachments'."
+```
+
+**Wiring.** ``services/mcp/service.py::_invoke_tool_with_resolved_credentials``
+calls ``translate_tool_error`` on the processed result whenever
+``isError`` is True (right after
+``ModernProtocolFeatures.process_structured_output``). On a match,
+two writes to the agent-bound payload:
+
+* Structured ``_runtime_hint = {"category": ..., "message": ...}``
+  field for observability and any future structured consumer.
+* Inline append to ``content``: ``"\n\n[Runtime hint] {hint}"`` so
+  the model literally reads the correction in the tool message on
+  the next turn (most reliable surface for self-correction).
+
+The translator never blocks the call. It only annotates an existing
+failure — at worst, the agent reads an extra sentence and ignores
+it. Original upstream error text is preserved verbatim.
+
+**Observability.** Reuses ``MCP_TOOL_CALL_COMPLETED`` (no new event
+type) with a new ``translation_category`` metadata field. ``None``
+when no pattern fired; the category string when one did. Lets us
+track in production which translations are actually firing without
+adding event type churn.
+
+**What this fix is NOT.** It does not validate parameters before
+sending — that's already done by the
+``_validate_inferred_parameters_against_results()`` machinery
+shipped in 0.20260410.0 for the fabricated-ID class, and the
+``parameters`` field on MCP server declarations for the org-level
+defaults class. It also does not attempt to disambiguate
+folder-vs-file at parameter inference time — that requires per-MCP
+semantic knowledge the runtime should not own.
+
+**What this fix DOES require.** Formations using ms365-mcp must
+declare ``parameters: { driveId: ..., siteId: ..., tenantId: ... }``
+on the server block to fully benefit from the parameter funnel —
+the WAC-translation hint covers the wrong-typed-ID case, but
+upstream failures from missing org-level constants are a config gap
+the formation must close.
+
+**Test coverage.** New ``tests/unit/test_mcp_error_translator.py``
+with 13 tests across four classes:
+
+* ``TestErrorTranslationContract`` — frozen-dataclass shape, stable
+  category id, non-empty hint string.
+* ``TestExcelWACPattern`` — positive matches with both arg-key
+  variants (``driveItemId`` and ``file_id``), case-insensitive
+  matching, server-agnostic firing across ``ms365-mcp``,
+  ``todo-helper-mcp``, and unknown servers.
+* ``TestNegativeGates`` — independent verification of each gate
+  (missing arg keys, non-matching content, empty inputs, non-dict
+  arguments).
+* ``TestServerIdGate`` — locks the ``server_id_regex`` semantics
+  via a probe pattern injected by ``monkeypatch`` (no shipped
+  pattern uses it yet, but the gate is part of the contract).
+* ``TestRegistryOrdering`` — first-match-wins on category overlap.
+
+Plus end-to-end injection sanity: a simulated Graph WAC response
+fed through ``ModernProtocolFeatures.process_structured_output`` →
+translator → result envelope produced an agent payload containing
+both the structured ``_runtime_hint`` field and the inline
+``[Runtime hint]`` suffix on ``content`` with the expected
+``folder`` and ``.xlsx`` markers.
+
+ruff/black clean, ``validate_events`` clean (no new event types),
+13/13 translator tests pass, full unit suite 1019 passed (the one
+pre-existing RCE auth failure unchanged on develop).
+
 ### Scheduler: restore job stat persistence + collapse doubled session_id + preserve delivery framing + disambiguate scheduled execution at agent boundary
 
 Three independent scheduler bugs surfaced by user testing on a recurring

--- a/src/muxi/runtime/services/mcp/service.py
+++ b/src/muxi/runtime/services/mcp/service.py
@@ -53,6 +53,7 @@ from .resources.discovery import MCPResourceDiscovery
 from .sampling.creator import MCPSamplingCreator
 from .templates.discovery import MCPTemplateDiscovery
 from .tool_filter import FilterReport, ToolFilterSpec, apply_filter
+from .tools.error_translator import translate_tool_error
 from .transports import CancellationToken, ModernProtocolFeatures, TransportDetector
 from .transports.base import MCPToolFilterEmptySetError
 
@@ -931,6 +932,32 @@ class MCPService:
                 # This handles structured output with isError field
                 processed_result = ModernProtocolFeatures.process_structured_output(result)
 
+                # Layer 2 of the MCP param funnel: when an upstream
+                # error message is misleading about its actual cause
+                # (e.g. Microsoft Graph's WAC-token error returned for
+                # a folder ID where a file ID was expected), append an
+                # agent-actionable hint to the result so the next-turn
+                # tool message gives the model a concrete correction
+                # path. The translator never blocks the call — it only
+                # annotates an existing failure.
+                translation = None
+                if processed_result.get("isError"):
+                    translation = translate_tool_error(
+                        tool_name=tool_name,
+                        arguments=parameters,
+                        error_text=str(processed_result.get("content", "")),
+                        server_id=server_id,
+                    )
+                    if translation is not None:
+                        processed_result["_runtime_hint"] = {
+                            "category": translation.category,
+                            "message": translation.hint,
+                        }
+                        processed_result["content"] = (
+                            f"{processed_result.get('content', '')}"
+                            f"\n\n[Runtime hint] {translation.hint}"
+                        )
+
                 # Enhanced observability with structured output info
                 observability.observe(
                     event_type=observability.ConversationEvents.MCP_TOOL_CALL_COMPLETED,
@@ -943,6 +970,9 @@ class MCPService:
                         "is_error": processed_result["isError"],
                         "success": not processed_result["isError"],
                         "protocol_version": "2025-06-18",
+                        "translation_category": (
+                            translation.category if translation is not None else None
+                        ),
                     },
                     description=(
                         f"MCP tool invocation completed with modern protocol: "

--- a/src/muxi/runtime/services/mcp/tools/error_translator.py
+++ b/src/muxi/runtime/services/mcp/tools/error_translator.py
@@ -112,8 +112,11 @@ def translate_tool_error(
 
     Args:
         tool_name: Name of the upstream MCP tool. Currently unused
-            for matching but reserved for future per-tool patterns
-            and emitted via observability when a translation fires.
+            for matching but reserved for future per-tool patterns.
+            The calling site in ``service.py`` also emits ``tool_name``
+            as part of the ``MCP_TOOL_CALL_COMPLETED`` event — that
+            emission is independent of whether a translation fires
+            and is not driven by this function.
         arguments: Arguments dict the agent passed to the tool. Used
             to gate patterns by required arg keys.
         error_text: Flattened content text from the upstream error
@@ -125,7 +128,7 @@ def translate_tool_error(
     Returns:
         First matching translation, or ``None``.
     """
-    if not error_text:
+    if not error_text or not error_text.strip():
         return None
 
     arg_keys = set(arguments.keys()) if isinstance(arguments, dict) else set()

--- a/src/muxi/runtime/services/mcp/tools/error_translator.py
+++ b/src/muxi/runtime/services/mcp/tools/error_translator.py
@@ -1,0 +1,142 @@
+"""MCP tool error translation — Layer 2 of the MCP param funnel.
+
+When an upstream MCP server returns an error whose surface text is
+misleading about the actual cause, this module annotates the result
+with an agent-actionable hint. The hint reaches the agent on the next
+turn via the tool message, giving the model a concrete correction
+path instead of forcing it to reason from a confusing upstream error.
+
+Concrete motivating case (Findings 4 and 6 from the 2026-04-29
+scheduler/MS365 testing run): when an Excel endpoint receives a
+driveItemId that points to a folder rather than a workbook, Microsoft
+Graph returns ``"Could not obtain a WAC access token"``. Read at face
+value, this looks like an auth failure — and the agent has been
+observed surfacing it to the user as a permissions problem rather
+than re-resolving the file ID. The runtime cannot disambiguate
+folder-vs-file inside a generic list response (that's per-server
+semantics), but it CAN spot the misleading error pattern after the
+fact and tell the agent what likely happened.
+
+Design notes:
+
+* Pattern registry is a frozen tuple of dataclass instances. New
+  patterns get appended to the registry; ordering matters
+  (first-match-wins) but the file is small enough that the order is
+  reviewable in one screen.
+* Each pattern gates on three signals: a content regex (what the
+  upstream said), a required-arg-key set (what the agent passed —
+  prevents matching text from unrelated tools), and an optional
+  server_id regex (when a pattern is server-specific).
+* The translator never blocks the call. It only annotates an existing
+  failure with extra context. This keeps the runtime agnostic about
+  whether a particular pattern is a true positive — at worst, the
+  agent reads an extra sentence and ignores it.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict, Optional, Sequence
+
+
+@dataclass(frozen=True)
+class ErrorTranslation:
+    """Outcome of a successful pattern match.
+
+    ``category`` is a stable identifier suitable for grouping in
+    observability dashboards; ``hint`` is the agent-readable
+    correction text that gets appended to the upstream error content.
+    """
+
+    category: str
+    hint: str
+
+
+@dataclass(frozen=True)
+class _ErrorPattern:
+    """Internal pattern declaration. Not exported.
+
+    Three signals, all of which must match for the pattern to fire:
+
+    * ``content_regex`` — case-insensitive search across the upstream
+      error text.
+    * ``required_arg_keys`` — at least one of these argument keys
+      must be present in the tool call. Empty tuple disables the
+      gate. Prevents matching error text from unrelated tool calls.
+    * ``server_id_regex`` — optional. When set, the pattern only
+      fires for servers whose id matches. Default ``None`` means the
+      pattern is server-agnostic.
+    """
+
+    category: str
+    content_regex: re.Pattern[str]
+    required_arg_keys: tuple[str, ...]
+    hint: str
+    server_id_regex: Optional[re.Pattern[str]] = None
+
+
+_PATTERNS: Sequence[_ErrorPattern] = (
+    _ErrorPattern(
+        category="excel_wac_token_folder_id",
+        content_regex=re.compile(r"could not obtain a wac access token", re.IGNORECASE),
+        required_arg_keys=("driveItemId", "file_id"),
+        hint=(
+            "Likely cause: the supplied driveItemId/file_id refers to a folder "
+            "rather than a workbook (.xlsx) file. Microsoft Graph Excel "
+            "endpoints return this WAC error when the target item is a "
+            "folder. Re-resolve the workbook ID via list-folder-files (or "
+            "the equivalent listing tool) and select the item whose name "
+            "ends in '.xlsx' — not a folder such as 'Attachments'."
+        ),
+    ),
+)
+
+
+def translate_tool_error(
+    tool_name: str,
+    arguments: Optional[Dict[str, object]],
+    error_text: Optional[str],
+    server_id: Optional[str] = None,
+) -> Optional[ErrorTranslation]:
+    """Match an MCP tool error against the registry.
+
+    Returns the first matching :class:`ErrorTranslation`, or ``None``
+    if no pattern fires. Always safe to call: empty/missing inputs
+    short-circuit to ``None`` rather than raising.
+
+    Callers should still gate invocation on the result actually being
+    an error (``isError`` true or ``status == "error"``) so the
+    translator never runs on a success body that happens to contain
+    matching strings.
+
+    Args:
+        tool_name: Name of the upstream MCP tool. Currently unused
+            for matching but reserved for future per-tool patterns
+            and emitted via observability when a translation fires.
+        arguments: Arguments dict the agent passed to the tool. Used
+            to gate patterns by required arg keys.
+        error_text: Flattened content text from the upstream error
+            response. Treated as a single haystack — pattern regexes
+            run against this with ``IGNORECASE``.
+        server_id: Optional MCP server id. Used to gate
+            server-specific patterns.
+
+    Returns:
+        First matching translation, or ``None``.
+    """
+    if not error_text:
+        return None
+
+    arg_keys = set(arguments.keys()) if isinstance(arguments, dict) else set()
+
+    for pattern in _PATTERNS:
+        if pattern.server_id_regex is not None:
+            if not server_id or not pattern.server_id_regex.search(server_id):
+                continue
+        if pattern.required_arg_keys and not arg_keys.intersection(pattern.required_arg_keys):
+            continue
+        if pattern.content_regex.search(error_text):
+            return ErrorTranslation(category=pattern.category, hint=pattern.hint)
+
+    return None

--- a/tests/unit/test_mcp_error_translator.py
+++ b/tests/unit/test_mcp_error_translator.py
@@ -144,14 +144,53 @@ class TestNegativeGates:
         assert result is None
 
     def test_no_match_for_empty_error_text(self):
-        for empty in (None, "", "   "):
-            # Spaces alone don't match any pattern — verify each.
+        """The guard must short-circuit on every form of effectively
+        empty input — including whitespace-only strings, which are
+        truthy in Python and would otherwise fall through to the
+        pattern loop."""
+        for empty in (None, "", "   ", "\n\n", "\t  \r\n"):
             result = et.translate_tool_error(
                 tool_name="list-excel-worksheets",
                 arguments={"driveItemId": "01..."},
                 error_text=empty,
             )
             assert result is None, f"empty input {empty!r} should return None"
+
+    def test_whitespace_only_short_circuits_before_pattern_loop(self, monkeypatch):
+        """Regression for the early-exit guard: an injected pattern
+        whose regex is permissive enough to match whitespace must NOT
+        fire when ``error_text`` is whitespace-only. Without the
+        ``.strip()`` check this test would pass through to the loop
+        and the permissive pattern would match — exactly the silent
+        future-proofing failure the reviewer flagged."""
+        permissive = et._ErrorPattern(
+            category="probe_permissive_match",
+            content_regex=re.compile(r".*", re.IGNORECASE | re.DOTALL),
+            required_arg_keys=("probe_arg",),
+            hint="should not appear",
+        )
+        monkeypatch.setattr(et, "_PATTERNS", (permissive,))
+
+        for whitespace in ("   ", "\n", "\t\t", " \n  "):
+            result = et.translate_tool_error(
+                tool_name="any",
+                arguments={"probe_arg": "x"},
+                error_text=whitespace,
+            )
+            assert result is None, (
+                f"whitespace-only input {whitespace!r} reached the pattern loop "
+                "and matched a permissive regex — the early-exit guard regressed."
+            )
+
+        # Sanity: the same permissive pattern DOES fire on real text,
+        # so the test above is meaningful (not vacuously passing
+        # because the pattern itself is broken).
+        sanity = et.translate_tool_error(
+            tool_name="any",
+            arguments={"probe_arg": "x"},
+            error_text="real content here",
+        )
+        assert sanity is not None and sanity.category == "probe_permissive_match"
 
     def test_no_match_for_empty_arguments(self):
         for empty_args in (None, {}):

--- a/tests/unit/test_mcp_error_translator.py
+++ b/tests/unit/test_mcp_error_translator.py
@@ -1,0 +1,242 @@
+"""Unit coverage for the MCP tool-error translator.
+
+Layer 2 of the MCP param funnel: when an upstream MCP server returns
+an error whose surface text is misleading, the translator annotates
+the result with an agent-actionable hint that surfaces in the
+next-turn tool message. See ``services/mcp/tools/error_translator.py``
+for the design doc and motivating case (Findings 4 and 6).
+
+These tests cover the matcher contract end-to-end:
+
+* Positive matches across both arg-key variants the WAC pattern
+  recognizes (driveItemId, file_id).
+* Negative gates: missing arg keys, non-matching content, empty
+  inputs, server_id mismatch when a pattern declares one.
+* Return type contract (frozen dataclass with stable category id).
+* Server-agnostic patterns (the only one currently shipped) fire
+  regardless of server_id.
+
+The wiring into ``services/mcp/service.py`` is verified separately by
+the live MS365 retry — keeping the translator pure and the wiring
+small means the unit-level surface here is just the helper itself.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import is_dataclass
+from typing import cast
+
+import pytest
+
+from muxi.runtime.services.mcp.tools import error_translator as et
+
+
+class TestErrorTranslationContract:
+    """The public ``ErrorTranslation`` shape must stay stable —
+    callers in ``service.py`` and any downstream consumers depend on
+    ``category`` being a stable identifier and ``hint`` being a
+    plain string suitable for direct injection into a tool message."""
+
+    def test_translation_is_frozen_dataclass(self):
+        result = et.translate_tool_error(
+            tool_name="list-excel-worksheets",
+            arguments={"driveItemId": "01..."},
+            error_text="Could not obtain a WAC access token.",
+        )
+        assert result is not None
+        assert is_dataclass(result), "ErrorTranslation must be a dataclass"
+        with pytest.raises((AttributeError, Exception)):
+            cast(et.ErrorTranslation, result).category = "mutated"  # type: ignore[misc]
+
+    def test_translation_returns_string_hint(self):
+        result = et.translate_tool_error(
+            tool_name="list-excel-worksheets",
+            arguments={"driveItemId": "01..."},
+            error_text="Could not obtain a WAC access token.",
+        )
+        assert result is not None
+        assert isinstance(result.hint, str) and result.hint, "Hint must be a non-empty string"
+        assert isinstance(result.category, str) and result.category, "Category must be non-empty"
+
+
+class TestExcelWACPattern:
+    """Positive coverage for the only pattern currently shipped:
+    Microsoft Graph's WAC-access-token error returned when an Excel
+    endpoint receives a folder ID where a file ID was expected."""
+
+    WAC_TEXT = (
+        "Microsoft Graph API error: 403 Forbidden - "
+        '{"error":{"code":"AccessDenied","message":"Could not obtain a WAC access token."}}'
+    )
+
+    def test_wac_with_drive_item_id_returns_hint(self):
+        result = et.translate_tool_error(
+            tool_name="list-excel-worksheets",
+            arguments={"driveItemId": "01SA7QZQ7HKJH6YEQPZNEY2JV3H7LXCTZU"},
+            error_text=self.WAC_TEXT,
+        )
+        assert result is not None
+        assert result.category == "excel_wac_token_folder_id"
+        assert "folder" in result.hint.lower()
+        assert ".xlsx" in result.hint  # the actionable specifier
+
+    def test_wac_with_file_id_returns_same_hint(self):
+        """``excel-write-range`` uses ``file_id`` instead of
+        ``driveItemId``. Both must trigger the same hint — Finding 6
+        is the same defect as Finding 4 with a different arg name."""
+        result = et.translate_tool_error(
+            tool_name="excel-write-range",
+            arguments={"file_id": "01SA7QZQ7HKJH6YEQPZNEY2JV3H7LXCTZU", "range": "B2"},
+            error_text=self.WAC_TEXT,
+        )
+        assert result is not None
+        assert result.category == "excel_wac_token_folder_id"
+
+    def test_wac_is_case_insensitive(self):
+        """Real Graph responses sometimes title-case parts of the
+        message. The matcher must use IGNORECASE so we don't get
+        false negatives on cosmetic upstream changes."""
+        result = et.translate_tool_error(
+            tool_name="list-excel-worksheets",
+            arguments={"driveItemId": "01..."},
+            error_text="COULD NOT OBTAIN A WAC ACCESS TOKEN.",
+        )
+        assert result is not None
+
+    def test_wac_pattern_is_server_agnostic(self):
+        """The current WAC pattern doesn't gate on server_id (multiple
+        MCP servers could proxy Graph). Verify it fires regardless."""
+        for server in (None, "ms365-mcp", "todo-helper-mcp", "spark-enterprise-graph"):
+            result = et.translate_tool_error(
+                tool_name="list-excel-worksheets",
+                arguments={"driveItemId": "01..."},
+                error_text=self.WAC_TEXT,
+                server_id=server,
+            )
+            assert result is not None, f"pattern should fire for server_id={server!r}"
+
+
+class TestNegativeGates:
+    """Each gate (content regex, required arg keys, server_id regex,
+    empty inputs) must independently prevent a false positive."""
+
+    def test_no_match_when_arg_keys_missing(self):
+        """The WAC pattern requires ``driveItemId`` or ``file_id`` in
+        the arguments. A WAC-text error from an unrelated tool with
+        different args must not trigger the hint."""
+        result = et.translate_tool_error(
+            tool_name="some-other-tool",
+            arguments={"unrelated_param": "value"},
+            error_text="Could not obtain a WAC access token.",
+        )
+        assert result is None
+
+    def test_no_match_when_content_does_not_match(self):
+        """A driveItemId-bearing call that fails for a different
+        reason (e.g. genuine 401 unauthorized) must pass through
+        without a hint."""
+        result = et.translate_tool_error(
+            tool_name="list-excel-worksheets",
+            arguments={"driveItemId": "01..."},
+            error_text="401 Unauthorized: bearer token expired",
+        )
+        assert result is None
+
+    def test_no_match_for_empty_error_text(self):
+        for empty in (None, "", "   "):
+            # Spaces alone don't match any pattern — verify each.
+            result = et.translate_tool_error(
+                tool_name="list-excel-worksheets",
+                arguments={"driveItemId": "01..."},
+                error_text=empty,
+            )
+            assert result is None, f"empty input {empty!r} should return None"
+
+    def test_no_match_for_empty_arguments(self):
+        for empty_args in (None, {}):
+            result = et.translate_tool_error(
+                tool_name="list-excel-worksheets",
+                arguments=empty_args,
+                error_text="Could not obtain a WAC access token.",
+            )
+            assert (
+                result is None
+            ), f"empty arguments {empty_args!r} should fail the required-arg gate"
+
+    def test_non_dict_arguments_treated_as_empty(self):
+        """Defensive: a malformed callsite that passes a non-dict
+        for arguments must not raise — the gate treats it as an
+        empty arg set and returns None."""
+        result = et.translate_tool_error(
+            tool_name="list-excel-worksheets",
+            arguments=cast(dict, "not-a-dict"),
+            error_text="Could not obtain a WAC access token.",
+        )
+        assert result is None
+
+
+class TestServerIdGate:
+    """The current registry has no server-gated pattern, but the gate
+    is part of the matcher contract. Lock the behavior so a future
+    pattern that adds ``server_id_regex`` works correctly."""
+
+    def test_server_gate_blocks_non_matching_server(self, monkeypatch):
+        # Inject a probe pattern that gates on a specific server.
+        probe = et._ErrorPattern(
+            category="probe_server_specific",
+            content_regex=re.compile(r"probe-error-text", re.IGNORECASE),
+            required_arg_keys=("probe_arg",),
+            hint="probe hint",
+            server_id_regex=re.compile(r"^only-this-server$"),
+        )
+        monkeypatch.setattr(et, "_PATTERNS", (probe,))
+
+        # Matching server: pattern fires.
+        match = et.translate_tool_error(
+            tool_name="probe",
+            arguments={"probe_arg": "x"},
+            error_text="probe-error-text in body",
+            server_id="only-this-server",
+        )
+        assert match is not None and match.category == "probe_server_specific"
+
+        # Non-matching server: gate blocks.
+        for server in (None, "other-server", "only-this-server-suffix-extra"):
+            blocked = et.translate_tool_error(
+                tool_name="probe",
+                arguments={"probe_arg": "x"},
+                error_text="probe-error-text in body",
+                server_id=server,
+            )
+            assert blocked is None, f"gate should block server_id={server!r}"
+
+
+class TestRegistryOrdering:
+    """First-match-wins is part of the contract. If two patterns
+    overlap on content but differ on category, the registry's order
+    decides which fires."""
+
+    def test_first_pattern_wins_on_overlap(self, monkeypatch):
+        first = et._ErrorPattern(
+            category="first_wins",
+            content_regex=re.compile(r"shared-text", re.IGNORECASE),
+            required_arg_keys=("arg",),
+            hint="first hint",
+        )
+        second = et._ErrorPattern(
+            category="second_loses",
+            content_regex=re.compile(r"shared-text", re.IGNORECASE),
+            required_arg_keys=("arg",),
+            hint="second hint",
+        )
+        monkeypatch.setattr(et, "_PATTERNS", (first, second))
+
+        result = et.translate_tool_error(
+            tool_name="any",
+            arguments={"arg": "x"},
+            error_text="shared-text appears here",
+        )
+        assert result is not None
+        assert result.category == "first_wins"
+        assert result.hint == "first hint"


### PR DESCRIPTION
## Context

Findings 4 and 6 from the 2026-04-29 MS365 testing run both surfaced the same defect: an Excel tool call (`list-excel-worksheets` and `excel-write-range` respectively) received a `driveItemId` / `file_id` that pointed to a folder rather than a workbook. Microsoft Graph returned 403 with `"Could not obtain a WAC access token"` — a WAC-token error that, read at face value, looks like an auth failure. The agent surfaced it to the user as a permissions problem rather than re-resolving the file ID.

## Why the existing parameter funnel doesn't catch this

The 0.20260410.0 release shipped a comprehensive parameter-handling stack:

- MCP server `parameters` declaration removes the LLM's need to infer org-level constants like `driveId`/`siteId`/`tenantId`
- `_validate_inferred_parameters_against_results()` rejects LLM-fabricated IDs not found in any prior successful result
- Clean-context binding prevents enhanced-prompt pollution
- Repair planning inserts discovery steps when required IDs are missing

The WAC case sits in a fourth class the funnel doesn't catch:

> The agent picks a **real** ID from a **real** prior tool result — it's just the **wrong type** for the next tool's contract. The Attachments folder ID *does* appear in `list-folder-files` output, so it isn't fabricated; the required param isn't missing; clean-context binding is irrelevant.

The runtime can't disambiguate folder-vs-file inside a generic list response without per-MCP semantics — that line stays on the model side. But the runtime *can* spot the misleading error pattern after the fact and tell the agent what likely happened, so the next turn carries an actionable correction instead of a confusing auth-flavored error.

## What this PR is NOT

- **Not** parameter validation before sending — covered by 0.20260410.0's `_validate_inferred_parameters_against_results()` and the `parameters` server-declaration field.
- **Not** folder-vs-file disambiguation at inference time — requires per-MCP semantic knowledge the runtime should not own.
- **Not** a fix for Findings 5 (embeddings/SIF) or 7 (local-LLM 118-tool catalog) — different epics.

## What this PR DOES require

Formations using ms365-mcp must declare `parameters: { driveId, siteId, tenantId }` on the server block to fully benefit from the parameter funnel. The WAC-translation hint covers the wrong-typed-ID residual case; upstream failures from missing org-level constants are a config gap the formation must close.

## Implementation

New module `src/muxi/runtime/services/mcp/tools/error_translator.py` with a small registry of `_ErrorPattern` declarations. Each pattern gates on three signals:

1. **Content regex** — case-insensitive search of the upstream error text
2. **Required arg keys** — at least one of these must be in the tool call's arguments (prevents matching unrelated tools)
3. **Optional server_id regex** — default `None` means server-agnostic; set when a pattern is server-specific

First-match-wins on overlap. Single shipped pattern catches the WAC case:

```python
_ErrorPattern(
    category="excel_wac_token_folder_id",
    content_regex=re.compile(r"could not obtain a wac access token", re.IGNORECASE),
    required_arg_keys=("driveItemId", "file_id"),
    hint=(
        "Likely cause: the supplied driveItemId/file_id refers to a folder "
        "rather than a workbook (.xlsx) file. Microsoft Graph Excel endpoints "
        "return this WAC error when the target item is a folder. Re-resolve "
        "the workbook ID via list-folder-files (or the equivalent listing "
        "tool) and select the item whose name ends in '.xlsx' — not a folder "
        "such as 'Attachments'."
    ),
)
```

## Wiring

`services/mcp/service.py::_invoke_tool_with_resolved_credentials` calls `translate_tool_error` on the processed result whenever `isError` is True (right after `ModernProtocolFeatures.process_structured_output`). On match, two writes to the agent-bound payload:

- **Structured field**: `_runtime_hint = {"category": ..., "message": ...}` for observability and any future structured consumer
- **Inline append to content**: `\n\n[Runtime hint] {hint}` so the model literally reads the correction in the tool message on the next turn (most reliable surface for self-correction)

The translator never blocks the call — it only annotates an existing failure. Original upstream error text preserved verbatim.

## What the agent now reads on the next turn

```
[upstream error JSON ...]

[Runtime hint] Likely cause: the supplied driveItemId/file_id refers
to a folder rather than a workbook (.xlsx) file. Microsoft Graph
Excel endpoints return this WAC error when the target item is a
folder. Re-resolve the workbook ID via list-folder-files (or the
equivalent listing tool) and select the item whose name ends in
'.xlsx' — not a folder such as 'Attachments'.
```

## Observability

Reuses `MCP_TOOL_CALL_COMPLETED` (no new event type) with a new `translation_category` metadata field. `None` when no pattern fired; the category string when one did. Production visibility into which translations actually fire, no event-count churn.

## Test coverage

`tests/unit/test_mcp_error_translator.py` — **13 tests across four classes:**

| Class | Coverage |
|---|---|
| `TestErrorTranslationContract` | Frozen-dataclass shape, stable category id, non-empty hint string |
| `TestExcelWACPattern` | Positive matches with both arg-key variants (`driveItemId` / `file_id`), case-insensitive matching, server-agnostic firing across `ms365-mcp`, `todo-helper-mcp`, and unknown servers |
| `TestNegativeGates` | Each gate independently — missing arg keys, non-matching content, empty inputs, non-dict arguments |
| `TestServerIdGate` | Locks `server_id_regex` semantics via probe pattern injected by `monkeypatch` (no shipped pattern uses it yet but the gate is part of the contract) |
| `TestRegistryOrdering` | First-match-wins on category overlap |

Plus end-to-end injection sanity (verified during development): a simulated Graph WAC response fed through `ModernProtocolFeatures.process_structured_output` → translator → result envelope produced an agent payload containing both the structured `_runtime_hint` field and the inline `[Runtime hint]` suffix on `content` with the expected `folder` and `.xlsx` markers.

## Quality gates

- ruff/black clean
- `scripts/validate_events.py` clean (no new event types)
- 13/13 translator tests pass
- Full unit suite: 1019 passed, 1 skipped (the one pre-existing RCE auth failure unchanged on develop)

## Future extension

The pattern registry is set up to accept more entries cheaply. Likely candidates as they show up in production:

- Graph 404 on Excel endpoints → "file ID may not exist or be inaccessible to the agent's credentials"
- Generic "InvalidAuthenticationToken" with credential context → credential refresh hint
- Per-server patterns gated via `server_id_regex` (the gate is wired; no entry uses it yet)

Each future pattern is one dataclass entry plus 1-2 unit tests. No structural change needed.

## Findings status after this PR

| # | Status |
|---|---|
| 4 — Excel read 403, wrong driveItemId | Addressed jointly: `parameters` declaration on ms365-mcp (formation config) + this WAC translation hint (runtime polish) |
| 6 — Excel write 403, same wrong file_id | Same as 4 — same root cause, same fix surface |
| 5 — Embeddings/SIF | Out of scope — different epic |
| 7 — Local-LLM 118-tool catalog | Out of scope — environmental, not a runtime defect |