### PR TITLE
PII/secret redaction hardening + entity-based redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 ## [unreleased]
 
+## v0.20260619.0
+
+### PII/secret redaction hardening + entity-based redaction
+
+Observability and memory now redact secrets and personal data far more
+thoroughly, and entity-based PII redaction (names, addresses, organizations,
+dates of birth, financial identifiers) is a built-in capability that is on by
+default.
+
+- **Redact by default in observability**: ``observe()`` now redacts every event
+  before emission instead of only a user-facing allow-list. Non-user events
+  (``SystemEvents``, ``MCP_*``, ``WORKFLOW_*``, ...) previously emitted raw
+  payloads that could carry secrets. A ``skip_redaction=True`` opt-out exists for
+  audited, non-sensitive events.
+- **Luhn-validated credit-card redaction**: 16-digit sequences are now masked
+  only when they pass the Luhn checksum, eliminating false positives on order
+  IDs, timestamps, and other long digit runs while still catching real cards.
+- **Unified sensitive vocabulary**: a shared ``utils/sensitive_terms.py`` holds
+  two term sets -- ``SENSITIVE_KEY_TERMS`` (substring-matched for dict keys) and
+  ``SENSITIVE_PREVIEW_TERMS`` (word-boundary-matched for free text) -- so the
+  observability redactor and the memory extractor stop drifting apart and avoid
+  ``"monkey"``-contains-``"key"`` style false positives.
+- **Entity-based PII redaction**: a pluggable detector layer
+  (``utils/redaction/``) sits after the regex layer. The default implementation
+  wraps Microsoft Presidio (spaCy ``en_core_web_sm``) and masks PERSON, ADDRESS,
+  ORG, date-of-birth (date entities only in birth context), and financial
+  identifiers using consistent indexed tokens (``[PERSON_1]``, ``[ORG_1]``, ...).
+  Generic dates and non-Luhn numbers are deliberately preserved.
+- **Core dependency, default on**: ``presidio-analyzer`` / ``presidio-anonymizer``
+  are now core dependencies (spaCy + ``en_core_web_sm`` were already core, used by
+  document chunking), so this is not an optional extra. A single
+  ``logging.redaction.entities`` flag (default ``true``) toggles the entity layer;
+  it is registered during formation load before observability is enabled. If the
+  model is unavailable the layer degrades gracefully to regex-only.
+- **Memory extractor gate**: the extractor reuses the shared vocabulary and the
+  entity detector so PII-bearing content is kept out of long-term memory.
+- **Lean image**: the lean ``Dockerfile`` now bakes ``en_core_web_sm`` into the
+  install prefix so default-on entity redaction works in the default image,
+  matching ``Dockerfile.production`` and the e2e image.
+
+Files touched:
+- ``utils/sensitive_terms.py`` -- NEW shared term sets
+- ``utils/security.py`` -- Luhn helpers, shared vocabulary, entity-layer composition
+- ``utils/redaction/{base,entity,__init__}.py`` -- NEW detector layer + Presidio impl
+- ``services/observability/__init__.py`` -- redact-by-default + ``skip_redaction``
+- ``services/memory/extractor.py`` -- shared vocabulary + entity-detector gate
+- ``formation/formation.py`` -- register detector from ``logging.redaction.entities``
+- ``formation/config/validation.py`` -- validate ``logging.redaction``
+- ``pyproject.toml`` -- presidio promoted to core dependencies
+- ``Dockerfile`` -- bake ``en_core_web_sm`` into the lean image
+- ``tests/unit/test_observability_redaction.py`` -- NEW redact-by-default tests
+- ``tests/unit/utils/test_redaction.py`` -- NEW detector/Presidio tests (incl. live)
+- ``tests/unit/utils/test_security.py`` -- Luhn coverage
+- ``e2e/tests/18_observability/test_18c_pii_redaction_observability.py`` -- NEW e2e:
+  pipeline redaction with the flag on and off
+- ``e2e/tests/18_observability/test_18d_pii_redaction_chat.py`` -- NEW e2e: real chat
+  turn never leaks secrets/PII into emitted events
+
 ## v0.20260616.0
 
 ## v0.20260616.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,11 @@ RUN ARCH=$(uname -m) && \
         echo "sqlite-vec: skipping recompilation for $ARCH"; \
     fi
 
-# Note: Skipping spaCy model download to save ~45MB
-# Can be downloaded at runtime if needed: python -m spacy download en_core_web_sm
+# Download the spaCy en_core_web_sm model (~45MB) into the install prefix so it
+# is copied into the runtime stage. Required by entity PII redaction (on by
+# default via logging.redaction.entities) and reused by semantic chunking.
+RUN uv pip install --prefix=/install --no-cache \
+    "en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl"
 
 # ============================================================================
 # Stage 2: Runtime - Minimal runtime environment

--- a/e2e/tests/18_observability/formations/formation-redaction/formation-no-entities.yaml
+++ b/e2e/tests/18_observability/formations/formation-redaction/formation-no-entities.yaml
@@ -1,0 +1,40 @@
+# PII redaction e2e formation - entity redaction disabled
+# Regex-based secret/PII redaction stays always-on; only the entity layer
+# (names/addresses/orgs/DOB/financial) is turned off here.
+schema: "1.0.0"
+id: redaction-test-no-entities
+description: "Formation with entity redaction disabled for e2e tests"
+
+llm:
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+    - embedding: "openai/text-embedding-3-small"
+
+runtime:
+  built_in_mcps: false
+
+memory:
+  buffer:
+    size: 10
+    vector_search: false
+
+logging:
+  system:
+    level: "error"
+    destination: "stdout"
+  conversation:
+    enabled: true
+    streams:
+      - transport: "stdout"
+        level: "info"
+        format: "jsonl"
+  redaction:
+    entities: false  # Entity layer off; regex layer remains active
+
+agents:
+  - id: assistant
+    name: "Redaction Assistant"
+    description: "Default assistant for redaction tests"
+    system_message: "You are a helpful test assistant. Keep responses brief and focused."

--- a/e2e/tests/18_observability/formations/formation-redaction/formation.yaml
+++ b/e2e/tests/18_observability/formations/formation-redaction/formation.yaml
@@ -1,0 +1,38 @@
+# PII redaction e2e formation - entity redaction enabled (default)
+schema: "1.0.0"
+id: redaction-test
+description: "Formation for PII/secret redaction e2e tests"
+
+llm:
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+    - embedding: "openai/text-embedding-3-small"
+
+runtime:
+  built_in_mcps: false  # Faster test startup
+
+memory:
+  buffer:
+    size: 10
+    vector_search: false
+
+logging:
+  system:
+    level: "error"
+    destination: "stdout"
+  conversation:
+    enabled: true
+    streams:
+      - transport: "stdout"
+        level: "info"
+        format: "jsonl"
+  redaction:
+    entities: true  # Default; stated explicitly for the test
+
+agents:
+  - id: assistant
+    name: "Redaction Assistant"
+    description: "Default assistant for redaction tests"
+    system_message: "You are a helpful test assistant. Keep responses brief and focused."

--- a/e2e/tests/18_observability/formations/formation-redaction/secrets.enc
+++ b/e2e/tests/18_observability/formations/formation-redaction/secrets.enc
@@ -1,0 +1,1 @@
+../../../../assets/secrets.enc

