### PR TITLE
feat: GBAC phase 1 - groups schema and formation auth gate

### DIFF
--- a/e2e/tests/19_api/formation-api-authgate-open/formation.yaml
+++ b/e2e/tests/19_api/formation-api-authgate-open/formation.yaml
@@ -1,0 +1,36 @@
+schema: "1.0.0"
+id: api-test-authgate-open
+description: "Formation with default (open) auth for auth gate testing"
+
+llm:
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+    - embedding: "openai/text-embedding-3-small"
+
+runtime:
+  built_in_mcps: false
+
+memory:
+  buffer:
+    size: 100
+    vector_search: false
+
+agents:
+  - id: assistant
+    name: "Auth Gate Test Assistant"
+    description: "A helpful assistant for testing the auth gate"
+    system_message: "You are a helpful assistant. Be concise and direct."
+
+server:
+  enabled: true
+  port: 8271
+  api_keys:
+    admin_key: test-admin-key-123
+    client_key: test-client-key-456
+
+logging:
+  system:
+    level: "error"
+    destination: "stdout"

--- a/e2e/tests/19_api/formation-api-authgate-open/secrets.enc
+++ b/e2e/tests/19_api/formation-api-authgate-open/secrets.enc
@@ -1,0 +1,1 @@
+../formation-api/secrets.enc

--- a/e2e/tests/19_api/formation-api-authgate-required/formation.yaml
+++ b/e2e/tests/19_api/formation-api-authgate-required/formation.yaml
@@ -1,0 +1,37 @@
+schema: "1.0.0"
+id: api-test-authgate-required
+description: "Formation with server.auth required for auth gate testing"
+
+llm:
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+    - embedding: "openai/text-embedding-3-small"
+
+runtime:
+  built_in_mcps: false
+
+memory:
+  buffer:
+    size: 100
+    vector_search: false
+
+agents:
+  - id: assistant
+    name: "Auth Gate Test Assistant"
+    description: "A helpful assistant for testing the auth gate"
+    system_message: "You are a helpful assistant. Be concise and direct."
+
+server:
+  enabled: true
+  port: 8271
+  auth: required
+  api_keys:
+    admin_key: test-admin-key-123
+    client_key: test-client-key-456
+
+logging:
+  system:
+    level: "error"
+    destination: "stdout"

--- a/e2e/tests/19_api/formation-api-authgate-required/secrets.enc
+++ b/e2e/tests/19_api/formation-api-authgate-required/secrets.enc
@@ -1,0 +1,1 @@
+../formation-api/secrets.enc

--- a/e2e/tests/19_api/formation-api-authgate-required/triggers/test-trigger.md
+++ b/e2e/tests/19_api/formation-api-authgate-required/triggers/test-trigger.md
@@ -1,0 +1,3 @@
+Test trigger activated with data: ${{ data.message }}
+
+Please respond with a brief confirmation.

