### PR TITLE
feat: per-session FAISS partitions in working memory

### DIFF
--- a/src/muxi/runtime/services/memory/working.py
+++ b/src/muxi/runtime/services/memory/working.py
@@ -98,6 +98,28 @@ except ValueError:
     # This is expected in tests or when imported from threads
     pass
 
+# Partition key for vectors that are not scoped to a single session:
+# non-"buffer" namespaces (sops, knowledge, docs) and "buffer" items
+# whose metadata carries no session_id.
+SHARED_PARTITION = "__shared__"
+
+
+class _IndexPartition:
+    """FAISS index state for a single working-memory partition.
+
+    Each partition owns its own ``IndexFlatL2`` plus the forward and
+    reverse mappings between global buffer indices and rows in that
+    index. Partitioning vectors per session keeps session-scoped
+    searches from scanning — and being crowded out of top-k by —
+    vectors that belong to other sessions.
+    """
+
+    def __init__(self, dimension: int):
+        self.index = faiss.IndexFlatL2(dimension)
+        self.index_mapping = {}  # Maps buffer indices to FAISS rows
+        self.reverse_index_mapping = {}  # Maps FAISS rows back to buffer indices
+        self.index_count = 0  # Number of vectors in this partition
+
 
 class WorkingMemory:
     """
@@ -233,14 +255,15 @@ class WorkingMemory:
         elif mode != "local" and mode != "remote":
             raise ValueError(f"Invalid mode: {mode}. Must be 'local' or 'remote'")
 
-        # Initialize vector storage with the provisional dim. The
-        # index will be rebuilt in-place the first time ``_ensure_dim``
-        # resolves a different real dim; this is safe because no vectors
-        # have been added yet.
-        self.index = faiss.IndexFlatL2(self.dimension)
-        self.index_mapping = {}  # Maps buffer indices to FAISS indices
-        self.reverse_index_mapping = {}  # Maps FAISS indices back to buffer indices
-        self.index_count = 0  # Counter for FAISS indices
+        # Initialize vector storage. Vectors are partitioned by session:
+        # each "buffer"-namespace item carrying a session_id goes to a
+        # per-session FAISS index; everything else (sops, knowledge,
+        # docs, buffer items without a session) shares the
+        # ``SHARED_PARTITION`` index. Partitions are created lazily on
+        # first write with the provisional dim and reset the first time
+        # ``_ensure_dim`` resolves a different real dim; this is safe
+        # because no vectors have been added yet.
+        self.partitions: Dict[str, _IndexPartition] = {}
         self.needs_rebuild = False  # Flag to track if index needs rebuilding
 
         # Key-value store for exact lookups with TTL
@@ -257,10 +280,11 @@ class WorkingMemory:
         :func:`services.memory.embedding.probe_dimension` for the
         configured model slug, stores the result on ``self._dimension``,
         and — if the probed dim differs from the provisional hint used
-        to build the initial FAISS index — rebuilds ``self.index`` at
-        the correct dimensionality. Rebuilding is safe here because
-        ``_ensure_dim`` is always invoked before the first embed
-        operation, so the index is guaranteed to be empty.
+        to build any early FAISS partitions — resets ``self.partitions``
+        so they are recreated at the correct dimensionality. Resetting
+        is safe here because ``_ensure_dim`` is always invoked before
+        the first embed operation, so the partitions are guaranteed to
+        be empty.
 
         Concurrent callers are serialized by ``self._dim_lock`` so only
         a single underlying ``probe_dimension`` call is issued even
@@ -279,15 +303,38 @@ class WorkingMemory:
             probed = await probe_dimension(self._embedding_model_name)
             if probed != self.dimension:
                 self.dimension = probed
-                # Safe rebuild: no embedded items exist yet before the
+                # Safe reset: no embedded items exist yet before the
                 # first ``_ensure_dim`` call.
-                self.index = faiss.IndexFlatL2(self.dimension)
-                self.index_mapping = {}
-                self.reverse_index_mapping = {}
-                self.index_count = 0
+                self.partitions = {}
                 self.needs_rebuild = False
             self._dimension = probed
             return probed
+
+    def _partition_key(self, namespace: str, metadata: Optional[Dict[str, Any]]) -> str:
+        """Derive the vector partition key for an item.
+
+        "buffer"-namespace items carrying a session_id are partitioned
+        per session; everything else (sops, knowledge, docs, and buffer
+        items with no session) shares one partition.
+        """
+        if namespace == "buffer":
+            session_id = (metadata or {}).get("session_id")
+            if session_id:
+                return str(session_id)
+        return SHARED_PARTITION
+
+    def _get_partition(self, key: str) -> _IndexPartition:
+        """Return the partition for ``key``, creating it lazily."""
+        partition = self.partitions.get(key)
+        if partition is None:
+            partition = _IndexPartition(self.dimension)
+            self.partitions[key] = partition
+        return partition
+
+    @property
+    def index_count(self) -> int:
+        """Total number of vectors across all partitions."""
+        return sum(partition.index_count for partition in self.partitions.values())
 
     @property
     def embedding_model_name(self) -> str:
@@ -354,10 +401,13 @@ class WorkingMemory:
 
                 item["embedding"] = embedding_vector
 
-                # Record the mapping from buffer index to FAISS index
+                # Route the vector to its partition (per-session for
+                # buffer items, shared otherwise) and record the
+                # buffer-index-to-FAISS-row mapping.
+                partition = self._get_partition(self._partition_key(namespace, metadata))
                 buffer_idx = len(self.buffer)
-                self.index_mapping[buffer_idx] = self.index_count
-                self.reverse_index_mapping[self.index_count] = buffer_idx
+                partition.index_mapping[buffer_idx] = partition.index_count
+                partition.reverse_index_mapping[partition.index_count] = buffer_idx
 
                 # Normalize embedding for better cosine similarity in FAISS
                 embedding_array = np.array([embedding_vector], dtype=np.float32)
@@ -365,11 +415,11 @@ class WorkingMemory:
                 if norm > 0:
                     embedding_array = embedding_array / norm
 
-                # Add the normalized embedding to the FAISS index
-                self.index.add(embedding_array)
+                # Add the normalized embedding to the partition's index
+                partition.index.add(embedding_array)
 
-                # Increment the FAISS index counter
-                self.index_count += 1
+                # Increment the partition's FAISS row counter
+                partition.index_count += 1
             except Exception as e:
                 # Handle embedding generation failures gracefully
                 _ = e  # remove this after implementing observability
@@ -387,40 +437,41 @@ class WorkingMemory:
 
     def _rebuild_index(self) -> None:
         """