--- a/e2e/tests/18_observability/test_18c_pii_redaction_observability.py
+++ b/e2e/tests/18_observability/test_18c_pii_redaction_observability.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+Test 18c: PII/secret redaction in the observability pipeline.
+
+Exercises the real runtime path end-to-end (no LLM required):
+  - A real formation is loaded and the overlord is started, which registers the
+    entity detector from ``logging.redaction.entities`` before observability is
+    enabled.
+  - Events are emitted through the real ``observe()`` -> EventLogger pipeline and
+    captured, proving secrets and PII are redacted before they reach any sink.
+  - Both flag states are verified: with ``entities: true`` names/orgs are masked;
+    with ``entities: false`` the entity layer is off but the always-on regex layer
+    still masks secrets.
+
+Standalone script (per e2e conventions): run directly, not via pytest.
+"""
+
+import asyncio
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from muxi.runtime.formation import Formation  # noqa: E402
+from muxi.runtime.services import observability  # noqa: E402
+from muxi.runtime.services.observability import ConversationEvents, EventLevel  # noqa: E402
+from muxi.runtime.utils.redaction import get_entity_detector  # noqa: E402
+
+FORMATION_DIR = Path(__file__).parent / "formations" / "formation-redaction"
+
+# Build secret-like values at runtime so no real-looking credential literal is
+# committed to source (keeps secret scanners quiet); they still match the
+# redactor's patterns.
+SECRET = "sk-" + "z" * 32
+CARD = "4111" + "1111" * 3  # Luhn-valid Visa test number
+EMAIL = "jane.doe@example.com"
+SSN = "123-45-6789"
+PERSON = "Jane Doe"
+ORG = "Microsoft"
+
+
+class CapturingLogger:
+    """Drop-in event sink that records the (already-redacted) events observe() emits."""
+
+    def __init__(self):
+        self._events = []
+        self._lock = threading.Lock()
+
+    def emit_event(
+        self,
+        event_type=None,
+        level=None,
+        data=None,
+        description=None,
+        request_context=None,
+        **kwargs,
+    ):
+        with self._lock:
+            self._events.append(
+                {
+                    "event": getattr(event_type, "value", str(event_type)),
+                    "data": data,
+                    "description": description,
+                }
+            )
+        return ""
+
+    def snapshot(self):
+        with self._lock:
+            return list(self._events)
+
+
+def _flush_background():
+    """observe() emits on a short-lived background thread; give it time to drain.
+
+    We deliberately do not call ``multitasking.wait_for_tasks()`` here: the
+    running formation keeps long-lived background tasks alive, so that call
+    would block indefinitely.
+    """
+    time.sleep(1.0)
+
+
+async def _emit_and_capture(formation_file: str, payload: dict):
+    """Load a formation, start the overlord, emit one event, and capture it."""
+    formation = Formation()
+    await formation.load(str(FORMATION_DIR / formation_file))
+    await formation.start_overlord()
+
+    detector = get_entity_detector()
+
+    capturing = CapturingLogger()
+    observability.set_runtime_event_logger(capturing)
+    observability.observe(
+        ConversationEvents.REQUEST_RECEIVED,
+        level=EventLevel.INFO,
+        data=payload,
+        description=f"request from {PERSON}: key {payload.get('secret', '')}",
+    )
+    _flush_background()
+    events = capturing.snapshot()
+
+    await formation.stop_overlord()
+    return detector, events
+
+
+async def run() -> bool:
+    print("=" * 70)
+    print("Test 18c: PII/secret redaction in the observability pipeline")
+    print("=" * 70)
+
+    checks = []
+
+    # ------------------------------------------------------------------
+    # Case 1: entity redaction enabled (default)
+    # ------------------------------------------------------------------
+    print("\n1. Loading formation with logging.redaction.entities: true ...")
+    payload = {
+        "secret": SECRET,
+        "email": EMAIL,
+        "card": CARD,
+        "ssn": SSN,
+        "note": f"Contact {PERSON} at {ORG} regarding the account.",
+    }
+    detector, events = await _emit_and_capture("formation.yaml", payload)
+    assert events, "no events were captured from the observe() pipeline"
+    blob = json.dumps(events)
+    print(f"   Captured {len(events)} event(s); entity detector active: {detector is not None}")
+
+    # Always-on regex layer: secrets/PII must never appear raw.
+    assert SECRET not in blob, "raw API key leaked into emitted event"
+    assert CARD not in blob, "raw credit card leaked into emitted event"
+    assert EMAIL not in blob, "raw email leaked into emitted event"
+    assert SSN not in blob, "raw SSN leaked into emitted event"
+    assert "***" in blob, "expected redaction markers in emitted event"
+    checks.append("Regex layer masks secret/card/email/SSN in emitted events")
+    print("   Secret, card, email, SSN all redacted (regex layer)")
+
+    # Entity layer (only when the spaCy model + presidio are available).
+    if detector is not None:
+        assert PERSON not in blob, "person name leaked despite entity redaction enabled"
+        assert ORG not in blob, "organization leaked despite entity redaction enabled"
+        assert "[PERSON_1]" in blob, "expected [PERSON_1] entity token"
+        assert "[ORG_1]" in blob, "expected [ORG_1] entity token"
+        checks.append("Entity layer masks PERSON/ORG with indexed tokens")
+        print(f"   '{PERSON}' -> [PERSON_1], '{ORG}' -> [ORG_1] (entity layer)")
+    else:
+        checks.append("Entity detector unavailable; regex layer verified (model not installed)")
+        print("   NOTE: entity detector not registered (presidio/model unavailable);")
+        print("         regex redaction still verified.")
+
+    # ------------------------------------------------------------------
+    # Case 2: entity redaction disabled - flag actually turns the layer off,
+    # but the regex layer stays active.
+    # ------------------------------------------------------------------
+    print("\n2. Loading formation with logging.redaction.entities: false ...")
+    secret2 = "sk-" + "q" * 32
+    payload2 = {"secret": secret2, "note": f"Contact {PERSON} at {ORG}."}
+    detector2, events2 = await _emit_and_capture("formation-no-entities.yaml", payload2)
+    assert events2, "no events were captured in the disabled case"
+    blob2 = json.dumps(events2)
+    print(f"   Captured {len(events2)} event(s); entity detector active: {detector2 is not None}")
+
+    assert detector2 is None, "entity detector should be unregistered when entities: false"
+    assert secret2 not in blob2, "raw secret leaked even though regex layer is always on"
+    assert PERSON in blob2, "person name should be preserved when entity layer is disabled"
+    checks.append("entities: false disables entity layer but regex layer still masks secrets")
+    print(f"   Detector off; secret redacted; '{PERSON}' preserved (entity layer disabled)")
+
+    # ------------------------------------------------------------------
+    # Summary
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 40)
+    print("\n### Test Result:")
+    print("  🎉 SUCCESS: PII/secret redaction verified end-to-end")
+    for c in checks:
+        print(f"  ✓ {c}")
+    print("\n" + "=" * 40)
+    print("\n### Chat transcript:")
+    print(f"\nUser: Contact {PERSON} at {ORG}; key {SECRET}; card {CARD}")
+    print("System (emitted event, redacted): " f"{json.dumps(events[0]['data'])}")
+    print(f"\nUser (entities off): Contact {PERSON} at {ORG}; key {secret2}")
+    print("System (emitted event, redacted): " f"{json.dumps(events2[0]['data'])}")
+
+    return True
+
+
+def main() -> int:
+    try:
+        ok = asyncio.run(run())
+        return 0 if ok else 1
+    except Exception as e:
+        import traceback
+
+        print(f"\n❌ FAIL: {e}")
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    import os
+
+    exit_code = main()
+    if exit_code == 0:
+        print("\nSUCCESS", flush=True)
+    os._exit(exit_code)

--- a/e2e/tests/18_observability/test_18d_pii_redaction_chat.py
+++ b/e2e/tests/18_observability/test_18d_pii_redaction_chat.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Test 18d: secrets/PII in a real chat never leak into observability events.
+
+Runs a real ``overlord.chat()`` turn whose user message embeds an API key, an
+email, and a personal name, captures every observability event emitted during
+the turn, and asserts none of the raw sensitive values appear in any event the
+runtime would route to a log sink.
+
+Requires a live LLM (OpenAI key from secrets.enc), like other Area 1/18 chat
+tests. Standalone script: run directly, not via pytest.
+"""
+
+import asyncio
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from muxi.runtime.formation import Formation  # noqa: E402
+from muxi.runtime.services import observability  # noqa: E402
+
+FORMATION_DIR = Path(__file__).parent / "formations" / "formation-redaction"
+
+# Constructed at runtime so no credential-looking literal is committed.
+SECRET = "sk-" + "z" * 32
+EMAIL = "jane.doe@example.com"
+PERSON = "Jane Doe"
+
+
+class CapturingLogger:
+    """Records (already-redacted) events emitted during the chat turn."""
+
+    def __init__(self):
+        self._events = []
+        self._lock = threading.Lock()
+
+    def emit_event(
+        self,
+        event_type=None,
+        level=None,
+        data=None,
+        description=None,
+        request_context=None,
+        **kwargs,
+    ):
+        with self._lock:
+            self._events.append(
+                {
+                    "event": getattr(event_type, "value", str(event_type)),
+                    "data": data,
+                    "description": description,
+                }
+            )
+        return ""
+
+    def snapshot(self):
+        with self._lock:
+            return list(self._events)
+
+
+def _flush_background():
+    # The running formation keeps long-lived multitasking tasks alive, so we
+    # cannot wait_for_tasks(); a short sleep lets the per-event emit threads drain.
+    time.sleep(1.0)
+
+
+async def run() -> bool:
+    print("=" * 70)
+    print("Test 18d: no secret/PII leak into observability events during chat")
+    print("=" * 70)
+
+    formation = Formation()
+    await formation.load(str(FORMATION_DIR / "formation.yaml"))
+    overlord = await formation.start_overlord()
+    print("\n1. Formation loaded and overlord started.")
+
+    capturing = CapturingLogger()
+    observability.set_runtime_event_logger(capturing)
+
+    message = (
+        f"My name is {PERSON}, my email is {EMAIL}, and my OpenAI key is {SECRET}. "
+        "Please just say hello."
+    )
+    print("\n2. Sending chat message containing a secret + PII ...")
+    response = await asyncio.wait_for(overlord.chat(message, user_id="redaction_user"), timeout=90)
+    response_text = getattr(response, "content", None) or str(response)
+
+    _flush_background()
+    events = capturing.snapshot()
+    await formation.stop_overlord()
+
+    print(
+        f"   Received response ({len(response_text)} chars); "
+        f"captured {len(events)} event(s) during the turn."
+    )
+
+    assert events, "expected the chat turn to emit observability events"
+    blob = json.dumps(events)
+
+    # The headline guarantee: the raw secret and email never reach a log sink.
+    assert SECRET not in blob, "raw API key leaked into an observability event"
+    assert EMAIL not in blob, "raw email leaked into an observability event"
+
+    checks = [
+        "Real chat turn completed",
+        f"{len(events)} observability events captured",
+        "Raw API key never appears in any emitted event",
+        "Raw email never appears in any emitted event",
+    ]
+
+    # If any event carried the user message and the entity layer is active, the
+    # name should be masked too; only assert when the name actually shows up.
+    detector_active = "[PERSON_1]" in blob
+    if PERSON in blob:
+        raise AssertionError("person name leaked unmasked into an observability event")
+    if detector_active:
+        checks.append("Person name masked to [PERSON_1] in emitted events")
+
+    print("\n" + "=" * 40)
+    print("\n### Test Result:")
+    print("  🎉 SUCCESS: chat secrets/PII redacted before reaching log sinks")
+    for c in checks:
+        print(f"  ✓ {c}")
+    print("\n" + "=" * 40)
+    print("\n### Chat transcript:")
+    print(f"\nUser: {message}")
+    print(f"System: {response_text[:200]}")
+
+    return True
+
+
+def main() -> int:
+    try:
+        ok = asyncio.run(run())
+        return 0 if ok else 1
+    except Exception as e:
+        import traceback
+
+        print(f"\n❌ FAIL: {e}")
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    import os
+
+    exit_code = main()
+    if exit_code == 0:
+        print("\nSUCCESS", flush=True)
+    os._exit(exit_code)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,20 @@ kafka = [
     "kafka-python>=2.0.0",  # Kafka streaming support for observability
 ]
 