--- a/e2e/tests/19_api/test_19x1_auth_gate.py
+++ b/e2e/tests/19_api/test_19x1_auth_gate.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Test 19x1: Formation user auth gate (server.auth: open | required).
+
+Covers GBAC Phase 1 gate behavior end to end:
+- auth open (default): unknown users can chat
+- auth required: unknown users get 401 on chat and trigger webhooks
+- auth required: users seeded in users/user_identifiers pass the gate
+"""
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from common import BaseE2ETest, TestOutputFormatter  # noqa: E402
+
+from muxi.runtime.utils.user_resolution import resolve_user_identifier  # noqa: E402
+
+KNOWN_USER = "alice@example.com"
+UNKNOWN_USER = "stranger@example.com"
+
+
+class TestAuthGate(BaseE2ETest):
+    def __init__(self):
+        super().__init__(
+            test_name="test_19x1_auth_gate",
+            test_description="Test formation user auth gate (server.auth)",
+            test_area="19_api",
+        )
+        self.base_url = "http://127.0.0.1:8271/v1"
+        self.headers = {
+            "X-Muxi-Client-Key": "test-client-key-456",
+            "Content-Type": "application/json",
+        }
+
+    async def _start(self, formation_dir: str):
+        await self.setup_formation(formation_path=Path(__file__).parent / formation_dir)
+        await self.formation.start_server(block=False)
+        await asyncio.sleep(2)
+
+    async def _stop(self):
+        await self.cleanup_formation()
+        self.formation = None
+        self.overlord = None
+        await asyncio.sleep(2)  # let the port fully release before the next server
+
+    async def test_19x1_auth_gate(self):
+        formatter, start_time = TestOutputFormatter(), time.time()
+        formatter.print_test_header(
+            test_name="test_19x1_auth_gate",
+            description="Test formation user auth gate (server.auth)",
+        )
+        checks = []
+        try:
+            # Phase A: auth open (default) - unknown users pass
+            print("\n1. Starting formation with default (open) auth...")
+            await self._start("formation-api-authgate-open")
+            print("✅ Formation ready")
+
+            async with httpx.AsyncClient(timeout=90.0) as client:
+                print("\n2. Testing chat as unknown user with auth open...")
+                r = await client.post(
+                    f"{self.base_url}/chat",
+                    headers={**self.headers, "X-Muxi-User-Id": UNKNOWN_USER},
+                    json={"message": "Reply with the single word OK", "stream": False},
+                )
+                assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text}"
+                print("✅ auth open: unknown user can chat")
+                checks.append("auth open: unknown user allowed")
+
+            await self._stop()
+
+            # Phase B: auth required - unknown users are rejected
+            print("\n3. Starting formation with server.auth: required...")
+            await self._start("formation-api-authgate-required")
+
+            print("\n4. Seeding known user into users/user_identifiers...")
+            await resolve_user_identifier(
+                identifier=KNOWN_USER,
+                formation_id="api-test-authgate-required",
+                db_manager=self.formation._db_manager,
+                kv_cache=None,
+                create_if_missing=True,
+            )
+            print(f"✅ Seeded user {KNOWN_USER}")
+
+            async with httpx.AsyncClient(timeout=90.0) as client:
+                print("\n5. Testing chat as unknown user with auth required...")
+                r = await client.post(
+                    f"{self.base_url}/chat",
+                    headers={**self.headers, "X-Muxi-User-Id": UNKNOWN_USER},
+                    json={"message": "Reply with the single word OK", "stream": False},
+                )
+                assert r.status_code == 401, f"Expected 401, got {r.status_code}: {r.text}"
+                assert "Unknown user" in r.text
+                print("✅ auth required: unknown user rejected with 401 on /chat")
+                checks.append("auth required: unknown user 401 on chat")
+
+                print("\n6. Testing trigger webhook as unknown user...")
+                r = await client.post(
+                    f"{self.base_url}/triggers/test-trigger",
+                    headers={**self.headers, "X-Muxi-User-Id": UNKNOWN_USER},
+                    json={"data": {"message": "hello"}},
+                )
+                assert r.status_code == 401, f"Expected 401, got {r.status_code}: {r.text}"
+                print("✅ auth required: unknown user rejected with 401 on trigger")
+                checks.append("auth required: unknown user 401 on trigger")
+
+                print("\n7. Testing chat as known user with auth required...")
+                r = await client.post(
+                    f"{self.base_url}/chat",
+                    headers={**self.headers, "X-Muxi-User-Id": KNOWN_USER},
+                    json={"message": "Reply with the single word OK", "stream": False},
+                )
+                assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text}"
+                print("✅ auth required: known user can chat")
+                checks.append("auth required: known user allowed")
+
+                print("\n8. Testing chat with known user in body (deprecated fallback)...")
+                r = await client.post(
+                    f"{self.base_url}/chat",
+                    headers=self.headers,
+                    json={
+                        "message": "Reply with the single word OK",
+                        "user_id": KNOWN_USER,
+                        "stream": False,
+                    },
+                )
+                assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text}"
+                print("✅ auth required: body user_id fallback works")
+                checks.append("auth required: body user_id fallback allowed")
+
+                print("\n9. Testing trigger webhook as known user...")
+                r = await client.post(
+                    f"{self.base_url}/triggers/test-trigger",
+                    headers={**self.headers, "X-Muxi-User-Id": KNOWN_USER},
+                    json={"data": {"message": "hello"}},
+                )
+                assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text}"
+                print("✅ auth required: known user can fire trigger")
+                checks.append("auth required: known user trigger allowed")
+
+            formatter.print_test_result(
+                test_name="test_19x1_auth_gate",
+                success=True,
+                checks=checks,
+                transcript=[],
+                duration=time.time() - start_time,
+            )
+        except Exception as e:
+            formatter.print_test_result(
+                test_name="test_19x1_auth_gate",
+                success=False,
+                checks=[f"Failed: {e}"],
+                transcript=[],
+                duration=time.time() - start_time,
+            )
+            import traceback
+
+            traceback.print_exc()
+            raise
+        finally:
+            if self.formation:
+                await self.cleanup_formation()
+
+
+async def main():
+    await TestAuthGate().test_19x1_auth_gate()
+
+
+if __name__ == "__main__":
+    os._exit(asyncio.run(main()) or 0)

--- a/src/muxi/runtime/formation/config/validation.py
+++ b/src/muxi/runtime/formation/config/validation.py
@@ -2603,6 +2603,12 @@ class FormationValidator:
             if not isinstance(port, int) or port < 1 or port > 65535:
                 self.result.add_error("Server port must be an integer between 1 and 65535")
 
+        # Validate auth mode
+        if "auth" in server_config:
+            auth = server_config["auth"]
+            if auth not in ("open", "required"):
+                self.result.add_error(f"Server auth must be 'open' or 'required', got: {auth!r}")
+
         # Validate api_keys
         if "api_keys" in server_config:
             api_keys = server_config["api_keys"]

--- a/src/muxi/runtime/formation/formation.py
+++ b/src/muxi/runtime/formation/formation.py
@@ -1378,11 +1378,25 @@ class Formation:
         # Store generated keys for later display
         self._generated_api_keys = generated_keys
 
+        # Auth mode: "open" (default) accepts any user identity;
+        # "required" rejects users not present in the user_identifiers table
+        auth_mode = server_config.get("auth", "open")
+        if auth_mode not in ("open", "required"):
+            raise ConfigurationValidationError(
+                [f"Server auth must be 'open' or 'required', got: {auth_mode!r}"],
+                {
+                    "current_value": auth_mode,
+                    "suggestion": "Set 'server.auth' to 'open' or 'required' in your formation.afs",
+                    "example": {"server": {"auth": "required"}},
+                },
+            )
+
         # Store server configuration for later use
         self._server_config = {
             "host": server_config.get("host", "127.0.0.1"),
             "port": server_config.get("port", 8271),
             "access_log": server_config.get("access_log", False),
+            "auth": auth_mode,
             "api_keys": self._api_keys,
         }
 

--- a/src/muxi/runtime/formation/initialization.py
+++ b/src/muxi/runtime/formation/initialization.py
@@ -1043,7 +1043,9 @@ def _create_all_database_tables(db_manager, embedding_dimension: int = 1536) -> 
         # Get Base from db module
         from ..services.db import Base
         from ..services.memory.long_term import (  # noqa: F401
+            Group,
             User,
+            UserGroup,
             ensure_memory_table_indexes,
             get_memory_model,
         )
@@ -1065,6 +1067,8 @@ def _create_all_database_tables(db_manager, embedding_dimension: int = 1536) -> 
         table_names = [
             "users",
             "user_identifiers",
+            "groups",
+            "user_groups",  # Group-based access control tables
             memories_table,  # Memory system tables (dimension-specific)
             "credentials",  # Credential storage
             "scheduled_jobs",

--- a/src/muxi/runtime/formation/server/auth.py
+++ b/src/muxi/runtime/formation/server/auth.py
@@ -2,13 +2,15 @@
 Authentication utilities for the Formation server.
 
 Provides dependency injection classes for validating API keys
-in incoming requests.
+and formation user identities in incoming requests.
 """
 
 import secrets
 
 from fastapi import HTTPException, Request
 from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_500_INTERNAL_SERVER_ERROR
