### PR TITLE
fix: preserve input order in LLM cache keys

### DIFF
--- a/src/muxi/runtime/services/llm/llm.py
+++ b/src/muxi/runtime/services/llm/llm.py
@@ -491,9 +491,14 @@ _retry_stats = {
 
 
 def _get_cache_key(operation: str, **kwargs) -> str:
-    """Generate a cache key from operation and parameters."""
-    # Create a hash of the operation and parameters
-    key_data = f"{operation}:{str(sorted(kwargs.items()))}"
+    """Generate a cache key from operation and parameters.
+
+    Uses json.dumps with sort_keys=True so the key is stable across
+    dict-key ordering but preserves the order of list-valued inputs
+    (e.g. batch embedding texts), keeping cached vectors aligned with
+    the order of the texts they were requested for.
+    """
+    key_data = f"{operation}:{json.dumps(kwargs, sort_keys=True, default=str)}"
     return hashlib.md5(key_data.encode()).hexdigest()
 
 

--- a/tests/unit/test_llm_cache_key.py
+++ b/tests/unit/test_llm_cache_key.py
@@ -1,0 +1,70 @@
+"""Regression tests for LLM response cache key generation.
+
+Background
+----------
+``services.llm.llm._get_cache_key`` previously built keys with
+``str(sorted(kwargs.items()))``. For batch embedding calls the input
+texts are a list-valued kwarg, and any normalization that ignores list
+order can map ``["A", "B", "C"]`` and ``["C", "B", "A"]`` to the same
+key, returning cached vectors misaligned with the requested texts.
+
+The fix serializes kwargs with ``json.dumps(kwargs, sort_keys=True,
+default=str)``: stable across dict-key ordering, but sensitive to the
+element order of list-valued inputs.
+
+These tests guard:
+
+1. Same batch texts in a different order produce DIFFERENT keys.
+2. Identical calls (including different kwarg insertion order) produce
+   the SAME key.
+3. Different operations or parameter values never share a key.
+"""
+
+from __future__ import annotations
+
+from muxi.runtime.services.llm.llm import _get_cache_key
+
+
+class TestGetCacheKeyOrderSensitivity:
+    """List-valued inputs must keep their order in the cache key."""
+
+    def test_batch_texts_in_different_order_produce_different_keys(self):
+        key_abc = _get_cache_key("embed_batch", model="m", input=["A", "B", "C"])
+        key_cba = _get_cache_key("embed_batch", model="m", input=["C", "B", "A"])
+        assert key_abc != key_cba
+
+    def test_two_element_swap_produces_different_keys(self):
+        key_ab = _get_cache_key("embed_batch", model="m", input=["A", "B"])
+        key_ba = _get_cache_key("embed_batch", model="m", input=["B", "A"])
+        assert key_ab != key_ba
+
+
+class TestGetCacheKeyDeterminism:
+    """Identical calls must always hit the same cache entry."""
+
+    def test_identical_calls_produce_same_key(self):
+        key_first = _get_cache_key("embed_batch", model="m", input=["A", "B", "C"])
+        key_second = _get_cache_key("embed_batch", model="m", input=["A", "B", "C"])
+        assert key_first == key_second
+
+    def test_kwarg_insertion_order_does_not_change_key(self):
+        key_model_first = _get_cache_key("embed", model="m", input="hello")
+        key_input_first = _get_cache_key("embed", input="hello", model="m")
+        assert key_model_first == key_input_first
+
+
+class TestGetCacheKeyIsolation:
+    """Distinct requests must never collide."""
+
+    def test_different_operations_produce_different_keys(self):
+        key_embed = _get_cache_key("embed", model="m", input="hello")
+        key_chat = _get_cache_key("chat", model="m", input="hello")
+        assert key_embed != key_chat
+
+    def test_non_json_values_are_stringified_not_dropped(self):
+        from pathlib import Path
+
+        # default=str handles values orjson cannot serialize natively
+        key_file_a = _get_cache_key("chat", model="m", file=Path("/tmp/a.wav"))
+        key_file_b = _get_cache_key("chat", model="m", file=Path("/tmp/b.wav"))
+        assert key_file_a != key_file_b


### PR DESCRIPTION
## Problem

`_get_cache_key(operation, **kwargs)` in `src/muxi/runtime/services/llm/llm.py` derived response-cache keys from `str(sorted(kwargs.items()))` — an ad-hoc Python repr of the parameters. This made no explicit guarantee about ordering semantics:

- For list-valued inputs (batch embedding `input=[...]`), nothing in the key derivation documented or tested that element order is preserved. Any future normalization of the texts (or a value-level sort) would silently map `["A", "B", "C"]` and `["C", "B", "A"]` to the same key.
- For dict-valued params (chat `messages` dicts, nested options), the repr depends on dict insertion order, so semantically identical requests could produce different keys and miss the cache.

## Failure scenario

Batch embedding results are cached as an ordered list of vectors keyed by the request parameters. If two calls with the same texts in different order ever share a key, the second caller receives vectors aligned to the first caller's text order — embeddings silently attached to the wrong texts, corrupting similarity search and memory ingestion downstream.

## Fix

Serialize kwargs with `json.dumps(kwargs, sort_keys=True, default=str)` (via the repo's `fastjson`/orjson wrapper). `sort_keys` only sorts dict keys, never list elements, so the key is now:

- **Stable** across kwarg/dict-key insertion order (same request → same key), and
- **Order-sensitive** for list-valued inputs (reordered batch texts → different key), by contract rather than by accident of repr.

Minimal change: one function body plus a docstring; cache semantics (TTL, storage, callers) untouched. The key-format change invalidates existing entries in the in-memory cache (5-minute TTL), which is acceptable.

## Test evidence

New `tests/unit/test_llm_cache_key.py` proves:

- `["A", "B", "C"]` vs `["C", "B", "A"]` (and a two-element swap) → different keys
- Identical calls, including different kwarg insertion order → same key
- Different operations never share a key; non-JSON values (e.g. `Path`) are stringified, not dropped

```
tests/unit/test_llm_cache_key.py  6 passed
tests/unit/ (full suite)          1095 passed, 3 skipped
```

Black (line 100), isort (profile black), and Ruff all pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)