### PR TITLE
perf: O(1) FAISS index reverse mapping in working memory

### DIFF
--- a/src/muxi/runtime/services/memory/working.py
+++ b/src/muxi/runtime/services/memory/working.py
@@ -239,6 +239,7 @@ class WorkingMemory:
         # have been added yet.
         self.index = faiss.IndexFlatL2(self.dimension)
         self.index_mapping = {}  # Maps buffer indices to FAISS indices
+        self.reverse_index_mapping = {}  # Maps FAISS indices back to buffer indices
         self.index_count = 0  # Counter for FAISS indices
         self.needs_rebuild = False  # Flag to track if index needs rebuilding
 
@@ -282,6 +283,7 @@ class WorkingMemory:
                 # first ``_ensure_dim`` call.
                 self.index = faiss.IndexFlatL2(self.dimension)
                 self.index_mapping = {}
+                self.reverse_index_mapping = {}
                 self.index_count = 0
                 self.needs_rebuild = False
             self._dimension = probed
@@ -355,6 +357,7 @@ class WorkingMemory:
                 # Record the mapping from buffer index to FAISS index
                 buffer_idx = len(self.buffer)
                 self.index_mapping[buffer_idx] = self.index_count
+                self.reverse_index_mapping[self.index_count] = buffer_idx
 
                 # Normalize embedding for better cosine similarity in FAISS
                 embedding_array = np.array([embedding_vector], dtype=np.float32)
@@ -396,6 +399,7 @@ class WorkingMemory:
         # Create a new index with the same dimension
         new_index = faiss.IndexFlatL2(self.dimension)
         new_mapping = {}
+        new_reverse_mapping = {}
         new_count = 0
 
         # Add embeddings from the current buffer to the new index
@@ -404,6 +408,7 @@ class WorkingMemory:
             if "embedding" in item and item["embedding"] is not None:
                 embeddings.append(item["embedding"])
                 new_mapping[i] = new_count
+                new_reverse_mapping[new_count] = i
                 new_count += 1
 
         # Add collected embeddings to the index if any exist
@@ -414,6 +419,7 @@ class WorkingMemory:
         # Replace the old index and mapping
         self.index = new_index
         self.index_mapping = new_mapping
+        self.reverse_index_mapping = new_reverse_mapping
         self.index_count = new_count
         self.needs_rebuild = False
 
@@ -807,14 +813,14 @@ class WorkingMemory:
             k = min(limit * 2, self.index_count)  # Get more results to allow for filtering
             distances, indices = self.index.search(query_np, k)
 
-            # Map FAISS indices back to buffer indices
+            # Map FAISS indices back to buffer indices via the reverse
+            # mapping (O(1) per result). FAISS pads with -1 when fewer
+            # than k vectors exist; those have no mapping and are skipped.
             buffer_indices = []
             for faiss_idx in indices[0]:
-                # Find the buffer index for this FAISS index
-                for buffer_idx, mapped_faiss_idx in self.index_mapping.items():
-                    if mapped_faiss_idx == faiss_idx:
-                        buffer_indices.append(buffer_idx)
-                        break
+                buffer_idx = self.reverse_index_mapping.get(int(faiss_idx))
+                if buffer_idx is not None:
+                    buffer_indices.append(buffer_idx)
 
             # Combine semantic score with recency score
             results = []
@@ -1140,6 +1146,7 @@ class WorkingMemory:
                 # Update mapping
                 buffer_idx = len(self.buffer) - 1
                 self.index_mapping[buffer_idx] = self.index_count
+                self.reverse_index_mapping[self.index_count] = buffer_idx
                 self.index_count += 1
 
             except Exception as e:
@@ -1169,6 +1176,7 @@ class WorkingMemory:
         # Reset FAISS index if enabled
         self.index = faiss.IndexFlatL2(self.dimension)
         self.index_mapping = {}
+        self.reverse_index_mapping = {}
         self.index_count = 0
         self.needs_rebuild = False
 

