### PR TITLE
feat: GBAC phase 2 - group loading and permission resolver

### DIFF
--- a/e2e/tests/19_api/formation-api-groups-circular/formation.yaml
+++ b/e2e/tests/19_api/formation-api-groups-circular/formation.yaml
@@ -1,0 +1,36 @@
+schema: "1.0.0"
+id: api-test-groups-circular
+description: "Formation with a groups/ directory for GBAC circular inheritance failure testing"
+
+llm:
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+    - embedding: "openai/text-embedding-3-small"
+
+runtime:
+  built_in_mcps: false
+
+memory:
+  buffer:
+    size: 100
+    vector_search: false
+
+agents:
+  - id: assistant
+    name: "Group Loading Test Assistant"
+    description: "A helpful assistant for testing group permission loading"
+    system_message: "You are a helpful assistant. Be concise and direct."
+
+server:
+  enabled: true
+  port: 8271
+  api_keys:
+    admin_key: test-admin-key-123
+    client_key: test-client-key-456
+
+logging:
+  system:
+    level: "error"
+    destination: "stdout"

--- a/e2e/tests/19_api/formation-api-groups-circular/groups/a.yaml
+++ b/e2e/tests/19_api/formation-api-groups-circular/groups/a.yaml
@@ -1,0 +1,4 @@
+name: "Group A"
+inherits: b
+agents:
+  - assistant

--- a/e2e/tests/19_api/formation-api-groups-circular/groups/b.yaml
+++ b/e2e/tests/19_api/formation-api-groups-circular/groups/b.yaml
@@ -1,0 +1,2 @@
+name: "Group B"
+inherits: a

--- a/e2e/tests/19_api/formation-api-groups-circular/secrets.enc
+++ b/e2e/tests/19_api/formation-api-groups-circular/secrets.enc
@@ -1,0 +1,1 @@
+../formation-api/secrets.enc

--- a/e2e/tests/19_api/formation-api-groups/formation.yaml
+++ b/e2e/tests/19_api/formation-api-groups/formation.yaml
@@ -1,0 +1,36 @@
+schema: "1.0.0"
+id: api-test-groups
+description: "Formation with a groups/ directory for GBAC group loading testing"
+
+llm:
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+    - embedding: "openai/text-embedding-3-small"
+
+runtime:
+  built_in_mcps: false
+
+memory:
+  buffer:
+    size: 100
+    vector_search: false
+
+agents:
+  - id: assistant
+    name: "Group Loading Test Assistant"
+    description: "A helpful assistant for testing group permission loading"
+    system_message: "You are a helpful assistant. Be concise and direct."
+
+server:
+  enabled: true
+  port: 8271
+  api_keys:
+    admin_key: test-admin-key-123
+    client_key: test-client-key-456
+
+logging:
+  system:
+    level: "error"
+    destination: "stdout"

--- a/e2e/tests/19_api/formation-api-groups/groups/admin.yaml
+++ b/e2e/tests/19_api/formation-api-groups/groups/admin.yaml
@@ -1,0 +1,4 @@
+name: "Administrator"
+agents: "*"
+triggers: "*"
+sops: "*"

--- a/e2e/tests/19_api/formation-api-groups/groups/analyst.yaml
+++ b/e2e/tests/19_api/formation-api-groups/groups/analyst.yaml
@@ -1,0 +1,11 @@
+name: "Business Analyst"
+description: "Analysis and reporting"
+inherits: base
+agents:
+  - researcher
+mcp_servers:
+  database-mcp:
+    tools:
+      deny: ["delete_*"]
+memory:
+  write: ["group:analyst"]

--- a/e2e/tests/19_api/formation-api-groups/groups/base.yaml
+++ b/e2e/tests/19_api/formation-api-groups/groups/base.yaml
@@ -1,0 +1,4 @@
+name: "Base User"
+description: "Baseline access every analyst inherits"
+agents:
+  - assistant

--- a/e2e/tests/19_api/formation-api-groups/secrets.enc
+++ b/e2e/tests/19_api/formation-api-groups/secrets.enc
@@ -1,0 +1,1 @@
+../formation-api/secrets.enc

--- a/e2e/tests/19_api/test_19x2_group_permissions.py
+++ b/e2e/tests/19_api/test_19x2_group_permissions.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Test 19x2: GBAC group permission loading (groups/ auto-discovery).
+
+Covers GBAC Phase 2 end to end:
+- a formation with a groups/ directory (including inheritance) loads and
+  serves a chat request -- zero behavior regression while groups are loaded
+- the PermissionResolver resolves seeded user_groups memberships with
+  inheritance, deny-overrides, and empty-membership semantics
+- a formation with circular group inheritance FAILS to load with a clear error
+"""
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from common import BaseE2ETest, TestOutputFormatter  # noqa: E402
+
+from muxi.runtime.datatypes.exceptions import ConfigurationValidationError  # noqa: E402
+from muxi.runtime.formation import Formation  # noqa: E402
+from muxi.runtime.services.memory.long_term import UserGroup  # noqa: E402
+
+ANALYST_USER = "alice@example.com"
+UNGROUPED_USER = "stranger@example.com"
+FORMATION_ID = "api-test-groups"
+
+
+class TestGroupPermissions(BaseE2ETest):
+    def __init__(self):
+        super().__init__(
+            test_name="test_19x2_group_permissions",
+            test_description="Test GBAC group permission loading and resolution",
+            test_area="19_api",
+        )
+        self.base_url = "http://127.0.0.1:8271/v1"
+        self.headers = {
+            "X-Muxi-Client-Key": "test-client-key-456",
+            "Content-Type": "application/json",
+        }
+
+    async def _seed_membership(self, user_id: str, group_id: str):
+        from sqlalchemy import delete
+
+        async with self.formation._db_manager.get_async_session() as session:
+            # Idempotent across runs: the formation SQLite DB persists
+            await session.execute(
+                delete(UserGroup).where(
+                    UserGroup.user_id == user_id,
+                    UserGroup.formation_id == FORMATION_ID,
+                )
+            )
+            await UserGroup.create(
+                session,
+                user_id=user_id,
+                group_id=group_id,
+                formation_id=FORMATION_ID,
+            )
+            await session.commit()
+
+    async def test_19x2_group_permissions(self):
+        formatter, start_time = TestOutputFormatter(), time.time()
+        formatter.print_test_header(
+            test_name="test_19x2_group_permissions",
+            description="Test GBAC group permission loading and resolution",
+        )
+        checks = []
+        try:
+            # Phase A: formation with groups/ loads and serves requests
+            print("\n1. Starting formation with a groups/ directory...")
+            await self.setup_formation(
+                formation_path=Path(__file__).parent / "formation-api-groups"
+            )
+            await self.formation.start_server(block=False)
+            await asyncio.sleep(2)
+            print("✅ Formation with groups/ loaded and server started")
+            checks.append("formation with groups/ loads")
+
+            print("\n2. Verifying group auto-discovery...")
+            resolver = self.formation.permission_resolver
+            assert resolver is not None, "permission_resolver not constructed"
+            assert resolver.group_ids == ("admin", "analyst", "base"), resolver.group_ids
+            print(f"✅ Auto-discovered groups: {', '.join(resolver.group_ids)}")
+            checks.append("groups auto-discovered from groups/ directory")
+
+            print("\n3. Testing chat with groups loaded (zero behavior regression)...")
+            async with httpx.AsyncClient(timeout=90.0) as client:
+                r = await client.post(
+                    f"{self.base_url}/chat",
+                    headers={**self.headers, "X-Muxi-User-Id": UNGROUPED_USER},
+                    json={"message": "Reply with the single word OK", "stream": False},
+                )
+                assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text}"
+            print("✅ Chat request served with groups loaded")
+            checks.append("chat works while groups are loaded (no regression)")
+
+            print("\n4. Seeding analyst group membership...")
+            await self._seed_membership(ANALYST_USER, "analyst")
+            print(f"✅ Seeded {ANALYST_USER} into group 'analyst'")
+
+            print("\n5. Resolving analyst permissions (with inheritance)...")
+            perms = await resolver.resolve(ANALYST_USER)
+            assert perms.group_ids == ("analyst",), perms.group_ids
+            assert perms.is_allowed("agents", "assistant"), "inherited grant missing"
+            assert perms.is_allowed("agents", "researcher"), "own grant missing"
+            assert not perms.is_allowed("agents", "hr-assistant"), "ungrated agent allowed"
+            effective = perms.effective_tools(
+                "assistant", "database-mcp", ["get_records", "delete_records"]
+            )
+            assert effective == {"get_records"}, effective
+            assert perms.memory_write_scopes == ("group:analyst",)
+            print("✅ Inheritance, deny override, and memory.write resolved correctly")
+            checks.append("analyst resolves with inherited grants and tool deny")
+
+            print("\n6. Resolving user with no memberships...")
+            perms = await resolver.resolve(UNGROUPED_USER)
+            assert perms.group_ids == ()
+            assert not perms.is_allowed("agents", "assistant")
+            print("✅ Empty membership resolves to empty permissions")
+            checks.append("empty membership resolves to empty permissions")
+
+            await self.cleanup_formation()
+            self.formation = None
+            self.overlord = None
+            await asyncio.sleep(2)  # let the port fully release
+
+            # Phase B: circular inheritance fails formation load
+            print("\n7. Loading formation with circular group inheritance...")
+            failed = False
+            try:
+                bad_formation = Formation()
+                await bad_formation.load(
+                    str(Path(__file__).parent / "formation-api-groups-circular")
+                )
+            except ConfigurationValidationError as e:
+                failed = True
+                message = str(e)
+                assert "Circular group inheritance" in message, message
+                print("✅ Formation load failed with a clear circular-inheritance error")
+                checks.append("circular inheritance fails formation load")
+            assert failed, "circular-inheritance formation loaded but should have failed"
+
+            formatter.print_test_result(
+                test_name="test_19x2_group_permissions",
+                success=True,
+                checks=checks,
+                transcript=[],
+                duration=time.time() - start_time,
+            )
+        except Exception as e:
+            formatter.print_test_result(
+                test_name="test_19x2_group_permissions",
+                success=False,
+                checks=[f"Failed: {e}"],
+                transcript=[],
+                duration=time.time() - start_time,
+            )
+            import traceback
+
+            traceback.print_exc()
+            raise
+        finally:
+            if self.formation:
+                await self.cleanup_formation()
+
+
+async def main():
+    await TestGroupPermissions().test_19x2_group_permissions()
+
+
+if __name__ == "__main__":
+    os._exit(asyncio.run(main()) or 0)

--- a/src/muxi/runtime/datatypes/observability.py
+++ b/src/muxi/runtime/datatypes/observability.py
@@ -85,6 +85,13 @@ class SystemEvents(Enum):
     # When identifiers are associated with user
 
     # ===================================================================
+    # GROUP-BASED ACCESS CONTROL EVENTS
+    # ===================================================================
+    GROUPS_LOADED = "gbac.groups.loaded"
+    # When group permission files are loaded from the formation's groups/
+    # directory at startup (GBAC Phase 2)
+
+    # ===================================================================
     # DOCUMENT CROSS-REFERENCE EVENTS
     # ===================================================================
     CROSS_REFERENCE_MANAGER_INITIALIZED = "cross_reference.manager.initialized"

--- a/src/muxi/runtime/formation/formation.py
+++ b/src/muxi/runtime/formation/formation.py
@@ -216,6 +216,11 @@ class Formation:
         # Registry of MCP servers that use user credentials
         self._mcp_servers_with_user_credentials: Dict[str, Dict[str, Any]] = {}
 
+        # Group-based access control (populated by _setup_groups when a
+        # groups/ directory is present in the formation)
+        self._group_permissions: Dict[str, Any] = {}
+        self._permission_resolver = None
+
     def set_secrets_manager(self, secrets_manager: SecretsManager) -> None:
         """
         Inject a pre-configured SecretsManager instance.
@@ -1092,6 +1097,9 @@ class Formation:
         # Generate API keys
         self._setup_auth()
 
+        # Load group permission files (GBAC) if a groups/ directory exists
+        self._setup_groups()
+
         # Prepare and validate service configurations
         self._setup_llm_config()
         self._setup_memory_config()
@@ -1235,6 +1243,7 @@ class Formation:
                 "scheduler_config": self._scheduler_config,
                 "runtime_config": self._runtime_config,
                 "agents_config": self._agents_config,
+                "permission_resolver": self._permission_resolver,
             }
         )
 
@@ -1399,6 +1408,102 @@ class Formation:
             "auth": auth_mode,
             "api_keys": self._api_keys,
         }
