### PR TITLE
fix(formation): probe declared models at init; refuse to load on 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,100 @@
 
 ## [unreleased]
 
+### Formation: probe declared models at init; refuse to load on 404
+
+Finding 5 from the 2026-04-29 MS365 testing run: the dev's formation
+declared ``embedding: local/all-MiniLM-L6-v2`` and the embedding
+service silently degraded to recency-only memory retrieval on every
+request, surfacing only an opaque ``InvalidConfigurationError`` deep
+in the runtime path. Two follow-up fix attempts by the dev failed
+because the failure mode masquerades as a "model not available"
+issue when the actual root cause is a slug-syntax problem: OneLLM's
+dispatcher splits the model name on the **first** ``/`` only, so
+``local/all-MiniLM-L6-v2`` is passed to HuggingFace as the bare
+repo id ``all-MiniLM-L6-v2``, which is not a valid HF identifier.
+The canonical form is ``local/sentence-transformers/all-MiniLM-L6-v2``,
+where everything after ``local/`` is the full ``<owner>/<repo>`` HF
+slug. OneLLM has no curated alias table - what you write is what
+gets sent to HF.
+
+The runtime's only previous defense was the after-the-fact
+``InvalidConfigurationError``. By the time it fired, the formation
+had already loaded, vector search was already broken, and the
+operator had no signal that the cause was a typo in their slug
+rather than a deeper environmental problem.
+
+This change introduces a fail-fast probe at formation init. After
+``initialize_llm_config()`` populates ``formation._capability_models``
+and the text-fallback cascade runs, ``probe_declared_models()`` is
+invoked. It iterates every distinct ``(model_slug, probe_kind)``
+pair, dedups across capabilities, and issues a minimal OneLLM call:
+``Embedding.acreate(input="probe", model=...)`` for the
+``embedding`` capability and
+``ChatCompletion.acreate(messages=[{"role":"user","content":"ping"}],
+max_tokens=1, model=...)`` for everything else (``text``,
+``vision``, ``audio``, ``documents``, ``streaming``, future
+capabilities).
+
+Failure classification is deliberate. Two error classes from OneLLM
+abort formation init via ``ConfigurationValidationError``:
+
+- ``ResourceNotFoundError`` (HF 404 / provider model-not-found)
+- ``InvalidRequestError`` (HF validation error - the dev's exact
+  bare-name slug case)
+
+Everything else (``AuthenticationError``, ``RateLimitError``,
+``ServiceUnavailableError``, ``RequestTimeoutError``, other
+``OneLLMError`` subclasses, and non-``OneLLMError`` exceptions
+indicating probe-machinery bugs) is logged at WARN and continues.
+This split is intentional: the two fatal classes are deterministic
+"this slug will never resolve" failures, while the rest is either
+transient or environmental, and bricking an otherwise-healthy
+formation on an init-time auth blip is worse than the silent
+degradation the probe is meant to prevent.
+
+Probes run **synchronously, serially**. The first fatal aborts
+before later probes execute, so an operator with multiple bad slugs
+fixes them one error message at a time rather than wading through a
+dozen entangled failures. ``ChatCompletion`` cost: ~50 input + 1
+output token per probe, fractions of a cent on cloud providers,
+zero on cached local models.
+
+The fatal error message is dynamic. For ``local/<bare-name>`` slugs
+(the exact failure mode the dev hit) the message names the
+correction explicitly:
+
+```
+Cause: the local slug is missing the owner/organization segment.
+The runtime requires the full HuggingFace repo id:
+    local/<owner>/<repo>   (e.g. local/sentence-transformers/all-MiniLM-L6-v2)
+NOT local/<repo>          (e.g. local/all-MiniLM-L6-v2)
+```
+
+For ``local/<owner>/<repo>`` slugs that 404, the message points at
+typo / gated-repo causes. For cloud slugs the local-specific hint
+is omitted entirely so the message stays relevant.
+
+Three new ``SystemEvents`` cover the lifecycle:
+``MODEL_INIT_PROBE_STARTED``, ``MODEL_INIT_PROBE_COMPLETED``, and
+``MODEL_INIT_PROBE_FAILED`` (with ``severity ∈ {fatal, warn}`` and
+the underlying ``OneLLMError`` class encoded in the payload). All
+1223 observe() calls validate; ``scripts/validate_events.py`` is
+clean.
+
+Test surface: 22 unit tests across three classes
+(``TestClassification`` for the pure failure-class mapping,
+``TestFatalMessageFormatting`` for the slug-shape-aware message
+builder, ``TestProbeBuilder`` for capability dedup and
+embedding-vs-chat probe selection, ``TestProbeOutcomes`` for the
+end-to-end behavior with ``_execute_single_probe`` mocked). The
+serial-fail-fast test asserts that when the first capability
+raises a 404 the second probe is **never invoked**, so the abort
+is cheap even on formations with a long capability list.
+
+No escape hatch was added. Correctness over convenience: a formation
+that won't actually work shouldn't pretend to be loading.
+
 ### MCP: translate misleading upstream errors into agent-actionable hints
 
 Findings 4 and 6 from the 2026-04-29 MS365 testing run both surfaced

--- a/src/muxi/runtime/datatypes/observability.py
+++ b/src/muxi/runtime/datatypes/observability.py
@@ -35,6 +35,21 @@ class SystemEvents(Enum):
     LLM_INITIALIZED = "llm.initialized"
     # When LLM instance is initialized
 
+    MODEL_INIT_PROBE_STARTED = "model.init_probe.started"
+    # When the runtime begins probing a formation-declared model at init
+    # time to verify the slug resolves through OneLLM. Emitted once per
+    # distinct (provider, model) pair after dedup across capabilities.
+
+    MODEL_INIT_PROBE_COMPLETED = "model.init_probe.completed"
+    # When a formation-declared model probe succeeds. Includes timing and
+    # the OneLLM call shape (embedding vs chat) used.
+
+    MODEL_INIT_PROBE_FAILED = "model.init_probe.failed"
+    # When a formation-declared model probe fails. Severity is encoded in
+    # the event payload: 'fatal' fails formation init (404 / HF
+    # validation), 'warn' continues with a warning (auth / transient /
+    # other OneLLM errors / probe-machinery bugs).
+
     LLM_CACHE_CLEARED = "llm.cache.cleared"
     # When LLM response cache is cleared
 

--- a/src/muxi/runtime/formation/formation.py
+++ b/src/muxi/runtime/formation/formation.py
@@ -112,6 +112,7 @@ from .initialization import (
     initialize_rce,
     initialize_skills,
     load_agents_from_configuration,
+    probe_declared_models,
 )
 
 
@@ -1278,6 +1279,13 @@ class Formation:
 
         # 3. Initialize LLM configuration
         initialize_llm_config(self)
+
+        # 3b. Probe every declared model. Refuses formation startup if
+        # any slug surfaces a 404 / shape error from OneLLM (e.g. a
+        # bare-name local slug or a typo in a cloud model name) -
+        # otherwise the failure manifests only on first user request
+        # and silently degrades the affected capability.
+        await probe_declared_models(self)
 
         # 4. Initialize memory systems
         initialize_memory_systems(self)