-        Rebuild the FAISS index after buffer overflow.
+        Rebuild the FAISS partitions after buffer overflow.
 
-        This internal method rebuilds the FAISS index and mapping when the buffer
-        is full and new items have displaced old ones. It ensures the vector search
-        stays in sync with the actual buffer contents.
+        This internal method rebuilds every partition's FAISS index and mappings
+        when the buffer is full and new items have displaced old ones. It ensures
+        the vector search stays in sync with the actual buffer contents. Partitions
+        that end up with no vectors (e.g. every item of a dead session was evicted)
+        are dropped entirely.
         """
         if not self._embedding_model_name:
             return
 
-        # Create a new index with the same dimension
-        new_index = faiss.IndexFlatL2(self.dimension)
-        new_mapping = {}
-        new_reverse_mapping = {}
-        new_count = 0
+        # Regroup embeddings from the current buffer into new partitions
+        new_partitions: Dict[str, _IndexPartition] = {}
+        embeddings_by_key: Dict[str, list] = {}
 
-        # Add embeddings from the current buffer to the new index
-        embeddings = []
         for i, item in enumerate(self.buffer):
             if "embedding" in item and item["embedding"] is not None:
-                embeddings.append(item["embedding"])
-                new_mapping[i] = new_count
-                new_reverse_mapping[new_count] = i
-                new_count += 1
+                key = self._partition_key(item.get("namespace", "buffer"), item.get("metadata"))
+                partition = new_partitions.get(key)
+                if partition is None:
+                    partition = _IndexPartition(self.dimension)
+                    new_partitions[key] = partition
+                    embeddings_by_key[key] = []
+                embeddings_by_key[key].append(item["embedding"])
+                partition.index_mapping[i] = partition.index_count
+                partition.reverse_index_mapping[partition.index_count] = i
+                partition.index_count += 1
 
-        # Add collected embeddings to the index if any exist
-        if embeddings:
+        # Add collected embeddings to each partition's index
+        for key, embeddings in embeddings_by_key.items():
             embeddings_array = np.array(embeddings, dtype=np.float32)
-            new_index.add(embeddings_array)
+            new_partitions[key].index.add(embeddings_array)
 
-        # Replace the old index and mapping
-        self.index = new_index
-        self.index_mapping = new_mapping
-        self.reverse_index_mapping = new_reverse_mapping
-        self.index_count = new_count
+        # Replace the old partitions
+        self.partitions = new_partitions
         self.needs_rebuild = False
 
     def check_memory_usage_and_cleanup(self) -> None:
@@ -809,82 +860,105 @@ class WorkingMemory:
             if norm > 0:
                 query_np = query_np / norm
 
-            # Search the FAISS index for similar vectors
-            k = min(limit * 2, self.index_count)  # Get more results to allow for filtering
-            distances, indices = self.index.search(query_np, k)
+            # Select which partitions to search. A session-scoped search
+            # only needs that session's partition — the hard session_id
+            # filter below excluded every other item anyway (items in
+            # other partitions carry no matching session_id). Namespaced
+            # searches without a session (sops / knowledge) only need
+            # the shared partition, where all non-"buffer" vectors live.
+            # Unscoped searches merge results from all partitions.
+            if session_id:
+                partition_keys = [str(session_id)]
+            elif namespace and namespace != "buffer":
+                partition_keys = [SHARED_PARTITION]
+            else:
+                partition_keys = list(self.partitions.keys())
 
-            # Map FAISS indices back to buffer indices via the reverse
-            # mapping (O(1) per result). FAISS pads with -1 when fewer
-            # than k vectors exist; those have no mapping and are skipped.
-            buffer_indices = []
-            for faiss_idx in indices[0]:
-                buffer_idx = self.reverse_index_mapping.get(int(faiss_idx))
-                if buffer_idx is not None:
-                    buffer_indices.append(buffer_idx)
-
-            # Combine semantic score with recency score
             results = []
-            for i, buffer_idx in enumerate(buffer_indices):
-                # Make sure buffer_idx is in range
-                if buffer_idx >= len(self.buffer):
+            for partition_key in partition_keys:
+                partition = self.partitions.get(partition_key)
+                if partition is None or partition.index_count == 0:
                     continue
 
-                item = self.buffer[buffer_idx].copy()
+                # Search the partition's FAISS index for similar vectors
+                k = min(limit * 2, partition.index_count)  # Extra results allow for filtering
+                distances, indices = partition.index.search(query_np, k)
 
-                # Apply namespace filter if provided
-                if namespace and item.get("namespace") != namespace:
-                    continue
+                # Map FAISS rows back to buffer indices via the reverse
+                # mapping (O(1) per result). FAISS pads with -1 when fewer
+                # than k vectors exist; those have no mapping and are skipped.
+                candidates = []
+                for i, faiss_idx in enumerate(indices[0]):
+                    buffer_idx = partition.reverse_index_mapping.get(int(faiss_idx))
+                    if buffer_idx is not None:
+                        candidates.append((buffer_idx, float(distances[0][i])))
 
-                # Check formation_id match (always filter by formation)
-                if item.get("metadata", {}).get("formation_id") != self.formation_id:
-                    continue
+                # Combine semantic score with recency score
+                partition_results = []
+                for buffer_idx, distance in candidates:
+                    # Make sure buffer_idx is in range
+                    if buffer_idx >= len(self.buffer):
+                        continue
 
-                # Apply session_id filter as a hard filter if provided
-                if session_id and item.get("metadata", {}).get("session_id") != session_id:
-                    continue
+                    item = self.buffer[buffer_idx].copy()
 
-                # Apply metadata filters if provided
-                if filter_metadata and not all(
-                    key in item["metadata"] and item["metadata"][key] == value
-                    for key, value in filter_metadata.items()
-                ):
-                    continue
+                    # Apply namespace filter if provided
+                    if namespace and item.get("namespace") != namespace:
+                        continue
 
-                # Calculate combined score without session weighting
-                # (session_id is now a hard filter applied above)
-                if namespace == "sops":
-                    # SOPs are indexed once at startup; their position in the
-                    # buffer is meaningless and the ``1 / (1 + L2²)`` transform
-                    # used below compresses the high-similarity range that
-                    # SOP-routing decisions live in. Return *true* cosine
-                    # similarity instead so the threshold callers compare
-                    # against (typically 0.7) means what operators expect.
-                    #
-                    # Vectors are unit-normalised (see L803), so for the
-                    # FAISS ``IndexFlatL2`` distance ``d``:
-                    #   d == ||a - b||² == 2 - 2·cos(a, b)
-                    #   cos == 1 - d / 2
-                    cos_sim = 1.0 - float(distances[0][i]) / 2.0
-                    # Clamp into [0, 1] — numerical noise on ``d ≈ 0`` or
-                    # ``d ≈ 2`` can drift fractionally outside the range.
-                    combined_score = max(0.0, min(1.0, cos_sim))
-                else:
-                    semantic_score = 1.0 / (1.0 + float(distances[0][i]))
-                    recency_score = 1.0 - (buffer_idx / len(self.buffer))
+                    # Check formation_id match (always filter by formation)
+                    if item.get("metadata", {}).get("formation_id") != self.formation_id:
+                        continue
 
-                    # Use original recency bias formula
-                    # This preserves perfect scores for exact matches
-                    combined_score = (
-                        1 - recency_bias
-                    ) * semantic_score + recency_bias * recency_score
+                    # Apply session_id filter as a hard filter if provided
+                    if session_id and item.get("metadata", {}).get("session_id") != session_id:
+                        continue
 
-                # Add score to the item
-                item["score"] = combined_score
-                results.append(item)
+                    # Apply metadata filters if provided
+                    if filter_metadata and not all(
+                        key in item["metadata"] and item["metadata"][key] == value
+                        for key, value in filter_metadata.items()
+                    ):
+                        continue
 
-                # Stop if we have enough results
-                if len(results) >= limit:
-                    break
+                    # Calculate combined score without session weighting
+                    # (session_id is now a hard filter applied above)
+                    if namespace == "sops":
+                        # SOPs are indexed once at startup; their position in the
+                        # buffer is meaningless and the ``1 / (1 + L2²)`` transform
+                        # used below compresses the high-similarity range that
+                        # SOP-routing decisions live in. Return *true* cosine
+                        # similarity instead so the threshold callers compare
+                        # against (typically 0.7) means what operators expect.
+                        #
+                        # Vectors are unit-normalised (see the query
+                        # normalization above), so for the FAISS
+                        # ``IndexFlatL2`` distance ``d``:
+                        #   d == ||a - b||² == 2 - 2·cos(a, b)
+                        #   cos == 1 - d / 2
+                        cos_sim = 1.0 - distance / 2.0
+                        # Clamp into [0, 1] — numerical noise on ``d ≈ 0`` or
+                        # ``d ≈ 2`` can drift fractionally outside the range.
+                        combined_score = max(0.0, min(1.0, cos_sim))
+                    else:
+                        semantic_score = 1.0 / (1.0 + distance)
+                        recency_score = 1.0 - (buffer_idx / len(self.buffer))
+
+                        # Use original recency bias formula
+                        # This preserves perfect scores for exact matches
+                        combined_score = (
+                            1 - recency_bias
+                        ) * semantic_score + recency_bias * recency_score
+
+                    # Add score to the item
+                    item["score"] = combined_score
+                    partition_results.append(item)
+
+                    # Stop if we have enough results from this partition
+                    if len(partition_results) >= limit:
+                        break
+
+                results.extend(partition_results)
 
             # If we don't have enough results, try recency search
             if not results:
@@ -1118,14 +1192,14 @@ class WorkingMemory:
             # write. Without this, a WorkingMemory built with a
             # provisional hint (e.g. default 768) and a model whose
             # true dim differs (e.g. 1536 for text-embedding-3-small)
-            # raises a shape mismatch on self.index.add(), which the
-            # broad except below silently swallows — the item lands
-            # in self.buffer but never in FAISS. A later add() or
-            # search() triggers _ensure_dim and rebuilds the index
-            # at the correct dim, but these early items are not
-            # re-indexed and their vector recall is permanently
+            # raises a shape mismatch on the partition's index.add(),
+            # which the broad except below silently swallows — the
+            # item lands in self.buffer but never in FAISS. A later
+            # add() or search() triggers _ensure_dim and resets the
+            # partitions at the correct dim, but these early items are
+            # not re-indexed and their vector recall is permanently
             # degraded. Calling _ensure_dim first makes the
-            # "safe rebuild: no embedded items exist yet" invariant
+            # "safe reset: no embedded items exist yet" invariant
             # in _ensure_dim actually hold regardless of which
             # writer (add vs add_with_embedding) wins the race to
             # the first insert.
@@ -1141,13 +1215,15 @@ class WorkingMemory:
                 if norm > 0:
                     embedding_np = embedding_np / norm
 
-                self.index.add(embedding_np)
+                # Route the vector to its partition (per-session for
+                # buffer items, shared otherwise) and update the mapping
+                partition = self._get_partition(self._partition_key(namespace, metadata))
+                partition.index.add(embedding_np)
 
-                # Update mapping
                 buffer_idx = len(self.buffer) - 1
-                self.index_mapping[buffer_idx] = self.index_count
-                self.reverse_index_mapping[self.index_count] = buffer_idx
-                self.index_count += 1
+                partition.index_mapping[buffer_idx] = partition.index_count
+                partition.reverse_index_mapping[partition.index_count] = buffer_idx
+                partition.index_count += 1
 
             except Exception as e:
                 # If FAISS fails, keep the item in buffer but disable vector search for this item
@@ -1167,17 +1243,15 @@ class WorkingMemory:
         """
         Clear the buffer memory.
 
