### PR TITLE
perf: batched background writer for observability transports

### DIFF
--- a/src/muxi/runtime/services/observability/logger.py
+++ b/src/muxi/runtime/services/observability/logger.py
@@ -5,7 +5,10 @@ This module contains the EventLogger class for handling event emission
 with configurable outputs and routing.
 """
 
+import atexit
+import queue
 import socket
+import threading
 import time
 from typing import Any, Dict, List, Optional, Union
 
@@ -32,7 +35,15 @@ class EventLogger:
     Two-tier logging architecture:
     - System events (SystemEvents, ErrorEvents, ServerEvents, APIEvents) -> system_destination
     - Conversation events (ConversationEvents) -> configured output (file, stdout, stream, trail)
+
+    File and network destinations are written by a single background
+    writer thread fed through a queue, so emitters never block on disk
+    or HTTP. stdout destinations stay synchronous to preserve console
+    ordering.
     """
+
+    # Max events drained per write batch by the background writer
+    _WRITER_BATCH_MAX = 100
 
     def __init__(
         self,
@@ -60,6 +71,11 @@ class EventLogger:
 
         self.muxi_version = get_version()
         self._server_id = self._get_server_id()
+
+        # Background writer state, created lazily on first non-stdout
+        # write so stdout-only loggers never spawn a thread
+        self._write_queue: Optional[queue.Queue] = None
+        self._writer_start_lock = threading.Lock()
 
     def set_server_ready(self, ready: bool = True) -> None:
         """Mark server as ready to enable JSONL output to stdout."""
@@ -217,12 +233,8 @@ class EventLogger:
             # Route ConversationEvents to configured output
             if self.output == "stdout":
                 print(event_line, flush=True)
-            elif self.output == "file":
-                self._emit_to_file(event_line)
-            elif self.output == "stream":
-                self._emit_to_stream(event_line)
-            elif self.output == "trail":
-                self._emit_to_trail(event_line)
+            elif self.output in ("file", "stream", "trail"):
+                self._enqueue_write(self.output, event_line)
 
         except Exception:
             # Silent failures to avoid disrupting main application flow
@@ -244,61 +256,103 @@ class EventLogger:
                 print(event_line, flush=True)
             return
 
-        # File path - write to system log file
-        try:
-            with open(self.system_destination, "a") as f:
-                f.write(event_line + "\n")
-                f.flush()
-        except Exception:
-            # Fallback to stdout if file write fails (only when server ready)
-            if self._server_ready:
-                print(event_line, flush=True)
+        # File path - write via the background writer
+        self._enqueue_write("system_file", event_line)
 
-    def _emit_to_file(self, event_line: str) -> None:
-        """Emit event to file output."""
-        file_path = self.output_config.get("path", f"{get_observability_dir()}/muxi.jsonl")
-        with open(file_path, "a") as f:
-            f.write(event_line + "\n")
-            f.flush()  # Ensure immediate write
+    def _enqueue_write(self, kind: str, event_line: str) -> None:
+        """Queue an event line for the background writer thread."""
+        if self._write_queue is None:
+            with self._writer_start_lock:
+                if self._write_queue is None:
+                    write_queue: queue.Queue = queue.Queue()
+                    writer = threading.Thread(
+                        target=self._writer_loop,
+                        args=(write_queue,),
+                        name="muxi-event-writer",
+                        daemon=True,
+                    )
+                    # Publish the queue only after the thread exists so
+                    # concurrent emitters never enqueue into a queue
+                    # nothing will ever drain
+                    self._write_queue = write_queue
+                    writer.start()
+                    atexit.register(self.flush)
+        self._write_queue.put((kind, event_line))
 
-    def _emit_to_stream(self, event_line: str) -> None:
-        """Emit event to stream output."""
-        stream_url = self.output_config.get("url")
-        if not stream_url:
+    def _writer_loop(self, write_queue: "queue.Queue") -> None:
+        """Drain the write queue in batches, grouped by destination.
+
+        A single writer thread owns all file appends and HTTP posts, so
+        emitters never block on I/O, per-destination ordering is FIFO,
+        and the HTTP session reuses connections across events.
+        """
+        session = requests.Session()
+        while True:
+            items = [write_queue.get()]
+            while len(items) < self._WRITER_BATCH_MAX:
+                try:
+                    items.append(write_queue.get_nowait())
+                except queue.Empty:
+                    break
+
+            grouped: Dict[str, List[str]] = {}
+            for kind, event_line in items:
+                grouped.setdefault(kind, []).append(event_line)
+
+            for kind, event_lines in grouped.items():
+                try:
+                    self._write_batch(kind, event_lines, session)
+                except Exception:
+                    # Transport failures must never disrupt the runtime
+                    pass
+
+            for _ in items:
+                write_queue.task_done()
+
+    def _write_batch(self, kind: str, event_lines: List[str], session: requests.Session) -> None:
+        """Write one batch of JSON-L lines to a single destination."""
+        payload = "\n".join(event_lines) + "\n"
+
+        if kind == "file":
+            file_path = self.output_config.get("path", f"{get_observability_dir()}/muxi.jsonl")
+            with open(file_path, "a") as f:
+                f.write(payload)
+        elif kind == "system_file":
+            try:
+                with open(self.system_destination, "a") as f:
+                    f.write(payload)
+            except Exception:
+                # Fallback to stdout if file write fails (only when server ready)
+                if self._server_ready:
+                    print(payload, end="", flush=True)
+        elif kind == "stream":
+            stream_url = self.output_config.get("url")
+            if stream_url:
+                session.post(
+                    stream_url,
+                    data=payload,
+                    headers={"Content-Type": "application/x-ndjson"},
+                    timeout=5,
+                )
+        elif kind == "trail":
+            trail_config = self.output_config.get("trail", {})
+            trail_url = trail_config.get("url")
+            if trail_url:
+                headers = {"Content-Type": "application/x-ndjson"}
+                # Add authentication if configured
+                if api_key := trail_config.get("api_key"):
+                    headers["Authorization"] = f"Bearer {api_key}"
+                session.post(trail_url, data=payload, headers=headers, timeout=10)
+
+    def flush(self, timeout: float = 2.0) -> None:
+        """Best-effort wait for queued events to reach their destination.
+
+        Registered via atexit so tail events are not lost on shutdown;
+        also useful in tests to assert on written output.
+        """
+        write_queue = self._write_queue
+        if write_queue is None:
             return
-
-        try:
-            requests.post(
-                stream_url,
-                data=event_line + "\n",
-                headers={"Content-Type": "application/x-ndjson"},
-                timeout=5,
-            )
-        except Exception:
-            # Silent failure for external stream connectivity issues
-            pass
-
-    def _emit_to_trail(self, event_line: str) -> None:
-        """Emit event to MUXI trail output."""
-        trail_config = self.output_config.get("trail", {})
-        trail_url = trail_config.get("url")
-
-        if not trail_url:
-            return
-
-        try:
-            headers = {"Content-Type": "application/x-ndjson"}
-
-            # Add authentication if configured
-            if api_key := trail_config.get("api_key"):
-                headers["Authorization"] = f"Bearer {api_key}"
-
-            requests.post(
-                trail_url,
-                data=event_line + "\n",
-                headers=headers,
-                timeout=10,
-            )
-        except Exception:
-            # Silent failure for external trail connectivity issues
-            pass
+        deadline = time.time() + timeout
+        while write_queue.unfinished_tasks and time.time() < deadline:
+            time.sleep(0.01)

--- a/src/muxi/runtime/services/observability/logger.py
+++ b/src/muxi/runtime/services/observability/logger.py
@@ -279,7 +279,7 @@ class EventLogger:
                     atexit.register(self.flush)
         self._write_queue.put((kind, event_line))
 
-    def _writer_loop(self, write_queue: "queue.Queue") -> None:
+    def _writer_loop(self, write_queue: queue.Queue) -> None:
         """Drain the write queue in batches, grouped by destination.
 
         A single writer thread owns all file appends and HTTP posts, so
@@ -287,27 +287,32 @@ class EventLogger:
         and the HTTP session reuses connections across events.
         """
         session = requests.Session()
-        while True:
-            items = [write_queue.get()]
-            while len(items) < self._WRITER_BATCH_MAX:
-                try:
-                    items.append(write_queue.get_nowait())
-                except queue.Empty:
-                    break
+        try:
+            while True:
+                items = [write_queue.get()]
+                while len(items) < self._WRITER_BATCH_MAX:
+                    try:
+                        items.append(write_queue.get_nowait())
+                    except queue.Empty:
+                        break
 
-            grouped: Dict[str, List[str]] = {}
-            for kind, event_line in items:
-                grouped.setdefault(kind, []).append(event_line)
+                grouped: Dict[str, List[str]] = {}
+                for kind, event_line in items:
+                    grouped.setdefault(kind, []).append(event_line)
 
-            for kind, event_lines in grouped.items():
-                try:
-                    self._write_batch(kind, event_lines, session)
-                except Exception:
-                    # Transport failures must never disrupt the runtime
-                    pass
+                for kind, event_lines in grouped.items():
+                    try:
+                        self._write_batch(kind, event_lines, session)
+                    except Exception:
+                        # Transport failures must never disrupt the runtime
+                        pass
 
-            for _ in items:
-                write_queue.task_done()
+                for _ in items:
+                    write_queue.task_done()
+        finally:
+            # Return pooled connections/TLS sockets cleanly if the loop
+            # ever exits (e.g. a non-Exception raise)
+            session.close()
 
     def _write_batch(self, kind: str, event_lines: List[str], session: requests.Session) -> None:
         """Write one batch of JSON-L lines to a single destination."""
@@ -353,6 +358,9 @@ class EventLogger:
         write_queue = self._write_queue
         if write_queue is None:
             return
-        deadline = time.time() + timeout
-        while write_queue.unfinished_tasks and time.time() < deadline:
-            time.sleep(0.01)
+        # Timed join: Queue.join() has no timeout parameter, so run it in
+        # a short-lived helper thread and bound the wait by joining that
+        # thread. Wakes as soon as the last task_done() fires.
+        joiner = threading.Thread(target=write_queue.join, daemon=True)
+        joiner.start()
+        joiner.join(timeout=timeout)

--- a/tests/unit/test_observability_writer.py
+++ b/tests/unit/test_observability_writer.py
@@ -1,0 +1,89 @@
+"""
+Unit tests for the EventLogger background writer.
+
+File and network destinations previously did a blocking open/write/flush
+or requests.post per event on the emitting thread. Events are now queued
+to a single writer thread that batches per destination. These tests pin:
+ordering, delivery via flush(), NDJSON batching for stream posts, and
+that stdout-only loggers never spawn the writer.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from muxi.runtime.datatypes.observability import (
+    ConversationEvents,
+    EventLevel,
+    SystemEvents,
+)
+from muxi.runtime.services.observability import EventLogger
+
+CONV_EVENT = ConversationEvents.MEMORY_WORKING_RETRIEVED
+SYS_EVENT = SystemEvents.CONFIG_FORMATION_LOADED
+
+
+class TestFileWriter:
+    def test_file_output_written_in_order(self, tmp_path):
+        log_path = tmp_path / "events.jsonl"
+        logger = EventLogger(
+            level=EventLevel.DEBUG, output="file", output_config={"path": str(log_path)}
+        )
+
+        for i in range(5):
+            logger.emit_event(CONV_EVENT, level=EventLevel.INFO, data={"seq": i})
+        logger.flush()
+
+        lines = log_path.read_text().strip().splitlines()
+        assert len(lines) == 5
+        assert [f'"seq":{i}' in line for i, line in enumerate(lines)] == [True] * 5
+
+    def test_system_file_destination_written(self, tmp_path):
+        log_path = tmp_path / "system.jsonl"
+        logger = EventLogger(system_level="debug", system_destination=str(log_path))
+
+        logger.emit_event(SYS_EVENT, level=EventLevel.INFO, data={"marker": "sys"})
+        logger.flush()
+
+        content = log_path.read_text()
+        assert '"marker":"sys"' in content
+
+
+class TestStreamWriter:
+    def test_stream_posts_ndjson_via_session(self):
+        logger = EventLogger(
+            level=EventLevel.DEBUG,
+            output="stream",
+            output_config={"url": "http://collector.test/ingest"},
+        )
+
+        mock_requests = MagicMock()
+        session = MagicMock()
+        mock_requests.Session.return_value = session
+
+        with patch("muxi.runtime.services.observability.logger.requests", mock_requests):
+            for i in range(3):
+                logger.emit_event(CONV_EVENT, level=EventLevel.INFO, data={"seq": i})
+            logger.flush()
+
+        assert session.post.call_count >= 1
+        posted_lines = []
+        for call in session.post.call_args_list:
+            assert call.args[0] == "http://collector.test/ingest"
+            body = call.kwargs["data"]
+            assert body.endswith("\n")
+            assert call.kwargs["headers"]["Content-Type"] == "application/x-ndjson"
+            posted_lines.extend(body.strip().splitlines())
+        assert len(posted_lines) == 3
+
+
+class TestWriterLifecycle:
+    def test_stdout_output_never_spawns_writer(self, capsys):
+        logger = EventLogger(level=EventLevel.DEBUG, output="stdout")
+
+        logger.emit_event(CONV_EVENT, level=EventLevel.INFO, data={"seq": 0})
+
+        assert logger._write_queue is None
+        assert '"seq":0' in capsys.readouterr().out
+
+    def test_flush_without_writer_is_noop(self):
+        logger = EventLogger(level=EventLevel.DEBUG, output="stdout")
+        logger.flush()

--- a/uv.lock
+++ b/uv.lock
@@ -3854,6 +3854,8 @@ dependencies = [
     { name = "pgvector" },
     { name = "pillow" },
     { name = "plotly" },
+    { name = "presidio-analyzer" },
+    { name = "presidio-anonymizer" },
     { name = "protobuf" },
     { name = "psutil" },
     { name = "psycopg2-binary" },
@@ -3970,6 +3972,8 @@ requires-dist = [
     { name = "pgvector", specifier = ">=0.4.2" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "plotly", specifier = ">=6.8.0" },
+    { name = "presidio-analyzer", specifier = ">=2.2" },
+    { name = "presidio-anonymizer", specifier = ">=2.2" },
     { name = "protobuf", specifier = ">=6.33.6,<8" },
     { name = "psutil", specifier = ">=7.2.2" },
     { name = "psycopg2-binary", specifier = ">=2.9.12" },
@@ -4647,10 +4651,16 @@ dependencies = [
     { name = "protobuf", marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/d5/372193dd3fddfd1fbeb0bf39aa41a27d1b12e4877570cb746635047d68a9/onnxruntime_gpu-1.27.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:404fb845dc06a04a28df5a2c6d5967bcf3f534e7df0b98507ff81686a1b49594", size = 220287841, upload-time = "2026-06-18T18:27:13.823Z" },
     { url = "https://files.pythonhosted.org/packages/e6/fd/f754a292136deebe4fba28443374f6c5f6dcb6a125270755dd54473dce06/onnxruntime_gpu-1.27.0-cp311-cp311-win_amd64.whl", hash = "sha256:c68799b35fc4818e6c1d50f5270681bf5ab8a652ac118e11a987b23f488e18dd", size = 213618726, upload-time = "2026-06-15T22:42:50.855Z" },
+    { url = "https://files.pythonhosted.org/packages/23/9b/2f31fa1d95dbe4e16522d76ec4d6db7f05ae7fb2c59f40bac414203aa0f8/onnxruntime_gpu-1.27.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b2b8d6afabf3c23c2c698639a16388816dc7298f388a9ddddf504b283990ea01", size = 220305746, upload-time = "2026-06-18T18:27:22.319Z" },
     { url = "https://files.pythonhosted.org/packages/91/65/cf76bd5b261a295f2257a39d9cd89876e5544531bc97f45732d9cb9ddff2/onnxruntime_gpu-1.27.0-cp312-cp312-win_amd64.whl", hash = "sha256:9f92c12578433cffa6017ec843f4b4c500b9ebaf65f6c4497ddec01af5cd5396", size = 213631079, upload-time = "2026-06-15T22:43:01.35Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/8d/6509743801131f1d3791f638ae31edef7701e93c7a4523d74115247dd7d1/onnxruntime_gpu-1.27.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e6eb554d35706ee154b583dd32e4167a93aa55d3670f59754f43860fd649b92", size = 220304092, upload-time = "2026-06-18T18:27:31.18Z" },
     { url = "https://files.pythonhosted.org/packages/ac/86/8865182eba89cde187163daacfa7f1eb64958616cd080dfb3482be4c8a36/onnxruntime_gpu-1.27.0-cp313-cp313-win_amd64.whl", hash = "sha256:ac352199fb6ac3e366b45a690bb47c9b1c92b1be0e3958149dd1a30285832b9f", size = 213623636, upload-time = "2026-06-15T22:43:10.548Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/16f5ba0f91bd8db5b2881ef1ec57d532c8f297b31b6a95ceab606f471c0a/onnxruntime_gpu-1.27.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b5652761f14bc74729ffbc8fdc01767e541e163459f2e10aa65af61d5db64c8", size = 220331411, upload-time = "2026-06-18T18:27:39.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/97/5584057e355e5d8de3ae5cdd81e946ad2c9d8253626614eac805750645af/onnxruntime_gpu-1.27.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:209caede76604509fb7451178f56daa5292a933478864aaff87c6c29d1257593", size = 220303692, upload-time = "2026-06-18T18:27:48.183Z" },
     { url = "https://files.pythonhosted.org/packages/93/7f/6446c80d38ee2c8ec82365f44f1a842993f497da9ebf46a6b37c2ef4d2b7/onnxruntime_gpu-1.27.0-cp314-cp314-win_amd64.whl", hash = "sha256:986b94d513b052dc06b93c5a424f072f07f40d66be40ce2d6320d76d84fa4919", size = 214270425, upload-time = "2026-06-15T22:43:20.017Z" },
+    { url = "https://files.pythonhosted.org/packages/83/06/e1b690df1c70772d76464c5d8b2d11b436ade1cf93a061303cdf9d72b3bf/onnxruntime_gpu-1.27.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:42696d6137d6974325a67c88a65dd41625e49bf076da79c658514b498b297142", size = 220327139, upload-time = "2026-06-18T18:27:59.096Z" },
 ]
 
 [[package]]
@@ -5024,6 +5034,15 @@ wheels = [
 ]
 
 [[package]]
+name = "phonenumbers"
+version = "9.0.34"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/c3/e154829a50679c38ae28ec9c4f151f2c425db5e70fd445266e76f6d6cd65/phonenumbers-9.0.34.tar.gz", hash = "sha256:00751c75d1166485ca80ce02ec15b6a61a2628e9b313381579330bc70c934075", size = 2306776, upload-time = "2026-07-03T06:30:37.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/0a/3a7980f3b071dde9a297d85cf6b18ba4bc2e5024e1c453b3da8a1dc14268/phonenumbers-9.0.34-py2.py3-none-any.whl", hash = "sha256:1221bf8e65bd2c02770226488af806d4636814bc997104d3a1f7de6ed6410bd2", size = 2595344, upload-time = "2026-07-03T06:30:33.913Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "12.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5210,6 +5229,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/37/aa/51e5b4109a4cdfae28c3613eeeb10764a3794ebef8de93ffbb109465bea3/preshed-3.0.13-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:670db59a52e1823b5f088c764df474e65b686592d4093adbeef14581c95ee2cb", size = 1959473, upload-time = "2026-03-23T08:57:15.706Z" },
     { url = "https://files.pythonhosted.org/packages/0e/6a/1d966f367a14c703dde629d150d996c1b727d442f620300b21c9ec1a24d1/preshed-3.0.13-cp314-cp314t-win_amd64.whl", hash = "sha256:b03e21b0bf95eb56e23973f32cabb930e94f352228652f81c0955dbd6967d904", size = 146229, upload-time = "2026-03-23T08:57:17.457Z" },
     { url = "https://files.pythonhosted.org/packages/22/80/368139067603e590a000122355f9c8576c8ebed4fb0b8849feaa2698489d/preshed-3.0.13-cp314-cp314t-win_arm64.whl", hash = "sha256:b980f3ea9bb74b7f94464bc3d6eb3c9162b6b79b531febd14c6465c24344d2cc", size = 119339, upload-time = "2026-03-23T08:57:18.882Z" },
+]
+
+[[package]]
+name = "presidio-analyzer"
+version = "2.2.362"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "phonenumbers" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "spacy" },
+    { name = "tldextract" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/8a/d6cf4bddbb11d9c78f5c9342bbbcde4f90fe4e3c7de114a836ec4ed8a6cf/presidio_analyzer-2.2.362-py3-none-any.whl", hash = "sha256:4c36438924b1fcb4df92ea5cf2d8dc57508808e116b10923c983b8732aa07d90", size = 201084, upload-time = "2026-03-15T12:40:43.801Z" },
+]
+
+[[package]]
+name = "presidio-anonymizer"
+version = "2.2.362"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/01/1c3404e8da63a979ae951b8822576bc0e52ca3a46a624ac9439786990c6d/presidio_anonymizer-2.2.362-py3-none-any.whl", hash = "sha256:b2d81542cb797360d18506a1aa73ea0dfacc44abca15248c81dd062f582e6b2b", size = 36603, upload-time = "2026-03-15T12:40:38.651Z" },
 ]
 
 [[package]]
@@ -6329,6 +6375,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "requests-file"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/f8/5dc70102e4d337063452c82e1f0d95e39abfe67aa222ed8a5ddeb9df8de8/requests_file-3.0.1.tar.gz", hash = "sha256:f14243d7796c588f3521bd423c5dea2ee4cc730e54a3cac9574d78aca1272576", size = 6967, upload-time = "2025-10-20T18:56:42.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/d5/de8f089119205a09da657ed4784c584ede8381a0ce6821212a6d4ca47054/requests_file-3.0.1-py2.py3-none-any.whl", hash = "sha256:d0f5eb94353986d998f80ac63c7f146a307728be051d4d1cd390dbdb59c10fa2", size = 4514, upload-time = "2025-10-20T18:56:41.184Z" },
 ]
 
 [[package]]
@@ -7498,6 +7556,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/96/d9/dfd086aa2d918c563a140720e0ce296cada1634efd2783d5cf51e05f984e/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6644c9c2b5cf3916f5a3641d7d12fdb3f006a7b3d9ff6acdaec44e29ab1ff91e", size = 1181863, upload-time = "2026-05-15T04:51:15.025Z" },
     { url = "https://files.pythonhosted.org/packages/2f/68/a18b4f307086954fdae32714cb4f85562e34f9d34ab206e61f1816aa6018/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cb65b60b9408563676d874a3a4ee573370066f0dc4e29d84e82e989c6517424", size = 1239218, upload-time = "2026-05-15T04:51:16.103Z" },
     { url = "https://files.pythonhosted.org/packages/16/5b/f2aa703a4fc5d2dff73460a7d46cc2f3f44aa0f3dd8eeb20d2a0ecf68862/tiktoken-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:85b78cc3a2c3d48723ca751fa981f1fedccd54194ca0471b957364353a898b07", size = 918110, upload-time = "2026-05-15T04:51:17.237Z" },
+]
+
+[[package]]
+name = "tldextract"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "idna" },
+    { name = "requests" },
+    { name = "requests-file" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/7b/644fbbb49564a6cb124a8582013315a41148dba2f72209bba14a84242bf0/tldextract-5.3.1.tar.gz", hash = "sha256:a72756ca170b2510315076383ea2993478f7da6f897eef1f4a5400735d5057fb", size = 126105, upload-time = "2025-12-28T23:58:05.532Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/42/0e49d6d0aac449ca71952ec5bae764af009754fcb2e76a5cc097543747b3/tldextract-5.3.1-py3-none-any.whl", hash = "sha256:6bfe36d518de569c572062b788e16a659ccaceffc486d243af0484e8ecf432d9", size = 105886, upload-time = "2025-12-28T23:58:04.071Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Every observability event routed to a file/stream/trail destination paid blocking I/O on its emitting thread ([logger.py](src/muxi/runtime/services/observability/logger.py)):

- `file`/system-file: `open()` + `write()` + `flush()` per event — one file open per event
- `stream`/`trail`: synchronous `requests.post()` per event with 5-10s timeouts and no connection reuse

`observe()` fires throughout request processing including inside streaming generators, so a slow disk or a slow collector directly taxes token delivery. Each event also spawned its own short-lived thread that then sat blocked on I/O (GIL churn), and per-event threads gave no ordering guarantee.

## Fix

All non-stdout destinations now go through a single lazily-started daemon writer thread fed by a `queue.Queue`:

- Emitters enqueue and return immediately — zero I/O on the hot path
- The writer drains up to 100 events per cycle, groups by destination, appends files once per batch, and posts NDJSON batches through a reused `requests.Session`
- Per-destination ordering is now guaranteed FIFO (an improvement over racing per-event threads)
- `flush()` is atexit-registered so tail events drain on shutdown; it is also handy in tests
- stdout destinations stay synchronous to preserve console ordering during startup/CLI use
- Failure semantics unchanged: transport errors are swallowed, system-file falls back to stdout when the server is ready

## Tests

- New `tests/unit/test_observability_writer.py` (5 tests): file ordering + delivery via flush, system-file destination, NDJSON batch posting via the shared session, stdout never spawns the writer, flush noop without writer.
- Full unit suite: 1094 passed, 3 skipped. `scripts/validate_events.py`: 1226 events, 100%.
- black/isort/ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)