+
+    def _setup_groups(self) -> None:
+        """
+        Auto-discover and load group permission files (GBAC Phase 2).
+
+        A ``groups/`` directory next to the formation file activates
+        permission loading -- groups are intentionally auto-discovered
+        (policy data, not architecture; no manifest declaration). Without
+        the directory the feature is inert and nothing changes.
+
+        Malformed group files, unknown inheritance parents, and circular
+        inheritance fail the formation load with a precise error.
+
+        This method is idempotent -- _prepare_services() may run more than
+        once (load() and start_overlord()); the resolver is built once so
+        its membership/resolution caches survive.
+        """
+        if self._permission_resolver is not None:
+            return
+
+        formation_dir = self._formation_path
+        if formation_dir and os.path.isfile(formation_dir):
+            formation_dir = os.path.dirname(formation_dir)
+        if not formation_dir:
+            return
+
+        groups_dir = os.path.join(formation_dir, "groups")
+        if not os.path.isdir(groups_dir):
+            # No groups/ directory: no restrictions, feature inert.
+            return
+
+        from ..services.gbac import GroupPermissionError, PermissionResolver, load_groups
+
+        try:
+            groups = load_groups(groups_dir)
+        except GroupPermissionError as e:
+            raise ConfigurationValidationError(
+                [f"Invalid group permission configuration: {e}"],
+                {
+                    "groups_dir": groups_dir,
+                    "suggestion": (
+                        "Fix the group file named in the error; see the group "
+                        "definition format in the group-based-access-control PRD"
+                    ),
+                },
+            ) from e
+
+        if not groups:
+            # An empty groups/ directory can express no policy; treat it as
+            # inert (same as absent) rather than locking every user out.
+            observability.observe(
+                event_type=observability.ErrorEvents.CONFIGURATION_ERROR,
+                level=observability.EventLevel.WARNING,
+                data={
+                    "service": "formation",
+                    "groups_dir": groups_dir,
+                    "formation_id": self.formation_id,
+                },
+                description=(
+                    f"groups/ directory at {groups_dir} contains no group files; "
+                    "group permission filtering stays inactive"
+                ),
+            )
+            return
+
+        runtime_config = self.config.get("runtime", {}) if self.config else {}
+        membership_ttl = 60.0
+        if isinstance(runtime_config, dict):
+            membership_ttl = float(runtime_config.get("group_membership_ttl", 60.0))
+
+        self._group_permissions = groups
+        self._permission_resolver = PermissionResolver(
+            groups=groups,
+            formation_id=self.formation_id,
+            db_manager_getter=lambda: getattr(self, "_db_manager", None),
+            membership_ttl=membership_ttl,
+        )
+
+        observability.observe(
+            event_type=observability.SystemEvents.GROUPS_LOADED,
+            level=observability.EventLevel.INFO,
+            data={
+                "service": "formation",
+                "formation_id": self.formation_id,
+                "groups_dir": groups_dir,
+                "group_count": len(groups),
+                "group_ids": sorted(groups),
+                "membership_ttl_seconds": membership_ttl,
+            },
+            description=f"Loaded {len(groups)} permission group(s) from {groups_dir}",
+        )
+
+    @property
+    def permission_resolver(self):
+        """The formation's GBAC PermissionResolver, or None when inactive."""
+        return self._permission_resolver
 
     def _setup_llm_config(self) -> None:
         """Setup and validate LLM configuration."""

--- a/src/muxi/runtime/formation/formation.py
+++ b/src/muxi/runtime/formation/formation.py
@@ -1486,19 +1486,17 @@ class Formation:
             membership_ttl=membership_ttl,
         )
 
-        observability.observe(
-            event_type=observability.SystemEvents.GROUPS_LOADED,
-            level=observability.EventLevel.INFO,
-            data={
-                "service": "formation",
-                "formation_id": self.formation_id,
-                "groups_dir": groups_dir,
-                "group_count": len(groups),
-                "group_ids": sorted(groups),
-                "membership_ttl_seconds": membership_ttl,
-            },
-            description=f"Loaded {len(groups)} permission group(s) from {groups_dir}",
-        )
+        # Observability is disabled during load(), so emitting here would be
+        # a silent no-op. Stash the event payload and emit it after
+        # observability.enable() in start_overlord().
+        self._groups_loaded_event = {
+            "service": "formation",
+            "formation_id": self.formation_id,
+            "groups_dir": groups_dir,
+            "group_count": len(groups),
+            "group_ids": sorted(groups),
+            "membership_ttl_seconds": membership_ttl,
+        }
 
     @property
     def permission_resolver(self):
@@ -2951,6 +2949,21 @@ class Formation:
             # Enable observability now that init is complete
             # This starts the flow of JSON observability events for runtime monitoring
             observability.enable()
+
+            # Deferred from _setup_groups(): the event is built during load()
+            # while observability is disabled, so it is emitted here instead
+            groups_event = getattr(self, "_groups_loaded_event", None)
+            if groups_event is not None:
+                observability.observe(
+                    event_type=observability.SystemEvents.GROUPS_LOADED,
+                    level=observability.EventLevel.INFO,
+                    data=groups_event,
+                    description=(
+                        f"Loaded {groups_event['group_count']} permission group(s) "
+                        f"from {groups_event['groups_dir']}"
+                    ),
+                )
+                self._groups_loaded_event = None
 
             return self._overlord
 

--- a/src/muxi/runtime/services/gbac/__init__.py
+++ b/src/muxi/runtime/services/gbac/__init__.py
@@ -1,0 +1,41 @@
+"""
+Group-Based Access Control (GBAC) services.
+
+Phase 2 of the group-based access control PRD: loading group permission
+files from a formation's ``groups/`` directory and resolving a user's
+effective permissions from their group memberships.
+
+Public surface:
+
+- ``load_groups(groups_dir)`` -- parse + inheritance-resolve every group
+  YAML file in a directory (fail-fast on malformed files or cycles).
+- ``PermissionResolver`` -- membership lookup (TTL-cached) plus
+  permission resolution (LRU-cached per group combination).
+- ``ResolvedPermissions`` -- the object Phase 3 consumes at request time
+  (``is_allowed``, ``filter``, ``effective_tools``, ``memory_write_scopes``).
+- ``GroupPermissionError`` -- raised for any malformed group definition;
+  the formation loader converts it into a load failure.
+
+Resource *filtering* (applying these permissions to agents, triggers,
+SOPs, and MCP tools at request time) is Phase 3 and intentionally not
+implemented here.
+"""
+
+from .loader import (
+    GroupPermissionError,
+    ResolvedGroup,
+    SectionRules,
+    ToolRules,
+    load_groups,
+)
+from .resolver import PermissionResolver, ResolvedPermissions
+
+__all__ = [
+    "GroupPermissionError",
+    "PermissionResolver",
+    "ResolvedGroup",
+    "ResolvedPermissions",
+    "SectionRules",
+    "ToolRules",
+    "load_groups",
+]