-        This method removes all items from the buffer and resets the FAISS index
-        if vector search is enabled. It effectively resets the memory to an empty state.
+        This method removes all items from the buffer and resets all FAISS
+        partitions if vector search is enabled. It effectively resets the memory
+        to an empty state.
         """
         # Clear the buffer
         self.buffer.clear()
 
-        # Reset FAISS index if enabled
-        self.index = faiss.IndexFlatL2(self.dimension)
-        self.index_mapping = {}
-        self.reverse_index_mapping = {}
-        self.index_count = 0
+        # Reset all FAISS partitions
+        self.partitions = {}
         self.needs_rebuild = False
 
         # Clear key-value store

--- a/src/muxi/runtime/services/memory/working.py
+++ b/src/muxi/runtime/services/memory/working.py
@@ -239,6 +239,7 @@ class WorkingMemory:
         # have been added yet.
         self.index = faiss.IndexFlatL2(self.dimension)
         self.index_mapping = {}  # Maps buffer indices to FAISS indices
+        self.reverse_index_mapping = {}  # Maps FAISS indices back to buffer indices
         self.index_count = 0  # Counter for FAISS indices
         self.needs_rebuild = False  # Flag to track if index needs rebuilding
 
@@ -282,6 +283,7 @@ class WorkingMemory:
                 # first ``_ensure_dim`` call.
                 self.index = faiss.IndexFlatL2(self.dimension)
                 self.index_mapping = {}
+                self.reverse_index_mapping = {}
                 self.index_count = 0
                 self.needs_rebuild = False
             self._dimension = probed
@@ -355,6 +357,7 @@ class WorkingMemory:
                 # Record the mapping from buffer index to FAISS index
                 buffer_idx = len(self.buffer)
                 self.index_mapping[buffer_idx] = self.index_count
+                self.reverse_index_mapping[self.index_count] = buffer_idx
 
                 # Normalize embedding for better cosine similarity in FAISS
                 embedding_array = np.array([embedding_vector], dtype=np.float32)
@@ -396,6 +399,7 @@ class WorkingMemory:
         # Create a new index with the same dimension
         new_index = faiss.IndexFlatL2(self.dimension)
         new_mapping = {}
+        new_reverse_mapping = {}
         new_count = 0
 
         # Add embeddings from the current buffer to the new index
@@ -404,6 +408,7 @@ class WorkingMemory:
             if "embedding" in item and item["embedding"] is not None:
                 embeddings.append(item["embedding"])
                 new_mapping[i] = new_count
+                new_reverse_mapping[new_count] = i
                 new_count += 1
 
         # Add collected embeddings to the index if any exist
@@ -414,6 +419,7 @@ class WorkingMemory:
         # Replace the old index and mapping
         self.index = new_index
         self.index_mapping = new_mapping
+        self.reverse_index_mapping = new_reverse_mapping
         self.index_count = new_count
         self.needs_rebuild = False
 
@@ -807,14 +813,14 @@ class WorkingMemory:
             k = min(limit * 2, self.index_count)  # Get more results to allow for filtering
             distances, indices = self.index.search(query_np, k)
 
-            # Map FAISS indices back to buffer indices
+            # Map FAISS indices back to buffer indices via the reverse
+            # mapping (O(1) per result). FAISS pads with -1 when fewer
+            # than k vectors exist; those have no mapping and are skipped.
             buffer_indices = []
             for faiss_idx in indices[0]:
-                # Find the buffer index for this FAISS index
-                for buffer_idx, mapped_faiss_idx in self.index_mapping.items():
-                    if mapped_faiss_idx == faiss_idx:
-                        buffer_indices.append(buffer_idx)
-                        break
+                buffer_idx = self.reverse_index_mapping.get(int(faiss_idx))
+                if buffer_idx is not None:
+                    buffer_indices.append(buffer_idx)
 
             # Combine semantic score with recency score
             results = []
@@ -1140,6 +1146,7 @@ class WorkingMemory:
                 # Update mapping
                 buffer_idx = len(self.buffer) - 1
                 self.index_mapping[buffer_idx] = self.index_count
+                self.reverse_index_mapping[self.index_count] = buffer_idx
                 self.index_count += 1
 
             except Exception as e:
@@ -1169,6 +1176,7 @@ class WorkingMemory:
         # Reset FAISS index if enabled
         self.index = faiss.IndexFlatL2(self.dimension)
         self.index_mapping = {}
+        self.reverse_index_mapping = {}
         self.index_count = 0
         self.needs_rebuild = False
 

--- a/tests/unit/test_working_memory_partitioning.py
+++ b/tests/unit/test_working_memory_partitioning.py
@@ -1,0 +1,205 @@
+"""Unit tests for per-session FAISS partitioning in ``WorkingMemory``.
+
+``WorkingMemory`` used to hold one ``IndexFlatL2`` for the whole
+formation and scope results with post-search Python filters. That made
+every search scan every session's vectors and — worse — let a busy
+session crowd another session's relevant items out of the global top-k
+(recall dilution). Vectors are now partitioned: "buffer"-namespace items
+carrying a session_id get a per-session index, everything else (sops,
+knowledge, docs, sessionless buffer items) shares ``SHARED_PARTITION``.
+
+These tests pin the partition-routing rules, the recall-dilution fix,
+namespaced (sops) search through the shared partition, rebuild-after-
+eviction consistency (including garbage collection of dead sessions),
+and clear().
+
+Patches ``probe_dimension`` / ``embed`` (as imported into ``working``)
+to avoid any OneLLM / network / HF calls.
+"""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import AsyncMock, patch
+
+from muxi.runtime.services.memory.working import SHARED_PARTITION, WorkingMemory
+
+DIM = 8
+
+
+def _one_hot(position: int) -> list:
+    """Distinct, orthogonal embedding for deterministic FAISS ranking."""
+    vector = [0.0] * DIM
+    vector[position] = 1.0
+    return vector
+
+
+def _mix(position_a: int, position_b: int) -> list:
+    """Unit vector halfway between two one-hot axes (cosine 0.707 to each)."""
+    weight = 1.0 / math.sqrt(2.0)
+    vector = [0.0] * DIM
+    vector[position_a] = weight
+    vector[position_b] = weight
+    return vector
+
+
+def _make_memory() -> WorkingMemory:
+    return WorkingMemory(
+        formation_id="test-formation",
+        max_size=10,
+        buffer_multiplier=10,
+        embedding_model="local/nomic-ai/nomic-embed-text-v1.5",
+    )
+
+
+def _patched():
+    return (
+        patch(
+            "muxi.runtime.services.memory.working.probe_dimension",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "muxi.runtime.services.memory.working.embed",
+            new_callable=AsyncMock,
+        ),
+    )
+
+
+async def test_sessions_land_in_separate_partitions():
+    probe_patch, embed_patch = _patched()
+    with probe_patch as mock_probe, embed_patch as mock_embed:
+        mock_probe.return_value = DIM
+        mock_embed.side_effect = [[_one_hot(i)] for i in range(4)]
+
+        mem = _make_memory()
+        await mem.add("a1", metadata={"session_id": "session-a"})
+        await mem.add("a2", metadata={"session_id": "session-a"})
+        await mem.add("b1", metadata={"session_id": "session-b"})
+        await mem.add("no session")  # buffer item without session_id
+
+        assert set(mem.partitions.keys()) == {"session-a", "session-b", SHARED_PARTITION}
+        assert mem.partitions["session-a"].index_count == 2
+        assert mem.partitions["session-b"].index_count == 1
+        assert mem.partitions[SHARED_PARTITION].index_count == 1
+        assert mem.index_count == 4
+
+
+async def test_session_search_not_crowded_out_by_other_session():
+    """Recall-dilution regression test.
+
+    One relevant item in session A, twenty items in session B that sit
+    exactly on the query vector, and a more recent decoy in session A.
+    With the old single formation-wide index, top-k (k = limit * 2 = 2)
+    was filled entirely by session B, the session filter emptied the
+    results, and the recency fallback returned session A's most recent
+    item — the decoy, without a semantic score. The per-session
+    partition must return the relevant item via vector search.
+    """
+    probe_patch, embed_patch = _patched()
+    with probe_patch as mock_probe, embed_patch as mock_embed:
+        mock_probe.return_value = DIM
+        embeddings = [[_mix(0, 1)]]  # session A: relevant (cos 0.707 to query)
+        embeddings += [[_one_hot(1)] for _ in range(20)]  # session B: on the query
+        embeddings += [[_one_hot(2)]]  # session A: recent decoy, orthogonal
+        mock_embed.side_effect = embeddings
+
+        mem = _make_memory()
+        await mem.add("relevant", metadata={"session_id": "session-a"})
+        for i in range(20):
+            await mem.add(f"noise {i}", metadata={"session_id": "session-b"})
+        await mem.add("decoy", metadata={"session_id": "session-a"})
+
+        results = await mem.search(
+            "query",
+            query_vector=_one_hot(1),
+            limit=1,
+            session_id="session-a",
+        )
+
+        assert len(results) == 1
+        assert results[0]["text"] == "relevant"
+        # Vector-search result, not the recency fallback the old
+        # single-index path degraded to.
+        assert "score" in results[0]
+
+
+async def test_sops_namespace_searchable_without_session_id():
+    probe_patch, embed_patch = _patched()
+    with probe_patch as mock_probe, embed_patch as mock_embed:
+        mock_probe.return_value = DIM
+        mock_embed.side_effect = [[_one_hot(1)], [_one_hot(2)]]
+
+        mem = _make_memory()
+        # Session traffic must not interfere with the sops partition.
+        await mem.add("chat a", metadata={"session_id": "session-a"})
+        await mem.add("chat b", metadata={"session_id": "session-b"})
+        await mem.add_with_embedding(
+            "deploy runbook",
+            embedding=_one_hot(0),
+            metadata={"sop_id": "sop-1"},
+            namespace="sops",
+        )
+
+        results = await mem.search(
+            "how do I deploy",
+            query_vector=_one_hot(0),
+            limit=3,
+            recency_bias=0.0,
+            namespace="sops",
+        )
+
+        assert len(results) == 1
+        assert results[0]["metadata"]["sop_id"] == "sop-1"
+        # sops scoring returns true cosine similarity; exact match ~= 1.0.
+        assert results[0]["score"] > 0.99
+
+
+async def test_rebuild_after_eviction_drops_empty_partitions():
+    probe_patch, embed_patch = _patched()
+    with probe_patch as mock_probe, embed_patch as mock_embed:
+        mock_probe.return_value = DIM
+        mock_embed.side_effect = [[_one_hot(i)] for i in range(4)] + [[_one_hot(3)]]
+
+        mem = _make_memory()
+        await mem.add("a1", metadata={"session_id": "session-a"})
+        await mem.add("a2", metadata={"session_id": "session-a"})
+        await mem.add("b1", metadata={"session_id": "session-b"})
+        await mem.add("b2", metadata={"session_id": "session-b"})
+
+        # Simulate eviction of all session A items (they are oldest),
+        # then rebuild as the search path would.
+        mem.buffer.popleft()
+        mem.buffer.popleft()
+        mem._rebuild_index()
+
+        # Dead session partition is garbage-collected.
+        assert set(mem.partitions.keys()) == {"session-b"}
+        partition = mem.partitions["session-b"]
+        assert partition.index_count == 2
+        # Buffer indices shifted after eviction; mappings must follow.
+        assert partition.index_mapping == {0: 0, 1: 1}
+        assert partition.reverse_index_mapping == {0: 0, 1: 1}
+
+        # Search still resolves the correct item post-rebuild (query
+        # embedding is the final side_effect entry, matching "b2").
+        results = await mem.search("query", limit=1, session_id="session-b")
+        assert results
+        assert results[0]["text"] == "b2"
+
+
+async def test_clear_resets_all_partitions():
+    probe_patch, embed_patch = _patched()
+    with probe_patch as mock_probe, embed_patch as mock_embed:
+        mock_probe.return_value = DIM
+        mock_embed.side_effect = [[_one_hot(i)] for i in range(3)]
+
+        mem = _make_memory()
+        await mem.add("a1", metadata={"session_id": "session-a"})
+        await mem.add("b1", metadata={"session_id": "session-b"})
+        await mem.add("shared")
+
+        mem.clear()
+
+        assert mem.partitions == {}
+        assert mem.index_count == 0
+        assert len(mem.buffer) == 0

--- a/tests/unit/test_working_memory_reverse_mapping.py
+++ b/tests/unit/test_working_memory_reverse_mapping.py
@@ -1,0 +1,152 @@
+"""Unit tests for the FAISS reverse index mapping in ``WorkingMemory``.
+
+Semantic search previously mapped FAISS result indices back to buffer
+indices by scanning the entire ``index_mapping`` dict per result
+(O(k*n)). ``reverse_index_mapping`` replaces that with O(1) lookups.
+These tests pin the invariant that both mappings stay exact inverses of
+each other across every write path (add, rebuild, clear) and that
+search results resolve to the correct buffer items.
+
+Patches ``probe_dimension`` / ``embed`` (as imported into ``working``)
+to avoid any OneLLM / network / HF calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from muxi.runtime.services.memory.working import WorkingMemory
+
+DIM = 8
+
+
+def _one_hot(position: int) -> list:
+    """Distinct, orthogonal embedding for deterministic FAISS ranking."""
+    vector = [0.0] * DIM
+    vector[position] = 1.0
+    return vector
+
+
+def _make_memory() -> WorkingMemory:
+    return WorkingMemory(
+        formation_id="test-formation",
+        max_size=10,
+        buffer_multiplier=2,
+        embedding_model="local/nomic-ai/nomic-embed-text-v1.5",
+    )
+
+
+def _assert_inverse(mem: WorkingMemory) -> None:
+    """Both mappings must be exact inverses of each other."""
+    assert mem.reverse_index_mapping == {
+        faiss_idx: buffer_idx for buffer_idx, faiss_idx in mem.index_mapping.items()
+    }
+    assert len(mem.reverse_index_mapping) == len(mem.index_mapping)
+
+
+async def test_mappings_stay_inverse_across_adds():
+    with (
+        patch(
+            "muxi.runtime.services.memory.working.probe_dimension",
+            new_callable=AsyncMock,
+        ) as mock_probe,
+        patch(
+            "muxi.runtime.services.memory.working.embed",
+            new_callable=AsyncMock,
+        ) as mock_embed,
+    ):
+        mock_probe.return_value = DIM
+        mock_embed.side_effect = [[_one_hot(i)] for i in range(4)]
+
+        mem = _make_memory()
+        for i in range(4):
+            await mem.add(f"memory {i}")
+
+        assert mem.index_count == 4
+        _assert_inverse(mem)
+
+
+async def test_search_resolves_correct_buffer_item():
+    with (
+        patch(
+            "muxi.runtime.services.memory.working.probe_dimension",
+            new_callable=AsyncMock,
+        ) as mock_probe,
+        patch(
+            "muxi.runtime.services.memory.working.embed",
+            new_callable=AsyncMock,
+        ) as mock_embed,
+    ):
+        mock_probe.return_value = DIM
+        # Three writes, then a search query identical to item 1's vector.
+        mock_embed.side_effect = [
+            [_one_hot(0)],
+            [_one_hot(1)],
+            [_one_hot(2)],
+            [_one_hot(1)],
+        ]
+
+        mem = _make_memory()
+        await mem.add("memory zero")
+        await mem.add("memory one")
+        await mem.add("memory two")
+
+        results = await mem.search("query matching memory one", limit=1)
+
+        assert results, "semantic search returned no results"
+        assert results[0]["text"] == "memory one"
+
+
+async def test_mappings_stay_inverse_after_rebuild():
+    with (
+        patch(
+            "muxi.runtime.services.memory.working.probe_dimension",
+            new_callable=AsyncMock,
+        ) as mock_probe,
+        patch(
+            "muxi.runtime.services.memory.working.embed",
+            new_callable=AsyncMock,
+        ) as mock_embed,
+    ):
+        mock_probe.return_value = DIM
+        mock_embed.side_effect = [[_one_hot(i)] for i in range(4)]
+
+        mem = _make_memory()
+        for i in range(4):
+            await mem.add(f"memory {i}")
+
+        # Simulate eviction: drop the oldest item so buffer indices
+        # shift, then rebuild the index as the search path would.
+        mem.buffer.popleft()
+        mem._rebuild_index()
+
+        assert mem.index_count == 3
+        _assert_inverse(mem)
+        # Buffer index 0 now holds what was item 1; FAISS row 0 must
+        # resolve back to buffer index 0.
+        assert mem.reverse_index_mapping[0] == 0
+
+
+async def test_clear_resets_both_mappings():
+    with (
+        patch(
+            "muxi.runtime.services.memory.working.probe_dimension",
+            new_callable=AsyncMock,
+        ) as mock_probe,
+        patch(
+            "muxi.runtime.services.memory.working.embed",
+            new_callable=AsyncMock,
+        ) as mock_embed,
+    ):
+        mock_probe.return_value = DIM
+        mock_embed.side_effect = [[_one_hot(i)] for i in range(2)]
+
+        mem = _make_memory()
+        await mem.add("memory zero")
+        await mem.add("memory one")
+
+        mem.clear()
+
+        assert mem.index_mapping == {}
+        assert mem.reverse_index_mapping == {}
+        assert mem.index_count == 0