--- a/tests/unit/test_working_memory_reverse_mapping.py
+++ b/tests/unit/test_working_memory_reverse_mapping.py
@@ -1,0 +1,152 @@
+"""Unit tests for the FAISS reverse index mapping in ``WorkingMemory``.
+
+Semantic search previously mapped FAISS result indices back to buffer
+indices by scanning the entire ``index_mapping`` dict per result
+(O(k*n)). ``reverse_index_mapping`` replaces that with O(1) lookups.
+These tests pin the invariant that both mappings stay exact inverses of
+each other across every write path (add, rebuild, clear) and that
+search results resolve to the correct buffer items.
+
+Patches ``probe_dimension`` / ``embed`` (as imported into ``working``)
+to avoid any OneLLM / network / HF calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from muxi.runtime.services.memory.working import WorkingMemory
+
+DIM = 8
+
+
+def _one_hot(position: int) -> list:
+    """Distinct, orthogonal embedding for deterministic FAISS ranking."""
+    vector = [0.0] * DIM
+    vector[position] = 1.0
+    return vector
+
+
+def _make_memory() -> WorkingMemory:
+    return WorkingMemory(
+        formation_id="test-formation",
+        max_size=10,
+        buffer_multiplier=2,
+        embedding_model="local/nomic-ai/nomic-embed-text-v1.5",
+    )
+
+
+def _assert_inverse(mem: WorkingMemory) -> None:
+    """Both mappings must be exact inverses of each other."""
+    assert mem.reverse_index_mapping == {
+        faiss_idx: buffer_idx for buffer_idx, faiss_idx in mem.index_mapping.items()
+    }
+    assert len(mem.reverse_index_mapping) == len(mem.index_mapping)
+
+
+async def test_mappings_stay_inverse_across_adds():
+    with (
+        patch(
+            "muxi.runtime.services.memory.working.probe_dimension",
+            new_callable=AsyncMock,
+        ) as mock_probe,
+        patch(
+            "muxi.runtime.services.memory.working.embed",
+            new_callable=AsyncMock,
+        ) as mock_embed,
+    ):
+        mock_probe.return_value = DIM
+        mock_embed.side_effect = [[_one_hot(i)] for i in range(4)]
+
+        mem = _make_memory()
+        for i in range(4):
+            await mem.add(f"memory {i}")
+
+        assert mem.index_count == 4
+        _assert_inverse(mem)
+
+
+async def test_search_resolves_correct_buffer_item():
+    with (
+        patch(
+            "muxi.runtime.services.memory.working.probe_dimension",
+            new_callable=AsyncMock,
+        ) as mock_probe,
+        patch(
+            "muxi.runtime.services.memory.working.embed",
+            new_callable=AsyncMock,
+        ) as mock_embed,
+    ):
+        mock_probe.return_value = DIM
+        # Three writes, then a search query identical to item 1's vector.
+        mock_embed.side_effect = [
+            [_one_hot(0)],
+            [_one_hot(1)],
+            [_one_hot(2)],
+            [_one_hot(1)],
+        ]
+
+        mem = _make_memory()
+        await mem.add("memory zero")
+        await mem.add("memory one")
+        await mem.add("memory two")
+
+        results = await mem.search("query matching memory one", limit=1)
+
+        assert results, "semantic search returned no results"
+        assert results[0]["text"] == "memory one"
+
+
+async def test_mappings_stay_inverse_after_rebuild():
+    with (
+        patch(
+            "muxi.runtime.services.memory.working.probe_dimension",
+            new_callable=AsyncMock,
+        ) as mock_probe,
+        patch(
+            "muxi.runtime.services.memory.working.embed",
+            new_callable=AsyncMock,
+        ) as mock_embed,
+    ):
+        mock_probe.return_value = DIM
+        mock_embed.side_effect = [[_one_hot(i)] for i in range(4)]
+
+        mem = _make_memory()
+        for i in range(4):
+            await mem.add(f"memory {i}")
+
+        # Simulate eviction: drop the oldest item so buffer indices
+        # shift, then rebuild the index as the search path would.
+        mem.buffer.popleft()
+        mem._rebuild_index()
+
+        assert mem.index_count == 3
+        _assert_inverse(mem)
+        # Buffer index 0 now holds what was item 1; FAISS row 0 must
+        # resolve back to buffer index 0.
+        assert mem.reverse_index_mapping[0] == 0
+
+
+async def test_clear_resets_both_mappings():
+    with (
+        patch(
+            "muxi.runtime.services.memory.working.probe_dimension",
+            new_callable=AsyncMock,
+        ) as mock_probe,
+        patch(
+            "muxi.runtime.services.memory.working.embed",
+            new_callable=AsyncMock,
+        ) as mock_embed,
+    ):
+        mock_probe.return_value = DIM
+        mock_embed.side_effect = [[_one_hot(i)] for i in range(2)]
+
+        mem = _make_memory()
+        await mem.add("memory zero")
+        await mem.add("memory one")
+
+        mem.clear()
+
+        assert mem.index_mapping == {}
+        assert mem.reverse_index_mapping == {}
+        assert mem.index_count == 0


### PR DESCRIPTION
## Problem

Every semantic search over working memory maps FAISS result rows back to buffer indices by scanning the entire `index_mapping` dict once per result:

```python
for faiss_idx in indices[0]:
    for buffer_idx, mapped_faiss_idx in self.index_mapping.items():  # full scan per result
        if mapped_faiss_idx == faiss_idx:
            ...
```

That is O(k*n) per search — with k≈20 results and a 1,000-item buffer, ~20,000 dict iterations on every chat request that uses semantic context, growing linearly with buffer size (up to 10k items).

## Fix

Maintain `reverse_index_mapping` (`{faiss_idx: buffer_idx}`) alongside the existing forward mapping at every write site — `add()`, `add_with_embedding()`, `_rebuild_index()`, the `_ensure_dim` dim-probe reset, and `clear()` — and resolve search results with O(1) lookups. FAISS pads with `-1` when fewer than k vectors exist; those resolve to `None` and are skipped, matching the old loop's behavior exactly.

## Tests

- New `tests/unit/test_working_memory_reverse_mapping.py`: pins the inverse-mapping invariant across adds, eviction+rebuild, and clear; verifies end-to-end that search resolves the correct buffer item.
- Full unit suite: **1093 passed, 3 skipped**.
- black/isort/ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)