--- a/src/muxi/runtime/services/gbac/loader.py
+++ b/src/muxi/runtime/services/gbac/loader.py
@@ -1,0 +1,485 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        GBAC Group Loader - group YAML parsing + inheritance resolution
+# Description:  Parses the simplified group definition format (2026-07-06 PRD
+#               revision) from a formation's groups/ directory and resolves
+#               inheritance into flat, ready-to-merge per-group permissions.
+# Role:         Load-time half of GBAC Phase 2. Every parse or inheritance
+#               problem raises GroupPermissionError naming the file and the
+#               exact problem, so the formation loader can fail fast.
+# Usage:        ``load_groups(groups_dir)`` returns ``{group_id: ResolvedGroup}``.
+#               Group id is the filename stem; groups are auto-discovered
+#               (no manifest declaration -- groups are policy data, not
+#               architecture; see the PRD's auto-discovery rationale).
+# Author:       MUXI Framework Team
+#
+# Format summary (see prds/group-based-access-control.md):
+#   name / description        optional strings
+#   inherits                  optional string or list of group ids
+#   agents/triggers/sops/     plain list (= allow-list), the string "*",
+#   native_apps               or long form {allow: [...], deny: [...]}
+#   agents entries            strings, or single-key dicts granting the agent
+#                             plus per-agent MCP tool overrides
+#   mcp_servers               {mcp-id: {tools: {allow/deny}}} group-wide
+#   memory                    {write: [...]} -- parsed and stored only;
+#                             enforcement belongs to the memory-namespaces PRD
+#
+# Inheritance semantics:
+#   * Parents resolve first (depth-first); unknown parents and cycles are
+#     load-time errors naming the group chain.
+#   * Section lists merge additively: child allow/deny are unioned onto the
+#     parent's. Deny always wins at match time, so a child deny overrides a
+#     parent allow (and a parent deny cannot be re-allowed by a child --
+#     deny is sticky by design).
+#   * Tool override blocks supersede, not merge: a child block for the same
+#     (agent, server) or (server) key replaces the parent's block entirely,
+#     mirroring the PRD's override-cascade semantics.
+# =============================================================================
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+# Sections that accept the list / "*" / {allow, deny} resource grammar.
+LIST_SECTIONS = ("agents", "triggers", "sops", "native_apps")
+
+_VALID_TOP_KEYS = frozenset(
+    {"name", "description", "inherits", "mcp_servers", "memory", *LIST_SECTIONS}
+)
+_VALID_RULE_KEYS = frozenset({"allow", "deny"})
+
+
+class GroupPermissionError(ValueError):
+    """A group permission file is malformed or inheritance cannot resolve."""
+
+
+@dataclass(frozen=True)
+class ToolRules:
+    """One ``tools: {allow: [...], deny: [...]}`` override block.
+
+    ``None`` means the key was not specified -- the distinction matters:
+    ``allow`` alone means *exactly this set*, ``deny`` alone means
+    *inherited minus these*, both means allow-then-subtract.
+    """
+
+    allow: Optional[Tuple[str, ...]] = None
+    deny: Optional[Tuple[str, ...]] = None
+
+
+@dataclass(frozen=True)
+class SectionRules:
+    """Allow/deny patterns for one resource section of one group.
+
+    ``specified`` records whether the section appeared in the file at all.
+    Unspecified sections grant nothing -- except ``native_apps``, where the
+    PRD defines "no section = all native Apps below operator privilege"
+    (interpreted by the resolver, not here).
+    """
+
+    specified: bool = False
+    allow: Tuple[str, ...] = ()
+    deny: Tuple[str, ...] = ()
+
+
+@dataclass
+class ResolvedGroup:
+    """A group definition with inheritance already applied."""
+
+    group_id: str
+    source_path: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+    inherits: Tuple[str, ...] = ()
+    agents: SectionRules = field(default_factory=SectionRules)
+    triggers: SectionRules = field(default_factory=SectionRules)
+    sops: SectionRules = field(default_factory=SectionRules)
+    native_apps: SectionRules = field(default_factory=SectionRules)
+    # agent_id -> mcp_id -> ToolRules (most specific cascade level)
+    agent_tool_overrides: Dict[str, Dict[str, ToolRules]] = field(default_factory=dict)
+    # mcp_id -> ToolRules (group-wide cascade level)
+    mcp_servers: Dict[str, ToolRules] = field(default_factory=dict)
+    memory_write: Tuple[str, ...] = ()
+
+    def section(self, kind: str) -> SectionRules:
+        """Return the SectionRules for ``kind`` (one of LIST_SECTIONS)."""
+        if kind not in LIST_SECTIONS:
+            raise KeyError(f"Unknown permission section: {kind!r}")
+        return getattr(self, kind)
+
+
+def _as_pattern_list(value: Any, *, context: str, path: str) -> Tuple[str, ...]:
+    """Normalize a string or list-of-strings into a tuple of patterns."""
+    if isinstance(value, str):
+        if not value.strip():
+            raise GroupPermissionError(f"{path}: {context} must not be an empty string")
+        return (value,)
+    if isinstance(value, list):
+        patterns: List[str] = []
+        for i, item in enumerate(value):
+            if not isinstance(item, str) or not item.strip():
+                raise GroupPermissionError(
+                    f"{path}: {context} entry {i} must be a non-empty string, "
+                    f"got: {type(item).__name__} = {item!r}"
+                )
+            patterns.append(item)
+        return tuple(patterns)
+    raise GroupPermissionError(
+        f"{path}: {context} must be a string or a list of strings, " f"got: {type(value).__name__}"
+    )
+
+
+def _parse_tool_rules(block: Any, *, context: str, path: str) -> ToolRules:
+    """Parse a ``tools: {allow/deny}`` dict into ToolRules."""
+    if not isinstance(block, dict) or not block:
+        raise GroupPermissionError(
+            f"{path}: {context} must be a mapping with 'allow' and/or 'deny' keys, "
+            f"got: {type(block).__name__}"
+        )
+    unknown = set(block) - _VALID_RULE_KEYS
+    if unknown:
+        raise GroupPermissionError(
+            f"{path}: {context} has unknown key(s) {sorted(unknown)}; "
+            "only 'allow' and 'deny' are supported"
+        )
+    allow = block.get("allow")
+    deny = block.get("deny")
+    return ToolRules(
+        allow=(
+            _as_pattern_list(allow, context=f"{context}.allow", path=path)
+            if allow is not None
+            else None
+        ),
+        deny=(
+            _as_pattern_list(deny, context=f"{context}.deny", path=path)
+            if deny is not None
+            else None
+        ),
+    )
+
+
+def _parse_server_overrides(block: Any, *, context: str, path: str) -> Dict[str, ToolRules]:
+    """Parse ``{mcp-id: {tools: {allow/deny}}}`` into per-server ToolRules."""
+    if not isinstance(block, dict) or not block:
+        raise GroupPermissionError(
+            f"{path}: {context} must be a mapping of MCP server id to a "
+            f"'tools' block, got: {type(block).__name__}"
+        )
+    overrides: Dict[str, ToolRules] = {}
+    for mcp_id, server_block in block.items():
+        if not isinstance(mcp_id, str) or not mcp_id.strip():
+            raise GroupPermissionError(
+                f"{path}: {context} server ids must be non-empty strings, got: {mcp_id!r}"
+            )
+        server_context = f"{context}.{mcp_id}"
+        if not isinstance(server_block, dict) or set(server_block) != {"tools"}:
+            raise GroupPermissionError(
+                f"{path}: {server_context} must be a mapping with exactly one "
+                f"'tools' key, got: {server_block!r}"
+            )
+        overrides[mcp_id] = _parse_tool_rules(
+            server_block["tools"], context=f"{server_context}.tools", path=path
+        )
+    return overrides
+
+
+def _parse_agent_entry(
+    entry: Any,
+    *,
+    index: int,
+    path: str,
+    allow: List[str],
+    overrides: Dict[str, Dict[str, ToolRules]],
+) -> None:
+    """Parse one entry of an agents allow list (string or grant+override dict)."""
+    if isinstance(entry, str):
+        if not entry.strip():
+            raise GroupPermissionError(f"{path}: agents entry {index} must not be empty")
+        allow.append(entry)
+        return
+    if isinstance(entry, dict):
+        if len(entry) != 1:
+            raise GroupPermissionError(
+                f"{path}: agents entry {index} must be a single-key mapping of "
+                f"agent id to per-server tool overrides, got keys: {sorted(entry)}"
+            )
+        agent_id, override_block = next(iter(entry.items()))
+        if not isinstance(agent_id, str) or not agent_id.strip():
+            raise GroupPermissionError(
+                f"{path}: agents entry {index} agent id must be a non-empty string"
+            )
+        allow.append(agent_id)
+        # ``- some-agent:`` with no body parses as {"some-agent": None};
+        # treat it as a plain grant with no overrides.
+        if override_block is None:
+            return
+        overrides[agent_id] = _parse_server_overrides(
+            override_block, context=f"agents.{agent_id}", path=path
+        )
+        return
+    raise GroupPermissionError(
+        f"{path}: agents entry {index} must be a string or a single-key "
+        f"mapping, got: {type(entry).__name__}"
+    )
+
+
+def _parse_section(
+    value: Any,
+    *,
+    section: str,
+    path: str,
+    overrides: Dict[str, Dict[str, ToolRules]],
+) -> SectionRules:
+    """Parse one resource section: plain list, "*", or {allow, deny}."""
+    context = section
+
+    def parse_allow_entries(entries: Any, sub_context: str) -> Tuple[str, ...]:
+        if isinstance(entries, str):
+            entries = [entries]
+        if not isinstance(entries, list):
+            raise GroupPermissionError(
+                f"{path}: {sub_context} must be a string or a list, "
+                f"got: {type(entries).__name__}"
+            )
+        allow: List[str] = []
+        for i, entry in enumerate(entries):
+            if section == "agents":
+                _parse_agent_entry(entry, index=i, path=path, allow=allow, overrides=overrides)
+            elif isinstance(entry, str) and entry.strip():
+                allow.append(entry)
+            else:
+                raise GroupPermissionError(
+                    f"{path}: {sub_context} entry {i} must be a non-empty string, "
+                    f"got: {type(entry).__name__} = {entry!r}"
+                )
+        return tuple(allow)
+
+    # Plain string ("*" or a single pattern) and plain list are allow-lists.
+    if isinstance(value, (str, list)):
+        return SectionRules(specified=True, allow=parse_allow_entries(value, context))
+
+    if isinstance(value, dict):
+        if not value:
+            raise GroupPermissionError(
+                f"{path}: {context} must not be an empty mapping; use the long "
+                "form {allow: [...], deny: [...]} with at least one key"
+            )
+        unknown = set(value) - _VALID_RULE_KEYS
+        if unknown:
+            raise GroupPermissionError(
+                f"{path}: {context} has unknown key(s) {sorted(unknown)}; "
+                "only 'allow' and 'deny' are supported"
+            )
+        allow = value.get("allow")
+        deny = value.get("deny")
+        return SectionRules(
+            specified=True,
+            allow=(parse_allow_entries(allow, f"{context}.allow") if allow is not None else ()),
+            deny=(
+                _as_pattern_list(deny, context=f"{context}.deny", path=path)
+                if deny is not None
+                else ()
+            ),
+        )
+
+    raise GroupPermissionError(
+        f'{path}: {context} must be a list, the string "*", or a mapping '
+        f"with allow/deny keys, got: {type(value).__name__}"
+    )
+
+
+def _parse_group_file(group_id: str, path: str) -> ResolvedGroup:
+    """Parse one group YAML file into an (unresolved) ResolvedGroup."""
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            raw = yaml.safe_load(fh)
+    except yaml.YAMLError as e:
+        raise GroupPermissionError(f"{path}: invalid YAML: {e}") from e
+    except OSError as e:
+        raise GroupPermissionError(f"{path}: cannot read group file: {e}") from e
+
+    # An empty file is a valid group that grants nothing.
+    if raw is None:
+        raw = {}
+    if not isinstance(raw, dict):
+        raise GroupPermissionError(
+            f"{path}: group file must contain a YAML mapping at the top level, "
+            f"got: {type(raw).__name__}"
+        )
+
+    unknown = set(raw) - _VALID_TOP_KEYS
+    if unknown:
+        raise GroupPermissionError(
+            f"{path}: unknown key(s) {sorted(unknown)}; supported keys are "
+            f"{sorted(_VALID_TOP_KEYS)}"
+        )
+
+    name = raw.get("name")
+    if name is not None and not isinstance(name, str):
+        raise GroupPermissionError(f"{path}: name must be a string")
+    description = raw.get("description")
+    if description is not None and not isinstance(description, str):
+        raise GroupPermissionError(f"{path}: description must be a string")
+
+    inherits_raw = raw.get("inherits")
+    inherits: Tuple[str, ...] = ()
+    if inherits_raw is not None:
+        inherits = _as_pattern_list(inherits_raw, context="inherits", path=path)
+
+    group = ResolvedGroup(
+        group_id=group_id,
+        source_path=path,
+        name=name,
+        description=description,
+        inherits=inherits,
+    )
+
+    overrides: Dict[str, Dict[str, ToolRules]] = {}
+    for section in LIST_SECTIONS:
+        if section in raw:
+            rules = _parse_section(raw[section], section=section, path=path, overrides=overrides)
+            setattr(group, section, rules)
+    group.agent_tool_overrides = overrides
+
+    if "mcp_servers" in raw:
+        group.mcp_servers = _parse_server_overrides(
+            raw["mcp_servers"], context="mcp_servers", path=path
+        )
+
+    if "memory" in raw:
+        memory_block = raw["memory"]
+        if not isinstance(memory_block, dict):
+            raise GroupPermissionError(
+                f"{path}: memory must be a mapping, got: {type(memory_block).__name__}"
+            )
+        unknown = set(memory_block) - {"write"}
+        if unknown:
+            raise GroupPermissionError(
+                f"{path}: memory has unknown key(s) {sorted(unknown)}; " "only 'write' is supported"
+            )
+        if "write" in memory_block:
+            group.memory_write = _as_pattern_list(
+                memory_block["write"], context="memory.write", path=path
+            )
+
+    return group
+
+
+def _merge_sections(base: SectionRules, overlay: SectionRules) -> SectionRules:
+    """Additively overlay a child's section rules on the inherited ones."""
+    if not overlay.specified:
+        return base
+    if not base.specified:
+        return overlay
+
+    def union(first: Tuple[str, ...], second: Tuple[str, ...]) -> Tuple[str, ...]:
+        merged = list(first)
+        merged.extend(p for p in second if p not in merged)
+        return tuple(merged)
+
+    return SectionRules(
+        specified=True,
+        allow=union(base.allow, overlay.allow),
+        deny=union(base.deny, overlay.deny),
+    )
+
+
+def _merge_groups(base: ResolvedGroup, overlay: ResolvedGroup) -> ResolvedGroup:
+    """Merge ``overlay`` (child) on top of ``base`` (resolved parents).
+
+    Sections merge additively; tool override blocks supersede per key;
+    memory write scopes union. Identity fields come from the overlay.
+    """
+    merged_agent_overrides: Dict[str, Dict[str, ToolRules]] = {
+        agent_id: dict(server_map) for agent_id, server_map in base.agent_tool_overrides.items()
+    }
+    for agent_id, server_map in overlay.agent_tool_overrides.items():
+        merged_agent_overrides.setdefault(agent_id, {}).update(server_map)
+
+    memory_write = list(base.memory_write)
+    memory_write.extend(s for s in overlay.memory_write if s not in memory_write)
+
+    return ResolvedGroup(
+        group_id=overlay.group_id,
+        source_path=overlay.source_path,
+        name=overlay.name,
+        description=overlay.description,
+        inherits=overlay.inherits,
+        agents=_merge_sections(base.agents, overlay.agents),
+        triggers=_merge_sections(base.triggers, overlay.triggers),
+        sops=_merge_sections(base.sops, overlay.sops),
+        native_apps=_merge_sections(base.native_apps, overlay.native_apps),
+        agent_tool_overrides=merged_agent_overrides,
+        mcp_servers={**base.mcp_servers, **overlay.mcp_servers},
+        memory_write=tuple(memory_write),
+    )
+
+
+def _resolve_inheritance(definitions: Dict[str, ResolvedGroup]) -> Dict[str, ResolvedGroup]:
+    """Resolve every group's inheritance chain (parents first, child on top)."""
+    resolved: Dict[str, ResolvedGroup] = {}
+
+    def resolve(group_id: str, chain: Tuple[str, ...]) -> ResolvedGroup:
+        if group_id in resolved:
+            return resolved[group_id]
+        if group_id in chain:
+            cycle_start = chain.index(group_id)
+            cycle = " -> ".join((*chain[cycle_start:], group_id))
+            raise GroupPermissionError(
+                f"Circular group inheritance detected: {cycle} "
+                f"(started from {definitions[group_id].source_path})"
+            )
+
+        definition = definitions[group_id]
+        merged = definition
+        if definition.inherits:
+            # Multiple parents merge left-to-right, then the child overlays.
+            base: Optional[ResolvedGroup] = None
+            for parent_id in definition.inherits:
+                if parent_id not in definitions:
+                    raise GroupPermissionError(
+                        f"{definition.source_path}: group '{group_id}' inherits "
+                        f"unknown group '{parent_id}' (no groups/{parent_id}.yaml)"
+                    )
+                parent = resolve(parent_id, (*chain, group_id))
+                base = parent if base is None else _merge_groups(base, parent)
+            merged = _merge_groups(base, definition)
+
+        resolved[group_id] = merged
+        return merged
+
+    for group_id in definitions:
+        resolve(group_id, ())
+    return resolved
+
+
+def load_groups(groups_dir: str) -> Dict[str, ResolvedGroup]:
+    """Load and resolve every group definition in ``groups_dir``.
+
+    Files matching ``*.yaml`` / ``*.yml`` are auto-discovered; the group id
+    is the filename stem. Malformed files, duplicate stems, unknown parents,
+    and inheritance cycles all raise :class:`GroupPermissionError`.
+
+    Returns:
+        Mapping of group id to its inheritance-resolved definition.
+    """
+    definitions: Dict[str, ResolvedGroup] = {}
+    for entry in sorted(os.listdir(groups_dir)):
+        stem, ext = os.path.splitext(entry)
+        if ext.lower() not in (".yaml", ".yml"):
+            continue
+        path = os.path.join(groups_dir, entry)
+        if not os.path.isfile(path):
+            continue
+        if stem in definitions:
+            raise GroupPermissionError(
+                f"{path}: duplicate group id '{stem}' "
+                f"(already defined by {definitions[stem].source_path})"
+            )
+        definitions[stem] = _parse_group_file(stem, path)
+
+    return _resolve_inheritance(definitions)