+
+from ...services import observability
 
 
 class AdminKeyAuth:
@@ -171,3 +173,102 @@ class DualKeyAuth:
             detail="A valid API key is required. Provide either 'X-Muxi-Admin-Key' or 'X-Muxi-Client-Key' header.",
             headers={"WWW-Authenticate": "ApiKey"},
         )
+
+
+class UserAuthGate:
+    """
+    Formation user auth gate dependency (server.auth: required).
+
+    When the formation config sets ``server.auth: required``, the user
+    identity carried by the request must resolve to a known user via the
+    user_identifiers table for this formation; unknown users receive 401.
+    With the default ``server.auth: open`` this dependency is a no-op.
+
+    Runs after API key validation: the key authenticates the caller
+    (application), this gate authorizes the end user it acts for.
+    """
+
+    # Endpoints whose deprecated JSON body ``user_id`` field participates in
+    # identity resolution (mirrors the chat routes' header-then-body order).
+    _BODY_FALLBACK_PATHS = frozenset({"/v1/chat", "/v1/audiochat"})
+
+    async def __call__(self, request: Request) -> None:
+        """
+        Reject the request if auth is required and the user is unknown.
+
+        Args:
+            request: The FastAPI request object
+
+        Raises:
+            HTTPException: 401 if the user identity is not in the database,
+                500 if auth is required but no database is configured
+        """
+        formation = getattr(request.app.state, "formation", None)
+        if formation is None:
+            return
+
+        server_config = getattr(formation, "_server_config", None) or {}
+        if server_config.get("auth", "open") != "required":
+            return
+
+        identity = await self._resolve_identity(request)
+
+        db_manager = getattr(formation, "_db_manager", None)
+        if db_manager is None:
+            raise HTTPException(
+                status_code=HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="server.auth is 'required' but no persistent database is configured",
+            )
+
+        from ...utils.user_resolution import resolve_user_identifier
+
+        resolved = await resolve_user_identifier(
+            identifier=identity,
+            formation_id=formation.formation_id,
+            db_manager=db_manager,
+            kv_cache=None,
+            create_if_missing=False,
+        )
+
+        if resolved is None:
+            observability.observe(
+                event_type=observability.ErrorEvents.AUTHENTICATION_FAILED,
+                level=observability.EventLevel.WARNING,
+                data={
+                    "service": "formation_api_server",
+                    "auth_gate": "user",
+                    "auth_mode": "required",
+                    "path": request.url.path,
+                    "user_id": identity,
+                    "formation_id": formation.formation_id,
+                },
+                description=f"Auth gate rejected unknown user {identity!r}",
+            )
+            raise HTTPException(
+                status_code=HTTP_401_UNAUTHORIZED,
+                detail=(
+                    f"Unknown user {identity!r}. This formation requires registered "
+                    "users (server.auth: required)."
+                ),
+            )
+
+    async def _resolve_identity(self, request: Request) -> str:
+        """
+        Resolve the user identity the way the gated routes do.
+
+        Order: X-Muxi-User-Id header, then (chat endpoints only) the
+        deprecated ``user_id`` body field, then the default user "0".
+        """
+        identity = request.headers.get("x-muxi-user-id")
+
+        if not identity and request.url.path in self._BODY_FALLBACK_PATHS:
+            try:
+                body = await request.json()
+            except Exception:
+                body = None
+            if isinstance(body, dict):
+                body_user_id = body.get("user_id")
+                if isinstance(body_user_id, str):
+                    identity = body_user_id
+
+        return identity or "0"