+# PII entity redaction — adds NER-based detection of names, addresses, orgs,
+# DOB, and financial identifiers for logs/telemetry/previews and the memory
+# extractor gate. Optional: when absent, redaction stays regex-only (secrets
+# are always scrubbed). Activates the logging.redaction.entities flag.
+#   pip install 'muxi-runtime[pii]'
+# The small spaCy model (~12MB) ships as a resolvable wheel URL; alternatively
+# run `python -m spacy download en_core_web_sm` after install.
+pii = [
+    "presidio-analyzer>=2.2",
+    "presidio-anonymizer>=2.2",
+    "spacy>=3.7",
+    "en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl",
+]
+
 # ---------------------------------------------------------------------------
 # Runtime variants
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,13 @@ dependencies = [
     "nltk>=3.9.4",  # Natural language processing for chunking
     "spacy>=3.8.14",  # Advanced NLP for semantic chunking (compatible with NumPy 2.x)
 
+    # PII entity redaction (names/addresses/orgs/DOB/financial) for logs,
+    # telemetry, previews, and the memory extractor gate. Reuses the spaCy
+    # en_core_web_sm model already required by document chunking. Toggle via
+    # logging.redaction.entities (default on).
+    "presidio-analyzer>=2.2",
+    "presidio-anonymizer>=2.2",
+
     # Image processing dependencies
     "Pillow>=12.2.0",  # PIL/Pillow for image processing
     "pdf2image>=1.17.0",  # Convert PDF pages to images (requires Poppler)
@@ -178,20 +185,6 @@ dependencies = [
 [project.optional-dependencies]
 kafka = [
     "kafka-python>=2.0.0",  # Kafka streaming support for observability
-]
-
-# PII entity redaction — adds NER-based detection of names, addresses, orgs,
-# DOB, and financial identifiers for logs/telemetry/previews and the memory
-# extractor gate. Optional: when absent, redaction stays regex-only (secrets
-# are always scrubbed). Activates the logging.redaction.entities flag.
-#   pip install 'muxi-runtime[pii]'
-# The small spaCy model (~12MB) ships as a resolvable wheel URL; alternatively
-# run `python -m spacy download en_core_web_sm` after install.
-pii = [
-    "presidio-analyzer>=2.2",
-    "presidio-anonymizer>=2.2",
-    "spacy>=3.7",
-    "en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl",
 ]
 
 # ---------------------------------------------------------------------------

--- a/src/muxi/runtime/formation/config/validation.py
+++ b/src/muxi/runtime/formation/config/validation.py
@@ -1821,6 +1821,20 @@ class FormationValidator:
         if "conversation" in logging_config:
             self._validate_logging_conversation_config(logging_config["conversation"])
 
+        # Validate redaction config (optional)
+        if "redaction" in logging_config:
+            self._validate_logging_redaction_config(logging_config["redaction"])
+
+    def _validate_logging_redaction_config(self, redaction_config: Dict[str, Any]) -> None:
+        """Validate logging.redaction configuration."""
+        if not isinstance(redaction_config, dict):
+            self.result.add_error("Logging 'redaction' must be a dictionary")
+            return
+
+        # Validate entities toggle (optional, defaults to True)
+        if "entities" in redaction_config and not isinstance(redaction_config["entities"], bool):
+            self.result.add_error("Logging redaction 'entities' must be a boolean")
+
     def _validate_logging_system_config(self, system_config: Dict[str, Any]) -> None:
         """Validate logging.system configuration."""
         if not isinstance(system_config, dict):

--- a/src/muxi/runtime/formation/formation.py
+++ b/src/muxi/runtime/formation/formation.py
@@ -2817,9 +2817,9 @@ class Formation:
                 )
             )
 
-            # Register the optional entity-redaction detector based on the
+            # Register the entity-redaction detector based on the
             # logging.redaction.entities flag (default on; regex-only fallback
-            # when the presidio extra is not installed).
+            # if the presidio NLP stack is unexpectedly unavailable).
             from ..utils.redaction import build_entity_detector, set_entity_detector
 
             redaction_config = (

--- a/src/muxi/runtime/formation/formation.py
+++ b/src/muxi/runtime/formation/formation.py
@@ -2827,9 +2827,7 @@ class Formation:
                 if isinstance(self._logging_config, dict)
                 else {}
             )
-            set_entity_detector(
-                build_entity_detector(redaction_config.get("entities", True))
-            )
+            set_entity_detector(build_entity_detector(redaction_config.get("entities", True)))
 
             # Enable observability now that init is complete
             # This starts the flow of JSON observability events for runtime monitoring

--- a/src/muxi/runtime/formation/formation.py
+++ b/src/muxi/runtime/formation/formation.py
@@ -2817,6 +2817,20 @@ class Formation:
                 )
             )
 
+            # Register the optional entity-redaction detector based on the
+            # logging.redaction.entities flag (default on; regex-only fallback
+            # when the presidio extra is not installed).
+            from ..utils.redaction import build_entity_detector, set_entity_detector
+
+            redaction_config = (
+                self._logging_config.get("redaction", {})
+                if isinstance(self._logging_config, dict)
+                else {}
+            )
+            set_entity_detector(
+                build_entity_detector(redaction_config.get("entities", True))
+            )
+
             # Enable observability now that init is complete
             # This starts the flow of JSON observability events for runtime monitoring
             observability.enable()

--- a/src/muxi/runtime/services/memory/extractor.py
+++ b/src/muxi/runtime/services/memory/extractor.py
@@ -35,6 +35,7 @@ import time
 from typing import Any, Set
 
 from ...utils.fastjson import json
+from ...utils.redaction import get_entity_detector
 from ...utils.sensitive_terms import SENSITIVE_KEY_TERMS
 from .. import observability
 
@@ -614,6 +615,11 @@ class MemoryExtractor:
                 if key_lower not in {"phone", "contact", "mobile"}:
                     return True
 
+            # Entity detection (names, addresses, orgs, DOB, financial) when enabled
+            detector = get_entity_detector()
+            if detector is not None and detector.detect(value):
+                return True
+
         return False
 
     def _should_update_existing(self, key, new_value, existing_value, importance):
@@ -667,6 +673,11 @@ class MemoryExtractor:
         import re
 
         if re.search(r"\b\d{3}-\d{2}-\d{4}\b", sentence):
+            return True
+
+        # Entity detection (names, addresses, orgs, DOB, financial) when enabled
+        detector = get_entity_detector()
+        if detector is not None and detector.detect(sentence):
             return True
 
         return False

--- a/src/muxi/runtime/services/memory/extractor.py
+++ b/src/muxi/runtime/services/memory/extractor.py
@@ -35,7 +35,7 @@ import time
 from typing import Any, Set
 
 from ...utils.fastjson import json
-from ...utils.redaction import get_entity_detector
+from ...utils.redaction import DEFAULT_ENTITY_THRESHOLD, get_entity_detector
 from ...utils.sensitive_terms import SENSITIVE_KEY_TERMS
 from .. import observability
 
@@ -615,9 +615,13 @@ class MemoryExtractor:
                 if key_lower not in {"phone", "contact", "mobile"}:
                     return True
 
-            # Entity detection (names, addresses, orgs, DOB, financial) when enabled
+            # Entity detection (names, addresses, orgs, DOB, financial) when enabled.
+            # Apply the same confidence threshold mask_spans uses so the memory
+            # gate and the observability redactor agree on what counts as PII.
             detector = get_entity_detector()
-            if detector is not None and detector.detect(value):
+            if detector is not None and any(
+                span.score >= DEFAULT_ENTITY_THRESHOLD for span in detector.detect(value)
+            ):
                 return True
 
         return False
@@ -675,9 +679,13 @@ class MemoryExtractor:
         if re.search(r"\b\d{3}-\d{2}-\d{4}\b", sentence):
             return True
 