--- a/src/muxi/runtime/services/gbac/resolver.py
+++ b/src/muxi/runtime/services/gbac/resolver.py
@@ -1,0 +1,322 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        GBAC Permission Resolver - membership lookup + resolution engine
+# Description:  Resolves a user's effective permissions from their group
+#               memberships (user_groups table) and the formation's loaded
+#               group definitions. Request-time half of GBAC Phase 2.
+# Role:         Exposes the API Phase 3 (resource filtering) consumes:
+#               ``PermissionResolver.resolve(user_id) -> ResolvedPermissions``
+#               with ``is_allowed`` / ``filter`` / ``effective_tools`` /
+#               ``memory_write_scopes``. Nothing here enforces anything --
+#               enforcement is Phase 3.
+# Usage:        Constructed by Formation._setup_groups() when a groups/
+#               directory is present. Membership rows are read by external
+#               user identifier + formation_id (per GBAC Phase 1's design)
+#               with a TTL cache (default 60s); resolution per group
+#               combination is cached in a small LRU.
+# Author:       MUXI Framework Team
+#
+# Resolution semantics (PRD "Permission Resolution Rules"):
+#   * Union of allows across the user's groups; any group's deny wins.
+#   * fnmatchcase globs in all pattern lists (same semantics as the MCP
+#     registry tool filter in services/mcp/tool_filter.py).
+#   * native_apps unspecified in a group = that group allows all native
+#     Apps (privilege gating of operator+ Apps is a Phase 3 concern).
+#   * No memberships = empty permissions ("registered but inactive").
+#
+# Tool override cascade (PRD "Tool Override Cascade"):
+#   group agent-scoped override > group server-wide override > inherited
+#   (agent attachment / registry) config. Within a block: allow alone =
+#   exactly that set (supersede, not intersect); deny alone = inherited
+#   minus denied; both = allow-then-subtract. Per-group effective sets are
+#   computed first, then merged across groups (union; any group's deny wins).
+#   Only groups that grant the agent participate in the merge -- the PRD
+#   scopes server-wide overrides to "every granted agent".
+# =============================================================================
+
+from __future__ import annotations
+
+import time
+from collections import OrderedDict
+from fnmatch import fnmatchcase
+from typing import Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+from .. import observability
+from .loader import LIST_SECTIONS, ResolvedGroup, ToolRules
+
+# Defaults from the PRD's performance section.
+DEFAULT_MEMBERSHIP_TTL_SECONDS = 60.0
+DEFAULT_RESOLUTION_CACHE_SIZE = 512
+
+
+def _matches(name: str, patterns: Iterable[str]) -> bool:
+    """True if ``name`` matches any fnmatch glob in ``patterns``."""
+    return any(fnmatchcase(name, pattern) for pattern in patterns)
+
+
+class ResolvedPermissions:
+    """Effective permissions for one combination of groups.
+
+    Instances are user-agnostic (cached per group combination) and expose
+    the read API Phase 3 consumes at request time.
+    """
+
+    def __init__(self, group_ids: Tuple[str, ...], groups: Tuple[ResolvedGroup, ...]):
+        self._group_ids = group_ids
+        self._groups = groups
+
+    @property
+    def group_ids(self) -> Tuple[str, ...]:
+        """The (sorted) group ids this resolution was computed from."""
+        return self._group_ids
+
+    @property
+    def has_groups(self) -> bool:
+        """False for the "registered but inactive" empty-membership state."""
+        return bool(self._groups)
+
+    @property
+    def memory_write_scopes(self) -> Tuple[str, ...]:
+        """Union of ``memory.write`` scopes across groups (parsed, not enforced)."""
+        scopes: List[str] = []
+        for group in self._groups:
+            scopes.extend(s for s in group.memory_write if s not in scopes)
+        return tuple(scopes)
+
+    def is_allowed(self, kind: str, resource_id: str) -> bool:
+        """True if the user's groups grant ``resource_id`` of type ``kind``.
+
+        ``kind`` is one of ``agents`` / ``triggers`` / ``sops`` /
+        ``native_apps``. Union of allows across groups; any group's deny
+        wins. With no group memberships everything is denied.
+        """
+        if kind not in LIST_SECTIONS:
+            raise KeyError(f"Unknown permission kind: {kind!r}; expected one of {LIST_SECTIONS}")
+        allowed = False
+        for group in self._groups:
+            rules = group.section(kind)
+            if _matches(resource_id, rules.deny):
+                return False
+            if kind == "native_apps" and not rules.specified:
+                # PRD: groups with no native_apps section allow all native
+                # Apps (operator+ privilege gating happens in Phase 3).
+                allowed = True
+            elif _matches(resource_id, rules.allow):
+                allowed = True
+        return allowed
+
+    def filter(self, kind: str, resource_ids: Sequence[str]) -> List[str]:
+        """Return the subset of ``resource_ids`` allowed for ``kind``, in order."""
+        return [rid for rid in resource_ids if self.is_allowed(kind, rid)]
+
+    def effective_tools(
+        self,
+        agent_id: str,
+        mcp_id: str,
+        inherited_tools: Sequence[str],
+        catalog: Optional[Sequence[str]] = None,
+    ) -> Set[str]:
+        """Compute the user's effective tool set for one agent+server attachment.
+
+        Args:
+            agent_id: The granted agent whose attachment is being resolved.
+            mcp_id: The MCP server id of the attachment.
+            inherited_tools: The tool names the agent would see with no group
+                override (registry catalog already narrowed by the agent
+                attachment's own ``tools:`` block).
+            catalog: The post-registry tool catalog for the server -- the
+                universe ``allow`` globs expand against, letting a group
+                override supersede (not intersect) the attachment config.
+                Defaults to ``inherited_tools``.
+
+        Returns:
+            The effective tool names. Empty when no group grants the agent
+            (or the user has no groups), and when overrides hide the server
+            (``tools: {deny: "*"}``).
+        """
+        universe = tuple(catalog) if catalog is not None else tuple(inherited_tools)
+        union: Set[str] = set()
+        deny_patterns: List[str] = []
+        for group in self._groups:
+            # Only groups that grant the agent participate: the PRD scopes
+            # group overrides to "every granted agent" on that server.
+            rules = group.section("agents")
+            if _matches(agent_id, rules.deny) or not _matches(agent_id, rules.allow):
+                continue
+            block = self._override_for(group, agent_id, mcp_id)
+            if block is None:
+                union.update(inherited_tools)
+                continue
+            if block.allow is not None:
+                effective = {t for t in universe if _matches(t, block.allow)}
+            else:
+                effective = set(inherited_tools)
+            if block.deny is not None:
+                effective = {t for t in effective if not _matches(t, block.deny)}
+                deny_patterns.extend(block.deny)
+            union.update(effective)
+
+        if deny_patterns:
+            union = {t for t in union if not _matches(t, deny_patterns)}
+        return union
+
+    @staticmethod
+    def _override_for(group: ResolvedGroup, agent_id: str, mcp_id: str) -> Optional[ToolRules]:
+        """Pick the group's most specific override block for agent+server."""
+        agent_scoped = group.agent_tool_overrides.get(agent_id, {}).get(mcp_id)
+        if agent_scoped is not None:
+            return agent_scoped
+        return group.mcp_servers.get(mcp_id)
+
+
+class PermissionResolver:
+    """Resolves users to effective permissions from group memberships.
+
+    Membership rows are read from the ``user_groups`` table by external
+    user identifier + formation id, cached with a TTL (default 60s).
+    Permission resolution per group combination is cached in an LRU.
+    """
+
+    def __init__(
+        self,
+        groups: Dict[str, ResolvedGroup],
+        formation_id: str,
+        db_manager_getter: Callable[[], Optional[object]],
+        membership_ttl: float = DEFAULT_MEMBERSHIP_TTL_SECONDS,
+        resolution_cache_size: int = DEFAULT_RESOLUTION_CACHE_SIZE,
+    ):
+        """
+        Args:
+            groups: Inheritance-resolved group definitions from
+                :func:`muxi.runtime.services.gbac.loader.load_groups`.
+            formation_id: Formation id for multi-formation isolation.
+            db_manager_getter: Callable returning the formation's database
+                manager (or None before memory initialization). Deferred so
+                the resolver can be constructed during config preparation.
+            membership_ttl: Seconds a user's membership lookup stays cached.
+            resolution_cache_size: Max cached group combinations (LRU).
+        """
+        self._groups = groups
+        self._formation_id = formation_id
+        self._db_manager_getter = db_manager_getter
+        self._membership_ttl = membership_ttl
+        self._membership_cache: Dict[str, Tuple[float, Tuple[str, ...]]] = {}
+        self._resolution_cache: "OrderedDict[Tuple[str, ...], ResolvedPermissions]" = OrderedDict()
+        self._resolution_cache_size = resolution_cache_size
+        self._warned_unknown_groups: Set[str] = set()
+
+    @property
+    def group_count(self) -> int:
+        """Number of loaded group definitions."""
+        return len(self._groups)
+
+    @property
+    def group_ids(self) -> Tuple[str, ...]:
+        """All loaded group ids, sorted."""
+        return tuple(sorted(self._groups))
+
+    async def resolve(self, user_id: str) -> ResolvedPermissions:
+        """Resolve ``user_id`` (external identifier) to effective permissions.
+
+        A user with no memberships resolves to empty permissions
+        ("registered but inactive"). Membership rows referencing group ids
+        without a matching group file grant nothing and are reported once
+        per group id via observability.
+
+        Raises:
+            Exception: Database errors propagate after a resolution-failure
+                event is emitted -- the caller (Phase 3) decides how to fail.
+        """
+        try:
+            member_group_ids = await self._get_memberships(user_id)
+        except Exception as e:
+            observability.observe(
+                event_type=observability.ErrorEvents.PROCESSING_ERROR,
+                level=observability.EventLevel.ERROR,
+                data={
+                    "service": "gbac_permission_resolver",
+                    "operation": "membership_lookup",
+                    "user_id": user_id,
+                    "formation_id": self._formation_id,
+                    "error": str(e),
+                },
+                description=f"GBAC permission resolution failed for user {user_id!r}: {e}",
+            )
+            raise
+
+        known = tuple(sorted(g for g in member_group_ids if g in self._groups))
+        unknown = sorted(set(member_group_ids) - set(known))
+        for group_id in unknown:
+            if group_id in self._warned_unknown_groups:
+                continue
+            self._warned_unknown_groups.add(group_id)
+            observability.observe(
+                event_type=observability.ErrorEvents.VALIDATION_FAILED,
+                level=observability.EventLevel.WARNING,
+                data={
+                    "service": "gbac_permission_resolver",
+                    "operation": "membership_resolution",
+                    "group_id": group_id,
+                    "formation_id": self._formation_id,
+                },
+                description=(
+                    f"user_groups references group {group_id!r} but no "
+                    f"groups/{group_id}.yaml exists; membership grants nothing"
+                ),
+            )
+
+        return self._resolve_combination(known)
+
+    def _resolve_combination(self, group_ids: Tuple[str, ...]) -> ResolvedPermissions:
+        """Return the (LRU-cached) resolution for a sorted group combination."""
+        cached = self._resolution_cache.get(group_ids)
+        if cached is not None:
+            self._resolution_cache.move_to_end(group_ids)
+            return cached
+
+        permissions = ResolvedPermissions(
+            group_ids=group_ids,
+            groups=tuple(self._groups[gid] for gid in group_ids),
+        )
+        self._resolution_cache[group_ids] = permissions
+        if len(self._resolution_cache) > self._resolution_cache_size:
+            self._resolution_cache.popitem(last=False)
+        return permissions
+
+    async def _get_memberships(self, user_id: str) -> Tuple[str, ...]:
+        """Read the user's group ids from user_groups, with TTL caching."""
+        now = time.monotonic()
+        cached = self._membership_cache.get(user_id)
+        if cached is not None and now - cached[0] < self._membership_ttl:
+            return cached[1]
+
+        db_manager = self._db_manager_getter()
+        if db_manager is None:
+            raise RuntimeError(
+                "Group permissions are configured but no persistent database "
+                "is available for membership lookup"
+            )
+
+        from sqlalchemy import select
+
+        from ..memory.long_term import UserGroup
+
+        async with db_manager.get_async_session() as session:
+            result = await session.execute(
+                select(UserGroup.group_id).where(
+                    UserGroup.user_id == user_id,
+                    UserGroup.formation_id == self._formation_id,
+                )
+            )
+            group_ids = tuple(row[0] for row in result.all())
+
+        self._membership_cache[user_id] = (now, group_ids)
+        return group_ids
+
+    def invalidate_memberships(self, user_id: Optional[str] = None) -> None:
+        """Drop cached memberships for one user (or all users)."""
+        if user_id is None:
+            self._membership_cache.clear()
+        else:
+            self._membership_cache.pop(user_id, None)