--- a/tests/unit/test_working_memory_reverse_mapping.py
+++ b/tests/unit/test_working_memory_reverse_mapping.py
@@ -3,9 +3,10 @@
 Semantic search previously mapped FAISS result indices back to buffer
 indices by scanning the entire ``index_mapping`` dict per result
 (O(k*n)). ``reverse_index_mapping`` replaces that with O(1) lookups.
-These tests pin the invariant that both mappings stay exact inverses of
-each other across every write path (add, rebuild, clear) and that
-search results resolve to the correct buffer items.
+Vectors now live in per-session partitions, so both mappings are kept
+per partition. These tests pin the invariant that both mappings stay
+exact inverses of each other across every write path (add, rebuild,
+clear) and that search results resolve to the correct buffer items.
 
 Patches ``probe_dimension`` / ``embed`` (as imported into ``working``)
 to avoid any OneLLM / network / HF calls.
@@ -15,7 +16,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
-from muxi.runtime.services.memory.working import WorkingMemory
+from muxi.runtime.services.memory.working import SHARED_PARTITION, WorkingMemory
 
 DIM = 8
 
@@ -37,11 +38,13 @@ def _make_memory() -> WorkingMemory:
 
 
 def _assert_inverse(mem: WorkingMemory) -> None:
-    """Both mappings must be exact inverses of each other."""
-    assert mem.reverse_index_mapping == {
-        faiss_idx: buffer_idx for buffer_idx, faiss_idx in mem.index_mapping.items()
-    }
-    assert len(mem.reverse_index_mapping) == len(mem.index_mapping)
+    """Both mappings must be exact inverses of each other in every partition."""
+    assert mem.partitions, "expected at least one partition"
+    for partition in mem.partitions.values():
+        assert partition.reverse_index_mapping == {
+            faiss_idx: buffer_idx for buffer_idx, faiss_idx in partition.index_mapping.items()
+        }
+        assert len(partition.reverse_index_mapping) == len(partition.index_mapping)
 
 
 async def test_mappings_stay_inverse_across_adds():