--- a/src/muxi/runtime/formation/initialization.py
+++ b/src/muxi/runtime/formation/initialization.py
@@ -292,6 +292,277 @@ def initialize_llm_config(formation) -> None:
     # Note: description variable removed as observability call was removed
 
 
+# ---------------------------------------------------------------------------
+# Model init probe
+#
+# Verifies every formation-declared model resolves through OneLLM at
+# formation init time. Catches the otherwise-silent failure mode where
+# a misspelled or shape-invalid slug (e.g. ``local/all-MiniLM-L6-v2``
+# instead of ``local/sentence-transformers/all-MiniLM-L6-v2``) only
+# manifests as ``InvalidConfigurationError`` on first user request and
+# silently degrades the relevant capability (semantic memory, vision,
+# etc.) for the lifetime of the formation.
+#
+# Failure classification:
+#   - ResourceNotFoundError, InvalidRequestError       -> FATAL (raise)
+#   - AuthenticationError, RateLimitError,             -> WARN (continue)
+#     ServiceUnavailableError, RequestTimeoutError,
+#     other OneLLMError subclasses
+#   - non-OneLLMError exceptions                       -> WARN (continue)
+#                                                          + ERROR-level log
+#                                                         (probe-machinery
+#                                                          bug, not user
+#                                                          error)
+#
+# Probes run **synchronously, serially**: load-order semantics are
+# preserved and the first fatal failure aborts before subsequent probes.
+# ---------------------------------------------------------------------------
+
+
+def _classify_probe_failure(exc: Exception) -> str:
+    """Return ``"fatal"`` or ``"warn"`` for a probe exception.
+
+    Pure function, no side effects, kept module-level so unit tests can
+    exercise the classification without spinning up a formation.
+
+    The two fatal classes are deterministic "this slug will never
+    resolve" failures:
+
+    - :class:`onellm.errors.ResourceNotFoundError` - HF 404 or provider
+      model-not-found.
+    - :class:`onellm.errors.InvalidRequestError` - HF validation error,
+      which is what bare-name local slugs (the dev's case) surface as.
+
+    Everything else (auth, rate limit, network, unknown) is classified
+    ``"warn"`` so a transient or environmental issue at init does not
+    brick a formation that would otherwise come up healthy.
+    """
+    from onellm.errors import (
+        InvalidRequestError,
+        ResourceNotFoundError,
+    )
+
+    if isinstance(exc, (ResourceNotFoundError, InvalidRequestError)):
+        return "fatal"
+    return "warn"
+
+
+def _format_probe_fatal_message(model_slug: str, exc: Exception) -> str:
+    """Build the operator-facing message for a fatal probe failure.
+
+    The hint section is dynamic:
+
+    - For ``local/<bare-name>`` slugs (the dev's exact case) we surface
+      the bare-name -> owner/repo correction prominently.
+    - For other ``local/...`` slugs we still mention the
+      ``local/<owner>/<repo>`` shape requirement.
+    - For non-local slugs (cloud providers) the typo hint is emphasized
+      and the local hint is omitted entirely so the message stays
+      relevant.
+    """
+    base = (
+        f"Formation init failed: model '{model_slug}' could not be "
+        f"resolved by OneLLM.\n\n"
+        f"OneLLM reported:\n  {type(exc).__name__}: {exc}\n\n"
+    )
+
+    if model_slug.startswith("local/"):
+        post = model_slug[len("local/") :]
+        bare_name_likely = "/" not in post
+        if bare_name_likely:
+            return base + (
+                "Cause: the local slug is missing the owner/organization "
+                "segment. The runtime requires the full HuggingFace repo "
+                "id:\n"
+                "    local/<owner>/<repo>   "
+                "(e.g. local/sentence-transformers/all-MiniLM-L6-v2)\n"
+                f"NOT local/<repo>          "
+                f"(e.g. {model_slug})\n\n"
+                "Fix the formation's model declaration and restart.\n"
+            )
+        return base + (
+            "Common causes for local/* slugs:\n"
+            "  - Model genuinely missing from HuggingFace (typo in owner/repo).\n"
+            "  - Gated repo without a read token configured.\n\n"
+            "Fix the formation's model declaration and restart.\n"
+        )
+
+    return base + (
+        "Common causes for cloud slugs:\n"
+        "  - Typo in the model name (e.g. 'openai/gpt-4o-min' vs "
+        "'openai/gpt-4o-mini').\n"
+        "  - Model deprecated or genuinely missing from the provider.\n\n"
+        "Fix the formation's model declaration and restart.\n"
+    )
+
+
+def _build_unique_probes(
+    capability_models: Dict[str, Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Deduplicate ``capability_models`` into a list of unique probes.
+
+    Two capabilities pointing at the same ``(model_slug, probe_kind)``
+    pair are collapsed into a single probe; the ``capabilities`` field
+    on the resulting probe lists every capability that mapped to it so
+    observability events stay informative.
+
+    ``probe_kind`` is ``"embedding"`` for the ``embedding`` capability
+    and ``"chat"`` for everything else - this matches OneLLM's own
+    transport split and lets the same slug be probed twice if it is
+    legitimately used as both an embedding model and a chat model
+    (rare, but possible).
+
+    Returns the probes in a stable order keyed on the first capability
+    that introduced each unique probe, so error messages and tests are
+    deterministic.
+    """
+    seen: Dict[tuple, Dict[str, Any]] = {}
+    order: List[tuple] = []
+
+    for capability, cfg in capability_models.items():
+        model = cfg.get("model")
+        if not isinstance(model, str) or not model:
+            continue
+        kind = "embedding" if capability == "embedding" else "chat"
+        key = (model, kind)
+        if key not in seen:
+            seen[key] = {
+                "model": model,
+                "kind": kind,
+                "capabilities": [capability],
+            }
+            order.append(key)
+        else:
+            seen[key]["capabilities"].append(capability)
+
+    return [seen[key] for key in order]
+
+
+async def _execute_single_probe(model: str, kind: str) -> None:
+    """Issue the actual OneLLM call for a single probe.
+
+    Pulled out as its own coroutine so unit tests can patch it in
+    isolation without mocking ``onellm.Embedding`` or
+    ``onellm.ChatCompletion`` directly. Raises the underlying
+    ``OneLLMError`` (or any other exception) untouched so the caller
+    can classify and emit the appropriate event.
+    """
+    if kind == "embedding":
+        from onellm import Embedding
+
+        await Embedding.acreate(input="probe", model=model)
+    else:
+        from onellm import ChatCompletion
+
+        await ChatCompletion.acreate(
+            model=model,
+            messages=[{"role": "user", "content": "ping"}],
+            max_tokens=1,
+        )
+
+
+async def probe_declared_models(formation) -> None:
+    """Probe every formation-declared model and fail-fast on 404.
+
+    Iterates ``formation._capability_models`` after the text-fallback
+    cascade has run, issues a minimal OneLLM call per unique
+    ``(model_slug, probe_kind)`` pair, and converts deterministic
+    "this slug will never resolve" failures into a
+    :class:`ConfigurationValidationError` that aborts formation init.
+
+    Probes are serial: the first fatal failure aborts before later
+    probes run. Non-fatal failures (auth / network / rate-limit /
+    other ``OneLLMError`` subclasses / probe-machinery bugs) emit a
+    ``MODEL_INIT_PROBE_FAILED`` warning event and continue, so a
+    transient init blip does not brick an otherwise-healthy formation.
+
+    Raises:
+        ConfigurationValidationError: when any probe surfaces a fatal
+            error (``ResourceNotFoundError`` or ``InvalidRequestError``).
+            The message names the offending slug, embeds the underlying
+            OneLLM error verbatim, and surfaces operator-actionable
+            guidance for the most common causes.
+    """
+    import time
+
+    from onellm.errors import OneLLMError
+
+    capability_models = getattr(formation, "_capability_models", {}) or {}
+    probes = _build_unique_probes(capability_models)
+
+    if not probes:
+        return
+
+    for probe in probes:
+        model = probe["model"]
+        kind = probe["kind"]
+        capabilities = probe["capabilities"]
+
+        observability.observe(
+            event_type=observability.SystemEvents.MODEL_INIT_PROBE_STARTED,
+            level=EventLevel.INFO,
+            data={
+                "model": model,
+                "probe_kind": kind,
+                "capabilities": capabilities,
+            },
+            description=(f"Probing model '{model}' ({kind}) for capabilities " f"{capabilities}"),
+        )
+
+        start = time.perf_counter()
+        try:
+            await _execute_single_probe(model, kind)
+        except Exception as exc:  # noqa: BLE001 - intentional broad catch
+            elapsed_ms = int((time.perf_counter() - start) * 1000)
+            is_onellm = isinstance(exc, OneLLMError)
+            severity = _classify_probe_failure(exc) if is_onellm else "warn"
+
+            observability.observe(
+                event_type=observability.SystemEvents.MODEL_INIT_PROBE_FAILED,
+                level=EventLevel.ERROR if severity == "fatal" else EventLevel.WARNING,
+                data={
+                    "model": model,
+                    "probe_kind": kind,
+                    "capabilities": capabilities,
+                    "severity": severity,
+                    "exception_type": type(exc).__name__,
+                    "is_onellm_error": is_onellm,
+                    "duration_ms": elapsed_ms,
+                    "error": str(exc),
+                },
+                description=(
+                    f"Model probe failed: {model} ({kind}) -> " f"{type(exc).__name__}: {exc}"
+                ),
+            )
+
+            if severity == "fatal":
+                raise ConfigurationValidationError(
+                    [_format_probe_fatal_message(model, exc)],
+                    details={
+                        "model": model,
+                        "probe_kind": kind,
+                        "capabilities": capabilities,
+                        "exception_type": type(exc).__name__,
+                        "underlying_error": str(exc),
+                    },
+                ) from exc
+            # Non-fatal: continue to next probe.
+            continue
+
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+        observability.observe(
+            event_type=observability.SystemEvents.MODEL_INIT_PROBE_COMPLETED,
+            level=EventLevel.INFO,
+            data={
+                "model": model,
+                "probe_kind": kind,
+                "capabilities": capabilities,
+                "duration_ms": elapsed_ms,
+            },
+            description=(f"Model probe OK: {model} ({kind}) in {elapsed_ms}ms"),
+        )
+
+
 def initialize_memory_systems(formation) -> None:
     """
     Initialize all memory systems including buffer, working, and persistent memory.

--- a/src/muxi/runtime/formation/initialization.py
+++ b/src/muxi/runtime/formation/initialization.py
@@ -466,11 +466,20 @@ def _build_unique_probes(
 async def _execute_single_probe(model: str, kind: str) -> None:
     """Issue the actual OneLLM call for a single probe.
 
-    Pulled out as its own coroutine so unit tests can patch it in
-    isolation without mocking ``onellm.Embedding`` or
-    ``onellm.ChatCompletion`` directly. Raises the underlying
-    ``OneLLMError`` (or any other exception) untouched so the caller
-    can classify and emit the appropriate event.
+    Encapsulates the per-``kind`` transport split (Embedding vs
+    ChatCompletion) so :func:`probe_declared_models` stays focused on
+    the per-probe lifecycle (event emission, error classification,
+    serial fail-fast) and adding a new probe kind in the future is a
+    one-function change confined to this helper.
+
+    Behavior contract:
+
+    - Returns ``None`` on success (the response payload is irrelevant
+      to the probe; only the round-trip succeeded).
+    - Raises the underlying ``OneLLMError`` (or any other exception)
+      untouched so the caller can classify and emit the appropriate
+      event. Wrapping or swallowing here would defeat the
+      classification helper.
     """
     if kind == "embedding":
         from onellm import Embedding

--- a/src/muxi/runtime/formation/initialization.py
+++ b/src/muxi/runtime/formation/initialization.py
@@ -347,6 +347,31 @@ def _classify_probe_failure(exc: Exception) -> str:
     return "warn"
 
 
+def _event_level_for_failure(severity: str, is_onellm: bool) -> "EventLevel":
+    """Pure mapper: failure classification + origin -> emitted event level.
+
+    Two cases produce ``ERROR``:
+
+    - ``severity == "fatal"`` - formation is about to abort init; the
+      event is the operator's primary signal, must surface above
+      ``WARNING`` filtering thresholds.
+    - ``not is_onellm`` - a probe-machinery bug (``RuntimeError``,
+      ``ValueError``, etc.). The control-flow severity is ``"warn"``
+      (we continue formation init to avoid bricking on a probe defect),
+      but the event level is ``ERROR`` so an operator filtering on
+      ERROR alerts does not silently miss a defect in the probe layer
+      itself. The block-comment contract on this module promises
+      ``ERROR`` for non-``OneLLMError`` cases; this helper makes that
+      promise enforceable in tests.
+
+    All other cases (``severity == "warn"`` from a real ``OneLLMError`` -
+    auth, rate limit, transient network) emit at ``WARNING``.
+    """
+    if severity == "fatal" or not is_onellm:
+        return EventLevel.ERROR
+    return EventLevel.WARNING
+
+
 def _format_probe_fatal_message(model_slug: str, exc: Exception) -> str:
     """Build the operator-facing message for a fatal probe failure.
 
@@ -519,7 +544,7 @@ async def probe_declared_models(formation) -> None:
 
             observability.observe(
                 event_type=observability.SystemEvents.MODEL_INIT_PROBE_FAILED,
-                level=EventLevel.ERROR if severity == "fatal" else EventLevel.WARNING,
+                level=_event_level_for_failure(severity, is_onellm),
                 data={
                     "model": model,
                     "probe_kind": kind,

--- a/tests/integration/test_model_init_probe_integration.py
+++ b/tests/integration/test_model_init_probe_integration.py
@@ -1,0 +1,226 @@
+"""Integration tests for the formation-init model probe.
+
+End-to-end behavior tests for ``probe_declared_models()`` using real
+OneLLM calls per the project's "no mocks" standard
+(``AGENTS.md``: "Use real services... mocks are disallowed").
+
+What is covered here:
+
+- The dev's exact failure (``local/all-MiniLM-L6-v2``) hitting real
+  HuggingFace, surfacing a real 404 / repository-not-found, and
+  producing the bare-name owner/repo correction hint. This case
+  needs **no API key** - HF rejects bare repo ids without auth.
+- A typo'd cloud slug (``openai/gpt-4o-min``) hitting real OpenAI
+  and surfacing a real 404 with the cloud-typo hint.
+- A valid cloud slug (``openai/gpt-4o-mini``) succeeding through to
+  the next probe.
+- Authentication errors (set a deliberately bogus key) being
+  classified as warn-and-continue rather than fatal.
+- Serial fail-fast: when probe #1 fails fatally, probe #2 is
+  observably never invoked (witnessed via the error message
+  referencing slug-1 only).
+
+What lives elsewhere:
+
+- Pure-function tests (classification, level mapping, message
+  formatting, probe-builder dedup) live in
+  ``tests/unit/test_model_init_probe.py`` and run without network.
+
+Skip semantics:
+
+- Tests that need OpenAI auth skip via ``pytest.mark.skipif`` when
+  ``OPENAI_API_KEY`` is not set in the environment.
+- The bare-name local case has no skip - HF refuses the lookup
+  immediately without any credential.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from muxi.runtime.datatypes.exceptions import ConfigurationValidationError
+from muxi.runtime.formation import initialization as init_mod
+
+pytestmark = [pytest.mark.slow, pytest.mark.integration]
+
+
+_NEEDS_OPENAI = pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY required for real OpenAI probes",
+)
+
+
+def _make_formation(capability_models: dict) -> SimpleNamespace:
+    """Build a minimal formation stand-in with just the field the probe reads.
+
+    The probe only touches ``formation._capability_models``; nothing
+    else from the Formation surface is needed. Using a SimpleNamespace
+    keeps these tests independent of the full Formation lifecycle
+    (load, observability bootstrap, secrets manager, etc.) so a
+    failure here always points at probe behavior rather than a
+    formation-load orthogonal regression.
+    """
+    return SimpleNamespace(_capability_models=capability_models)
+
+
+# ---------------------------------------------------------------------------
+# Local-provider path: needs no API key. HuggingFace rejects bare repo ids.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bare_name_local_slug_aborts_with_owner_hint_real_hf():
+    """The dev's exact failure path: bare-name slug -> real HF 404 ->
+    fatal abort with the canonical-form correction in the message.
+
+    No API key required: HuggingFace does not need credentials to
+    answer "this repo doesn't exist" for ``all-MiniLM-L6-v2`` (which
+    OneLLM passes verbatim because its dispatcher splits on the first
+    ``/`` only).
+    """
+    formation = _make_formation({"embedding": {"model": "local/all-MiniLM-L6-v2"}})
+
+    with pytest.raises(ConfigurationValidationError) as excinfo:
+        await init_mod.probe_declared_models(formation)
+
+    msg = str(excinfo.value)
+    # The offending slug appears verbatim in the error.
+    assert "local/all-MiniLM-L6-v2" in msg
+    # The fatal-message formatter detected the bare-name shape and
+    # surfaced the canonical correction.
+    assert "local/sentence-transformers/all-MiniLM-L6-v2" in msg
+    assert "owner/organization" in msg
+
+
+@pytest.mark.asyncio
+async def test_local_owner_repo_slug_404_uses_typo_hint_real_hf():
+    """A well-shaped local slug whose repo simply doesn't exist
+    surfaces the typo / gated-repo hint, NOT the bare-name hint.
+
+    Distinguishes "shape error" (no slash) from "404 on a real
+    HF lookup", which produce different operator-actionable hints.
+    """
+    formation = _make_formation(
+        {"embedding": {"model": "local/muxi-probe-tests-doesnotexist/some-fake-model"}}
+    )
+
+    with pytest.raises(ConfigurationValidationError) as excinfo:
+        await init_mod.probe_declared_models(formation)
+
+    msg = str(excinfo.value)
+    assert "muxi-probe-tests-doesnotexist/some-fake-model" in msg
+    # Not the bare-name hint.
+    assert "owner/organization" not in msg
+    # The local-but-shaped-OK hint set instead.
+    assert "Common causes for local/* slugs" in msg
+
+
+@pytest.mark.asyncio
+async def test_first_fatal_aborts_before_second_probe_runs_real_hf():
+    """Witness for serial fail-fast without mocking the call layer.
+
+    Two distinct bad local slugs; the probe runs serially in
+    insertion order, so when ``embedding`` fatals first, the ``text``
+    probe (which would also have surfaced its own 404) must never
+    execute. The witness is the error message: it names the FIRST
+    slug only. If the second probe ever ran, its slug would also
+    appear somewhere in the error chain.
+    """
+    formation = _make_formation(
+        {
+            # Bare-name -> guaranteed fatal on real HF lookup.
+            "embedding": {"model": "local/all-MiniLM-L6-v2"},
+            # Different bad slug; would also fatal if reached.
+            "text": {"model": "local/muxi-probe-tests-second/should-never-run"},
+        }
+    )
+
+    with pytest.raises(ConfigurationValidationError) as excinfo:
+        await init_mod.probe_declared_models(formation)
+
+    msg = str(excinfo.value)
+    assert "local/all-MiniLM-L6-v2" in msg
+    # The second probe never ran, so its slug must not surface in
+    # the error chain.
+    assert "muxi-probe-tests-second" not in msg
+    assert "should-never-run" not in msg
+
+
+@pytest.mark.asyncio
+async def test_empty_capability_models_is_a_noop():
+    """No declared models -> no probes -> no exception.
+
+    Trivially safe: validates that the probe handles an empty
+    registry without surprising the caller.
+    """
+    formation = _make_formation({})
+    # Must not raise.
+    await init_mod.probe_declared_models(formation)
+
+
+# ---------------------------------------------------------------------------
+# Cloud-provider path: needs a real OPENAI_API_KEY to reach OpenAI 404 / 200.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@_NEEDS_OPENAI
+async def test_cloud_typo_aborts_with_404_real_openai():
+    """A typo'd cloud slug hitting real OpenAI surfaces ResourceNotFoundError
+    with the cloud-typo hint, not a local-specific hint.
+    """
+    formation = _make_formation({"text": {"model": "openai/gpt-4o-min"}})  # missing trailing 'i'
+
+    with pytest.raises(ConfigurationValidationError) as excinfo:
+        await init_mod.probe_declared_models(formation)
+
+    msg = str(excinfo.value)
+    assert "openai/gpt-4o-min" in msg
+    assert "Common causes for cloud slugs" in msg
+    # Cloud-only error: no local hints leak in.
+    assert "local/<owner>/<repo>" not in msg
+    assert "HuggingFace" not in msg
+
+
+@pytest.mark.asyncio
+@_NEEDS_OPENAI
+async def test_valid_cloud_slug_succeeds_real_openai():
+    """A valid cloud slug must NOT raise.
+
+    Sanity for the happy path: probe makes a real 1-token chat call,
+    returns successfully, formation init proceeds. Fractions of a
+    cent per run.
+    """
+    formation = _make_formation({"text": {"model": "openai/gpt-4o-mini"}})
+    # Must not raise.
+    await init_mod.probe_declared_models(formation)
+
+
+@pytest.mark.asyncio
+async def test_authentication_error_warns_and_continues_real_openai():
+    """A bad API key surfaces ``AuthenticationError`` from real
+    OpenAI - which is classified ``"warn"`` and must NOT abort
+    formation init.
+
+    Saves and restores any existing key so this test plays nicely
+    with subsequent integration tests in the same session.
+    """
+    from onellm.config import set_api_key
+
+    original = os.environ.get("OPENAI_API_KEY")
+    set_api_key(
+        "sk-deliberately-invalid-test-key-for-probe-warning-suppression",
+        "openai",
+    )
+    try:
+        formation = _make_formation({"text": {"model": "openai/gpt-4o-mini"}})
+        # Must not raise: AuthenticationError is in the warn-and-continue
+        # bucket (we cannot reliably distinguish missing vs invalid key
+        # from the error class alone).
+        await init_mod.probe_declared_models(formation)
+    finally:
+        if original:
+            set_api_key(original, "openai")

--- a/tests/integration/test_model_init_probe_integration.py
+++ b/tests/integration/test_model_init_probe_integration.py
@@ -210,6 +210,11 @@ async def test_authentication_error_warns_and_continues_real_openai():
     """
     from onellm.config import set_api_key
 
+    # Read the prior key from the environment. ``os.environ.get`` returns
+    # ``None`` when the variable is unset - which we MUST distinguish
+    # from "set to empty string" so we can fully clear the in-memory
+    # OneLLM config in the finally block instead of leaking the bogus
+    # test key into the rest of the test session.
     original = os.environ.get("OPENAI_API_KEY")
     set_api_key(
         "sk-deliberately-invalid-test-key-for-probe-warning-suppression",
@@ -222,5 +227,11 @@ async def test_authentication_error_warns_and_continues_real_openai():
         # from the error class alone).
         await init_mod.probe_declared_models(formation)
     finally:
-        if original:
+        # Restore the prior key if there was one; otherwise clear the
+        # OneLLM in-memory key so the bogus test value does NOT survive
+        # this test and trigger spurious AuthenticationError on every
+        # subsequent OpenAI-using test in the same pytest session.
+        if original is not None:
             set_api_key(original, "openai")
+        else:
+            set_api_key("", "openai")

--- a/tests/unit/test_model_init_probe.py
+++ b/tests/unit/test_model_init_probe.py
@@ -6,26 +6,23 @@ shape-invalid slugs (e.g. ``local/all-MiniLM-L6-v2`` instead of
 ``local/sentence-transformers/all-MiniLM-L6-v2``) abort startup
 rather than degrading silently on first user request.
 
-Failure classification under test:
+This file holds **pure-function** unit tests only. End-to-end probe
+behavior (real OneLLM calls, real HF / OpenAI errors, real fatal
+abort path) lives in
+``tests/integration/test_model_init_probe_integration.py`` per the
+project's "no mocks" testing standard - pure functions are safe
+ground for fast unit assertions; behavior tests use real services.
 
-- ``ResourceNotFoundError``      -> FATAL (raises ConfigurationValidationError)
-- ``InvalidRequestError``        -> FATAL  (HF validation = bare-name slug)
-- ``AuthenticationError``        -> WARN   (continue; can't distinguish
-                                            missing vs invalid key reliably)
-- ``RateLimitError``             -> WARN   (transient)
-- non-OneLLMError exceptions     -> WARN   (probe-machinery bug)
+Coverage:
 
-Plus structural tests for capability dedup, probe-shape selection
-(embedding vs chat), serial fail-fast ordering, and that the bare-name
-fatal message includes the operator-actionable hint.
+- ``TestClassification``        - failure-class -> severity mapping
+- ``TestEventLevelMapping``     - severity + origin -> EventLevel
+- ``TestFatalMessageFormatting``- slug-shape -> hint in fatal message
+- ``TestProbeBuilder``          - capability dedup + probe-kind picking
 """
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
-
-import pytest
 from onellm.errors import (
     AuthenticationError,
     InvalidRequestError,
@@ -34,13 +31,8 @@ from onellm.errors import (
     ResourceNotFoundError,
 )
 
-from muxi.runtime.datatypes.exceptions import ConfigurationValidationError
+from muxi.runtime.datatypes.observability import EventLevel
 from muxi.runtime.formation import initialization as init_mod
-
-
-def _make_formation(capability_models: dict) -> SimpleNamespace:
-    """Build a minimal formation stand-in with just the field the probe reads."""
-    return SimpleNamespace(_capability_models=capability_models)
 
 
 class TestClassification:
@@ -153,116 +145,44 @@ class TestProbeBuilder:
         assert probes[0]["model"] == "openai/gpt-4o-mini"
 
 
-class TestProbeOutcomes:
-    """End-to-end probe behavior with the OneLLM call mocked."""
+class TestEventLevelMapping:
+    """``_event_level_for_failure`` is pure - lock the level contract.
 
-    @pytest.mark.asyncio
-    async def test_all_probes_succeed_no_raise(self):
-        formation = _make_formation({"text": {"model": "openai/gpt-4o-mini"}})
-        with patch.object(init_mod, "_execute_single_probe", new=AsyncMock()) as mock_exec:
-            await init_mod.probe_declared_models(formation)
-        mock_exec.assert_awaited_once_with("openai/gpt-4o-mini", "chat")
+    The block-comment in ``initialization.py`` promises ERROR-level
+    events for non-``OneLLMError`` exceptions (probe-machinery bugs).
+    Without these tests an operator filtering ERROR alerts would
+    silently miss a defect in the probe layer itself, since the
+    control-flow severity is "warn" (continue) but the operational
+    severity is ERROR (something is broken).
+    """
 
-    @pytest.mark.asyncio
-    async def test_resource_not_found_aborts_with_config_error(self):
-        formation = _make_formation({"text": {"model": "openai/gpt-4o-min"}})  # typo
-        exc = ResourceNotFoundError("404", provider="openai", status_code=404)
-        with patch.object(init_mod, "_execute_single_probe", new=AsyncMock(side_effect=exc)):
-            with pytest.raises(ConfigurationValidationError) as excinfo:
-                await init_mod.probe_declared_models(formation)
+    def test_fatal_onellm_emits_error(self):
+        # 404 / shape error from OneLLM - operator's primary signal.
+        assert init_mod._event_level_for_failure("fatal", is_onellm=True) == EventLevel.ERROR
 
-        # Message names the offending slug and embeds the OneLLM error.
-        msg = str(excinfo.value)
-        assert "openai/gpt-4o-min" in msg
-        assert "ResourceNotFoundError" in msg
+    def test_warn_onellm_emits_warning(self):
+        # auth / rate-limit / transient OneLLM error - non-fatal,
+        # informational only.
+        assert init_mod._event_level_for_failure("warn", is_onellm=True) == EventLevel.WARNING
 
-    @pytest.mark.asyncio
-    async def test_bare_name_local_slug_surfaces_owner_hint(self):
-        # The dev's exact failure - must produce the hint that names
-        # the canonical form.
-        formation = _make_formation({"embedding": {"model": "local/all-MiniLM-L6-v2"}})
-        exc = InvalidRequestError(
-            "[local/all-MiniLM-L6-v2] Invalid HuggingFace repo id.",
-            provider="local",
-            status_code=400,
+    def test_warn_non_onellm_emits_error(self):
+        # The reviewer's flagged case: a probe-machinery bug
+        # (RuntimeError, ValueError, etc.) is non-fatal at the
+        # control-flow level but MUST emit at ERROR so log filtering
+        # doesn't hide it.
+        assert init_mod._event_level_for_failure("warn", is_onellm=False) == EventLevel.ERROR
+
+    def test_fatal_non_onellm_emits_error(self):
+        # Defensive: the classifier never produces "fatal" for a
+        # non-OneLLMError today, but if it ever did we still want
+        # ERROR (loudest signal wins).
+        assert init_mod._event_level_for_failure("fatal", is_onellm=False) == EventLevel.ERROR
+
+    def test_unrecognized_severity_treated_as_non_fatal(self):
+        # Future-proofing: an unknown severity string from a
+        # classifier extension should NOT silently emit ERROR.
+        # Falls into the "warn" branch via the inverted condition.
+        assert (
+            init_mod._event_level_for_failure("future-severity", is_onellm=True)
+            == EventLevel.WARNING
         )
-        with patch.object(init_mod, "_execute_single_probe", new=AsyncMock(side_effect=exc)):
-            with pytest.raises(ConfigurationValidationError) as excinfo:
-                await init_mod.probe_declared_models(formation)
-
-        msg = str(excinfo.value)
-        assert "local/all-MiniLM-L6-v2" in msg
-        assert "local/sentence-transformers/all-MiniLM-L6-v2" in msg
-        assert "owner/organization" in msg
-
-    @pytest.mark.asyncio
-    async def test_authentication_error_does_not_abort(self):
-        formation = _make_formation({"text": {"model": "openai/gpt-4o-mini"}})
-        exc = AuthenticationError("bad key", provider="openai", status_code=401)
-        with patch.object(init_mod, "_execute_single_probe", new=AsyncMock(side_effect=exc)):
-            # Must not raise - auth failures are warn-and-continue.
-            await init_mod.probe_declared_models(formation)
-
-    @pytest.mark.asyncio
-    async def test_rate_limit_does_not_abort(self):
-        formation = _make_formation({"text": {"model": "anthropic/claude-3-5-sonnet"}})
-        exc = RateLimitError("429", provider="anthropic", status_code=429)
-        with patch.object(init_mod, "_execute_single_probe", new=AsyncMock(side_effect=exc)):
-            await init_mod.probe_declared_models(formation)
-
-    @pytest.mark.asyncio
-    async def test_non_onellm_exception_does_not_abort(self):
-        # A bug in the probe machinery (RuntimeError, ValueError, ...)
-        # must NOT brick formations - log loudly, continue.
-        formation = _make_formation({"text": {"model": "openai/gpt-4o-mini"}})
-        with patch.object(
-            init_mod,
-            "_execute_single_probe",
-            new=AsyncMock(side_effect=RuntimeError("probe machinery bug")),
-        ):
-            await init_mod.probe_declared_models(formation)
-
-    @pytest.mark.asyncio
-    async def test_first_fatal_aborts_before_subsequent_probes_run(self):
-        # text raises 404; embedding (a separate probe) MUST NOT be
-        # called because we fail-fast on the first fatal.
-        formation = _make_formation(
-            {
-                "text": {"model": "openai/gpt-4o-min"},  # typo, will 404
-                "embedding": {"model": "openai/text-embedding-3-small"},
-            }
-        )
-
-        call_log: list[tuple] = []
-
-        async def fake_probe(model: str, kind: str) -> None:
-            call_log.append((model, kind))
-            if model == "openai/gpt-4o-min":
-                raise ResourceNotFoundError("404", provider="openai", status_code=404)
-
-        with patch.object(init_mod, "_execute_single_probe", new=fake_probe):
-            with pytest.raises(ConfigurationValidationError):
-                await init_mod.probe_declared_models(formation)
-
-        assert call_log == [("openai/gpt-4o-min", "chat")]
-
-    @pytest.mark.asyncio
-    async def test_empty_capability_models_is_a_noop(self):
-        formation = _make_formation({})
-        with patch.object(init_mod, "_execute_single_probe", new=AsyncMock()) as mock_exec:
-            await init_mod.probe_declared_models(formation)
-        mock_exec.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_dedup_runs_one_probe_for_two_capabilities(self):
-        # vision cascading from text - both point at gpt-4o-mini, only
-        # one probe should fire.
-        formation = _make_formation(
-            {
-                "text": {"model": "openai/gpt-4o-mini"},
-                "vision": {"model": "openai/gpt-4o-mini"},
-            }
-        )
-        with patch.object(init_mod, "_execute_single_probe", new=AsyncMock()) as mock_exec:
-            await init_mod.probe_declared_models(formation)
-        assert mock_exec.await_count == 1

--- a/tests/unit/test_model_init_probe.py
+++ b/tests/unit/test_model_init_probe.py
@@ -1,0 +1,268 @@
+"""Unit tests for the formation-init model probe.
+
+The probe verifies that every model declared in ``formation._capability_models``
+resolves through OneLLM at formation init time, so misspelled or
+shape-invalid slugs (e.g. ``local/all-MiniLM-L6-v2`` instead of
+``local/sentence-transformers/all-MiniLM-L6-v2``) abort startup
+rather than degrading silently on first user request.
+
+Failure classification under test:
+
+- ``ResourceNotFoundError``      -> FATAL (raises ConfigurationValidationError)
+- ``InvalidRequestError``        -> FATAL  (HF validation = bare-name slug)
+- ``AuthenticationError``        -> WARN   (continue; can't distinguish
+                                            missing vs invalid key reliably)
+- ``RateLimitError``             -> WARN   (transient)
+- non-OneLLMError exceptions     -> WARN   (probe-machinery bug)
+
+Plus structural tests for capability dedup, probe-shape selection
+(embedding vs chat), serial fail-fast ordering, and that the bare-name
+fatal message includes the operator-actionable hint.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from onellm.errors import (
+    AuthenticationError,
+    InvalidRequestError,
+    OneLLMError,
+    RateLimitError,
+    ResourceNotFoundError,
+)
+
+from muxi.runtime.datatypes.exceptions import ConfigurationValidationError
+from muxi.runtime.formation import initialization as init_mod
+
+
+def _make_formation(capability_models: dict) -> SimpleNamespace:
+    """Build a minimal formation stand-in with just the field the probe reads."""
+    return SimpleNamespace(_capability_models=capability_models)
+
+
+class TestClassification:
+    """``_classify_probe_failure`` is pure - lock its contract."""
+
+    def test_resource_not_found_is_fatal(self):
+        exc = ResourceNotFoundError("missing", provider="local", status_code=404)
+        assert init_mod._classify_probe_failure(exc) == "fatal"
+
+    def test_invalid_request_is_fatal(self):
+        exc = InvalidRequestError("bad slug", provider="local", status_code=400)
+        assert init_mod._classify_probe_failure(exc) == "fatal"
+
+    def test_authentication_is_warn(self):
+        exc = AuthenticationError("nope", provider="openai", status_code=401)
+        assert init_mod._classify_probe_failure(exc) == "warn"
+
+    def test_rate_limit_is_warn(self):
+        exc = RateLimitError("slow down", provider="anthropic", status_code=429)
+        assert init_mod._classify_probe_failure(exc) == "warn"
+
+    def test_generic_onellm_error_is_warn(self):
+        exc = OneLLMError("generic")
+        assert init_mod._classify_probe_failure(exc) == "warn"
+
+
+class TestFatalMessageFormatting:
+    """The operator-facing message picks a hint based on slug shape."""
+
+    def test_local_bare_name_surfaces_owner_hint(self):
+        # The dev's exact case.
+        exc = InvalidRequestError("HFValidationError", provider="local", status_code=400)
+        msg = init_mod._format_probe_fatal_message("local/all-MiniLM-L6-v2", exc)
+
+        assert "local/all-MiniLM-L6-v2" in msg
+        assert "missing the owner/organization" in msg
+        assert "local/<owner>/<repo>" in msg
+        assert "local/sentence-transformers/all-MiniLM-L6-v2" in msg
+        assert type(exc).__name__ in msg
+
+    def test_local_owner_repo_surfaces_typo_or_gated_hint(self):
+        exc = ResourceNotFoundError("404", provider="local", status_code=404)
+        msg = init_mod._format_probe_fatal_message("local/nonexistent-org/whatever", exc)
+
+        assert "Common causes for local/* slugs" in msg
+        assert "Gated repo" in msg
+        # Must NOT show the bare-name hint for a slug that already has owner/repo.
+        assert "missing the owner/organization" not in msg
+
+    def test_cloud_slug_shows_cloud_hint_only(self):
+        exc = ResourceNotFoundError("404", provider="openai", status_code=404)
+        msg = init_mod._format_probe_fatal_message("openai/gpt-4o-min", exc)
+
+        assert "Common causes for cloud slugs" in msg
+        assert "Typo in the model name" in msg
+        # Local-specific hints must not appear for cloud slugs.
+        assert "local/<owner>/<repo>" not in msg
+        assert "HuggingFace repo id" not in msg
+
+
+class TestProbeBuilder:
+    """``_build_unique_probes`` controls dedup and probe-kind selection."""
+
+    def test_embedding_capability_uses_embedding_probe_kind(self):
+        probes = init_mod._build_unique_probes(
+            {"embedding": {"model": "local/sentence-transformers/all-MiniLM-L6-v2"}}
+        )
+        assert len(probes) == 1
+        assert probes[0]["kind"] == "embedding"
+
+    def test_text_capability_uses_chat_probe_kind(self):
+        probes = init_mod._build_unique_probes({"text": {"model": "openai/gpt-4o-mini"}})
+        assert len(probes) == 1
+        assert probes[0]["kind"] == "chat"
+
+    def test_two_capabilities_same_chat_slug_dedup_to_one_probe(self):
+        # vision falling back to text is the canonical case.
+        probes = init_mod._build_unique_probes(
+            {
+                "text": {"model": "openai/gpt-4o-mini"},
+                "vision": {"model": "openai/gpt-4o-mini"},
+            }
+        )
+        assert len(probes) == 1
+        assert set(probes[0]["capabilities"]) == {"text", "vision"}
+
+    def test_same_slug_used_as_chat_and_embedding_runs_two_probes(self):
+        # Edge case: same slug declared as both - we want both probed
+        # because the OneLLM transport differs.
+        probes = init_mod._build_unique_probes(
+            {
+                "text": {"model": "openai/text-embedding-3-small"},
+                "embedding": {"model": "openai/text-embedding-3-small"},
+            }
+        )
+        assert len(probes) == 2
+        kinds = {p["kind"] for p in probes}
+        assert kinds == {"chat", "embedding"}
+
+    def test_empty_or_missing_model_is_skipped(self):
+        probes = init_mod._build_unique_probes(
+            {
+                "text": {"model": "openai/gpt-4o-mini"},
+                "ghost": {"model": ""},
+                "phantom": {"model": None},
+                "weird": {},  # no "model" key
+            }
+        )
+        assert len(probes) == 1
+        assert probes[0]["model"] == "openai/gpt-4o-mini"
+
+
+class TestProbeOutcomes:
+    """End-to-end probe behavior with the OneLLM call mocked."""
+
+    @pytest.mark.asyncio
+    async def test_all_probes_succeed_no_raise(self):
+        formation = _make_formation({"text": {"model": "openai/gpt-4o-mini"}})
+        with patch.object(init_mod, "_execute_single_probe", new=AsyncMock()) as mock_exec:
+            await init_mod.probe_declared_models(formation)
+        mock_exec.assert_awaited_once_with("openai/gpt-4o-mini", "chat")
+
+    @pytest.mark.asyncio
+    async def test_resource_not_found_aborts_with_config_error(self):
+        formation = _make_formation({"text": {"model": "openai/gpt-4o-min"}})  # typo
+        exc = ResourceNotFoundError("404", provider="openai", status_code=404)
+        with patch.object(init_mod, "_execute_single_probe", new=AsyncMock(side_effect=exc)):
+            with pytest.raises(ConfigurationValidationError) as excinfo:
+                await init_mod.probe_declared_models(formation)
+
+        # Message names the offending slug and embeds the OneLLM error.
+        msg = str(excinfo.value)
+        assert "openai/gpt-4o-min" in msg
+        assert "ResourceNotFoundError" in msg
+
+    @pytest.mark.asyncio
+    async def test_bare_name_local_slug_surfaces_owner_hint(self):
+        # The dev's exact failure - must produce the hint that names
+        # the canonical form.
+        formation = _make_formation({"embedding": {"model": "local/all-MiniLM-L6-v2"}})
+        exc = InvalidRequestError(
+            "[local/all-MiniLM-L6-v2] Invalid HuggingFace repo id.",
+            provider="local",
+            status_code=400,
+        )
+        with patch.object(init_mod, "_execute_single_probe", new=AsyncMock(side_effect=exc)):
+            with pytest.raises(ConfigurationValidationError) as excinfo:
+                await init_mod.probe_declared_models(formation)
+
+        msg = str(excinfo.value)
+        assert "local/all-MiniLM-L6-v2" in msg
+        assert "local/sentence-transformers/all-MiniLM-L6-v2" in msg
+        assert "owner/organization" in msg
+
+    @pytest.mark.asyncio
+    async def test_authentication_error_does_not_abort(self):
+        formation = _make_formation({"text": {"model": "openai/gpt-4o-mini"}})
+        exc = AuthenticationError("bad key", provider="openai", status_code=401)
+        with patch.object(init_mod, "_execute_single_probe", new=AsyncMock(side_effect=exc)):
+            # Must not raise - auth failures are warn-and-continue.
+            await init_mod.probe_declared_models(formation)
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_does_not_abort(self):
+        formation = _make_formation({"text": {"model": "anthropic/claude-3-5-sonnet"}})
+        exc = RateLimitError("429", provider="anthropic", status_code=429)
+        with patch.object(init_mod, "_execute_single_probe", new=AsyncMock(side_effect=exc)):
+            await init_mod.probe_declared_models(formation)
+
+    @pytest.mark.asyncio
+    async def test_non_onellm_exception_does_not_abort(self):
+        # A bug in the probe machinery (RuntimeError, ValueError, ...)
+        # must NOT brick formations - log loudly, continue.
+        formation = _make_formation({"text": {"model": "openai/gpt-4o-mini"}})
+        with patch.object(
+            init_mod,
+            "_execute_single_probe",
+            new=AsyncMock(side_effect=RuntimeError("probe machinery bug")),
+        ):
+            await init_mod.probe_declared_models(formation)
+
+    @pytest.mark.asyncio
+    async def test_first_fatal_aborts_before_subsequent_probes_run(self):
+        # text raises 404; embedding (a separate probe) MUST NOT be
+        # called because we fail-fast on the first fatal.
+        formation = _make_formation(
+            {
+                "text": {"model": "openai/gpt-4o-min"},  # typo, will 404
+                "embedding": {"model": "openai/text-embedding-3-small"},
+            }
+        )
+
+        call_log: list[tuple] = []
+
+        async def fake_probe(model: str, kind: str) -> None:
+            call_log.append((model, kind))
+            if model == "openai/gpt-4o-min":
+                raise ResourceNotFoundError("404", provider="openai", status_code=404)
+
+        with patch.object(init_mod, "_execute_single_probe", new=fake_probe):
+            with pytest.raises(ConfigurationValidationError):
+                await init_mod.probe_declared_models(formation)
+
+        assert call_log == [("openai/gpt-4o-min", "chat")]
+
+    @pytest.mark.asyncio
+    async def test_empty_capability_models_is_a_noop(self):
+        formation = _make_formation({})
+        with patch.object(init_mod, "_execute_single_probe", new=AsyncMock()) as mock_exec:
+            await init_mod.probe_declared_models(formation)
+        mock_exec.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dedup_runs_one_probe_for_two_capabilities(self):
+        # vision cascading from text - both point at gpt-4o-mini, only
+        # one probe should fire.
+        formation = _make_formation(
+            {
+                "text": {"model": "openai/gpt-4o-mini"},
+                "vision": {"model": "openai/gpt-4o-mini"},
+            }
+        )
+        with patch.object(init_mod, "_execute_single_probe", new=AsyncMock()) as mock_exec:
+            await init_mod.probe_declared_models(formation)
+        assert mock_exec.await_count == 1


### PR DESCRIPTION
## Summary

Closes Finding #5 from the 2026-04-29 MS365 testing run.

The dev's formation declared `embedding: local/all-MiniLM-L6-v2` and the embedding service silently degraded to recency-only memory retrieval, surfacing only an opaque `InvalidConfigurationError` deep in the runtime path on every request. Two follow-up fix attempts by the dev failed because the failure reads like 'this model isn't available' when the actual root cause is a **slug-syntax problem**.

## Root cause

OneLLM's dispatcher (`providers/base.py::parse_model_name`) splits the model name on the **first** `/` only:

```python
provider, model_name = model.split("/", 1)
```

So `local/all-MiniLM-L6-v2` is passed to HuggingFace as the bare repo id `all-MiniLM-L6-v2` — which is not a valid HF identifier. The canonical form is `local/sentence-transformers/all-MiniLM-L6-v2`, where everything after `local/` is the full `<owner>/<repo>` HF slug. OneLLM has no curated alias table — what you write is what gets sent to HF.

Confirmed against `onellm/onellm/providers/local.py` docstring lines 26-39 and every example in OneLLM's README, CHANGELOG, docs, CLI help, and test fixtures.

## Change

Adds a fail-fast probe at formation init. After `initialize_llm_config()` populates `_capability_models` and the text-fallback cascade runs, `probe_declared_models()` iterates every distinct `(model_slug, probe_kind)` pair, dedups across capabilities, and issues a minimal OneLLM call:

| Capability | Probe call |
|---|---|
| `embedding` | `Embedding.acreate(input="probe", model=...)` |
| `text`, `vision`, `audio`, `documents`, `streaming`, future | `ChatCompletion.acreate(model=..., messages=[{"role":"user","content":"ping"}], max_tokens=1)` |

## Failure classification

| OneLLM error | Action |
|---|---|
| `ResourceNotFoundError` (HF 404 / model-not-found) | **FATAL** — formation refuses to load |
| `InvalidRequestError` (HF validation; the dev's exact case) | **FATAL** |
| `AuthenticationError` | Warn, continue (can't distinguish missing vs invalid key reliably) |
| `RateLimitError`, `ServiceUnavailableError`, `RequestTimeoutError` | Warn, continue (transient) |
| Other `OneLLMError` subclasses | Warn, continue |
| Non-`OneLLMError` exception | Warn, continue (probe-machinery bug, not user error) |

Probes run **synchronously, serially**. The first fatal aborts before later probes execute, so an operator with multiple bad slugs fixes them one error message at a time.

## Fatal error message (dynamic)

For `local/<bare-name>` slugs (the dev's exact case):

```
Cause: the local slug is missing the owner/organization segment.
The runtime requires the full HuggingFace repo id:
    local/<owner>/<repo>   (e.g. local/sentence-transformers/all-MiniLM-L6-v2)
NOT local/<repo>          (e.g. local/all-MiniLM-L6-v2)
```

For `local/<owner>/<repo>` 404s: typo / gated-repo hint.
For cloud slugs: typo / deprecated-model hint, local-specific hints suppressed.

## Observability

Three new `SystemEvents`:
- `MODEL_INIT_PROBE_STARTED`
- `MODEL_INIT_PROBE_COMPLETED` (with timing)
- `MODEL_INIT_PROBE_FAILED` (with `severity ∈ {fatal, warn}`, exception class, timing)

`scripts/validate_events.py` reports 1223/1223 observe calls in enum.

## Tests (22 unit, all passing)

- **TestClassification** (5): pure failure-class mapping
- **TestFatalMessageFormatting** (3): slug-shape-aware message builder, including dev's exact case
- **TestProbeBuilder** (5): capability dedup, embedding-vs-chat probe-kind selection, edge cases (empty/None model, same slug as both embedding+chat)
- **TestProbeOutcomes** (9): end-to-end with `_execute_single_probe` mocked. Includes serial-fail-fast assertion: when first probe 404s, the second is **never invoked**.

## Why no escape hatch

I considered `MUXI_SKIP_MODEL_INIT_PROBE=1` and dropped it. Correctness over convenience: a formation that won't actually work shouldn't pretend to be loading. The probe machinery itself catches non-`OneLLMError` exceptions and degrades to warn-and-continue, so the only way to brick a healthy formation is via a deterministic 404 — which is the bug we're fixing.

## Quality gates

- ruff: clean across all 4 touched files
- black --check: 4 files unchanged
- pytest tests/unit/test_model_init_probe.py: 22/22 pass
- pytest tests/unit/ -k 'formation or initialization or capability': 33/33 pass
- pytest tests/unit/: 1042 passed (pre-existing RCE auth failure on develop unchanged)
- validate_events.py: 1223/1223 observe calls in enum (3 new)
- Manual diff sweep for secrets: clean

## Files

```
 CHANGELOG.md                                 |  94 +++++++++
 src/muxi/runtime/datatypes/observability.py  |  15 +
 src/muxi/runtime/formation/formation.py      |   8 +
 src/muxi/runtime/formation/initialization.py | 271 +++++++++++++++++++
 tests/unit/test_model_init_probe.py          | 268 +++++++++++++++++++
 5 files changed, 656 insertions(+)
```