--- a/src/muxi/runtime/services/gbac/resolver.py
+++ b/src/muxi/runtime/services/gbac/resolver.py
@@ -135,6 +135,12 @@ class ResolvedPermissions:
             (or the user has no groups), and when overrides hide the server
             (``tools: {deny: "*"}``).
         """
+        # Deny-wins must hold here independently of callers: if ANY group
+        # denies the agent, the user cannot reach it, so its tool surface
+        # is empty regardless of what other groups would grant.
+        if not self.is_allowed("agents", agent_id):
+            return set()
+
         universe = tuple(catalog) if catalog is not None else tuple(inherited_tools)
         union: Set[str] = set()
         deny_patterns: List[str] = []
@@ -142,7 +148,7 @@ class ResolvedPermissions:
             # Only groups that grant the agent participate: the PRD scopes
             # group overrides to "every granted agent" on that server.
             rules = group.section("agents")
-            if _matches(agent_id, rules.deny) or not _matches(agent_id, rules.allow):
+            if not _matches(agent_id, rules.allow):
                 continue
             block = self._override_for(group, agent_id, mcp_id)
             if block is None:
@@ -157,6 +163,10 @@ class ResolvedPermissions:
                 deny_patterns.extend(block.deny)
             union.update(effective)
 
+        # Cross-group deny sweep: "any group's deny wins" applies to the
+        # merged union, so an explicit deny in one group also strips tools
+        # contributed by groups that had no override block at all. This
+        # asymmetry is intentional -- deny is global, allow is per-group.
         if deny_patterns:
             union = {t for t in union if not _matches(t, deny_patterns)}
         return union

--- a/tests/unit/test_gbac_phase2.py
+++ b/tests/unit/test_gbac_phase2.py
@@ -949,3 +949,27 @@ class TestCrossGroupAgentDenialInEffectiveTools:
         perms = perms_for(groups, "restrictors", "granters")
         assert not perms.is_allowed("agents", "agent-x")
         assert perms.effective_tools("agent-x", "db", INHERITED) == set()
+
+
+class TestGroupsLoadedEventDeferral:
+    """GROUPS_LOADED must not be swallowed by the load-time observability gate.
+
+    _setup_groups() runs during load() while observability is disabled, so
+    it stashes the event payload; start_overlord() emits it after enable().
+    """
+
+    def test_setup_groups_stashes_event_instead_of_emitting(self, tmp_path):
+        (tmp_path / "groups").mkdir()
+        (tmp_path / "groups" / "analyst.yaml").write_text("agents: [researcher]\n")
+        stub = SimpleNamespace(
+            _formation_path=str(tmp_path),
+            _permission_resolver=None,
+            _group_permissions={},
+            formation_id=FORMATION_ID,
+            config={"runtime": {}},
+        )
+        Formation._setup_groups(stub)
+        event = stub._groups_loaded_event
+        assert event is not None
+        assert event["group_count"] == 1
+        assert event["group_ids"] == ["analyst"]

--- a/tests/unit/test_gbac_phase2.py
+++ b/tests/unit/test_gbac_phase2.py
@@ -1,0 +1,924 @@
+"""Unit tests for GBAC Phase 2: group loading and the permission resolution engine.
+
+Covers the Phase 2 surfaces of the group-based access control PRD
+(2026-07-06 revision):
+
+1. Parsing -- the simplified group file format: plain-list shorthand, "*",
+   long form {allow, deny}, agent grant+override entries, mcp_servers
+   overrides, memory.write, and precise fail-fast errors for malformed files.
+2. Inheritance -- parents resolve first, child overlays additively, child
+   deny overrides parent allow, tool override blocks supersede per key,
+   circular and unknown parents are load-time errors.
+3. Resolution -- multi-group union of allows, any-deny-wins, fnmatch globs,
+   the four-level tool override cascade, and empty-membership behavior.
+4. Resolver -- membership TTL cache, LRU resolution cache, unknown
+   membership group ids, and formation wiring (auto-discovery).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.orm import sessionmaker
+
+from muxi.runtime.datatypes.exceptions import ConfigurationValidationError
+from muxi.runtime.formation.formation import Formation
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.gbac import (
+    GroupPermissionError,
+    PermissionResolver,
+    ResolvedPermissions,
+    load_groups,
+)
+from muxi.runtime.services.memory.long_term import UserGroup
+
+FORMATION_ID = "gbac-phase2-test"
+
+
+def make_groups(tmp_path, files: dict) -> dict:
+    """Write group YAML files into tmp_path/groups and load them."""
+    groups_dir = tmp_path / "groups"
+    groups_dir.mkdir(exist_ok=True)
+    for filename, content in files.items():
+        (groups_dir / filename).write_text(content)
+    return load_groups(str(groups_dir))
+
+
+def perms_for(groups: dict, *group_ids: str) -> ResolvedPermissions:
+    """Build a ResolvedPermissions for a combination of loaded groups."""
+    ordered = tuple(sorted(group_ids))
+    return ResolvedPermissions(group_ids=ordered, groups=tuple(groups[gid] for gid in ordered))
+
+
+class TestGroupFileParsing:
+    """Parsing: the simplified group definition format."""
+
+    def test_plain_list_is_allow_list(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {"analyst.yaml": "agents:\n  - researcher\n  - report-writer\n"},
+        )
+        rules = groups["analyst"].agents
+        assert rules.specified
+        assert rules.allow == ("researcher", "report-writer")
+        assert rules.deny == ()
+
+    def test_group_id_is_filename_stem(self, tmp_path):
+        groups = make_groups(tmp_path, {"read-only.yml": 'sops: "*"\n'})
+        assert set(groups) == {"read-only"}
+        assert groups["read-only"].group_id == "read-only"
+
+    def test_star_string_section(self, tmp_path):
+        groups = make_groups(tmp_path, {"admin.yaml": 'sops: "*"\n'})
+        assert groups["admin"].sops.allow == ("*",)
+
+    def test_long_form_allow_and_deny(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {"ops.yaml": ("triggers:\n" '  allow: ["*"]\n' "  deny: [deploy-*]\n")},
+        )
+        rules = groups["ops"].triggers
+        assert rules.allow == ("*",)
+        assert rules.deny == ("deploy-*",)
+
+    def test_long_form_scalar_deny(self, tmp_path):
+        """The PRD writes tools: {deny: \"*\"}; scalar strings normalize to lists."""
+        groups = make_groups(
+            tmp_path,
+            {"locked.yaml": 'mcp_servers:\n  database-mcp:\n    tools:\n      deny: "*"\n'},
+        )
+        rules = groups["locked"].mcp_servers["database-mcp"]
+        assert rules.allow is None
+        assert rules.deny == ("*",)
+
+    def test_optional_metadata_fields(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "analyst.yaml": (
+                    'name: "Business Analyst"\n'
+                    'description: "Analysis and reporting"\n'
+                    "agents: [researcher]\n"
+                )
+            },
+        )
+        group = groups["analyst"]
+        assert group.name == "Business Analyst"
+        assert group.description == "Analysis and reporting"
+
+    def test_agent_entry_with_tool_override(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "analyst.yaml": (
+                    "agents:\n"
+                    "  - researcher\n"
+                    "  - db-assistant:\n"
+                    "      database-mcp:\n"
+                    "        tools:\n"
+                    "          allow: [get_financials, list_orders]\n"
+                )
+            },
+        )
+        group = groups["analyst"]
+        # The dict entry grants the agent AND records the override
+        assert group.agents.allow == ("researcher", "db-assistant")
+        override = group.agent_tool_overrides["db-assistant"]["database-mcp"]
+        assert override.allow == ("get_financials", "list_orders")
+        assert override.deny is None
+
+    def test_agent_entry_with_empty_body_is_plain_grant(self, tmp_path):
+        """``- some-agent:`` with no body parses as a plain grant."""
+        groups = make_groups(tmp_path, {"g.yaml": "agents:\n  - helper:\n"})
+        assert groups["g"].agents.allow == ("helper",)
+        assert groups["g"].agent_tool_overrides == {}
+
+    def test_mcp_servers_group_wide_override(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "analyst.yaml": (
+                    "mcp_servers:\n"
+                    "  database-mcp:\n"
+                    "    tools:\n"
+                    "      deny: [update_*, delete_*]\n"
+                )
+            },
+        )
+        rules = groups["analyst"].mcp_servers["database-mcp"]
+        assert rules.allow is None
+        assert rules.deny == ("update_*", "delete_*")
+
+    def test_memory_write_parsing(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {"analyst.yaml": "memory:\n  write: [group:analyst, group:shared]\n"},
+        )
+        assert groups["analyst"].memory_write == ("group:analyst", "group:shared")
+
+    def test_memory_write_scalar(self, tmp_path):
+        groups = make_groups(tmp_path, {"g.yaml": "memory:\n  write: group:g\n"})
+        assert groups["g"].memory_write == ("group:g",)
+
+    def test_empty_file_is_valid_empty_group(self, tmp_path):
+        groups = make_groups(tmp_path, {"inactive.yaml": ""})
+        group = groups["inactive"]
+        assert not group.agents.specified
+        assert group.agents.allow == ()
+
+    def test_non_yaml_files_are_ignored(self, tmp_path):
+        groups_dir = tmp_path / "groups"
+        groups_dir.mkdir()
+        (groups_dir / "notes.md").write_text("# not a group")
+        (groups_dir / "real.yaml").write_text("agents: [a]\n")
+        groups = load_groups(str(groups_dir))
+        assert set(groups) == {"real"}
+
+
+class TestGroupFileErrors:
+    """Parsing: malformed files fail with errors naming file and problem."""
+
+    def assert_error(self, tmp_path, files: dict, *fragments: str):
+        with pytest.raises(GroupPermissionError) as exc_info:
+            make_groups(tmp_path, files)
+        message = str(exc_info.value)
+        for fragment in fragments:
+            assert fragment in message, f"{fragment!r} not in error: {message}"
+
+    def test_invalid_yaml_names_file(self, tmp_path):
+        self.assert_error(tmp_path, {"bad.yaml": "agents: [unclosed\n"}, "bad.yaml", "invalid YAML")
+
+    def test_non_mapping_top_level(self, tmp_path):
+        self.assert_error(tmp_path, {"bad.yaml": "- just\n- a\n- list\n"}, "bad.yaml", "mapping")
+
+    def test_unknown_top_level_key(self, tmp_path):
+        self.assert_error(
+            tmp_path, {"bad.yaml": "agent: [typo]\n"}, "bad.yaml", "unknown key", "agent"
+        )
+
+    def test_unknown_rule_key_in_long_form(self, tmp_path):
+        self.assert_error(
+            tmp_path,
+            {"bad.yaml": "triggers:\n  whitelist: [x]\n"},
+            "bad.yaml",
+            "'allow' and 'deny'",
+        )
+
+    def test_non_string_section_entry(self, tmp_path):
+        self.assert_error(tmp_path, {"bad.yaml": "sops:\n  - 42\n"}, "bad.yaml", "sops", "entry 0")
+
+    def test_agent_entry_multi_key_dict(self, tmp_path):
+        self.assert_error(
+            tmp_path,
+            {"bad.yaml": "agents:\n  - a: {m: {tools: {allow: [t]}}}\n    b: {}\n"},
+            "bad.yaml",
+            "single-key",
+        )
+
+    def test_mcp_server_missing_tools_key(self, tmp_path):
+        self.assert_error(
+            tmp_path,
+            {"bad.yaml": "mcp_servers:\n  db:\n    allow: [x]\n"},
+            "bad.yaml",
+            "'tools'",
+        )
+
+    def test_empty_tools_block(self, tmp_path):
+        self.assert_error(
+            tmp_path,
+            {"bad.yaml": "mcp_servers:\n  db:\n    tools: {}\n"},
+            "bad.yaml",
+            "allow",
+        )
+
+    def test_memory_unknown_key(self, tmp_path):
+        self.assert_error(tmp_path, {"bad.yaml": "memory:\n  read: [x]\n"}, "bad.yaml", "write")
+
+    def test_duplicate_group_stems(self, tmp_path):
+        self.assert_error(
+            tmp_path,
+            {"dup.yaml": "agents: [a]\n", "dup.yml": "agents: [b]\n"},
+            "duplicate group id 'dup'",
+        )
+
+
+class TestInheritance:
+    """Inheritance: parents first, child overlays, deny is sticky."""
+
+    def test_child_inherits_parent_allows(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "base.yaml": "agents: [helper]\nsops: [onboarding]\n",
+                "analyst.yaml": "inherits: base\nagents: [researcher]\n",
+            },
+        )
+        perms = perms_for(groups, "analyst")
+        assert perms.is_allowed("agents", "helper")
+        assert perms.is_allowed("agents", "researcher")
+        assert perms.is_allowed("sops", "onboarding")
+
+    def test_child_deny_overrides_parent_allow(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "base.yaml": 'agents: "*"\n',
+                "restricted.yaml": ("inherits: base\nagents:\n  deny: [hr-assistant]\n"),
+            },
+        )
+        perms = perms_for(groups, "restricted")
+        assert perms.is_allowed("agents", "code-assistant")
+        assert not perms.is_allowed("agents", "hr-assistant")
+
+    def test_parent_deny_is_sticky(self, tmp_path):
+        """A child allow cannot resurrect a parent's deny (deny wins)."""
+        groups = make_groups(
+            tmp_path,
+            {
+                "base.yaml": 'agents:\n  allow: ["*"]\n  deny: [hr-assistant]\n',
+                "child.yaml": "inherits: base\nagents: [hr-assistant]\n",
+            },
+        )
+        assert not perms_for(groups, "child").is_allowed("agents", "hr-assistant")
+
+    def test_inherits_list_of_parents(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "a.yaml": "agents: [agent-a]\n",
+                "b.yaml": "triggers: [trigger-b]\n",
+                "both.yaml": "inherits: [a, b]\nsops: [sop-c]\n",
+            },
+        )
+        perms = perms_for(groups, "both")
+        assert perms.is_allowed("agents", "agent-a")
+        assert perms.is_allowed("triggers", "trigger-b")
+        assert perms.is_allowed("sops", "sop-c")
+
+    def test_transitive_inheritance(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "a.yaml": "agents: [agent-a]\n",
+                "b.yaml": "inherits: a\nagents: [agent-b]\n",
+                "c.yaml": "inherits: b\nagents: [agent-c]\n",
+            },
+        )
+        perms = perms_for(groups, "c")
+        for agent in ("agent-a", "agent-b", "agent-c"):
+            assert perms.is_allowed("agents", agent)
+
+    def test_circular_inheritance_names_cycle(self, tmp_path):
+        with pytest.raises(GroupPermissionError) as exc_info:
+            make_groups(
+                tmp_path,
+                {
+                    "a.yaml": "inherits: b\n",
+                    "b.yaml": "inherits: c\n",
+                    "c.yaml": "inherits: a\n",
+                },
+            )
+        message = str(exc_info.value)
+        assert "Circular group inheritance" in message
+        for gid in ("a", "b", "c"):
+            assert gid in message
+
+    def test_self_inheritance_is_a_cycle(self, tmp_path):
+        with pytest.raises(GroupPermissionError, match="Circular"):
+            make_groups(tmp_path, {"a.yaml": "inherits: a\n"})
+
+    def test_unknown_parent_errors(self, tmp_path):
+        with pytest.raises(GroupPermissionError) as exc_info:
+            make_groups(tmp_path, {"a.yaml": "inherits: nonexistent\n"})
+        message = str(exc_info.value)
+        assert "nonexistent" in message
+        assert "a.yaml" in message
+
+    def test_tool_override_supersedes_on_inherit(self, tmp_path):
+        """Child's tools block for the same server replaces the parent's."""
+        groups = make_groups(
+            tmp_path,
+            {
+                "base.yaml": (
+                    "agents: [db-assistant]\n"
+                    "mcp_servers:\n  db:\n    tools:\n      deny: [delete_*]\n"
+                ),
+                "child.yaml": (
+                    "inherits: base\n" "mcp_servers:\n  db:\n    tools:\n      allow: [get_*]\n"
+                ),
+            },
+        )
+        child = groups["child"]
+        assert child.mcp_servers["db"].allow == ("get_*",)
+        assert child.mcp_servers["db"].deny is None  # parent's block replaced
+
+    def test_tool_override_inherited_when_child_silent(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "base.yaml": (
+                    "agents: [db-assistant]\n"
+                    "mcp_servers:\n  db:\n    tools:\n      deny: [delete_*]\n"
+                ),
+                "child.yaml": "inherits: base\n",
+            },
+        )
+        assert groups["child"].mcp_servers["db"].deny == ("delete_*",)
+
+    def test_memory_write_unions_on_inherit(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "base.yaml": "memory:\n  write: [group:base]\n",
+                "child.yaml": "inherits: base\nmemory:\n  write: [group:child]\n",
+            },
+        )
+        perms = perms_for(groups, "child")
+        assert perms.memory_write_scopes == ("group:base", "group:child")
+
+
+class TestMultiGroupResolution:
+    """Resolution: union of allows across groups, any deny wins."""
+
+    def test_union_of_allows(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "eng.yaml": "agents: [code-assistant]\n",
+                "atlas.yaml": "agents: [project-assistant]\n",
+            },
+        )
+        perms = perms_for(groups, "eng", "atlas")
+        assert perms.is_allowed("agents", "code-assistant")
+        assert perms.is_allowed("agents", "project-assistant")
+        assert not perms.is_allowed("agents", "hr-assistant")
+
+    def test_any_group_deny_wins(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "broad.yaml": 'agents: "*"\n',
+                "narrow.yaml": "agents:\n  deny: [hr-assistant]\n",
+            },
+        )
+        perms = perms_for(groups, "broad", "narrow")
+        assert perms.is_allowed("agents", "code-assistant")
+        assert not perms.is_allowed("agents", "hr-assistant")
+
+    def test_wildcard_globs(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "ops.yaml": (
+                    "triggers:\n" '  allow: ["report-*", "invoice-??"]\n' '  deny: ["report-x*"]\n'
+                )
+            },
+        )
+        perms = perms_for(groups, "ops")
+        assert perms.is_allowed("triggers", "report-daily")
+        assert perms.is_allowed("triggers", "report-")  # '*' matches empty
+        assert not perms.is_allowed("triggers", "report-x1")  # deny glob
+        assert perms.is_allowed("triggers", "invoice-42")  # '?' one char each
+        assert not perms.is_allowed("triggers", "invoice-1")
+        assert not perms.is_allowed("triggers", "Report-daily")  # case-sensitive
+
+    def test_empty_membership_denies_everything(self, tmp_path):
+        groups = make_groups(tmp_path, {"g.yaml": 'agents: "*"\n'})
+        perms = perms_for(groups)  # no groups: registered but inactive
+        assert not perms.has_groups
+        assert not perms.is_allowed("agents", "anything")
+        assert not perms.is_allowed("native_apps", "memory-visualizer")
+        assert perms.memory_write_scopes == ()
+        assert perms.effective_tools("agent", "mcp", ["t1", "t2"]) == set()
+
+    def test_native_apps_unspecified_allows_all(self, tmp_path):
+        groups = make_groups(tmp_path, {"g.yaml": "agents: [a]\n"})
+        assert perms_for(groups, "g").is_allowed("native_apps", "memory-visualizer")
+
+    def test_native_apps_specified_restricts(self, tmp_path):
+        groups = make_groups(tmp_path, {"g.yaml": "native_apps:\n  - memory-visualizer\n"})
+        perms = perms_for(groups, "g")
+        assert perms.is_allowed("native_apps", "memory-visualizer")
+        assert not perms.is_allowed("native_apps", "formation-editor")
+
+    def test_filter_preserves_order(self, tmp_path):
+        groups = make_groups(tmp_path, {"g.yaml": "agents: [b, a]\n"})
+        perms = perms_for(groups, "g")
+        assert perms.filter("agents", ["a", "x", "b"]) == ["a", "b"]
+
+    def test_unknown_kind_raises(self, tmp_path):
+        groups = make_groups(tmp_path, {"g.yaml": "agents: [a]\n"})
+        with pytest.raises(KeyError):
+            perms_for(groups, "g").is_allowed("workflows", "x")
+
+    def test_memory_write_union_across_groups(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "a.yaml": "memory:\n  write: [group:a, group:shared]\n",
+                "b.yaml": "memory:\n  write: [group:b, group:shared]\n",
+            },
+        )
+        perms = perms_for(groups, "a", "b")
+        assert set(perms.memory_write_scopes) == {"group:a", "group:b", "group:shared"}
+
+
+INHERITED = ["get_financials", "list_orders", "update_order", "delete_order"]
+
+
+class TestToolOverrideCascade:
+    """The four-level tool override cascade and cross-group merge."""
+
+    def test_no_override_passes_inherited_through(self, tmp_path):
+        groups = make_groups(tmp_path, {"g.yaml": "agents: [db-assistant]\n"})
+        perms = perms_for(groups, "g")
+        assert perms.effective_tools("db-assistant", "db", INHERITED) == set(INHERITED)
+
+    def test_group_wide_deny_subtracts_from_inherited(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "g.yaml": (
+                    "agents: [db-assistant]\n"
+                    "mcp_servers:\n  db:\n    tools:\n      deny: [update_*, delete_*]\n"
+                )
+            },
+        )
+        perms = perms_for(groups, "g")
+        assert perms.effective_tools("db-assistant", "db", INHERITED) == {
+            "get_financials",
+            "list_orders",
+        }
+
+    def test_allow_alone_is_exactly_that_set(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "g.yaml": (
+                    "agents: [db-assistant]\n"
+                    "mcp_servers:\n  db:\n    tools:\n      allow: [get_financials]\n"
+                )
+            },
+        )
+        perms = perms_for(groups, "g")
+        assert perms.effective_tools("db-assistant", "db", INHERITED) == {"get_financials"}
+
+    def test_allow_supersedes_not_intersects(self, tmp_path):
+        """An allow can reach catalog tools the attachment config excluded."""
+        groups = make_groups(
+            tmp_path,
+            {
+                "g.yaml": (
+                    "agents: [db-assistant]\n"
+                    "mcp_servers:\n  db:\n    tools:\n      allow: [run_report]\n"
+                )
+            },
+        )
+        perms = perms_for(groups, "g")
+        catalog = INHERITED + ["run_report"]
+        # run_report is outside the attachment surface but in the catalog:
+        # the group override supersedes the attachment config.
+        effective = perms.effective_tools("db-assistant", "db", INHERITED, catalog=catalog)
+        assert effective == {"run_report"}
+
+    def test_allow_and_deny_is_allow_then_subtract(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "g.yaml": (
+                    "agents: [db-assistant]\n"
+                    "mcp_servers:\n  db:\n    tools:\n"
+                    '      allow: ["*_order", get_financials]\n'
+                    "      deny: [delete_order]\n"
+                )
+            },
+        )
+        perms = perms_for(groups, "g")
+        assert perms.effective_tools("db-assistant", "db", INHERITED) == {
+            "update_order",
+            "get_financials",
+        }
+
+    def test_deny_star_hides_server(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "g.yaml": (
+                    "agents: [db-assistant]\n" 'mcp_servers:\n  db:\n    tools:\n      deny: "*"\n'
+                )
+            },
+        )
+        perms = perms_for(groups, "g")
+        assert perms.effective_tools("db-assistant", "db", INHERITED) == set()
+
+    def test_agent_scoped_override_beats_group_wide(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "g.yaml": (
+                    "agents:\n"
+                    "  - db-assistant:\n"
+                    "      db:\n"
+                    "        tools:\n"
+                    "          allow: [get_financials]\n"
+                    "mcp_servers:\n  db:\n    tools:\n      deny: [get_*]\n"
+                )
+            },
+        )
+        perms = perms_for(groups, "g")
+        # The agent-scoped block wins for db-assistant on db
+        assert perms.effective_tools("db-assistant", "db", INHERITED) == {"get_financials"}
+
+    def test_group_wide_applies_to_other_granted_agents(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "g.yaml": (
+                    "agents:\n"
+                    "  - other-agent\n"
+                    "  - db-assistant:\n"
+                    "      db:\n"
+                    "        tools:\n"
+                    "          allow: [get_financials]\n"
+                    "mcp_servers:\n  db:\n    tools:\n      deny: [delete_*]\n"
+                )
+            },
+        )
+        perms = perms_for(groups, "g")
+        # other-agent has no agent-scoped block; group-wide deny applies
+        assert perms.effective_tools("other-agent", "db", INHERITED) == {
+            "get_financials",
+            "list_orders",
+            "update_order",
+        }
+
+    def test_cross_group_union_of_effective_sets(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "a.yaml": (
+                    "agents: [db-assistant]\n"
+                    "mcp_servers:\n  db:\n    tools:\n      allow: [get_financials]\n"
+                ),
+                "b.yaml": (
+                    "agents: [db-assistant]\n"
+                    "mcp_servers:\n  db:\n    tools:\n      allow: [list_orders]\n"
+                ),
+            },
+        )
+        perms = perms_for(groups, "a", "b")
+        assert perms.effective_tools("db-assistant", "db", INHERITED) == {
+            "get_financials",
+            "list_orders",
+        }
+
+    def test_cross_group_any_deny_wins(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "open.yaml": "agents: [db-assistant]\n",
+                "strict.yaml": (
+                    "agents: [db-assistant]\n"
+                    "mcp_servers:\n  db:\n    tools:\n      deny: [delete_*]\n"
+                ),
+            },
+        )
+        perms = perms_for(groups, "open", "strict")
+        # open contributes the full inherited set, but strict's deny wins
+        assert perms.effective_tools("db-assistant", "db", INHERITED) == {
+            "get_financials",
+            "list_orders",
+            "update_order",
+        }
+
+    def test_non_granting_group_does_not_contribute(self, tmp_path):
+        """A group that doesn't grant the agent joins neither allows nor denies."""
+        groups = make_groups(
+            tmp_path,
+            {
+                "granting.yaml": (
+                    "agents: [db-assistant]\n"
+                    "mcp_servers:\n  db:\n    tools:\n      allow: [get_financials]\n"
+                ),
+                "unrelated.yaml": (
+                    "agents: [other-agent]\n" 'mcp_servers:\n  db:\n    tools:\n      deny: "*"\n'
+                ),
+            },
+        )
+        perms = perms_for(groups, "granting", "unrelated")
+        # unrelated's server-wide deny does not apply: it grants no access
+        # to db-assistant in the first place ("every granted agent").
+        assert perms.effective_tools("db-assistant", "db", INHERITED) == {"get_financials"}
+
+    def test_agent_denying_group_does_not_contribute(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "granting.yaml": "agents: [db-assistant]\n",
+                "denying.yaml": "agents:\n  deny: [db-assistant]\n",
+            },
+        )
+        perms = perms_for(groups, "granting", "denying")
+        # Agent-level deny wins first; the cascade result is moot but must
+        # not include the denying group's (nonexistent) surface.
+        assert not perms.is_allowed("agents", "db-assistant")
+        assert perms.effective_tools("db-assistant", "db", INHERITED) == set(INHERITED)
+
+
+@pytest.fixture
+def membership_db(tmp_path):
+    """File-backed SQLite DatabaseManager with the user_groups table."""
+    db_manager = DatabaseManager(f"sqlite:///{tmp_path}/gbac.db")
+    Base.metadata.create_all(db_manager.engine, tables=[UserGroup.__table__])
+    yield db_manager
+    db_manager.engine.dispose()
+
+
+def add_membership(db_manager, user_id: str, group_id: str) -> None:
+    Session = sessionmaker(bind=db_manager.engine)
+    with Session() as session:
+        session.add(UserGroup(user_id=user_id, group_id=group_id, formation_id=FORMATION_ID))
+        session.commit()
+
+
+def make_resolver(groups: dict, db_manager, **kwargs) -> PermissionResolver:
+    return PermissionResolver(
+        groups=groups,
+        formation_id=FORMATION_ID,
+        db_manager_getter=lambda: db_manager,
+        **kwargs,
+    )
+
+
+class TestPermissionResolver:
+    """Resolver: membership lookup, TTL cache, LRU resolution cache."""
+
+    async def test_resolve_user_with_memberships(self, tmp_path, membership_db):
+        groups = make_groups(
+            tmp_path,
+            {"hr.yaml": "agents: [hr-assistant]\n", "eng.yaml": "agents: [code-assistant]\n"},
+        )
+        add_membership(membership_db, "alice@example.com", "hr")
+        resolver = make_resolver(groups, membership_db)
+
+        perms = await resolver.resolve("alice@example.com")
+        assert perms.group_ids == ("hr",)
+        assert perms.is_allowed("agents", "hr-assistant")
+        assert not perms.is_allowed("agents", "code-assistant")
+
+    async def test_resolve_multi_group_user(self, tmp_path, membership_db):
+        groups = make_groups(
+            tmp_path,
+            {"eng.yaml": "agents: [code-assistant]\n", "atlas.yaml": "agents: [atlas-bot]\n"},
+        )
+        add_membership(membership_db, "dave@example.com", "eng")
+        add_membership(membership_db, "dave@example.com", "atlas")
+        resolver = make_resolver(groups, membership_db)
+
+        perms = await resolver.resolve("dave@example.com")
+        assert perms.group_ids == ("atlas", "eng")
+        assert perms.is_allowed("agents", "code-assistant")
+        assert perms.is_allowed("agents", "atlas-bot")
+
+    async def test_empty_membership_resolves_to_empty_permissions(self, tmp_path, membership_db):
+        groups = make_groups(tmp_path, {"g.yaml": 'agents: "*"\n'})
+        resolver = make_resolver(groups, membership_db)
+
+        perms = await resolver.resolve("nobody@example.com")
+        assert perms.group_ids == ()
+        assert not perms.has_groups
+        assert not perms.is_allowed("agents", "anything")
+
+    async def test_unknown_membership_group_grants_nothing(self, tmp_path, membership_db):
+        groups = make_groups(tmp_path, {"real.yaml": "agents: [a]\n"})
+        add_membership(membership_db, "bob@example.com", "real")
+        add_membership(membership_db, "bob@example.com", "ghost")  # no ghost.yaml
+        resolver = make_resolver(groups, membership_db)
+
+        perms = await resolver.resolve("bob@example.com")
+        assert perms.group_ids == ("real",)
+
+    async def test_membership_ttl_caches_within_window(self, tmp_path, membership_db):
+        groups = make_groups(tmp_path, {"a.yaml": "agents: [x]\n", "b.yaml": "agents: [y]\n"})
+        add_membership(membership_db, "carol@example.com", "a")
+        resolver = make_resolver(groups, membership_db, membership_ttl=60.0)
+
+        perms = await resolver.resolve("carol@example.com")
+        assert perms.group_ids == ("a",)
+
+        # New membership is invisible while the TTL cache is warm
+        add_membership(membership_db, "carol@example.com", "b")
+        perms = await resolver.resolve("carol@example.com")
+        assert perms.group_ids == ("a",)
+
+        # Invalidation forces a fresh lookup
+        resolver.invalidate_memberships("carol@example.com")
+        perms = await resolver.resolve("carol@example.com")
+        assert perms.group_ids == ("a", "b")
+
+    async def test_membership_ttl_expires(self, tmp_path, membership_db):
+        groups = make_groups(tmp_path, {"a.yaml": "agents: [x]\n", "b.yaml": "agents: [y]\n"})
+        add_membership(membership_db, "erin@example.com", "a")
+        resolver = make_resolver(groups, membership_db, membership_ttl=0.05)
+
+        perms = await resolver.resolve("erin@example.com")
+        assert perms.group_ids == ("a",)
+
+        add_membership(membership_db, "erin@example.com", "b")
+        await asyncio.sleep(0.06)
+        perms = await resolver.resolve("erin@example.com")
+        assert perms.group_ids == ("a", "b")
+
+    async def test_resolution_cached_per_group_combination(self, tmp_path, membership_db):
+        groups = make_groups(tmp_path, {"a.yaml": "agents: [x]\n", "b.yaml": "agents: [y]\n"})
+        add_membership(membership_db, "u1@example.com", "a")
+        add_membership(membership_db, "u2@example.com", "a")
+        add_membership(membership_db, "u3@example.com", "b")
+        resolver = make_resolver(groups, membership_db)
+
+        p1 = await resolver.resolve("u1@example.com")
+        p2 = await resolver.resolve("u2@example.com")
+        p3 = await resolver.resolve("u3@example.com")
+        assert p1 is p2  # same combination -> same cached object
+        assert p1 is not p3
+
+    async def test_resolve_without_database_raises(self, tmp_path):
+        groups = make_groups(tmp_path, {"g.yaml": "agents: [a]\n"})
+        resolver = PermissionResolver(
+            groups=groups,
+            formation_id=FORMATION_ID,
+            db_manager_getter=lambda: None,
+        )
+        with pytest.raises(RuntimeError, match="no persistent database"):
+            await resolver.resolve("alice@example.com")
+
+
+class TestFormationWiring:
+    """Auto-discovery: _setup_groups activates iff groups/ exists."""
+
+    @staticmethod
+    def _formation_stub(tmp_path) -> SimpleNamespace:
+        return SimpleNamespace(
+            _formation_path=str(tmp_path),
+            _permission_resolver=None,
+            _group_permissions={},
+            formation_id=FORMATION_ID,
+            config={"runtime": {}},
+        )
+
+    def test_no_groups_dir_is_inert(self, tmp_path):
+        stub = self._formation_stub(tmp_path)
+        Formation._setup_groups(stub)
+        assert stub._permission_resolver is None
+        assert stub._group_permissions == {}
+
+    def test_groups_dir_activates_resolver(self, tmp_path):
+        (tmp_path / "groups").mkdir()
+        (tmp_path / "groups" / "analyst.yaml").write_text("agents: [researcher]\n")
+        stub = self._formation_stub(tmp_path)
+        Formation._setup_groups(stub)
+        assert stub._permission_resolver is not None
+        assert stub._permission_resolver.group_ids == ("analyst",)
+
+    def test_groups_dir_next_to_formation_file(self, tmp_path):
+        """When the formation path is a file, groups/ sits in its directory."""
+        formation_file = tmp_path / "formation.afs"
+        formation_file.write_text("id: test\n")
+        (tmp_path / "groups").mkdir()
+        (tmp_path / "groups" / "g.yaml").write_text("agents: [a]\n")
+        stub = self._formation_stub(tmp_path)
+        stub._formation_path = str(formation_file)
+        Formation._setup_groups(stub)
+        assert stub._permission_resolver is not None
+
+    def test_empty_groups_dir_is_inert(self, tmp_path):
+        (tmp_path / "groups").mkdir()
+        stub = self._formation_stub(tmp_path)
+        Formation._setup_groups(stub)
+        assert stub._permission_resolver is None
+
+    def test_malformed_group_file_fails_load(self, tmp_path):
+        (tmp_path / "groups").mkdir()
+        (tmp_path / "groups" / "bad.yaml").write_text("agent: [typo]\n")
+        stub = self._formation_stub(tmp_path)
+        with pytest.raises(ConfigurationValidationError) as exc_info:
+            Formation._setup_groups(stub)
+        assert "bad.yaml" in str(exc_info.value)
+
+    def test_circular_inheritance_fails_load(self, tmp_path):
+        (tmp_path / "groups").mkdir()
+        (tmp_path / "groups" / "a.yaml").write_text("inherits: b\n")
+        (tmp_path / "groups" / "b.yaml").write_text("inherits: a\n")
+        stub = self._formation_stub(tmp_path)
+        with pytest.raises(ConfigurationValidationError) as exc_info:
+            Formation._setup_groups(stub)
+        assert "Circular" in str(exc_info.value)
+
+    def test_setup_groups_is_idempotent(self, tmp_path):
+        (tmp_path / "groups").mkdir()
+        (tmp_path / "groups" / "g.yaml").write_text("agents: [a]\n")
+        stub = self._formation_stub(tmp_path)
+        Formation._setup_groups(stub)
+        resolver = stub._permission_resolver
+        Formation._setup_groups(stub)
+        assert stub._permission_resolver is resolver
+
+    def test_membership_ttl_configurable_via_runtime(self, tmp_path):
+        (tmp_path / "groups").mkdir()
+        (tmp_path / "groups" / "g.yaml").write_text("agents: [a]\n")
+        stub = self._formation_stub(tmp_path)
+        stub.config = {"runtime": {"group_membership_ttl": 5}}
+        Formation._setup_groups(stub)
+        assert stub._permission_resolver._membership_ttl == 5.0
+
+
+class TestSlackMotivatingExample:
+    """The PRD's Slack example end to end at the resolution layer."""
+
+    @pytest.fixture
+    def org_groups(self, tmp_path):
+        return make_groups(
+            tmp_path,
+            {
+                "hr.yaml": "agents: [hr-assistant]\n",
+                "finance.yaml": "agents: [finance-assistant]\n",
+                "engineering.yaml": "agents: [code-assistant]\n",
+                "project-atlas.yaml": (
+                    "agents: [code-assistant]\n"
+                    "mcp_servers:\n"
+                    "  projects:\n"
+                    "    tools:\n"
+                    "      allow: [lookup_atlas]\n"
+                ),
+            },
+        )
+
+    def test_alice_hr_reaches_hr_assistant(self, org_groups):
+        alice = perms_for(org_groups, "hr")
+        assert alice.is_allowed("agents", "hr-assistant")
+        assert not alice.is_allowed("agents", "finance-assistant")
+
+    def test_carol_engineering_cannot_reach_hr(self, org_groups):
+        carol = perms_for(org_groups, "engineering")
+        assert not carol.is_allowed("agents", "hr-assistant")
+        assert carol.is_allowed("agents", "code-assistant")
+
+    def test_dave_atlas_gets_lookup_atlas_tool(self, org_groups):
+        dave = perms_for(org_groups, "engineering", "project-atlas")
+        catalog = ["lookup_atlas", "lookup_other"]
+        effective = dave.effective_tools(
+            "code-assistant", "projects", ["lookup_other"], catalog=catalog
+        )
+        # engineering contributes the inherited surface; project-atlas's
+        # override adds lookup_atlas (union across groups)
+        assert effective == {"lookup_atlas", "lookup_other"}
+
+    def test_carol_without_atlas_never_sees_lookup_atlas(self, org_groups):
+        carol = perms_for(org_groups, "engineering")
+        catalog = ["lookup_atlas", "lookup_other"]
+        effective = carol.effective_tools(
+            "code-assistant", "projects", ["lookup_other"], catalog=catalog
+        )
+        assert "lookup_atlas" not in effective