@@ -122,9 +125,10 @@ async def test_mappings_stay_inverse_after_rebuild():
 
         assert mem.index_count == 3
         _assert_inverse(mem)
-        # Buffer index 0 now holds what was item 1; FAISS row 0 must
-        # resolve back to buffer index 0.
-        assert mem.reverse_index_mapping[0] == 0
+        # Buffer index 0 now holds what was item 1; FAISS row 0 in the
+        # shared partition (no session_id on these items) must resolve
+        # back to buffer index 0.
+        assert mem.partitions[SHARED_PARTITION].reverse_index_mapping[0] == 0
 
 
 async def test_clear_resets_both_mappings():
@@ -147,6 +151,5 @@ async def test_clear_resets_both_mappings():
 
         mem.clear()
 
-        assert mem.index_mapping == {}
-        assert mem.reverse_index_mapping == {}
+        assert mem.partitions == {}
         assert mem.index_count == 0


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #190** — merge #190 (`perf/working-memory-reverse-mapping`) first. This branch builds on the O(1) reverse index mapping added there.

## Problem

`WorkingMemory` is instantiated once per formation and held ONE `faiss.IndexFlatL2` for all users, sessions, and namespaces. Scoping (formation always; namespace and session_id when provided) happened as post-search Python filtering. Two consequences:

1. **Scan cost**: every semantic search scanned the entire formation index, regardless of how narrow the scope was.
2. **Recall dilution**: `k = min(limit * 2, index_count)` retrieved top-k across ALL sessions, then filtered. A busy multi-user formation crowds a session's relevant items out of the global top-k entirely.

Concrete example (now a regression test, verified failing on the pre-change code): session A has 1 relevant item and 1 more-recent decoy; session B has 20 items sitting exactly on the query vector. Searching session A with `limit=1` gives `k=2`, both top-2 hits are session B, the hard session filter empties the results, and the code degrades to the recency fallback — which returns the **decoy** (most recent session-A item) with no semantic score. On the old code this run returns `('decoy', score=absent)`; with this PR it returns `('relevant', score=present)`.

## Design

`WorkingMemory` now holds a dict of `_IndexPartition` objects, each owning its own `IndexFlatL2`, forward/reverse buffer-index↔FAISS-row mappings, and count.

**Partition key rules** (derived at insert time from item namespace + metadata):
- `"buffer"`-namespace items with a truthy `session_id` in metadata → partition keyed by that session_id
- Everything else — namespaces `sops`, `knowledge` (docs), and buffer items with no session_id — → shared partition `"__shared__"`

**Search routing**:
- `session_id` provided → search ONLY that session's partition. Equivalent result set to before: the existing post-search hard filter (`item.metadata.session_id != session_id → skip`) already excluded every item now living in other partitions (verified — non-buffer items carry no session_id metadata, so `None != session_id` skipped them too).
- `namespace` provided without session_id (sops/knowledge pattern) → search only the shared partition, where all non-buffer vectors live.
- Neither → search all partitions with the same `k = limit * 2` per partition, merge, sort by combined score, truncate to `limit` after the existing filters.