--- a/src/muxi/runtime/formation/server/server.py
+++ b/src/muxi/runtime/formation/server/server.py
@@ -661,7 +661,7 @@ class FormationServer:
         """Register client interaction endpoints."""
         from fastapi import Depends
 
-        from .auth import ClientKeyAuth, DualKeyAuth
+        from .auth import ClientKeyAuth, DualKeyAuth, UserAuthGate
 
         # Import scheduler from admin routes (has dual-auth endpoint GET /scheduler/jobs)
         from .routes.admin import scheduler
@@ -683,11 +683,18 @@ class FormationServer:
         # Create auth dependencies
         client_auth = ClientKeyAuth(self.client_key)
         dual_auth = DualKeyAuth(self.admin_key, self.client_key)
+        user_auth_gate = UserAuthGate()
+
+        # Routers that accept only ClientKey and carry a formation user
+        # identity, so they additionally pass the user auth gate
+        # (server.auth: required rejects unknown users with 401)
+        user_gated_routers = [
+            chat.router,
+            triggers.router,
+        ]
 
         # Routers that accept only ClientKey
         client_only_routers = [
-            chat.router,
-            triggers.router,
             users.router,
             sessions.router,
             skills.router,
@@ -702,6 +709,13 @@ class FormationServer:
             memory.router,
             scheduler.router,  # GET /scheduler/jobs needs both keys
         ]
+
+        for router in user_gated_routers:
+            app.include_router(
+                router,
+                prefix="/v1",
+                dependencies=[Depends(client_auth), Depends(user_auth_gate)],
+            )
 
         for router in client_only_routers:
             app.include_router(router, prefix="/v1", dependencies=[Depends(client_auth)])

--- a/src/muxi/runtime/services/memory/long_term.py
+++ b/src/muxi/runtime/services/memory/long_term.py
@@ -115,6 +115,52 @@ class UserIdentifier(Base, AsyncModelMixin):
     )
 
 