--- a/tests/unit/test_gbac_phase2.py
+++ b/tests/unit/test_gbac_phase2.py
@@ -661,10 +661,11 @@ class TestToolOverrideCascade:
             },
         )
         perms = perms_for(groups, "granting", "denying")
-        # Agent-level deny wins first; the cascade result is moot but must
-        # not include the denying group's (nonexistent) surface.
+        # Agent-level deny wins everywhere: is_allowed and effective_tools
+        # must agree, so a globally denied agent has an EMPTY tool surface
+        # even though another group grants it (review follow-up on #204).
         assert not perms.is_allowed("agents", "db-assistant")
-        assert perms.effective_tools("db-assistant", "db", INHERITED) == set(INHERITED)
+        assert perms.effective_tools("db-assistant", "db", INHERITED) == set()
 
 
 @pytest.fixture
@@ -922,3 +923,29 @@ class TestSlackMotivatingExample:
             "code-assistant", "projects", ["lookup_other"], catalog=catalog
         )
         assert "lookup_atlas" not in effective
+
+
+class TestCrossGroupAgentDenialInEffectiveTools:
+    """A globally denied agent has an empty tool surface (review follow-up).
+
+    is_allowed() and effective_tools() must agree even when the granting
+    group carries a permissive agent-scoped tool override.
+    """
+
+    def test_denied_agent_with_permissive_override_is_empty(self, tmp_path):
+        groups = make_groups(
+            tmp_path,
+            {
+                "restrictors.yaml": "agents:\n  deny: [agent-x]\n",
+                "granters.yaml": (
+                    "agents:\n"
+                    "  - agent-x:\n"
+                    "      db:\n"
+                    "        tools:\n"
+                    '          allow: "*"\n'
+                ),
+            },
+        )
+        perms = perms_for(groups, "restrictors", "granters")
+        assert not perms.is_allowed("agents", "agent-x")
+        assert perms.effective_tools("agent-x", "db", INHERITED) == set()


