### PR TITLE
fix: stop session-filtering knowledge searches

### DIFF
--- a/src/muxi/runtime/formation/agents/knowledge/handler.py
+++ b/src/muxi/runtime/formation/agents/knowledge/handler.py
@@ -544,9 +544,14 @@ class KnowledgeHandler:
         query: str,
         top_k: int = 5,
         generate_embeddings_fn: Optional[Callable] = None,
-        session_id: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        """Search across all knowledge sources with performance optimization."""
+        """Search across all knowledge sources with performance optimization.
+
+        Knowledge is agent-scoped, not session-scoped: chunks are stored
+        without a session_id, so the underlying vector search must not be
+        session-filtered. Passing a session_id here used to exclude every
+        knowledge chunk and silently return zero results.
+        """
         search_start_time = time.time()
 
         # Log search start
@@ -593,14 +598,15 @@ class KnowledgeHandler:
             # Use standard search parameters
             search_k = top_k
 
-            # Use WorkingMemory for document search with documents namespace
+            # Use WorkingMemory for document search with documents namespace.
+            # No session_id: knowledge chunks carry none, so a session filter
+            # would exclude all of them.
             memory_results = await self.working_memory.search(
                 query="",  # Empty since we provide vector
                 query_vector=query_vector.tolist(),
                 limit=search_k * 2,  # Get more results for filtering
                 recency_bias=0.05,  # Very low for documents - favor semantic similarity
                 namespace=DOCUMENT_NAMESPACE,
-                session_id=session_id,
             )
 
             # Convert to standard format
@@ -1497,12 +1503,13 @@ class KnowledgeHandler:
         results = {"knowledge": [], "memory": [], "unified": []}
 
         try:
-            # Search knowledge sources (use stored embedding function if not provided)
+            # Search knowledge sources (use stored embedding function if not
+            # provided). Knowledge is agent-scoped; session_id only applies to
+            # the conversational working-memory search below.
             knowledge_results = await self.search(
                 query=query,
                 top_k=knowledge_limit or top_k,
                 generate_embeddings_fn=generate_embeddings_fn or self._generate_embeddings_fn,
-                session_id=session_id,
             )
             results["knowledge"] = knowledge_results
 

--- a/tests/unit/test_knowledge_search_session_scope.py
+++ b/tests/unit/test_knowledge_search_session_scope.py
@@ -1,0 +1,86 @@
+"""Regression tests for session scoping in knowledge search.
+
+Knowledge chunks are stored in working memory without a session_id
+(knowledge is agent-scoped, not session-scoped), but the handler used to
+forward the caller's session_id into the vector search. Working memory
+applies session_id as a hard filter, so every session-scoped knowledge
+search silently returned zero results. These tests pin the contract:
+the knowledge leg is never session-filtered, while the conversational
+memory leg in search_unified keeps its session scoping.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from muxi.runtime.formation.agents.knowledge.handler import (
+    DOCUMENT_NAMESPACE,
+    KnowledgeHandler,
+)
+
+DIM = 8
+
+
+def _make_working_memory_mock() -> MagicMock:
+    wm = MagicMock()
+    wm.add_with_embedding = AsyncMock()
+    wm.search = AsyncMock(
+        return_value=[
+            {
+                "text": "MUXI offers three pricing plans.",
+                "score": 0.92,
+                "metadata": {"document_id": "doc-1", "source": "pricing.md"},
+            }
+        ]
+    )
+    wm.get_items_by_metadata = MagicMock(return_value=[])
+    wm.remove_by_metadata = MagicMock(return_value=0)
+    return wm
+
+
+def _make_handler() -> KnowledgeHandler:
+    handler = KnowledgeHandler(
+        agent_id_or_sources="test-agent",
+        formation_id="test-formation",
+        embedding_dimension=DIM,
+        working_memory=_make_working_memory_mock(),
+        auto_inject_knowledge=False,
+    )
+    handler._generate_embeddings_fn = AsyncMock(return_value=[[0.1] * DIM])
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_knowledge_search_is_not_session_filtered():
+    handler = _make_handler()
+
+    results = await handler.search(query="What pricing plans does MUXI offer?", top_k=3)
+
+    assert len(results) == 1
+    search_kwargs = handler.working_memory.search.await_args.kwargs
+    assert search_kwargs["namespace"] == DOCUMENT_NAMESPACE
+    assert "session_id" not in search_kwargs
+
+
+@pytest.mark.asyncio
+async def test_unified_search_scopes_only_the_memory_leg():
+    handler = _make_handler()
+
+    results = await handler.search_unified(
+        query="What pricing plans does MUXI offer?",
+        top_k=3,
+        session_id="session-123",
+    )
+
+    calls = handler.working_memory.search.await_args_list
+    knowledge_calls = [c for c in calls if c.kwargs.get("namespace") == DOCUMENT_NAMESPACE]
+    memory_calls = [c for c in calls if c.kwargs.get("namespace") != DOCUMENT_NAMESPACE]
+    assert len(knowledge_calls) == 1
+    assert len(memory_calls) == 1
+
+    # The regression: a session-scoped call must still surface knowledge
+    assert "session_id" not in knowledge_calls[0].kwargs
+    assert results["knowledge"], "session-scoped unified search returned no knowledge results"
+
+    # Conversational memory stays session-scoped
+    assert memory_calls[0].kwargs["session_id"] == "session-123"


### PR DESCRIPTION
## Problem

Knowledge chunks are stored in working memory without a `session_id` — knowledge is agent-scoped, not session-scoped. But `KnowledgeHandler.search()` forwarded the caller's `session_id` into the working-memory vector search, where it acts as a hard filter (and, post-#200, routes the search to the session's partition). Since no knowledge chunk can ever match a session filter, **every session-scoped knowledge search silently returned zero results** and fell back to nothing.

Found during the #200 caller analysis and confirmed live in `e2e/tests/6_knowledge/test_6d1` logs: `knowledge_results: 0` on an agent querying its own knowledge base.

## Fix

- Remove the `session_id` parameter from `KnowledgeHandler.search()` (knowledge is agent-scoped; the only caller is `search_unified`).
- `search_unified()` keeps its `session_id` and still applies it to the conversational working-memory leg — that scoping is correct — but no longer forwards it to the knowledge leg.

## Evidence

Before (develop, e2e 6d1 run): `"results_count":0, "knowledge_results":0` on every session-scoped knowledge query.
After (this branch, same test): `"results_count":5, "knowledge_results":5` on every knowledge query, isolation assertions all still pass, exit 0.

## Tests

- New `tests/unit/test_knowledge_search_session_scope.py`: the knowledge leg is never session-filtered and returns results; the memory leg in `search_unified` keeps `session_id`.
- Full unit suite: 1142 passed, 3 skipped. black/isort/ruff clean.
- e2e `test_6d1_agent_knowledge_isolation.py` passes on the branch (twice).

## Note

Test 3 of e2e 6d1 prints `can access its own knowledge: True/False` from a keyword heuristic (>2 of 4 words in the LLM reply) without asserting — it can print False even with correct retrieval depending on model phrasing. Might be worth tightening in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)