+class Group(Base, AsyncModelMixin):
+    """
+    Group table for group-based access control.
+
+    Groups are policy data: membership rows in user_groups reference them,
+    and group_id matches the group YAML filename stem (permission resolution
+    is loaded from the formation's groups/ directory at runtime).
+    """
+
+    __tablename__ = "groups"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    group_id = Column(String(255), nullable=False)
+    name = Column(String(255))
+    description = Column(Text)
+    formation_id = Column(String(255), nullable=False, index=True)
+    created_at = Column(DateTime, nullable=False, default=utc_now_naive)
+    updated_at = Column(DateTime, default=utc_now_naive, onupdate=utc_now_naive)
+
+    # Composite unique constraint to ensure group_id uniqueness per formation
+    __table_args__ = (UniqueConstraint("group_id", "formation_id", name="uq_group_formation"),)
+
+
+class UserGroup(Base, AsyncModelMixin):
+    """
+    User-to-group membership table.
+
+    user_id stores the external user identifier (email, Slack ID, etc.) as
+    populated by operators; it is resolved through the user_identifiers table
+    at request time, mirroring how identities enter the runtime.
+    """
+
+    __tablename__ = "user_groups"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(String(255), nullable=False, index=True)
+    group_id = Column(String(255), nullable=False, index=True)
+    formation_id = Column(String(255), nullable=False, index=True)
+    created_at = Column(DateTime, default=utc_now_naive)
+
+    # Composite unique constraint to prevent duplicate memberships per formation
+    __table_args__ = (
+        UniqueConstraint("user_id", "group_id", "formation_id", name="uq_user_group_formation"),
+    )
+
+
 # Dynamic Memory model factory — one ORM class per embedding dimension.
 # Table name: memories_{dimension} (e.g. memories_384, memories_768, memories_1536).
 _memory_models: Dict[int, Any] = {}