### PR DESCRIPTION
## Summary

GBAC Phase 2 (Group Permission Loading) per the 2026-07-06 revision of `prds/group-based-access-control.md`. Builds on Phase 1 (#202: `groups`/`user_groups` schema, `server.auth`, `UserAuthGate`).

Scope is loading + resolution only: auto-discovery of `groups/`, YAML parsing, the permission resolution engine, and membership caching. Resource FILTERING (applying permissions to agents/triggers/SOPs/MCP at request time) is Phase 3 and intentionally not included -- nothing in this PR changes request behavior.

## What's new

- **`src/muxi/runtime/services/gbac/`** -- new package:
  - `loader.py`: parses the simplified group definition format and resolves inheritance at load time. Group id = filename stem; `*.yaml`/`*.yml` auto-discovered (no manifest declaration -- groups are policy data, per the PRD's rationale). Malformed files, duplicate stems, unknown parents, and inheritance cycles raise `GroupPermissionError` naming the file and the exact problem.
  - `resolver.py`: `PermissionResolver` (membership lookup + caches) and `ResolvedPermissions` (the request-time read API).
- **`Formation._setup_groups()`** -- wired into `_prepare_services()` right after `_setup_auth()` (groups are config-only, so they load before any service init). A `groups/` directory next to the formation file activates loading; without it the feature is inert and zero behavior changes. Load failures surface as `ConfigurationValidationError` (fail-fast, consistent with the loader).
- **Observability**: new `SystemEvents.GROUPS_LOADED` (`gbac.groups.loaded`) emitted at startup; resolution failures reuse `ErrorEvents.PROCESSING_ERROR` / `ErrorEvents.VALIDATION_FAILED`. `scripts/validate_events.py` stays 100% (1231/1231).

## Resolution semantics (PRD "Permission Resolution Rules")

- Plain lists are allow-lists; `"*"` allows everything; long form `{allow: [...], deny: [...]}` where subtraction is needed.
- Union of allows across a user's groups; **any group's deny wins**.
- fnmatch globs (`fnmatchcase`, same semantics as `services/mcp/tool_filter.py`) in all pattern lists.
- Inheritance: parents resolve first (string or list, transitive), child overlays additively; child deny overrides parent allow. Circular inheritance and unknown parents are load-time errors naming the cycle/file.
- No memberships = empty permissions ("registered but inactive").

### Tool override cascade

`effective_tools(agent_id, mcp_id, inherited_tools, catalog=None)` implements the four-level cascade: group agent-scoped override > group server-wide override > inherited (agent attachment/registry) config.

- `allow` alone = exactly that set (supersede, **not** intersect -- globs expand against `catalog`, defaulting to `inherited_tools`).
- `deny` alone = inherited minus denied.
- Both = allow-then-subtract. `tools: {deny: "*"}` hides the server.
- Per-group effective sets computed first, then merged across groups: union of allows, any group's deny wins.

## API for Phase 3

```python
resolver = formation.permission_resolver          # None when groups/ absent
perms = await resolver.resolve(user_id)           # external identifier, per Phase 1
perms.is_allowed("agents" | "triggers" | "sops" | "native_apps", resource_id)
perms.filter(kind, candidate_ids)                 # order-preserving subset
perms.effective_tools(agent_id, mcp_id, inherited_tools, catalog=None)
perms.memory_write_scopes                         # parsed only; memory-namespaces PRD enforces
perms.group_ids / perms.has_groups
```

Membership rows are read from `user_groups` by external identifier + formation_id with a TTL cache (default 60s, configurable via `runtime.group_membership_ttl`); resolution per group combination is LRU-cached, per the PRD's performance section. `resolver.invalidate_memberships(user_id=None)` drops the TTL cache.

## Semantic decisions beyond the PRD (for PRD backfill)

The PRD leaves a few edges open; this PR defines them explicitly:

1. **Parent deny is sticky**: a child (or sibling group) allow cannot resurrect a resource the parent denied -- deny always wins at match time. The PRD only specifies "deny in the child overrides allow in the parent"; the converse is now also deny-wins.
2. **Inheritance merge granularity**: section lists (`agents`/`triggers`/`sops`/`native_apps`, `memory.write`) merge additively; tool override *blocks* supersede per `(agent, server)` / `(server)` key -- a child's block replaces the parent's block entirely, mirroring the cascade's supersede rule.
3. **Only granting groups join the tool merge**: a group that doesn't grant the agent contributes neither allows nor denies to `effective_tools` (the PRD scopes server-wide overrides to "every granted agent").
4. **Override lookup keys are exact**: globs work inside `tools.allow`/`tools.deny` lists; the `agent-id`/`mcp-id` keys of override blocks match exactly (no glob keys -- avoids multi-match ambiguity).
5. **`native_apps` unspecified = allow-all for that group** (operator+ privilege gating is Phase 3, per the MCP Apps section). All other sections unspecified = grant nothing.
6. **Empty `groups/` directory is inert** (plus a WARNING event) rather than activating filtering with zero groups -- avoids the "leftover scaffolding locks every user out in Phase 3" foot-gun.
7. **Single-pattern string sections**: any string (not just `"*"`) is accepted as a one-element allow-list (`sops: report-*`).
8. **`- agent-id:` with an empty body** parses as a plain grant.
9. **Unknown top-level keys are load-time errors** (typo like `agent:` would otherwise silently grant nothing).
10. **Memberships referencing unknown group ids** grant nothing and emit a WARNING event once per group id.
11. **Group-level vocabulary is strictly `allow`/`deny`** -- the `whitelist`/`blacklist` aliases remain registry-only.
12. **Resolution failures** (e.g. DB errors) emit `ErrorEvents.PROCESSING_ERROR` and re-raise; the Phase 3 caller decides fail-open vs fail-closed.

## Tests

### Unit (`tests/unit/test_gbac_phase2.py`, 75 tests)

Parsing (shorthand, `"*"`, long form, agent grant+override entries, `mcp_servers`, `memory.write`, precise errors incl. duplicate stems), inheritance (additive overlay, child-deny-overrides-parent-allow, sticky parent deny, multi-parent, transitive, cycle/self/unknown-parent errors, supersede-per-key tool blocks), multi-group resolution (union, any-deny-wins, fnmatch edge cases incl. `?` and case sensitivity, empty membership, native_apps defaults), the full cascade precedence (all four levels, supersede-not-intersect, allow-then-subtract, hidden server, cross-group union + deny-wins, non-granting group exclusion), resolver caching (TTL warm/expiry/invalidate, LRU identity per combination), and formation wiring (auto-discovery on/off, file-adjacent `groups/`, idempotency, TTL config). Includes the PRD's Slack motivating example at the resolution layer.

```
tests/unit: 1236 passed, 3 skipped
scripts/validate_events.py: 1231/1231 (100%)
black / isort / ruff / flake8: clean on changed files
```

## E2E

New standalone test `e2e/tests/19_api/test_19x2_group_permissions.py` (fixtures `formation-api-groups` with 3 groups incl. inheritance, and `formation-api-groups-circular`):

- formation with `groups/` loads, auto-discovers `admin`/`analyst`/`base`, and serves a chat request (zero behavior regression while groups are loaded)
- seeded `user_groups` membership resolves with inheritance, group-wide tool deny, and `memory.write`; empty membership resolves to empty permissions
- the circular-inheritance formation FAILS to load with `Circular group inheritance detected: a -> b -> a (started from .../groups/a.yaml)`

Result: `SUCCESS`, exit 0.

Regression sample (`cd e2e && uv run python run_random_tests.py 5`): first run was 1/5 -- the four failures were all `Failed to initialize SecretsManager`, an artifact of the fresh git worktree missing the gitignored `.key` symlinks that exist in the main checkout (unrelated to this change; the failing loads never reached group code). After replicating the local `.key` links, all four failed tests pass individually and a fresh 5/5 random sample passes:

```
[1/5] 13_triggers/test_13a5_trigger_with_explicit_sop.py ... PASS (29.6s)
[2/5] 19_api/test_19h1_users.py ... PASS (28.6s)
[3/5] 21_skills/test_21b4_sop_skill_directive_activation.py ... PASS (33.7s)
[4/5] 6_knowledge/test_6e3_unsupported_files.py ... PASS (30.5s)
[5/5] 9_async/test_9a5_webhook_yaml_override_chat.py ... PASS (35.0s)
TOTAL: 5/5 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