-        # Entity detection (names, addresses, orgs, DOB, financial) when enabled
+        # Entity detection (names, addresses, orgs, DOB, financial) when enabled.
+        # Apply the same confidence threshold mask_spans uses so the memory gate
+        # and the observability redactor agree on what counts as PII.
         detector = get_entity_detector()
-        if detector is not None and detector.detect(sentence):
+        if detector is not None and any(
+            span.score >= DEFAULT_ENTITY_THRESHOLD for span in detector.detect(sentence)
+        ):
             return True
 
         return False

--- a/src/muxi/runtime/services/memory/extractor.py
+++ b/src/muxi/runtime/services/memory/extractor.py
@@ -35,6 +35,7 @@ import time
 from typing import Any, Set
 
 from ...utils.fastjson import json
+from ...utils.sensitive_terms import SENSITIVE_KEY_TERMS
 from .. import observability
 
 
@@ -93,18 +94,7 @@ class MemoryExtractor:
         self.similarity_threshold = similarity_threshold
 
         # Add default privacy settings
-        self._sensitive_key_patterns = {
-            "password",
-            "social_security",
-            "ssn",
-            "credit_card",
-            "bank_account",
-            "passport",
-            "license",
-            "secret",
-            "private",
-            "confidential",
-        }
+        self._sensitive_key_patterns = SENSITIVE_KEY_TERMS
 
     async def process_conversation_turn(
         self, user_message, agent_response, user_id, message_count=1

--- a/src/muxi/runtime/services/observability/__init__.py
+++ b/src/muxi/runtime/services/observability/__init__.py
@@ -169,6 +169,7 @@ def observe(
     level: EventLevel = EventLevel.INFO,
     data: Optional[Dict[str, Any]] = None,
     description: str = "",
+    skip_redaction: bool = False,
 ) -> None:
     """
     Emit an observability event (non-blocking).
@@ -183,6 +184,9 @@ def observe(
         level: Event level (defaults to INFO)
         data: Additional event data
         description: Human-readable description
+        skip_redaction: When True, emit raw data without redaction. Use only for
+            audited, non-sensitive events where raw values are required. Redaction
+            is applied to every event by default.
     """
     global _enabled
 
@@ -198,26 +202,16 @@ def observe(
         if not configured_logger:
             return
 
-        # Conditionally redact PII based on event type
-        # Only redact for user-facing events (conversation, errors, API, user-related)
-        should_redact = False
-        if isinstance(event_type, (ConversationEvents, ErrorEvents, APIEvents)):
-            should_redact = True
-        elif isinstance(event_type, str):
-            # Check for user-related keywords in string event types
-            event_type_lower = event_type.lower()
-            if any(
-                keyword in event_type_lower
-                for keyword in ["user", "conversation", "message", "error", "api"]
-            ):
-                should_redact = True
-
-        if should_redact:
-            redacted_data = _redact_data_recursive(data or {})
-            redacted_description = _redact_data_recursive(description) if description else ""
-        else:
+        # Redact PII/secrets by default for every event. The previous event-type
+        # allow-list left non-user events (SystemEvents, MCP_*, WORKFLOW_*, ...)
+        # unredacted, which could leak secrets carried in their payloads. Callers
+        # may opt out via skip_redaction for audited, non-sensitive events.
+        if skip_redaction:
             redacted_data = data or {}
             redacted_description = description or ""
+        else:
+            redacted_data = _redact_data_recursive(data or {})
+            redacted_description = _redact_data_recursive(description) if description else ""
 
         # Get request context
         from .context import get_current_request_context

--- a/src/muxi/runtime/utils/redaction/__init__.py
+++ b/src/muxi/runtime/utils/redaction/__init__.py
@@ -1,0 +1,20 @@
+"""Entity-based redaction layer (optional, opt-out via logging.redaction.entities)."""
+
+from .base import (
+    EntityDetector,
+    Span,
+    get_entity_detector,
+    mask_spans,
+    set_entity_detector,
+)
+from .entity import PresidioDetector, build_entity_detector
+
+__all__ = [
+    "EntityDetector",
+    "Span",
+    "get_entity_detector",
+    "set_entity_detector",
+    "mask_spans",
+    "PresidioDetector",
+    "build_entity_detector",
+]

--- a/src/muxi/runtime/utils/redaction/__init__.py
+++ b/src/muxi/runtime/utils/redaction/__init__.py
@@ -1,6 +1,7 @@
 """Entity-based redaction layer (optional, opt-out via logging.redaction.entities)."""
 
 from .base import (
+    DEFAULT_ENTITY_THRESHOLD,
     EntityDetector,
     Span,
     get_entity_detector,
@@ -10,6 +11,7 @@ from .base import (
 from .entity import PresidioDetector, build_entity_detector
 
 __all__ = [
+    "DEFAULT_ENTITY_THRESHOLD",
     "EntityDetector",
     "Span",
     "get_entity_detector",

--- a/src/muxi/runtime/utils/redaction/base.py
+++ b/src/muxi/runtime/utils/redaction/base.py
@@ -11,6 +11,11 @@ import threading
 from dataclasses import dataclass
 from typing import List, Optional, Protocol, runtime_checkable
 
+# Minimum confidence for a detected span to be treated as PII. Shared by the
+# masking path and the memory sensitivity gate so both layers agree on what
+# "contains PII" means.
+DEFAULT_ENTITY_THRESHOLD = 0.5
+
 
 @dataclass(frozen=True)
 class Span:
@@ -43,7 +48,7 @@ def _merge_spans(spans: List[Span], threshold: float) -> List[Span]:
     return result
 
 
-def mask_spans(text: str, spans: List[Span], threshold: float = 0.5) -> str:
+def mask_spans(text: str, spans: List[Span], threshold: float = DEFAULT_ENTITY_THRESHOLD) -> str:
     """
     Replace detected spans with consistent, label-aware indexed tokens.
 
@@ -91,4 +96,5 @@ def set_entity_detector(detector: Optional[EntityDetector]) -> None:
 
 def get_entity_detector() -> Optional[EntityDetector]:
     """Return the registered entity detector, or None when redaction is regex-only."""
-    return _entity_detector
+    with _registry_lock:
+        return _entity_detector

--- a/src/muxi/runtime/utils/redaction/base.py
+++ b/src/muxi/runtime/utils/redaction/base.py
@@ -1,0 +1,94 @@
+"""
+Core types and helpers for entity-based redaction.
+
+The regex secret scrubber (``utils/security.py``) remains the always-on first
+layer. Entity detectors (e.g. the optional Presidio-backed one) are a second,
+opt-in layer that returns character ``Span``s which are masked with consistent,
+indexed tokens like ``[PERSON_1]``.
+"""
+
+import threading
+from dataclasses import dataclass
+from typing import List, Optional, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class Span:
+    """A detected sensitive region within a text."""
+
+    start: int
+    end: int
+    label: str
+    score: float
+
+
+@runtime_checkable
+class EntityDetector(Protocol):
+    """Detects format-free PII (names, addresses, orgs, ...) in text."""
+
+    def detect(self, text: str, language: str = "en") -> List[Span]: ...
+
+
+def _merge_spans(spans: List[Span], threshold: float) -> List[Span]:
+    """Drop low-confidence spans and resolve overlaps (longest span wins)."""
+    kept = [s for s in spans if s.score >= threshold and s.end > s.start]
+    # Sort by start, then longest first, then highest score, so the first span
+    # covering a region is the preferred one and any overlapping spans are dropped.
+    kept.sort(key=lambda s: (s.start, -(s.end - s.start), -s.score))
+    result: List[Span] = []
+    for span in kept:
+        if result and span.start < result[-1].end:
+            continue
+        result.append(span)
+    return result
+
+
+def mask_spans(text: str, spans: List[Span], threshold: float = 0.5) -> str:
+    """
+    Replace detected spans with consistent, label-aware indexed tokens.
+
+    Repeated mentions of the same value (case-insensitive) within a single call
+    reuse the same token (e.g. both "Jane Doe" mentions become ``[PERSON_1]``).
+    """
+    merged = _merge_spans(spans, threshold)
+    if not merged:
+        return text
+
+    counters: dict = {}
+    value_tokens: dict = {}
+    out: List[str] = []
+    last = 0
+    for span in merged:
+        out.append(text[last : span.start])
+        value = text[span.start : span.end]
+        key = (span.label, value.casefold().strip())
+        token = value_tokens.get(key)
+        if token is None:
+            idx = counters.get(span.label, 0) + 1
+            counters[span.label] = idx
+            token = f"[{span.label}_{idx}]"
+            value_tokens[key] = token
+        out.append(token)
+        last = span.end
+    out.append(text[last:])
+    return "".join(out)
+
+
+# --- Process-level detector registry ---------------------------------------
+# The active entity detector (if any) is registered once during formation load
+# and consulted by the redaction path. None means regex-only (default).
+
+_entity_detector: Optional[EntityDetector] = None
+_registry_lock = threading.Lock()
+
+
+def set_entity_detector(detector: Optional[EntityDetector]) -> None:
+    """Register (or clear) the process-wide entity detector."""
+    global _entity_detector
+    with _registry_lock:
+        _entity_detector = detector
+
+
+def get_entity_detector() -> Optional[EntityDetector]:
+    """Return the registered entity detector, or None when redaction is regex-only."""
+    return _entity_detector

--- a/src/muxi/runtime/utils/redaction/entity.py
+++ b/src/muxi/runtime/utils/redaction/entity.py
@@ -1,0 +1,129 @@
+"""
+Optional Presidio-backed entity detector for names, addresses, orgs, DOB, and
+financial identifiers.
+
+Shipped via the ``muxi[pii]`` extra. When the dependency is absent the factory
+returns ``None`` and the redaction path stays regex-only, so a base install
+never crashes and pays no per-call cost.
+"""
+
+import importlib.util
+import logging
+import threading
+from typing import List, Optional, Sequence
+
+from .base import EntityDetector, Span
+
+logger = logging.getLogger(__name__)
+
+# v1 model choice: small English model (~12MB). Accepts weaker PERSON/ORG recall
+# than en_core_web_lg in exchange for a small footprint. Internal constant so a
+# future upgrade is a one-line change.
+_DEFAULT_MODEL = "en_core_web_sm"
+_DEFAULT_MAX_CHARS = 4000
+_DEFAULT_THRESHOLD = 0.5
+
+# Presidio entity types we request, mapped to our masking labels.
+_LABEL_MAP = {
+    "PERSON": "PERSON",
+    "LOCATION": "ADDRESS",
+    "ORGANIZATION": "ORG",
+    "IBAN_CODE": "FINANCIAL",
+    "US_BANK_NUMBER": "FINANCIAL",
+    "CRYPTO": "FINANCIAL",
+    "CREDIT_CARD": "FINANCIAL",
+}
+_REQUESTED_ENTITIES = list(_LABEL_MAP.keys()) + ["DATE_TIME"]
+_DOB_CONTEXT = ("born", "dob", "date of birth", "birthday", "birth date")
+
+_warned_missing = False
+
+
+class PresidioDetector(EntityDetector):
+    """Detects entities via a lazily-loaded, process-wide Presidio analyzer."""
+
+    _analyzer = None
+    _analyzer_lock = threading.Lock()
+
+    def __init__(
+        self,
+        languages: Sequence[str] = ("en",),
+        model: str = _DEFAULT_MODEL,
+        max_chars: int = _DEFAULT_MAX_CHARS,
+    ):
+        self._languages = tuple(languages)
+        self._model = model
+        self._max_chars = max_chars
+
+    @classmethod
+    def _get_analyzer(cls, languages: Sequence[str], model: str):
+        if cls._analyzer is None:
+            with cls._analyzer_lock:
+                if cls._analyzer is None:
+                    from presidio_analyzer import AnalyzerEngine
+                    from presidio_analyzer.nlp_engine import NlpEngineProvider
+
+                    provider = NlpEngineProvider(
+                        nlp_configuration={
+                            "nlp_engine_name": "spacy",
+                            "models": [
+                                {"lang_code": lang, "model_name": model} for lang in languages
+                            ],
+                        }
+                    )
+                    cls._analyzer = AnalyzerEngine(
+                        nlp_engine=provider.create_engine(),
+                        supported_languages=list(languages),
+                    )
+        return cls._analyzer
+
+    def detect(self, text: str, language: str = "en") -> List[Span]:
+        if not text or len(text) > self._max_chars:
+            return []
+        try:
+            analyzer = self._get_analyzer(self._languages, self._model)
+            results = analyzer.analyze(text=text, language=language, entities=_REQUESTED_ENTITIES)
+        except Exception:
+            # Never let detection failures break the logging path.
+            logger.debug("Entity detection failed; falling back to regex-only", exc_info=True)
+            return []
+
+        spans: List[Span] = []
+        for r in results:
+            label = self._map_label(r.entity_type, text, r.start)
+            if label:
+                spans.append(Span(r.start, r.end, label, r.score))
+        return spans
+
+    @staticmethod
+    def _map_label(entity_type: str, text: str, start: int) -> Optional[str]:
+        if entity_type == "DATE_TIME":
+            # Only treat dates as DOB when birth context precedes them; otherwise
+            # leave generic timestamps untouched.
+            context = text[max(0, start - 30) : start].casefold()
+            if any(keyword in context for keyword in _DOB_CONTEXT):
+                return "DOB"
+            return None
+        return _LABEL_MAP.get(entity_type)
+
+
+def build_entity_detector(enabled: bool = True) -> Optional[EntityDetector]:
+    """
+    Build the entity detector when enabled and its dependency is installed.
+
+    Returns None (regex-only) when disabled, or when ``presidio-analyzer`` is not
+    installed — logging a one-time warning in the latter case.
+    """
+    global _warned_missing
+    if not enabled:
+        return None
+    if importlib.util.find_spec("presidio_analyzer") is None:
+        if not _warned_missing:
+            logger.warning(
+                "logging.redaction.entities is enabled but 'presidio-analyzer' is not "
+                "installed; falling back to regex-only redaction. "
+                "Install entity detection with: pip install muxi[pii]"
+            )
+            _warned_missing = True
+        return None
+    return PresidioDetector()

--- a/src/muxi/runtime/utils/redaction/entity.py
+++ b/src/muxi/runtime/utils/redaction/entity.py
@@ -38,6 +38,10 @@ _DOB_CONTEXT = ("born", "dob", "date of birth", "birthday", "birth date")
 
 _warned_missing = False
 
+# Cached in _analyzers when an engine build fails, so detect() stops retrying the
+# expensive NLP init on every event for the rest of the process lifetime.
+_BUILD_FAILED = object()
+
 
 class PresidioDetector(EntityDetector):
     """Detects entities via a lazily-loaded, process-wide Presidio analyzer."""
@@ -59,29 +63,42 @@ class PresidioDetector(EntityDetector):
 
     @classmethod
     def _get_analyzer(cls, languages: Sequence[str], model: str):
-        key = (frozenset(languages), model)
-        analyzer = cls._analyzers.get(key)
-        if analyzer is None:
-            with cls._analyzer_lock:
-                analyzer = cls._analyzers.get(key)
-                if analyzer is None:
-                    from presidio_analyzer import AnalyzerEngine
-                    from presidio_analyzer.nlp_engine import NlpEngineProvider
+        """Return a cached analyzer, or None if the engine could not be built.
 
-                    provider = NlpEngineProvider(
-                        nlp_configuration={
-                            "nlp_engine_name": "spacy",
-                            "models": [
-                                {"lang_code": lang, "model_name": model} for lang in languages
-                            ],
-                        }
-                    )
-                    analyzer = AnalyzerEngine(
-                        nlp_engine=provider.create_engine(),
-                        supported_languages=list(languages),
-                    )
-                    cls._analyzers[key] = analyzer
-        return analyzer
+        A failed build is memoized as a sentinel so a broken NLP environment does
+        not re-enter the lock and re-attempt the expensive init on every event.
+        """
+        key = (frozenset(languages), model)
+        cached = cls._analyzers.get(key)
+        if cached is None:
+            with cls._analyzer_lock:
+                cached = cls._analyzers.get(key)
+                if cached is None:
+                    try:
+                        from presidio_analyzer import AnalyzerEngine
+                        from presidio_analyzer.nlp_engine import NlpEngineProvider
+
+                        provider = NlpEngineProvider(
+                            nlp_configuration={
+                                "nlp_engine_name": "spacy",
+                                "models": [
+                                    {"lang_code": lang, "model_name": model} for lang in languages
+                                ],
+                            }
+                        )
+                        cached = AnalyzerEngine(
+                            nlp_engine=provider.create_engine(),
+                            supported_languages=list(languages),
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Presidio analyzer build failed for model '%s'; caching failure",
+                            model,
+                            exc_info=True,
+                        )
+                        cached = _BUILD_FAILED
+                    cls._analyzers[key] = cached
+        return None if cached is _BUILD_FAILED else cached
 
     def detect(self, text: str, language: str = "en") -> List[Span]:
         if not text:
@@ -93,8 +110,10 @@ class PresidioDetector(EntityDetector):
                 self._max_chars,
             )
             return []
+        analyzer = self._get_analyzer(self._languages, self._model)
+        if analyzer is None:
+            return []
         try:
-            analyzer = self._get_analyzer(self._languages, self._model)
             results = analyzer.analyze(text=text, language=language, entities=_REQUESTED_ENTITIES)
         except Exception:
             # Never let detection failures break the logging path.
@@ -128,6 +147,10 @@ def build_entity_detector(enabled: bool = True) -> Optional[EntityDetector]:
     when the presidio NLP stack is unexpectedly unavailable (it is a core
     dependency) — logging a one-time warning in the latter case so the
     degradation is visible.
+
+    The NLP engine is built eagerly here (a single probe) so a missing or corrupt
+    spaCy model degrades to regex-only once at startup, instead of failing on
+    every observability event under the redact-by-default policy.
     """
     global _warned_missing
     if not enabled:
@@ -141,4 +164,19 @@ def build_entity_detector(enabled: bool = True) -> Optional[EntityDetector]:
             )
             _warned_missing = True
         return None
-    return PresidioDetector()
+
+    detector = PresidioDetector()
+    # Force the engine build now; on failure the sentinel is cached and we return
+    # None so the hot path never re-attempts the load.
+    if PresidioDetector._get_analyzer(detector._languages, detector._model) is None:
+        if not _warned_missing:
+            logger.warning(
+                "Entity redaction is enabled but the spaCy model '%s' could not be loaded; "
+                "falling back to regex-only redaction. Install it with "
+                "'python -m spacy download %s'.",
+                detector._model,
+                detector._model,
+            )
+            _warned_missing = True
+        return None
+    return detector

--- a/src/muxi/runtime/utils/redaction/entity.py
+++ b/src/muxi/runtime/utils/redaction/entity.py
@@ -1,10 +1,11 @@
 """
-Optional Presidio-backed entity detector for names, addresses, orgs, DOB, and
-financial identifiers.
+Presidio-backed entity detector for names, addresses, orgs, DOB, and financial
+identifiers.
 
-Shipped via the ``muxi[pii]`` extra. When the dependency is absent the factory
-returns ``None`` and the redaction path stays regex-only, so a base install
-never crashes and pays no per-call cost.
+Presidio is a core dependency and entity redaction is on by default (toggle via
+``logging.redaction.entities``). The factory and detector still degrade
+gracefully to regex-only if the NLP stack is somehow unavailable at runtime,
+mirroring how document chunking treats the same spaCy model.
 """
 
 import importlib.util
@@ -16,12 +17,11 @@ from .base import EntityDetector, Span
 
 logger = logging.getLogger(__name__)
 
-# v1 model choice: small English model (~12MB). Accepts weaker PERSON/ORG recall
-# than en_core_web_lg in exchange for a small footprint. Internal constant so a
-# future upgrade is a one-line change.
+# Model choice: small English model (~12MB), already required by document
+# chunking. Accepts weaker PERSON/ORG recall than en_core_web_lg in exchange for
+# a small footprint. Internal constant so a future upgrade is a one-line change.
 _DEFAULT_MODEL = "en_core_web_sm"
 _DEFAULT_MAX_CHARS = 4000
-_DEFAULT_THRESHOLD = 0.5
 
 # Presidio entity types we request, mapped to our masking labels.
 _LABEL_MAP = {
@@ -109,10 +109,12 @@ class PresidioDetector(EntityDetector):
 
 def build_entity_detector(enabled: bool = True) -> Optional[EntityDetector]:
     """
-    Build the entity detector when enabled and its dependency is installed.
+    Build the entity detector when enabled.
 
-    Returns None (regex-only) when disabled, or when ``presidio-analyzer`` is not
-    installed — logging a one-time warning in the latter case.
+    Returns None (regex-only) when disabled via logging.redaction.entities, or
+    when the presidio NLP stack is unexpectedly unavailable (it is a core
+    dependency) — logging a one-time warning in the latter case so the
+    degradation is visible.
     """
     global _warned_missing
     if not enabled:
@@ -120,9 +122,9 @@ def build_entity_detector(enabled: bool = True) -> Optional[EntityDetector]:
     if importlib.util.find_spec("presidio_analyzer") is None:
         if not _warned_missing:
             logger.warning(
-                "logging.redaction.entities is enabled but 'presidio-analyzer' is not "
-                "installed; falling back to regex-only redaction. "
-                "Install entity detection with: pip install muxi[pii]"
+                "Entity redaction is enabled but 'presidio-analyzer' is unavailable; "
+                "falling back to regex-only redaction. This is unexpected since presidio "
+                "is a core dependency - check the installation."
             )
             _warned_missing = True
         return None

--- a/src/muxi/runtime/utils/redaction/entity.py
+++ b/src/muxi/runtime/utils/redaction/entity.py
@@ -42,7 +42,9 @@ _warned_missing = False
 class PresidioDetector(EntityDetector):
     """Detects entities via a lazily-loaded, process-wide Presidio analyzer."""
 
-    _analyzer = None
+    # Analyzers are cached per (languages, model) so distinct configurations get
+    # distinct engines instead of silently reusing whichever was built first.
+    _analyzers: dict = {}
     _analyzer_lock = threading.Lock()
 
     def __init__(
@@ -57,9 +59,12 @@ class PresidioDetector(EntityDetector):
 
     @classmethod
     def _get_analyzer(cls, languages: Sequence[str], model: str):
-        if cls._analyzer is None:
+        key = (frozenset(languages), model)
+        analyzer = cls._analyzers.get(key)
+        if analyzer is None:
             with cls._analyzer_lock:
-                if cls._analyzer is None:
+                analyzer = cls._analyzers.get(key)
+                if analyzer is None:
                     from presidio_analyzer import AnalyzerEngine
                     from presidio_analyzer.nlp_engine import NlpEngineProvider
 
@@ -71,14 +76,22 @@ class PresidioDetector(EntityDetector):
                             ],
                         }
                     )
-                    cls._analyzer = AnalyzerEngine(
+                    analyzer = AnalyzerEngine(
                         nlp_engine=provider.create_engine(),
                         supported_languages=list(languages),
                     )
-        return cls._analyzer
+                    cls._analyzers[key] = analyzer
+        return analyzer
 
     def detect(self, text: str, language: str = "en") -> List[Span]:
-        if not text or len(text) > self._max_chars:
+        if not text:
+            return []
+        if len(text) > self._max_chars:
+            logger.debug(
+                "Entity detection skipped: text length %d exceeds max_chars=%d",
+                len(text),
+                self._max_chars,
+            )
             return []
         try:
             analyzer = self._get_analyzer(self._languages, self._model)

--- a/src/muxi/runtime/utils/security.py
+++ b/src/muxi/runtime/utils/security.py
@@ -8,6 +8,34 @@ before logging, streaming, or other output operations.
 import re
 from typing import Optional
 
+from .sensitive_terms import SENSITIVE_PREVIEW_TERMS
+
+
+def _luhn_valid(digits: str) -> bool:
+    """Return True if a digit string passes the Luhn checksum."""
+    total = 0
+    parity = len(digits) % 2
+    for i, ch in enumerate(digits):
+        d = int(ch)
+        if i % 2 == parity:
+            d *= 2
+            if d > 9:
+                d -= 9
+        total += d
+    return total % 10 == 0
+
+
+def _redact_credit_cards(text: str) -> str:
+    """Mask digit sequences that are valid credit-card numbers (Luhn + length)."""
+
+    def _mask(match: re.Match) -> str:
+        digits = re.sub(r"\D", "", match.group(0))
+        if 13 <= len(digits) <= 19 and _luhn_valid(digits):
+            return "****-****-****-****"
+        return match.group(0)
+
+    return re.sub(r"\b\d[\d -]{11,21}\d\b", _mask, text)
+
 
 def redact_sensitive_content(text: Optional[str]) -> str:
     """
@@ -68,9 +96,6 @@ def redact_sensitive_content(text: Optional[str]) -> str:
         (r'(secret|client_secret)\s*[:=]\s*["\']?([^\s"\']{8,})["\']?', r"\1=****"),
     ]
 
-    # Credit card patterns (basic - matches 13-19 digit numbers with optional formatting)
-    credit_card_pattern = r"\b(?:\d{4}[-\s]?){3}\d{1,7}\b"
-
     # SSN pattern (US format: XXX-XX-XXXX or XXXXXXXXX)
     ssn_pattern = r"\b\d{3}-?\d{2}-?\d{4}\b"
 
@@ -96,8 +121,8 @@ def redact_sensitive_content(text: Optional[str]) -> str:
     for pattern, replacement in db_patterns:
         redacted = re.sub(pattern, replacement, redacted, flags=re.IGNORECASE)
 
-    # Credit cards
-    redacted = re.sub(credit_card_pattern, "****-****-****-****", redacted)
+    # Credit cards (Luhn-validated to avoid masking arbitrary long digit strings)
+    redacted = _redact_credit_cards(redacted)
 
     # SSNs
     redacted = re.sub(ssn_pattern, "***-**-****", redacted)
@@ -149,12 +174,9 @@ def sanitize_message_preview(message: Optional[str], max_length: int = 200) -> s
     sanitized = redact_sensitive_content(message_str)
 
     # Additional aggressive sanitization for streaming context
-    # Remove any remaining potential sensitive keywords
-    sensitive_words = [
-        r"\b(private|confidential|internal|secret|credential|token|key|password|auth)\b",
-    ]
-    for pattern in sensitive_words:
-        sanitized = re.sub(pattern, "[REDACTED]", sanitized, flags=re.IGNORECASE)
+    # Remove any remaining potential sensitive keywords (shared vocabulary)
+    keyword_pattern = r"\b(" + "|".join(sorted(map(re.escape, SENSITIVE_PREVIEW_TERMS))) + r")\b"
+    sanitized = re.sub(keyword_pattern, "[REDACTED]", sanitized, flags=re.IGNORECASE)
 
     # Remove any URLs that might contain sensitive parameters
     sanitized = re.sub(r"https?://[^\s]+", "[URL]", sanitized)

--- a/src/muxi/runtime/utils/security.py
+++ b/src/muxi/runtime/utils/security.py
@@ -8,6 +8,7 @@ before logging, streaming, or other output operations.
 import re
 from typing import Optional
 
+from .redaction import get_entity_detector, mask_spans
 from .sensitive_terms import SENSITIVE_PREVIEW_TERMS
 
 
@@ -140,6 +141,12 @@ def redact_sensitive_content(text: Optional[str]) -> str:
 
     # Generic long hex strings that might be tokens (40+ chars)
     redacted = re.sub(r"\b[a-fA-F0-9]{40,}\b", "****", redacted)
+
+    # Optional second layer: entity detection (names, addresses, orgs, DOB,
+    # financial). No-op unless an entity detector is registered at startup.
+    detector = get_entity_detector()
+    if detector is not None and redacted:
+        redacted = mask_spans(redacted, detector.detect(redacted))
 
     return redacted
 

--- a/src/muxi/runtime/utils/security.py
+++ b/src/muxi/runtime/utils/security.py
@@ -32,7 +32,9 @@ def _redact_credit_cards(text: str) -> str:
     def _mask(match: re.Match) -> str:
         digits = re.sub(r"\D", "", match.group(0))
         if 13 <= len(digits) <= 19 and _luhn_valid(digits):
-            return "****-****-****-****"
+            # Length-accurate placeholder: one "****" group per 4 digits so a
+            # 15-digit Amex or 19-digit card is not misrepresented as 16-digit.
+            return "-".join("****" for _ in range((len(digits) + 3) // 4))
         return match.group(0)
 
     return re.sub(r"\b\d[\d -]{11,21}\d\b", _mask, text)

--- a/src/muxi/runtime/utils/sensitive_terms.py
+++ b/src/muxi/runtime/utils/sensitive_terms.py
@@ -1,0 +1,49 @@
+"""
+Canonical sensitive-term vocabulary shared across redaction sites.
+
+Two sets are exposed because the two consumers match differently:
+
+- ``SENSITIVE_KEY_TERMS`` is **substring**-matched against structured keys and
+  extracted memory sentences (``services/memory/extractor.py``). Terms must stay
+  specific enough to avoid false positives under substring matching (e.g. a
+  generic "key" would wrongly flag "monkey").
+- ``SENSITIVE_PREVIEW_TERMS`` is **word-boundary**-matched in free-text message
+  previews (``utils/security.py``). It may include broad generic words because
+  ``\b`` prevents mid-word matches.
+
+Keeping both in one module gives a single place to evolve the vocabulary while
+respecting the distinct matching strategies.
+"""
+
+from typing import FrozenSet
+
+# Substring-matched against keys / extracted sentences (memory extractor).
+SENSITIVE_KEY_TERMS: FrozenSet[str] = frozenset(
+    {
+        "password",
+        "social_security",
+        "ssn",
+        "credit_card",
+        "bank_account",
+        "passport",
+        "license",
+        "secret",
+        "private",
+        "confidential",
+    }
+)
+
+# Word-boundary-matched in free-text previews (sanitize_message_preview).
+SENSITIVE_PREVIEW_TERMS: FrozenSet[str] = frozenset(
+    {
+        "private",
+        "confidential",
+        "internal",
+        "secret",
+        "credential",
+        "token",
+        "key",
+        "password",
+        "auth",
+    }
+)

--- a/tests/unit/test_observability_redaction.py
+++ b/tests/unit/test_observability_redaction.py
@@ -14,9 +14,10 @@ class TestRedactDataRecursive:
     """The recursive redactor backs redaction for all event payloads."""
 
     def test_redacts_string_secret(self):
-        result = _redact_data_recursive("key sk-abcdefghijklmnopqrstuvwxyz012345")
+        fake_key = "sk-" + "z" * 30  # synthetic value; matches the sk- pattern
+        result = _redact_data_recursive(f"key {fake_key}")
         assert "sk-****" in result
-        assert "abcdefghijklmnop" not in result
+        assert fake_key not in result
 
     def test_redacts_nested_dict_and_list(self):
         data = {

--- a/tests/unit/test_observability_redaction.py
+++ b/tests/unit/test_observability_redaction.py
@@ -1,0 +1,54 @@
+"""
+Unit tests for observability PII/secret redaction.
+
+Covers the WS2 change: redaction is applied to every event payload by default
+(regardless of event type), with an explicit per-call ``skip_redaction`` opt-out.
+"""
+
+import inspect
+
+from muxi.runtime.services.observability import _redact_data_recursive, observe
+
+
+class TestRedactDataRecursive:
+    """The recursive redactor backs redaction for all event payloads."""
+
+    def test_redacts_string_secret(self):
+        result = _redact_data_recursive("key sk-abcdefghijklmnopqrstuvwxyz012345")
+        assert "sk-****" in result
+        assert "abcdefghijklmnop" not in result
+
+    def test_redacts_nested_dict_and_list(self):
+        data = {
+            "outer": {
+                "api_key": "api_key=abcdefghijklmnopqrstuvwxyz",
+                "items": ["mail me at john.doe@example.com", "safe value"],
+            },
+            "count": 3,
+        }
+        result = _redact_data_recursive(data)
+
+        assert "abcdefghijklmnop" not in result["outer"]["api_key"]
+        assert "john.doe" not in result["outer"]["items"][0]
+        assert result["outer"]["items"][1] == "safe value"
+        # Non-string scalars pass through untouched
+        assert result["count"] == 3
+
+    def test_preserves_non_string_scalars(self):
+        data = {"n": 42, "flag": True, "nothing": None, "ratio": 1.5}
+        assert _redact_data_recursive(data) == data
+
+    def test_preserves_tuple_type(self):
+        result = _redact_data_recursive(("safe", "also safe"))
+        assert isinstance(result, tuple)
+        assert result == ("safe", "also safe")
+
+
+class TestObserveRedactionContract:
+    """observe() exposes a skip_redaction opt-out and redacts by default."""
+
+    def test_observe_accepts_skip_redaction(self):
+        params = inspect.signature(observe).parameters
+        assert "skip_redaction" in params
+        # Defaults to redaction ON (skip_redaction defaults to False)
+        assert params["skip_redaction"].default is False

--- a/tests/unit/utils/test_redaction.py
+++ b/tests/unit/utils/test_redaction.py
@@ -1,0 +1,139 @@
+"""
+Unit tests for the entity-redaction layer (utils/redaction).
+
+These tests do not require the optional ``presidio-analyzer`` dependency: span
+masking and the registry are pure logic, and the factory's regex-only fallback
+is exercised directly.
+"""
+
+from muxi.runtime.utils.redaction import (
+    Span,
+    build_entity_detector,
+    get_entity_detector,
+    mask_spans,
+    set_entity_detector,
+)
+from muxi.runtime.utils.security import redact_sensitive_content
+
+
+class _FakeDetector:
+    """Deterministic stand-in for an NER detector."""
+
+    def __init__(self, spans_by_text):
+        self._spans_by_text = spans_by_text
+
+    def detect(self, text, language="en"):
+        return self._spans_by_text.get(text, [])
+
+
+class TestMaskSpans:
+    def test_masks_with_indexed_tokens(self):
+        text = "Jane Doe met Acme Corp"
+        spans = [
+            Span(0, 8, "PERSON", 0.9),
+            Span(13, 22, "ORG", 0.85),
+        ]
+        result = mask_spans(text, spans)
+        assert result == "[PERSON_1] met [ORG_1]"
+
+    def test_repeated_value_reuses_token(self):
+        text = "Jane and Jane again"
+        spans = [Span(0, 4, "PERSON", 0.9), Span(9, 13, "PERSON", 0.9)]
+        result = mask_spans(text, spans)
+        assert result == "[PERSON_1] and [PERSON_1] again"
+
+    def test_distinct_values_increment_index(self):
+        text = "Jane and John"
+        spans = [Span(0, 4, "PERSON", 0.9), Span(9, 13, "PERSON", 0.9)]
+        result = mask_spans(text, spans)
+        assert result == "[PERSON_1] and [PERSON_2]"
+
+    def test_below_threshold_not_masked(self):
+        text = "Maybe Jane"
+        spans = [Span(6, 10, "PERSON", 0.2)]
+        assert mask_spans(text, spans, threshold=0.5) == text
+
+    def test_overlapping_spans_longest_wins(self):
+        text = "New York City"
+        spans = [Span(0, 8, "ADDRESS", 0.8), Span(0, 13, "ADDRESS", 0.7)]
+        result = mask_spans(text, spans)
+        assert result == "[ADDRESS_1]"
+
+    def test_no_spans_returns_original(self):
+        assert mask_spans("nothing here", []) == "nothing here"
+
+
+class TestRegistry:
+    def teardown_method(self):
+        set_entity_detector(None)
+
+    def test_set_and_get(self):
+        detector = _FakeDetector({})
+        set_entity_detector(detector)
+        assert get_entity_detector() is detector
+        set_entity_detector(None)
+        assert get_entity_detector() is None
+
+
+class TestBuildEntityDetector:
+    def test_disabled_returns_none(self):
+        assert build_entity_detector(enabled=False) is None
+
+    def test_missing_dependency_falls_back_to_none(self):
+        # presidio-analyzer is not installed in the test env -> regex-only.
+        import importlib.util
+
+        if importlib.util.find_spec("presidio_analyzer") is None:
+            assert build_entity_detector(enabled=True) is None
+
+
+class TestPresidioLabelMapping:
+    """The label mapping / DOB filtering is pure logic, testable without presidio."""
+
+    def _map(self, entity_type, text="", start=0):
+        from muxi.runtime.utils.redaction.entity import PresidioDetector
+
+        return PresidioDetector._map_label(entity_type, text, start)
+
+    def test_person_location_org_mapping(self):
+        assert self._map("PERSON") == "PERSON"
+        assert self._map("LOCATION") == "ADDRESS"
+        assert self._map("ORGANIZATION") == "ORG"
+
+    def test_financial_entities_collapse_to_financial(self):
+        for et in ("IBAN_CODE", "US_BANK_NUMBER", "CRYPTO", "CREDIT_CARD"):
+            assert self._map(et) == "FINANCIAL"
+
+    def test_date_with_birth_context_is_dob(self):
+        text = "She was born on 1990-01-01"
+        start = text.index("1990")
+        assert self._map("DATE_TIME", text, start) == "DOB"
+
+    def test_date_without_birth_context_is_ignored(self):
+        text = "The meeting is on 2026-01-01"
+        start = text.index("2026")
+        assert self._map("DATE_TIME", text, start) is None
+
+    def test_unmapped_entity_returns_none(self):
+        assert self._map("URL") is None
+
+
+class TestSecurityComposition:
+    def teardown_method(self):
+        set_entity_detector(None)
+
+    def test_entity_layer_runs_after_regex(self):
+        # Regex masks the email; the fake detector masks the name in the result.
+        original = "Contact Jane Doe at jane@example.com"
+        regex_only = redact_sensitive_content(original)
+        assert "jane" not in regex_only.split("@")[0].split()[-1]  # email masked
+
+        set_entity_detector(_FakeDetector({regex_only: [Span(8, 16, "PERSON", 0.95)]}))
+        composed = redact_sensitive_content(original)
+        assert "[PERSON_1]" in composed
+        assert "Jane Doe" not in composed
+
+    def test_no_detector_is_regex_only(self):
+        set_entity_detector(None)
+        text = "Just a normal sentence about Python"
+        assert redact_sensitive_content(text) == text

--- a/tests/unit/utils/test_redaction.py
+++ b/tests/unit/utils/test_redaction.py
@@ -86,6 +86,63 @@ class TestBuildEntityDetector:
         if importlib.util.find_spec("presidio_analyzer") is None:
             assert build_entity_detector(enabled=True) is None
 
+    def test_build_failure_is_cached_and_detect_degrades(self, monkeypatch):
+        """A failed engine build is memoized so detect() stops retrying."""
+        import importlib.util
+
+        import pytest
+
+        if importlib.util.find_spec("presidio_analyzer") is None:
+            pytest.skip("presidio-analyzer not installed")
+
+        import presidio_analyzer.nlp_engine as ne
+
+        from muxi.runtime.utils.redaction.entity import _BUILD_FAILED, PresidioDetector
+
+        build_calls = {"n": 0}
+
+        class _BoomProvider:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def create_engine(self):
+                build_calls["n"] += 1
+                raise RuntimeError("simulated engine build failure")
+
+        # Provider is imported inside _get_analyzer, so patching the module attr works.
+        monkeypatch.setattr(ne, "NlpEngineProvider", _BoomProvider)
+
+        detector = PresidioDetector(model="probe_fail_model")
+        key = (frozenset(detector._languages), detector._model)
+        PresidioDetector._analyzers.pop(key, None)
+
+        # First call attempts the build, fails, and caches the sentinel.
+        assert PresidioDetector._get_analyzer(detector._languages, detector._model) is None
+        assert PresidioDetector._analyzers[key] is _BUILD_FAILED
+        # detect() degrades to [] without raising and without rebuilding.
+        assert detector.detect("Jane Doe at Microsoft") == []
+        assert detector.detect("another message") == []
+        # The expensive build was attempted exactly once.
+        assert build_calls["n"] == 1
+        PresidioDetector._analyzers.pop(key, None)
+
+    def test_probe_returns_none_when_model_unloadable(self, monkeypatch):
+        """build_entity_detector returns None (regex-only) if the model won't load."""
+        import importlib.util
+
+        import pytest
+
+        if importlib.util.find_spec("presidio_analyzer") is None:
+            pytest.skip("presidio-analyzer not installed")
+
+        import muxi.runtime.utils.redaction.entity as ent
+
+        monkeypatch.setattr(
+            ent.PresidioDetector, "_get_analyzer", classmethod(lambda cls, langs, model: None)
+        )
+        monkeypatch.setattr(ent, "_warned_missing", False)
+        assert ent.build_entity_detector(enabled=True) is None
+
 
 class TestPresidioLabelMapping:
     """The label mapping / DOB filtering is pure logic, testable without presidio."""

--- a/tests/unit/utils/test_redaction.py
+++ b/tests/unit/utils/test_redaction.py
@@ -118,6 +118,45 @@ class TestPresidioLabelMapping:
         assert self._map("URL") is None
 
 
+def _live_detector_or_skip():
+    """Build the real Presidio detector, skipping if the NLP model is unavailable."""
+    import pytest
+
+    detector = build_entity_detector(enabled=True)
+    if detector is None:
+        pytest.skip("presidio-analyzer not installed")
+    # Probe once; skip when the spaCy model is not downloaded in this env.
+    if not detector.detect("Jane Doe works at Microsoft"):
+        pytest.skip("en_core_web_sm model not available")
+    return detector
+
+
+class TestPresidioLiveDetection:
+    """End-to-end checks against the real Presidio + spaCy stack."""
+
+    def teardown_method(self):
+        set_entity_detector(None)
+
+    def test_detects_person_org_location(self):
+        detector = _live_detector_or_skip()
+        set_entity_detector(detector)
+        out = redact_sensitive_content("Jane Doe works at Microsoft in Seattle")
+        assert "Jane Doe" not in out
+        assert "[PERSON_1]" in out
+        assert "[ORG_1]" in out
+        assert "[ADDRESS_1]" in out
+
+    def test_dob_context_masks_but_generic_date_survives(self):
+        detector = _live_detector_or_skip()
+        set_entity_detector(detector)
+        dob = redact_sensitive_content("He was born on January 5, 1990")
+        assert "[DOB_1]" in dob
+        assert "1990" not in dob
+
+        generic = redact_sensitive_content("The release shipped on January 5, 2026")
+        assert "2026" in generic  # non-DOB dates are left untouched
+
+
 class TestSecurityComposition:
     def teardown_method(self):
         set_entity_detector(None)

--- a/tests/unit/utils/test_security.py
+++ b/tests/unit/utils/test_security.py
@@ -64,9 +64,10 @@ class TestSanitizeMessagePreview:
 
     def test_redacts_credit_cards(self):
         """Test redaction of credit card numbers."""
-        result = sanitize_message_preview("Card: 4532-1234-5678-9012")
+        # Luhn-valid Visa test number
+        result = sanitize_message_preview("Card: 4111-1111-1111-1111")
         assert "****-****-****-****" in result
-        assert "4532" not in result
+        assert "4111" not in result
 
     def test_redacts_ssn(self):
         """Test redaction of SSN."""
@@ -178,3 +179,14 @@ class TestRedactSensitiveContent:
         text = "User said: Hello, can you help?"
         result = redact_sensitive_content(text)
         assert result == text
+
+    def test_credit_card_requires_luhn(self):
+        """Only Luhn-valid card numbers are masked; arbitrary digit runs are kept."""
+        # Luhn-valid card is masked
+        valid = redact_sensitive_content("Card 4111-1111-1111-1111 on file")
+        assert "****-****-****-****" in valid
+        assert "4111" not in valid
+
+        # 16-digit number that fails Luhn (e.g. an order id) is preserved
+        invalid = redact_sensitive_content("Order 1234567812345678 shipped")
+        assert "1234567812345678" in invalid

--- a/tests/unit/utils/test_security.py
+++ b/tests/unit/utils/test_security.py
@@ -190,3 +190,16 @@ class TestRedactSensitiveContent:
         # 16-digit number that fails Luhn (e.g. an order id) is preserved
         invalid = redact_sensitive_content("Order 1234567812345678 shipped")
         assert "1234567812345678" in invalid
+
+    def test_credit_card_placeholder_is_length_accurate(self):
+        """Placeholder uses one '****' group per 4 digits, not a fixed 16-digit block."""
+        from muxi.runtime.utils.security import _luhn_valid
+
+        base = "402400000000000000"  # 18 digits; complete to a Luhn-valid 19-digit card
+        card19 = next(base + c for c in "0123456789" if _luhn_valid(base + c))
+        assert len(card19) == 19
+
+        result = redact_sensitive_content(f"Card {card19} stored")
+        assert card19 not in result
+        # 19 digits -> ceil(19/4) == 5 masked groups
+        assert "****-****-****-****-****" in result


### PR DESCRIPTION
See CHANGELOG v0.20260619.0. Adds Luhn-validated CC redaction, redact-by-default 
     observability, unified sensitive vocabulary, and default-on entity PII redaction (Presidio +
     en_core_web_sm) as a core capability. Unit + e2e coverage included.