--- a/tests/unit/test_gbac_phase1.py
+++ b/tests/unit/test_gbac_phase1.py
@@ -1,0 +1,296 @@
+"""Unit tests for GBAC Phase 1: groups schema, server.auth config, and the user auth gate.
+
+Covers the three Phase 1 surfaces of the group-based access control PRD:
+
+1. Schema -- the ``groups`` and ``user_groups`` SQLAlchemy models create
+   cleanly on SQLite and enforce their per-formation composite uniques.
+2. Config -- ``server.auth`` accepts ``open``/``required`` (default ``open``)
+   and rejects anything else at both validation and extraction time.
+3. Gate -- ``UserAuthGate`` is a no-op when auth is open, rejects unknown
+   users with 401 when auth is required, and admits known users seeded in
+   the ``users``/``user_identifiers`` tables.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+from starlette.requests import Request
+
+from muxi.runtime.datatypes.exceptions import ConfigurationValidationError
+from muxi.runtime.formation.config.validation import FormationValidator
+from muxi.runtime.formation.formation import Formation
+from muxi.runtime.formation.server.auth import UserAuthGate
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.long_term import Group, User, UserGroup, UserIdentifier
+from muxi.runtime.utils.user_resolution import resolve_user_identifier
+
+FORMATION_ID = "gbac-test-formation"
+
+GBAC_TABLES = [
+    User.__table__,
+    UserIdentifier.__table__,
+    Group.__table__,
+    UserGroup.__table__,
+]
+
+
+@pytest.fixture
+def sqlite_session():
+    """In-memory SQLite session with the users/identifiers/groups tables created."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=GBAC_TABLES)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+class TestGroupModels:
+    """Schema: groups and user_groups models on SQLite."""
+
+    def test_group_creation(self, sqlite_session):
+        """A group row persists with its PRD columns plus formation_id."""
+        sqlite_session.add(
+            Group(
+                group_id="analyst",
+                name="Business Analyst",
+                description="Analysis and reporting",
+                formation_id=FORMATION_ID,
+            )
+        )
+        sqlite_session.commit()
+
+        group = sqlite_session.execute(select(Group)).scalar_one()
+        assert group.group_id == "analyst"
+        assert group.name == "Business Analyst"
+        assert group.description == "Analysis and reporting"
+        assert group.formation_id == FORMATION_ID
+        assert group.created_at is not None
+
+    def test_group_id_unique_per_formation(self, sqlite_session):
+        """Duplicate group_id in the same formation is rejected."""
+        sqlite_session.add(Group(group_id="analyst", formation_id=FORMATION_ID))
+        sqlite_session.commit()
+
+        sqlite_session.add(Group(group_id="analyst", formation_id=FORMATION_ID))
+        with pytest.raises(IntegrityError):
+            sqlite_session.commit()
+
+    def test_group_id_reusable_across_formations(self, sqlite_session):
+        """The same group_id may exist in different formations."""
+        sqlite_session.add(Group(group_id="analyst", formation_id=FORMATION_ID))
+        sqlite_session.add(Group(group_id="analyst", formation_id="other-formation"))
+        sqlite_session.commit()
+
+        count = len(sqlite_session.execute(select(Group)).scalars().all())
+        assert count == 2
+
+    def test_user_group_membership(self, sqlite_session):
+        """Membership rows store the external identifier string as user_id."""
+        sqlite_session.add(
+            UserGroup(user_id="alice@example.com", group_id="analyst", formation_id=FORMATION_ID)
+        )
+        sqlite_session.commit()
+
+        membership = sqlite_session.execute(select(UserGroup)).scalar_one()
+        assert membership.user_id == "alice@example.com"
+        assert membership.group_id == "analyst"
+        assert membership.formation_id == FORMATION_ID
+        assert membership.created_at is not None
+
+    def test_user_group_unique_per_formation(self, sqlite_session):
+        """Duplicate membership in the same formation is rejected."""
+        sqlite_session.add(
+            UserGroup(user_id="alice@example.com", group_id="analyst", formation_id=FORMATION_ID)
+        )
+        sqlite_session.commit()
+
+        sqlite_session.add(
+            UserGroup(user_id="alice@example.com", group_id="analyst", formation_id=FORMATION_ID)
+        )
+        with pytest.raises(IntegrityError):
+            sqlite_session.commit()
+
+
+class TestServerAuthValidation:
+    """Config: server.auth validation in FormationValidator."""
+
+    @staticmethod
+    def _auth_errors(validator: FormationValidator) -> list:
+        return [e for e in validator.result.errors if "auth" in e.lower()]
+
+    def test_auth_absent_is_valid(self):
+        validator = FormationValidator()
+        validator._validate_server_config({"port": 8271})
+        assert not self._auth_errors(validator)
+
+    def test_auth_open_accepted(self):
+        validator = FormationValidator()
+        validator._validate_server_config({"auth": "open"})
+        assert not self._auth_errors(validator)
+
+    def test_auth_required_accepted(self):
+        validator = FormationValidator()
+        validator._validate_server_config({"auth": "required"})
+        assert not self._auth_errors(validator)
+
+    def test_auth_garbage_rejected(self):
+        validator = FormationValidator()
+        validator._validate_server_config({"auth": "banana"})
+        errors = self._auth_errors(validator)
+        assert len(errors) == 1
+        assert "'open' or 'required'" in errors[0]
+
+
+class TestServerAuthExtraction:
+    """Config: server.auth extraction in Formation._setup_auth."""
+
+    @staticmethod
+    def _formation_stub(server_config: dict) -> SimpleNamespace:
+        return SimpleNamespace(config={"server": server_config}, _api_keys={})
+
+    def test_auth_defaults_to_open(self):
+        stub = self._formation_stub({})
+        Formation._setup_auth(stub)
+        assert stub._server_config["auth"] == "open"
+
+    def test_auth_required_stored(self):
+        stub = self._formation_stub({"auth": "required"})
+        Formation._setup_auth(stub)
+        assert stub._server_config["auth"] == "required"
+
+    def test_auth_invalid_raises(self):
+        stub = self._formation_stub({"auth": "banana"})
+        with pytest.raises(ConfigurationValidationError):
+            Formation._setup_auth(stub)
+
+
+def _make_request(
+    formation,
+    path: str = "/v1/chat",
+    headers: dict | None = None,
+    body: bytes = b"",
+) -> Request:
+    """Build a minimal starlette Request wired to a stub formation."""
+    app = SimpleNamespace(state=SimpleNamespace(formation=formation))
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()],
+        "app": app,
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(scope, receive)
+
+
+@pytest.fixture
+async def gate_db(tmp_path):
+    """File-backed SQLite DatabaseManager with one known user seeded."""
+    db_manager = DatabaseManager(f"sqlite:///{tmp_path}/gate.db")
+    Base.metadata.create_all(db_manager.engine, tables=GBAC_TABLES)
+    await resolve_user_identifier(
+        identifier="alice@example.com",
+        formation_id=FORMATION_ID,
+        db_manager=db_manager,
+        kv_cache=None,
+        create_if_missing=True,
+    )
+    yield db_manager
+    db_manager.engine.dispose()
+
+
+def _formation_stub(auth: str, db_manager=None) -> SimpleNamespace:
+    return SimpleNamespace(
+        _server_config={"auth": auth, "host": "127.0.0.1", "port": 8271},
+        _db_manager=db_manager,
+        formation_id=FORMATION_ID,
+    )
+
+
+class TestUserAuthGate:
+    """Gate: UserAuthGate dependency behavior."""
+
+    async def test_auth_open_lets_unknown_user_through(self):
+        """With auth open the gate is a no-op (no database access needed)."""
+        gate = UserAuthGate()
+        request = _make_request(
+            _formation_stub("open", db_manager=None),
+            headers={"X-Muxi-User-Id": "stranger@example.com"},
+        )
+        assert await gate(request) is None
+
+    async def test_auth_required_rejects_unknown_user(self, gate_db):
+        gate = UserAuthGate()
+        request = _make_request(
+            _formation_stub("required", gate_db),
+            headers={"X-Muxi-User-Id": "stranger@example.com"},
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await gate(request)
+        assert exc_info.value.status_code == 401
+        assert "stranger@example.com" in exc_info.value.detail
+
+    async def test_auth_required_allows_known_user(self, gate_db):
+        gate = UserAuthGate()
+        request = _make_request(
+            _formation_stub("required", gate_db),
+            headers={"X-Muxi-User-Id": "alice@example.com"},
+        )
+        assert await gate(request) is None
+
+    async def test_auth_required_rejects_anonymous_default_user(self, gate_db):
+        """No identity resolves to the default user "0", unknown unless seeded."""
+        gate = UserAuthGate()
+        request = _make_request(_formation_stub("required", gate_db))
+        with pytest.raises(HTTPException) as exc_info:
+            await gate(request)
+        assert exc_info.value.status_code == 401
+
+    async def test_auth_required_chat_body_fallback_known_user(self, gate_db):
+        """The deprecated body user_id is honored on chat endpoints."""
+        gate = UserAuthGate()
+        request = _make_request(
+            _formation_stub("required", gate_db),
+            path="/v1/chat",
+            headers={"Content-Type": "application/json"},
+            body=b'{"message": "hi", "user_id": "alice@example.com"}',
+        )
+        assert await gate(request) is None
+
+    async def test_auth_required_body_ignored_on_trigger_routes(self, gate_db):
+        """Trigger routes read identity from the header only, so the gate does too."""
+        gate = UserAuthGate()
+        request = _make_request(
+            _formation_stub("required", gate_db),
+            path="/v1/triggers/test-trigger",
+            headers={"Content-Type": "application/json"},
+            body=b'{"data": {}, "user_id": "alice@example.com"}',
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await gate(request)
+        assert exc_info.value.status_code == 401
+
+    async def test_auth_required_without_database_fails_closed(self):
+        gate = UserAuthGate()
+        request = _make_request(
+            _formation_stub("required", db_manager=None),
+            headers={"X-Muxi-User-Id": "alice@example.com"},
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await gate(request)
+        assert exc_info.value.status_code == 500


### PR DESCRIPTION
## Summary

Implements **Phase 1 (Database & Auth Gate)** of the group-based access control PRD (`engineering/prds/group-based-access-control.md`, 2026-07-06 revision). Group YAML loading, permission resolution, resource filtering, and caching are Phase 2/3 and intentionally not included -- no placeholders were added.

## What's in

### 1. Schema: `groups` and `user_groups` tables

New `Group` and `UserGroup` SQLAlchemy models in `src/muxi/runtime/services/memory/long_term.py`, next to the existing `User`/`UserIdentifier` identity substrate, and wired into `_create_all_database_tables()` (`formation/initialization.py`) so they are created on both Postgres and SQLite exactly like every other table.

**Deviations from the PRD schema, and why:**

- **`formation_id` columns + composite uniques** (not in the PRD tables): every other table in this codebase is formation-scoped (`users`, `user_identifiers`, `credentials`); the PRD's "unique group_id" becomes `UNIQUE(group_id, formation_id)` and memberships are `UNIQUE(user_id, group_id, formation_id)`.
- **Integer autoincrement PKs instead of UUID**: matches the local convention (`users`, `user_identifiers` use Integer PKs). The PRD's UUID choice was cosmetic; the codebase pattern wins.
- **`user_groups.user_id` is the external identifier string (VARCHAR)**, as the PRD specifies. Membership rows reference external identifiers (email, Slack ID, ...) as populated by operators, and are resolved through `user_identifiers` at gate time -- there is no FK to `users.id`, deliberately, so operators can populate memberships before a user's first interaction.

### 2. Config: `server.auth: "required" | "open"` (default `"open"`)

- Validated in `FormationValidator._validate_server_config()` -- anything other than `open`/`required` is a validation error.
- Extracted in `Formation._setup_auth()` into `_server_config["auth"]`; invalid values raise `ConfigurationValidationError` at load time as a second line of defense for programmatic loads that bypass file validation.
- **Backward compatibility: the default is `open`.** A formation without `server.auth` behaves exactly as before -- the gate is a no-op and never touches the database.

### 3. Auth gate

`UserAuthGate` in `formation/server/auth.py`, following the existing dependency-class pattern (`ClientKeyAuth`/`DualKeyAuth`). Registered in `_register_client_routes()` as an additional router-level dependency on the **chat** and **triggers** routers only:

```
dependencies=[Depends(client_auth), Depends(user_auth_gate)]
```

- **Placement rationale:** the client key authenticates the calling application; the gate then authorizes the end user the request acts for. Putting it at the same dependency layer keeps one auth surface, ordered key-then-user, without inventing new middleware.
- Identity resolution mirrors what the gated routes themselves do: `X-Muxi-User-Id` header first, then (chat endpoints only) the deprecated JSON body `user_id`, then the default user `"0"`. Anonymous requests under `auth: required` are therefore checked as user `"0"` -- present in single-user SQLite deployments once seeded, absent by default in multi-user Postgres.
- Unknown users are resolved via the existing `resolve_user_identifier(..., create_if_missing=False)` utility against `user_identifiers` for this formation and rejected with **401** and a structured JSON error (`UNAUTHORIZED` envelope via the existing error handler).
- **Admin-key routes are not gated** (operators are not formation users) and **health endpoints are untouched**.
- Fail-closed: `auth: required` with no persistent database configured returns 500 with a clear message rather than letting requests through.

### 4. Observability

Gate rejections emit the existing `ErrorEvents.AUTHENTICATION_FAILED` event with `auth_gate`, `auth_mode`, `path`, `user_id`, and `formation_id` metadata (reused an existing enum member rather than adding one). `scripts/validate_events.py` stays at **100%** (1227/1227).

## Tests

### Unit (`tests/unit/test_gbac_phase1.py`, 19 tests)

- Model creation on SQLite in-memory; composite unique enforcement; cross-formation reuse of `group_id`.
- Config validation: absent/`open`/`required` accepted, garbage rejected; extraction default `open`, invalid raises.
- Gate: open lets unknown users through (no DB touched), required 401s unknown users, admits seeded known users, checks the anonymous `"0"` default, honors the chat body fallback, ignores body identity on trigger routes, fails closed without a DB.

```
tests/unit: 1161 passed, 3 skipped
```

### E2E

New standalone test `e2e/tests/19_api/test_19x1_auth_gate.py` with two dedicated formations (`formation-api-authgate-open`, `formation-api-authgate-required`):

```
SUCCESS: test_19x1_auth_gate (exit 0)
  - auth open: unknown user allowed
  - auth required: unknown user 401 on chat
  - auth required: unknown user 401 on trigger
  - auth required: known user allowed          (seeded via users/user_identifiers)
  - auth required: body user_id fallback allowed
  - auth required: known user trigger allowed
```

Regression sample (`run_random_tests.py 5`): first sample hit 3 failures (`1_foundation/test_1a_2`, `1_foundation/test_1a_4`, `6_knowledge/test_6e2`) that turned out to be missing gitignored `.key`/fixture symlinks in the fresh worktree -- all 3 pass (exit 0) after restoring the fixtures, unrelated to this change. A clean re-run then passed **5/5** (`21_skills/test_21b3`, `21_skills/test_21c1`, `3_multimodal/test_3b4`, `3_multimodal/test_3j2`, `3_multimodal/test_3j3`).

## Out of scope (Phase 2/3)

`groups/` YAML auto-discovery, permission resolution (inheritance/wildcards/deny-overrides), resource filtering, and user-to-group lookup caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)