**Preserved exactly**: the sops cosine special-case (`1 - d/2`, clamped), the `1/(1+d)` + recency-bias hybrid formula, the -1 FAISS padding skip via the reverse mapping, the `index_count == 0` fast path (`index_count` is now a property totalling partitions), and `get_stats()["vector_index_size"]`. Public API unchanged. `_rebuild_index()` regroups the buffer into fresh partitions and drops empty ones — this garbage-collects partitions of dead sessions as their items are evicted. `_ensure_dim()` and `clear()` reset all partitions. `restore_session()` re-adds items with `embedding=None` and marks `needs_rebuild`; the next rebuild routes them via their `session_id` metadata into the right partition.

## Verified caller analysis

Read every `WorkingMemory.search` call site before finalizing the partition rules:

- **chat_orchestrator.py** (buffer context, recency floor, role turns): always passes `{"user_id": ..., "session_id": ...}` via `filter_metadata` when a session exists; `search()` extracts `session_id` from `filter_metadata` before partition selection, so routing works unchanged. When session_id is absent both the stored items and the search are sessionless → shared partition / all-partition merge, same results.
- **sops.py:777**: passes `namespace="sops"`, never a session_id → shared partition. ✓
- **knowledge/handler.py:597 + :1512**: adds chunks with `namespace="knowledge"` and NO session_id in metadata, but the search passes `session_id=session_id`. Surprise finding: under the pre-existing hard filter, any non-None session_id already excluded ALL knowledge items (`metadata.session_id` is `None` ≠ session_id), so that path returned the recency fallback (empty) before and after this change — behavior preserved, though it looks like a latent caller bug worth a separate look. With `session_id=None` the shared partition serves knowledge items as before.
- **documents/storage/buffer_memory.py**: document chunks are added through `WorkingMemory.add` with the *default* `"buffer"` namespace and no session_id in metadata → shared partition; `search_documents` never passes session_id → all-partition merge finds them. ✓

No code outside `working.py` reads `.index` / `.index_mapping` / `.reverse_index_mapping` / `.index_count` except the reverse-mapping unit test, which was updated to the partitioned structure (invariants kept: forward/reverse mappings inverse per partition, search resolves the correct item, clear resets).

## Remote mode

The faissx client is a drop-in for the faiss module, so the same code runs in remote mode — note that remote mode now creates **one server-side index per partition** (per active session plus one shared) instead of a single index per formation. Partitions are created lazily on first write and dropped on rebuild when empty, so the server-side index count tracks live sessions.

## Test evidence

- New `tests/unit/test_working_memory_partitioning.py` (5 tests): partition routing for two sessions + shared, the recall-dilution regression above, sops search without session_id, rebuild-after-eviction consistency + empty-partition GC, and clear(). The dilution test was run against the pre-change code and fails there (returns the decoy via recency fallback, no score).
- `tests/unit/test_working_memory_reverse_mapping.py` updated to per-partition structure, coverage kept.
- Full unit suite: **1098 passed, 3 skipped** in 64s.
- black / isort / ruff clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)