### PR TITLE
feat: GBAC phase 3 - resource filtering enforcement

### DIFF
--- a/e2e/tests/19_api/formation-api-enforcement/formation.yaml
+++ b/e2e/tests/19_api/formation-api-enforcement/formation.yaml
@@ -1,0 +1,40 @@
+schema: "1.0.0"
+id: api-test-enforcement
+description: "Formation reproducing the PRD's Slack example for GBAC Phase 3 enforcement testing"
+
+llm:
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+    - embedding: "openai/text-embedding-3-small"
+
+runtime:
+  built_in_mcps: false
+
+memory:
+  buffer:
+    size: 100
+    vector_search: false
+
+agents:
+  - id: hr-assistant
+    name: "HR Assistant"
+    description: "Answers questions about employees, salaries, and HR data"
+    system_message: "You are an HR assistant. Be concise and direct."
+  - id: code-assistant
+    name: "Code Assistant"
+    description: "Answers engineering and codebase questions"
+    system_message: "You are an engineering assistant. Be concise and direct."
+
+server:
+  enabled: true
+  port: 8271
+  api_keys:
+    admin_key: test-admin-key-123
+    client_key: test-client-key-456
+
+logging:
+  system:
+    level: "error"
+    destination: "stdout"

--- a/e2e/tests/19_api/formation-api-enforcement/groups/engineering.yaml
+++ b/e2e/tests/19_api/formation-api-enforcement/groups/engineering.yaml
@@ -1,0 +1,4 @@
+name: "Engineering"
+description: "Engineering staff -- codebase access"
+agents:
+  - code-assistant

--- a/e2e/tests/19_api/formation-api-enforcement/groups/hr.yaml
+++ b/e2e/tests/19_api/formation-api-enforcement/groups/hr.yaml
@@ -1,0 +1,6 @@
+name: "Human Resources"
+description: "HR staff -- employee data access"
+agents:
+  - hr-assistant
+triggers:
+  - hr-report

--- a/e2e/tests/19_api/formation-api-enforcement/secrets.enc
+++ b/e2e/tests/19_api/formation-api-enforcement/secrets.enc
@@ -1,0 +1,1 @@
+../formation-api/secrets.enc

--- a/e2e/tests/19_api/formation-api-enforcement/triggers/hr-report.md
+++ b/e2e/tests/19_api/formation-api-enforcement/triggers/hr-report.md
@@ -1,0 +1,3 @@
+HR report requested for event: ${{ data.event }}
+
+Acknowledge the HR report request in one short sentence. Do not use any tools.

--- a/e2e/tests/19_api/test_19x3_permission_enforcement.py
+++ b/e2e/tests/19_api/test_19x3_permission_enforcement.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Test 19x3: GBAC resource filtering enforcement (Phase 3).
+
+Reproduces the PRD's Slack example with two groups and two agents:
+- a user in group ``hr`` reaches ``hr-assistant``
+- the same request from a user in group ``engineering`` never selects
+  ``hr-assistant`` -- a directly-addressed denied agent produces the exact
+  same error as a nonexistent agent (no information leak), and routed
+  requests select a permitted agent instead
+- a denied trigger returns 403 with a generic message; a permitted one runs
+- a registered user with no group memberships gets a graceful response
+
+Note on identity: this local e2e runs on the SQLite backend, which is
+single-user by MUXI convention -- every chat request executes as user "0".
+The test therefore moves user "0" between groups across phases (with an
+explicit membership-cache invalidation, mirroring the 60s TTL expiry a
+multi-user Postgres deployment would see). The trigger channel resolves
+the caller's header identity directly (same pattern as the Phase 1 auth
+gate), so it exercises two distinct users in a single phase.
+"""
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from common import BaseE2ETest, TestOutputFormatter  # noqa: E402
+
+from muxi.runtime.services.memory.long_term import UserGroup  # noqa: E402
+
+CHAT_USER = "0"  # SQLite backend: all chat requests execute as user "0"
+HR_USER = "alice@example.com"
+ENG_USER = "carol@example.com"
+FORMATION_ID = "api-test-enforcement"
+
+
+class TestPermissionEnforcement(BaseE2ETest):
+    def __init__(self):
+        super().__init__(
+            test_name="test_19x3_permission_enforcement",
+            test_description="Test GBAC Phase 3 resource filtering enforcement",
+            test_area="19_api",
+        )
+        self.base_url = "http://127.0.0.1:8271/v1"
+        self.headers = {
+            "X-Muxi-Client-Key": "test-client-key-456",
+            "Content-Type": "application/json",
+        }
+
+    def _user_headers(self, user_id: str) -> dict:
+        return {**self.headers, "X-Muxi-User-Id": user_id}
+
+    async def _set_memberships(self, user_id: str, *group_ids: str):
+        """Replace a user's memberships and invalidate the resolver cache."""
+        from sqlalchemy import delete
+
+        async with self.formation._db_manager.get_async_session() as session:
+            # Idempotent across runs: the formation SQLite DB persists
+            await session.execute(
+                delete(UserGroup).where(
+                    UserGroup.user_id == user_id,
+                    UserGroup.formation_id == FORMATION_ID,
+                )
+            )
+            for group_id in group_ids:
+                await UserGroup.create(
+                    session,
+                    user_id=user_id,
+                    group_id=group_id,
+                    formation_id=FORMATION_ID,
+                )
+            await session.commit()
+        # Equivalent to waiting out the 60s membership TTL
+        self.formation.permission_resolver.invalidate_memberships(user_id)
+
+    async def test_19x3_permission_enforcement(self):
+        formatter, start_time = TestOutputFormatter(), time.time()
+        formatter.print_test_header(
+            test_name="test_19x3_permission_enforcement",
+            description="Test GBAC Phase 3 resource filtering enforcement",
+        )
+        checks = []
+        try:
+            print("\n1. Starting formation with groups/, two agents, and a trigger...")
+            await self.setup_formation(
+                formation_path=Path(__file__).parent / "formation-api-enforcement"
+            )
+            await self.formation.start_server(block=False)
+            await asyncio.sleep(2)
+            resolver = self.formation.permission_resolver
+            assert resolver is not None, "permission_resolver not constructed"
+            assert resolver.group_ids == ("engineering", "hr"), resolver.group_ids
+            print("✅ Formation loaded with groups: engineering, hr")
+            checks.append("formation with enforcement groups loads")
+
+            print("\n2. Seeding memberships (chat user→hr, alice→hr, carol→engineering)...")
+            await self._set_memberships(CHAT_USER, "hr")
+            await self._set_memberships(HR_USER, "hr")
+            await self._set_memberships(ENG_USER, "engineering")
+            print("✅ Memberships seeded")
+
+            async with httpx.AsyncClient(timeout=120.0) as client:
+                print("\n3. HR-group user directly addresses hr-assistant (permitted)...")
+                r = await client.post(
+                    f"{self.base_url}/chat",
+                    headers=self._user_headers(HR_USER),
+                    json={
+                        "message": "Reply with the single word OK",
+                        "agent_id": "hr-assistant",
+                        "stream": False,
+                    },
+                )
+                assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text}"
+                print("✅ Permitted direct address returns 200")
+                checks.append("group-A user reaches agent-A (direct address)")
+
+                print("\n4. Trigger channel: alice (hr) permitted, carol (engineering) denied...")
+                r = await client.post(
+                    f"{self.base_url}/triggers/hr-report",
+                    headers=self._user_headers(HR_USER),
+                    json={"data": {"event": "quarterly-review"}, "use_async": False},
+                )
+                assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text}"
+                print("✅ Permitted trigger executed (200)")
+                checks.append("permitted trigger fires")
+
+                r = await client.post(
+                    f"{self.base_url}/triggers/hr-report",
+                    headers=self._user_headers(ENG_USER),
+                    json={"data": {"event": "quarterly-review"}, "use_async": False},
+                )
+                assert r.status_code == 403, f"Expected 403, got {r.status_code}: {r.text}"
+                assert "hr-report" not in r.text, "403 detail must not echo the trigger name"
+                print("✅ Denied trigger returns 403 with a generic message")
+                checks.append("denied trigger returns 403")
+
+                print("\n5. Switching chat user to group engineering...")
+                await self._set_memberships(CHAT_USER, "engineering")
+
+                print("\n6. Engineering user directly addresses hr-assistant (denied)...")
+                r_denied = await client.post(
+                    f"{self.base_url}/chat",
+                    headers=self._user_headers(ENG_USER),
+                    json={
+                        "message": "Reply with the single word OK",
+                        "agent_id": "hr-assistant",
+                        "stream": False,
+                    },
+                )
+                r_unknown = await client.post(
+                    f"{self.base_url}/chat",
+                    headers=self._user_headers(ENG_USER),
+                    json={
+                        "message": "Reply with the single word OK",
+                        "agent_id": "ghost-agent",
+                        "stream": False,
+                    },
+                )
+                assert r_denied.status_code == r_unknown.status_code, (
+                    f"Denied ({r_denied.status_code}) and unknown "
+                    f"({r_unknown.status_code}) status codes differ"
+                )
+                denied_msg = (r_denied.json().get("error") or {}).get("message", "")
+                unknown_msg = (r_unknown.json().get("error") or {}).get("message", "")
+                assert denied_msg and unknown_msg, (denied_msg, unknown_msg)
+                assert (
+                    denied_msg.replace("hr-assistant", "ghost-agent") == unknown_msg
+                ), f"Denied agent error leaks information: {denied_msg!r} vs {unknown_msg!r}"
+                print("✅ Denied agent is indistinguishable from a nonexistent one")
+                checks.append("denied direct address == unknown agent (no leak)")
+
+                print("\n7. Engineering user asks an HR question (routed)...")
+                r = await client.post(
+                    f"{self.base_url}/chat",
+                    headers=self._user_headers(ENG_USER),
+                    json={
+                        "message": (
+                            "What is Dave's salary? " "If you can't access that, say so briefly."
+                        ),
+                        "session_id": "sess-19x3-eng",
+                        "stream": False,
+                    },
+                )
+                assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text}"
+                selected = self.formation._overlord.agent_router._session_last_agent.get(
+                    "sess-19x3-eng"
+                )
+                assert selected != "hr-assistant", (
+                    f"Denied agent hr-assistant was selected for engineering user "
+                    f"(selected={selected!r})"
+                )
+                print(f"✅ hr-assistant never selected (selected: {selected or 'overlord-direct'})")
+                checks.append("denied agent never selected for group-B user")
+
+                print("\n8. User with no group memberships chats (graceful response)...")
+                await self._set_memberships(CHAT_USER)  # clear all memberships
+                r = await client.post(
+                    f"{self.base_url}/chat",
+                    headers=self._user_headers("stranger@example.com"),
+                    json={"message": "What is Dave's salary?", "stream": False},
+                )
+                assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text}"
+                assert (
+                    "no_capabilities" in r.text
+                ), f"Expected graceful no-capabilities response, got: {r.text[:300]}"
+                print("✅ No-groups user gets a graceful response (no crash)")
+                checks.append("no-groups user gets graceful response")
+
+            formatter.print_test_result(
+                test_name="test_19x3_permission_enforcement",
+                success=True,
+                checks=checks,
+                transcript=[],
+                duration=time.time() - start_time,
+            )
+            print("\nSUCCESS")
+        except Exception as e:
+            formatter.print_test_result(
+                test_name="test_19x3_permission_enforcement",
+                success=False,
+                checks=[f"Failed: {e}"],
+                transcript=[],
+                duration=time.time() - start_time,
+            )
+            import traceback
+
+            traceback.print_exc()
+            raise
+        finally:
+            if self.formation:
+                await self.cleanup_formation()
+
+
+async def main():
+    await TestPermissionEnforcement().test_19x3_permission_enforcement()
+
+
+if __name__ == "__main__":
+    os._exit(asyncio.run(main()) or 0)

--- a/src/muxi/runtime/datatypes/observability.py
+++ b/src/muxi/runtime/datatypes/observability.py
@@ -91,6 +91,10 @@ class SystemEvents(Enum):
     # When group permission files are loaded from the formation's groups/
     # directory at startup (GBAC Phase 2)
 
+    PERMISSION_FILTERED = "gbac.permissions.filtered"
+    # When request-time permission filtering removes resources (agents,
+    # SOPs, MCP tools) from a user's view (GBAC Phase 3)
+
     # ===================================================================
     # DOCUMENT CROSS-REFERENCE EVENTS
     # ===================================================================

--- a/src/muxi/runtime/formation/agents/agent.py
+++ b/src/muxi/runtime/formation/agents/agent.py
@@ -1470,6 +1470,23 @@ class Agent:
                 # Use agent-specific tool registry to get only tools this agent has access to
                 available_tools = mcp_service.get_tool_registry(self.agent_id)
 
+                # GBAC Phase 3: narrow the per-turn tool surface to the
+                # requesting user's effective set (group tool-override
+                # cascade). ``available_tools`` is the inherited view
+                # (post-registry, post-attachment); ``mcp_service.
+                # tool_registry`` is the post-registry catalog that group
+                # allow-overrides expand against. No-op when the formation
+                # has no groups/ directory. The filtered dict feeds both
+                # the planning prompt and the LLM tool schema, so a denied
+                # tool is never visible nor callable in this turn.
+                from ...services.gbac import enforcement as gbac_enforcement
+
+                available_tools = gbac_enforcement.effective_tool_registry(
+                    self.agent_id,
+                    available_tools,
+                    catalogs=getattr(mcp_service, "tool_registry", None),
+                )
+
                 # Tool isolation now working with shared + agent-specific tools
 
                 # Format tools for LLM if any are available

--- a/src/muxi/runtime/formation/overlord/agent_router.py
+++ b/src/muxi/runtime/formation/overlord/agent_router.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Optional
 
 from ...datatypes.exceptions import NoAvailableAgentsError, SecurityViolation
 from ...services import observability
+from ...services.gbac import enforcement as gbac
 
 
 class AgentRouter:
@@ -299,6 +300,11 @@ class AgentRouter:
         available_agents = await self.overlord.active_agent_tracker.get_available_agents(
             list(self.overlord.agents.keys()), request_id=request_id
         )
+
+        # GBAC Phase 3: the routing LLM only ever sees agents the requesting
+        # user's groups permit -- a denied agent is simply not a capability
+        # the model has (no-op without a groups/ directory).
+        available_agents = gbac.filter_ids("agents", available_agents)
 
         if not available_agents:
             raise NoAvailableAgentsError("No agents available for new requests")
@@ -602,6 +608,9 @@ Your response: [agent-id] or SECURITY_BLOCK"""
         available_agents = await self.overlord.active_agent_tracker.get_available_agents(
             list(self.overlord.agents.keys()), request_id=request_id
         )
+
+        # GBAC Phase 3: constrain the fallback heuristic to permitted agents
+        available_agents = gbac.filter_ids("agents", available_agents)
 
         if not available_agents:
             raise NoAvailableAgentsError("No agents available for new requests")

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -1020,8 +1020,20 @@ class Overlord:
             if not self._ensure_sop_system():
                 return None
 
+            # GBAC Phase 3: exclude SOPs the requesting user's groups don't
+            # permit. Over-fetch a few candidates so a denied top match
+            # doesn't hide a permitted lower-ranked one; no-op when no
+            # permissions are set (no groups/ directory).
+            from ...services.gbac import enforcement as gbac
+
+            permissions = gbac.get_current_permissions()
+            top_k = 1 if permissions is None else 5
+
             # Search for relevant SOPs
-            relevant_sops = await self.sop_system.find_relevant_sops(message, top_k=1)
+            relevant_sops = await self.sop_system.find_relevant_sops(message, top_k=top_k)
+            if permissions is not None and relevant_sops:
+                allowed = set(gbac.filter_ids("sops", [sop["id"] for sop in relevant_sops]))
+                relevant_sops = [sop for sop in relevant_sops if sop["id"] in allowed]
             relevant_sop = relevant_sops[0] if relevant_sops else None
 
             # Filter out low-relevance SOPs
@@ -5411,6 +5423,78 @@ Agent response: {raw_response}"""
     # ASYNC REQUEST-RESPONSE ORCHESTRATION)
     # ===================================================================
 
+    async def _apply_permission_gate(
+        self, user_id: Any, agent_name: Optional[str]
+    ) -> Optional[MuxiResponse]:
+        """Resolve GBAC permissions once per request and gate agent access.
+
+        GBAC Phase 3 (resource filtering). When the formation has a
+        ``groups/`` directory, the requesting user's effective permissions
+        are resolved ONCE here (Phase 2's TTL/LRU caches make this cheap)
+        and stored in the request context. Downstream enforcement sites --
+        agent routing, workflow decomposition/execution, SOP matching, and
+        the per-turn MCP tool surface -- read that context instead of
+        re-resolving. Without a resolver this is a strict no-op.
+
+        Returns:
+            A graceful MuxiResponse when the user's groups grant no agents
+            at all ("registered but inactive" -- PRD resolution rule 6),
+            otherwise None to continue normal processing.
+
+        Raises:
+            ValueError: When a directly-addressed agent is denied. The
+                error type and message are identical to ``get_agent()``'s
+                unknown-agent error so a denied agent is indistinguishable
+                from a nonexistent one (no information leak).
+        """
+        from ...services.gbac import enforcement as gbac
+
+        resolver = self._configured_services.get("permission_resolver")
+        if resolver is None or user_id is None:
+            # Feature inert (no groups/ directory), or no requesting user
+            # yet (the orchestrator rejects multi-user requests without a
+            # user id). Clear any permissions inherited from a previous
+            # request in this context.
+            gbac.set_current_permissions(None)
+            return None
+
+        # Match the orchestrator's user-id normalization so membership
+        # lookups behave identically across entry points.
+        resolved_user = str(user_id).lower().strip()
+        permissions = await resolver.resolve(resolved_user)
+        gbac.set_current_permissions(permissions)
+
+        # A directly-addressed denied agent behaves exactly like an
+        # unknown agent -- same error type and message as get_agent().
+        if agent_name and not permissions.is_allowed("agents", agent_name):
+            gbac.observe_denied(
+                "agents",
+                agent_name,
+                user_id=resolved_user,
+                formation_id=self.formation_id,
+                channel="direct_address",
+            )
+            raise ValueError(f"No agent with ID '{agent_name}' exists")
+
+        # A user whose groups grant no agents at all gets a graceful
+        # reply instead of a routing failure (PRD: "registered but
+        # inactive" users are allowed in but can reach no resources).
+        if not permissions.filter("agents", list(self.agents.keys())):
+            gbac.observe_denied(
+                "agents",
+                "*",
+                user_id=resolved_user,
+                formation_id=self.formation_id,
+                reason="no_permitted_agents",
+            )
+            return MuxiResponse(
+                role="assistant",
+                content="I'm sorry, but I'm not able to help with that request.",
+                metadata={"handled_by": "overlord_direct", "reason": "no_capabilities"},
+            )
+
+        return None
+
     async def chat(
         self,
         message: str,
@@ -6310,6 +6394,28 @@ Agent response: {raw_response}"""
         if request_id and self.request_tracker.is_cancelled(request_id):
             await self.request_tracker.clear_cancelled(request_id)
             raise RequestCancelledException(request_id)
+
+        # ===================================================================
+        # GBAC PERMISSION GATE (Phase 3)
+        # ===================================================================
+        # Resolve the requesting user's permissions once per request and
+        # stash them in the request context for every downstream
+        # enforcement site (routing, workflow, SOP matching, MCP tool
+        # surface). This runs inside the sync/streaming/async execution
+        # task so streaming requests emit proper events. Strict no-op for
+        # formations without a groups/ directory. A directly-addressed
+        # denied agent raises the same ValueError as an unknown agent.
+        gate_response = await self._apply_permission_gate(user_id, agent_name)
+        if gate_response is not None:
+            # No permitted agents ("registered but inactive"): graceful
+            # reply, mirroring the fast-path completion behavior.
+            streaming.stream(
+                "completed",
+                gate_response.content,
+                status="success",
+                processing_time_ms=int((time.time() - start_time) * 1000),
+            )
+            return gate_response
 
         # ===================================================================
         # EARLY LLM HEALTH CHECK
@@ -7414,7 +7520,13 @@ Agent response: {raw_response}"""
                 # Build context with available SOPs for the analyzer
                 analysis_context = {"request_tracker": self.request_tracker}
                 if self._ensure_sop_system() and self.sop_system.enabled:
-                    analysis_context["available_sops"] = list(self.sop_system.sops.keys())
+                    # GBAC Phase 3: the analyzer LLM only sees SOPs the
+                    # requesting user's groups permit (no-op without groups/).
+                    from ...services.gbac import enforcement as gbac
+
+                    analysis_context["available_sops"] = gbac.filter_ids(
+                        "sops", list(self.sop_system.sops.keys())
+                    )
 
                 # Check for cancellation before request analysis
                 if request_id and self.request_tracker.is_cancelled(request_id):
@@ -7620,9 +7732,19 @@ Agent response: {raw_response}"""
 
                 # Check for explicit SOP request
                 if analysis.explicit_sop_request:
-                    # User explicitly requested a specific SOP
+                    # User explicitly requested a specific SOP.
+                    # GBAC Phase 3: a denied SOP takes the same "not found"
+                    # path as a nonexistent one (no information leak), and
+                    # the "available SOPs" list shown to the user is
+                    # filtered to what their groups permit.
+                    from ...services.gbac import enforcement as gbac
+
                     sop_id = analysis.explicit_sop_request
-                    if self._ensure_sop_system() and sop_id in self.sop_system.sops:
+                    if (
+                        self._ensure_sop_system()
+                        and sop_id in self.sop_system.sops
+                        and gbac.is_allowed("sops", sop_id)
+                    ):
                         observability.observe(
                             event_type=observability.ConversationEvents.SOP_MATCHED,
                             level=observability.EventLevel.INFO,
@@ -7651,8 +7773,22 @@ Agent response: {raw_response}"""
                         )
                     else:
                         # SOP explicitly requested but not found - return error to user
-                        available_sops = (
-                            list(self.sop_system.sops.keys()) if self.sop_system else []
+                        if (
+                            self.sop_system
+                            and sop_id in self.sop_system.sops
+                            and not gbac.is_allowed("sops", sop_id)
+                        ):
+                            # Exists but denied: log the permission decision
+                            # (the user-facing path stays "not found").
+                            gbac.observe_denied(
+                                "sops",
+                                sop_id,
+                                user_id=str(user_id) if user_id else None,
+                                request_id=request_id,
+                            )
+                        available_sops = gbac.filter_ids(
+                            "sops",
+                            list(self.sop_system.sops.keys()) if self.sop_system else [],
                         )
                         observability.observe(
                             event_type=observability.ConversationEvents.SOP_NOT_FOUND,

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -5461,8 +5461,10 @@ Agent response: {raw_response}"""
             # _process_sync_chat call with message=original_message).
             # ContextVar mutations are visible within the same coroutine,
             # so clearing here would un-filter the REMAINDER of the outer
-            # request. Inherit the outer requester's permissions instead.
-            return gbac.get_current_permissions()
+            # request. Leave the outer requester's permissions in place
+            # and return None -- any non-None return from this gate is
+            # treated as a MuxiResponse by the caller.
+            return None
 
         # Match the orchestrator's user-id normalization so membership
         # lookups behave identically across entry points.

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -5450,13 +5450,19 @@ Agent response: {raw_response}"""
         from ...services.gbac import enforcement as gbac
 
         resolver = self._configured_services.get("permission_resolver")
-        if resolver is None or user_id is None:
-            # Feature inert (no groups/ directory), or no requesting user
-            # yet (the orchestrator rejects multi-user requests without a
-            # user id). Clear any permissions inherited from a previous
-            # request in this context.
+        if resolver is None:
+            # Feature inert (no groups/ directory). Nothing can have set
+            # permissions in this context, but clear defensively in case
+            # the formation was reloaded without groups mid-process.
             gbac.set_current_permissions(None)
             return None
+        if user_id is None:
+            # Internal/system re-entry (e.g. the recursive
+            # _process_sync_chat call with message=original_message).
+            # ContextVar mutations are visible within the same coroutine,
+            # so clearing here would un-filter the REMAINDER of the outer
+            # request. Inherit the outer requester's permissions instead.
+            return gbac.get_current_permissions()
 
         # Match the orchestrator's user-id normalization so membership
         # lookups behave identically across entry points.

--- a/src/muxi/runtime/formation/server/routes/client/triggers.py
+++ b/src/muxi/runtime/formation/server/routes/client/triggers.py
@@ -241,6 +241,30 @@ async def execute_trigger(
     if not formation.is_overlord_running():
         raise HTTPException(status_code=503, detail="Overlord not available")
 
+    # GBAC Phase 3: a trigger fires only when the requesting user's groups
+    # permit it. Per the PRD's channel table, API/webhook callers get a 403
+    # with a generic message. No-op when the formation has no groups/
+    # directory. The membership lookup is TTL-cached by the resolver.
+    resolver = formation.permission_resolver
+    if resolver is not None:
+        from .....services.gbac import enforcement as gbac_enforcement
+
+        # Normalize the identifier the same way the overlord chat path does
+        permissions = await resolver.resolve(str(user_id).lower().strip())
+        if not permissions.is_allowed("triggers", trigger_name):
+            gbac_enforcement.observe_denied(
+                "triggers",
+                trigger_name,
+                user_id=user_id,
+                formation_id=formation_id,
+                group_ids=list(permissions.group_ids),
+                channel="api",
+            )
+            raise HTTPException(
+                status_code=403,
+                detail="Insufficient permissions to execute this trigger",
+            )
+
     # Get formation directory
     formation_path = formation.get_formation_path()
     if not formation_path:

--- a/src/muxi/runtime/formation/server/routes/client/triggers.py
+++ b/src/muxi/runtime/formation/server/routes/client/triggers.py
@@ -255,9 +255,9 @@ async def execute_trigger(
             gbac_enforcement.observe_denied(
                 "triggers",
                 trigger_name,
+                permissions=permissions,
                 user_id=user_id,
                 formation_id=formation_id,
-                group_ids=list(permissions.group_ids),
                 channel="api",
             )
             raise HTTPException(

--- a/src/muxi/runtime/formation/workflow/decomposer.py
+++ b/src/muxi/runtime/formation/workflow/decomposer.py
@@ -460,11 +460,17 @@ Analysis Results:
         """
         info_parts = ["Available agent capabilities and tools:\n"]
 
+        # GBAC Phase 3: the decomposition LLM only sees agents the
+        # requesting user's groups permit (no-op without a groups/ dir).
+        from ...services.gbac import enforcement as gbac
+
+        agent_registry = gbac.filter_agent_registry(self.agent_registry)
+
         # Get agent capabilities
-        if self.agent_registry:
+        if agent_registry:
 
             info_parts.append("**Available Agents and Their Capabilities:**")
-            for agent_id, agent in self.agent_registry.items():
+            for agent_id, agent in agent_registry.items():
                 # Get all agent attributes
                 agent_name = getattr(agent, "name", agent_id)
                 agent_description = getattr(agent, "description", "")
@@ -536,8 +542,8 @@ Analysis Results:
         all_capabilities = set()
         capability_examples = {}
 
-        if self.agent_registry:
-            for agent_id, agent in self.agent_registry.items():
+        if agent_registry:
+            for agent_id, agent in agent_registry.items():
                 specialties = (
                     getattr(agent, "specialization", None)
                     or getattr(agent, "specialties", None)

--- a/src/muxi/runtime/formation/workflow/executor.py
+++ b/src/muxi/runtime/formation/workflow/executor.py
@@ -20,6 +20,7 @@ from ...datatypes.workflow_models import (
     create_execution_result,
 )
 from ...services import observability, streaming
+from ...services.gbac import enforcement as gbac_enforcement
 from ...utils.fastjson import json
 from ..agents.agent import Agent
 from ..agents.skill_dispatch import _rce_artifact_to_muxi, run_skill_command
@@ -1062,7 +1063,34 @@ class WorkflowExecutor:
 
         return inputs
 
+    def _with_permitted_registry(self, select_fn):
+        """Run an agent-selection function against the GBAC-permitted registry.
+
+        GBAC Phase 3: workflow task assignment must not reach agents the
+        requesting user's groups deny -- even when a (hallucinated or
+        stale) plan names one explicitly. Selection functions read
+        ``self.agent_registry`` throughout, so we temporarily swap in the
+        filtered view (the same pattern ``_select_agent_for_task_excluding``
+        already uses; safe because selection is fully synchronous). No-op
+        when no permissions are set (no groups/ directory).
+        """
+        permitted = gbac_enforcement.filter_agent_registry(self.agent_registry)
+        if permitted is self.agent_registry:
+            return select_fn()
+        original_registry = self.agent_registry
+        self.agent_registry = permitted
+        try:
+            return select_fn()
+        finally:
+            self.agent_registry = original_registry
+
     def _select_agent_for_spec(
+        self, spec: TaskSpecification, state: TaskExecutionState
+    ) -> Optional[Agent]:
+        """Select best agent for a spec, constrained to permitted agents."""
+        return self._with_permitted_registry(lambda: self._select_agent_for_spec_impl(spec, state))
+
+    def _select_agent_for_spec_impl(
         self, spec: TaskSpecification, state: TaskExecutionState
     ) -> Optional[Agent]:
         """
@@ -1204,6 +1232,10 @@ class WorkflowExecutor:
         return best_agent
 
     def _select_agent_for_task(self, task: SubTask) -> Optional[Agent]:
+        """Select best agent for a task, constrained to permitted agents."""
+        return self._with_permitted_registry(lambda: self._select_agent_for_task_impl(task))
+
+    def _select_agent_for_task_impl(self, task: SubTask) -> Optional[Agent]:
         """
         Select best agent for task based on configured routing strategy.
 

--- a/src/muxi/runtime/services/gbac/__init__.py
+++ b/src/muxi/runtime/services/gbac/__init__.py
@@ -16,11 +16,23 @@ Public surface:
 - ``GroupPermissionError`` -- raised for any malformed group definition;
   the formation loader converts it into a load failure.
 
-Resource *filtering* (applying these permissions to agents, triggers,
-SOPs, and MCP tools at request time) is Phase 3 and intentionally not
-implemented here.
+Resource *filtering* (Phase 3) lives in ``enforcement``: the overlord
+resolves the requesting user's permissions once per request and stores
+them in a ContextVar; the enforcement helpers filter agents, SOPs,
+triggers, and MCP tool surfaces at each site, and are strict no-ops when
+no permissions are set (formations without a ``groups/`` directory).
 """
 
+from .enforcement import (
+    effective_tool_registry,
+    filter_agent_registry,
+    filter_ids,
+    get_current_permissions,
+    is_allowed,
+    observe_denied,
+    reset_current_permissions,
+    set_current_permissions,
+)
 from .loader import (
     GroupPermissionError,
     ResolvedGroup,
@@ -37,5 +49,13 @@ __all__ = [
     "ResolvedPermissions",
     "SectionRules",
     "ToolRules",
+    "effective_tool_registry",
+    "filter_agent_registry",
+    "filter_ids",
+    "get_current_permissions",
+    "is_allowed",
     "load_groups",
+    "observe_denied",
+    "reset_current_permissions",
+    "set_current_permissions",
 ]

--- a/src/muxi/runtime/services/gbac/enforcement.py
+++ b/src/muxi/runtime/services/gbac/enforcement.py
@@ -1,0 +1,202 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        GBAC Enforcement - request-scoped permission filtering helpers
+# Description:  Phase 3 of the group-based access control PRD. Holds the
+#               request-scoped ResolvedPermissions (resolved once per request
+#               by the overlord) and exposes the filtering helpers every
+#               enforcement site consumes: agent routing, workflow
+#               decomposition/execution, SOP matching, and the per-turn MCP
+#               tool surface.
+# Role:         The permissions travel in a ContextVar so deep call sites
+#               (router, workflow executor, agent tool assembly) can consult
+#               them without threading a parameter through a dozen
+#               signatures. ContextVars propagate into asyncio tasks created
+#               by the chat orchestrator (streaming + async paths copy the
+#               context explicitly or via asyncio.create_task).
+# Usage:        ``Overlord.chat()`` resolves the requesting user's
+#               permissions once (Phase 2 caches make this cheap) and calls
+#               ``set_current_permissions``. Every helper here is a strict
+#               no-op when no permissions are set -- formations without a
+#               groups/ directory see zero behavior change.
+# Author:       MUXI Framework Team
+#
+# Mental-model compliance (PRD "The Mental Model"):
+#   Filtering removes denied resources from what the LLM can see; it never
+#   produces "permission denied" replies in the conversation. Hard denials
+#   (403 on triggers, unknown-agent behavior on direct addressing) are
+#   emitted as observability events, not surfaced as resource-revealing
+#   errors to the requester.
+# =============================================================================
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from typing import Any, Dict, List, Optional, Sequence
+
+from .. import observability
+from .resolver import ResolvedPermissions
+
+# Request-scoped permissions. None means "no enforcement" (no groups/
+# directory, or a system-initiated flow with no requesting user).
+_current_permissions: ContextVar[Optional[ResolvedPermissions]] = ContextVar(
+    "gbac_current_permissions", default=None
+)
+
+
+def set_current_permissions(
+    permissions: Optional[ResolvedPermissions],
+) -> "Token[Optional[ResolvedPermissions]]":
+    """Set the request-scoped permissions (or None to disable enforcement)."""
+    return _current_permissions.set(permissions)
+
+
+def get_current_permissions() -> Optional[ResolvedPermissions]:
+    """The requesting user's resolved permissions, or None when inactive."""
+    return _current_permissions.get()
+
+
+def reset_current_permissions(token: "Token[Optional[ResolvedPermissions]]") -> None:
+    """Restore the permissions saved by a previous ``set_current_permissions``."""
+    _current_permissions.reset(token)
+
+
+def is_allowed(kind: str, resource_id: str) -> bool:
+    """True if the current request may use ``resource_id`` of type ``kind``.
+
+    Always True when no permissions are set (enforcement inactive).
+    """
+    permissions = get_current_permissions()
+    if permissions is None:
+        return True
+    return permissions.is_allowed(kind, resource_id)
+
+
+def filter_ids(kind: str, resource_ids: Sequence[str]) -> List[str]:
+    """Return the subset of ``resource_ids`` the current request may use.
+
+    Emits a ``gbac.permissions.filtered`` event when filtering actually
+    removed something (permission-decision observability, PRD Phase 3/4).
+    """
+    resource_ids = list(resource_ids)
+    permissions = get_current_permissions()
+    if permissions is None:
+        return resource_ids
+    allowed = permissions.filter(kind, resource_ids)
+    if len(allowed) != len(resource_ids):
+        removed = [rid for rid in resource_ids if rid not in allowed]
+        observability.observe(
+            event_type=observability.SystemEvents.PERMISSION_FILTERED,
+            level=observability.EventLevel.DEBUG,
+            data={
+                "service": "gbac_enforcement",
+                "kind": kind,
+                "removed": removed,
+                "allowed_count": len(allowed),
+                "group_ids": list(permissions.group_ids),
+            },
+            description=(
+                f"GBAC filtered {len(removed)} {kind} for groups "
+                f"{list(permissions.group_ids)}: {removed}"
+            ),
+        )
+    return allowed
+
+
+def filter_agent_registry(registry: Dict[str, Any]) -> Dict[str, Any]:
+    """Filter an ``{agent_id: agent}`` mapping to permitted agents.
+
+    Returns the *same* object when enforcement is inactive so callers can
+    cheaply detect the no-op case (``result is registry``).
+    """
+    permissions = get_current_permissions()
+    if permissions is None:
+        return registry
+    allowed = set(filter_ids("agents", list(registry.keys())))
+    return {agent_id: agent for agent_id, agent in registry.items() if agent_id in allowed}
+
+
+def effective_tool_registry(
+    agent_id: str,
+    registry: Dict[str, Dict[str, Any]],
+    catalogs: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """Narrow an agent's per-server tool registry to the user's effective set.
+
+    Applies the PRD tool override cascade via
+    :meth:`ResolvedPermissions.effective_tools` for each attached server.
+
+    Args:
+        agent_id: The agent whose tool surface is being assembled.
+        registry: ``{server_id: {tool_name: tool_info}}`` -- the agent's
+            inherited tool view (post-registry, post-attachment).
+        catalogs: ``{server_id: {tool_name: tool_info}}`` -- the
+            post-registry catalog per server (the universe group ``allow``
+            overrides expand against, letting a group supersede the
+            attachment config). Defaults to ``registry``.
+
+    Returns:
+        The filtered registry. Servers whose effective tool set is empty
+        are omitted entirely (``tools: {deny: "*"}`` hides the server).
+        Returns ``registry`` unchanged when enforcement is inactive.
+    """
+    permissions = get_current_permissions()
+    if permissions is None:
+        return registry
+
+    catalogs = catalogs if catalogs is not None else registry
+    filtered: Dict[str, Dict[str, Any]] = {}
+    removed: Dict[str, List[str]] = {}
+    for server_id, tools in registry.items():
+        catalog_tools = catalogs.get(server_id, tools)
+        allowed = permissions.effective_tools(
+            agent_id,
+            server_id,
+            inherited_tools=list(tools.keys()),
+            catalog=list(catalog_tools.keys()),
+        )
+        # A group allow-override supersedes the attachment config, so the
+        # effective set may include catalog tools outside the inherited
+        # view -- source tool definitions from both, attachment view first.
+        source = {**catalog_tools, **tools}
+        kept = {name: info for name, info in source.items() if name in allowed}
+        dropped = [name for name in source if name not in allowed]
+        if kept:
+            filtered[server_id] = kept
+        if dropped:
+            removed[server_id] = dropped
+
+    if removed:
+        observability.observe(
+            event_type=observability.SystemEvents.PERMISSION_FILTERED,
+            level=observability.EventLevel.DEBUG,
+            data={
+                "service": "gbac_enforcement",
+                "kind": "mcp_tools",
+                "agent_id": agent_id,
+                "removed": removed,
+                "group_ids": list(permissions.group_ids),
+            },
+            description=(
+                f"GBAC narrowed the tool surface for agent {agent_id!r}: "
+                + ", ".join(f"{sid} -{len(names)}" for sid, names in removed.items())
+            ),
+        )
+    return filtered
+
+
+def observe_denied(kind: str, resource_id: str, **data: Any) -> None:
+    """Emit a permission-denial event (hard denial, e.g. 403 or direct address)."""
+    permissions = get_current_permissions()
+    observability.observe(
+        event_type=observability.ErrorEvents.AUTHORIZATION_FAILED,
+        level=observability.EventLevel.WARNING,
+        data={
+            "service": "gbac_enforcement",
+            "kind": kind,
+            "resource_id": resource_id,
+            "group_ids": list(permissions.group_ids) if permissions else [],
+            **data,
+        },
+        description=f"GBAC denied {kind[:-1] if kind.endswith('s') else kind} {resource_id!r}",
+    )

--- a/src/muxi/runtime/services/gbac/enforcement.py
+++ b/src/muxi/runtime/services/gbac/enforcement.py
@@ -160,7 +160,10 @@ def effective_tool_registry(
         # view -- source tool definitions from both, attachment view first.
         source = {**catalog_tools, **tools}
         kept = {name: info for name, info in source.items() if name in allowed}
-        dropped = [name for name in source if name not in allowed]
+        # Report only tools removed from the agent's inherited view --
+        # catalog-only tools were never on this agent's surface, so their
+        # absence is not a "drop" worth alerting on.
+        dropped = [name for name in tools if name not in allowed]
         if kept:
             filtered[server_id] = kept
         if dropped:
@@ -185,9 +188,17 @@ def effective_tool_registry(
     return filtered
 
 
-def observe_denied(kind: str, resource_id: str, **data: Any) -> None:
-    """Emit a permission-denial event (hard denial, e.g. 403 or direct address)."""
-    permissions = get_current_permissions()
+def observe_denied(
+    kind: str, resource_id: str, permissions: Optional[Any] = None, **data: Any
+) -> None:
+    """Emit a permission-denial event (hard denial, e.g. 403 or direct address).
+
+    Callers outside the chat pipeline (e.g. the trigger route) never set the
+    permissions ContextVar; they pass their locally resolved ``permissions``
+    explicitly so group_ids are recorded structurally rather than via a
+    caller-supplied kwarg override.
+    """
+    permissions = permissions if permissions is not None else get_current_permissions()
     observability.observe(
         event_type=observability.ErrorEvents.AUTHORIZATION_FAILED,
         level=observability.EventLevel.WARNING,

--- a/tests/unit/test_gbac_phase3.py
+++ b/tests/unit/test_gbac_phase3.py
@@ -568,9 +568,11 @@ class TestNestedReentryPreservesPermissions:
         await overlord._apply_permission_gate("alice", None)
         assert enforcement.get_current_permissions() is perms
 
-        # Nested internal re-entry: outer permissions must survive
+        # Nested internal re-entry: gate returns None (the caller treats
+        # any non-None return as a MuxiResponse) while the outer
+        # permissions survive untouched in the context
         result = await overlord._apply_permission_gate(None, None)
-        assert result is perms
+        assert result is None
         assert enforcement.get_current_permissions() is perms
         assert resolver.calls == 1  # no second resolve
 

--- a/tests/unit/test_gbac_phase3.py
+++ b/tests/unit/test_gbac_phase3.py
@@ -549,3 +549,29 @@ class TestWorkflowFiltering:
         )
         selected = executor._select_agent_for_task(task)
         assert selected.agent_id == "hr-assistant"
+
+
+class TestNestedReentryPreservesPermissions:
+    """Internal re-entries must not un-filter the outer request.
+
+    _process_sync_chat re-enters itself synchronously with user_id=None;
+    ContextVar mutations are visible within the same coroutine, so the
+    gate must inherit (not clear) the outer requester's permissions
+    (review follow-up on #207).
+    """
+
+    async def test_gate_with_none_user_inherits_outer_context(self, tmp_path):
+        perms = make_perms(tmp_path, {"g.yaml": "agents: [a]\n"}, "g")
+        resolver = FakeResolver(perms)
+        overlord = make_overlord_stub(resolver, {"a": object()})
+
+        await overlord._apply_permission_gate("alice", None)
+        assert enforcement.get_current_permissions() is perms
+
+        # Nested internal re-entry: outer permissions must survive
+        result = await overlord._apply_permission_gate(None, None)
+        assert result is perms
+        assert enforcement.get_current_permissions() is perms
+        assert resolver.calls == 1  # no second resolve
+
+        enforcement.set_current_permissions(None)

--- a/tests/unit/test_gbac_phase3.py
+++ b/tests/unit/test_gbac_phase3.py
@@ -1,0 +1,551 @@
+"""Unit tests for GBAC Phase 3: request-time resource filtering enforcement.
+
+Covers the Phase 3 surfaces of the group-based access control PRD
+(2026-07-06 revision):
+
+1. Context -- the request-scoped permissions ContextVar and the no-op
+   guarantee when no permissions are set (no groups/ directory).
+2. Agents -- routing only sees permitted agents; a directly-addressed
+   denied agent behaves exactly like an unknown agent; a user whose
+   groups grant no agents gets a graceful reply; workflow decomposition
+   and task assignment are constrained to permitted agents.
+3. SOPs -- SOP matching and the analyzer's available-SOP list exclude
+   SOPs the user's groups don't permit.
+4. Triggers -- the API trigger route returns 403 for denied triggers.
+5. MCP tools -- the per-turn tool surface passes through the group tool
+   override cascade (``effective_tools``).
+6. Single resolve -- permissions are resolved once per request by the
+   overlord gate; enforcement sites read the context, not the resolver.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Optional
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+from starlette.requests import Request
+
+from muxi.runtime.datatypes.exceptions import NoAvailableAgentsError
+from muxi.runtime.datatypes.response import MuxiResponse
+from muxi.runtime.datatypes.workflow import SubTask
+from muxi.runtime.formation.overlord.active_agents_tracker import ActiveAgentsTracker
+from muxi.runtime.formation.overlord.agent_router import AgentRouter
+from muxi.runtime.formation.overlord.overlord import Overlord
+from muxi.runtime.formation.server.routes.client.triggers import (
+    TriggerRequest,
+    execute_trigger,
+)
+from muxi.runtime.formation.workflow.decomposer import TaskDecomposer
+from muxi.runtime.formation.workflow.executor import WorkflowExecutor
+from muxi.runtime.services.gbac import ResolvedPermissions, enforcement, load_groups
+
+FORMATION_ID = "gbac-phase3-test"
+
+
+def make_perms(tmp_path, files: dict, *group_ids: str) -> ResolvedPermissions:
+    """Load group YAML files and build a ResolvedPermissions for group_ids."""
+    groups_dir = tmp_path / "groups"
+    groups_dir.mkdir(exist_ok=True)
+    for filename, content in files.items():
+        (groups_dir / filename).write_text(content)
+    groups = load_groups(str(groups_dir))
+    ordered = tuple(sorted(group_ids))
+    return ResolvedPermissions(group_ids=ordered, groups=tuple(groups[gid] for gid in ordered))
+
+
+@pytest.fixture(autouse=True)
+def clean_permission_context():
+    """Every test starts and ends with no request-scoped permissions."""
+    token = enforcement.set_current_permissions(None)
+    yield
+    enforcement.reset_current_permissions(token)
+
+
+class FakeResolver:
+    """Counts resolve() calls and returns a fixed ResolvedPermissions."""
+
+    def __init__(self, permissions: ResolvedPermissions):
+        self.permissions = permissions
+        self.calls = 0
+        self.resolved_user_ids: list = []
+
+    async def resolve(self, user_id: str) -> ResolvedPermissions:
+        self.calls += 1
+        self.resolved_user_ids.append(user_id)
+        return self.permissions
+
+
+# ===================================================================
+# 1. Context helpers and no-op guarantees
+# ===================================================================
+
+
+class TestPermissionContext:
+    def test_default_is_none(self):
+        assert enforcement.get_current_permissions() is None
+
+    def test_set_get_reset(self, tmp_path):
+        perms = make_perms(tmp_path, {"g.yaml": "agents: [a]\n"}, "g")
+        token = enforcement.set_current_permissions(perms)
+        assert enforcement.get_current_permissions() is perms
+        enforcement.reset_current_permissions(token)
+        assert enforcement.get_current_permissions() is None
+
+    def test_is_allowed_true_without_permissions(self):
+        assert enforcement.is_allowed("agents", "anything")
+        assert enforcement.is_allowed("sops", "anything")
+        assert enforcement.is_allowed("triggers", "anything")
+
+    def test_filter_ids_passthrough_without_permissions(self):
+        ids = ["a", "b", "c"]
+        assert enforcement.filter_ids("agents", ids) == ids
+
+    def test_filter_agent_registry_identity_without_permissions(self):
+        registry = {"a": object(), "b": object()}
+        assert enforcement.filter_agent_registry(registry) is registry
+
+    def test_effective_tool_registry_identity_without_permissions(self):
+        registry = {"server": {"tool": {"description": "x"}}}
+        assert enforcement.effective_tool_registry("agent", registry) is registry
+
+
+class TestFilterHelpers:
+    def test_filter_ids_applies_permissions(self, tmp_path):
+        perms = make_perms(tmp_path, {"g.yaml": "agents:\n  - hr-*\n"}, "g")
+        enforcement.set_current_permissions(perms)
+        assert enforcement.filter_ids("agents", ["hr-assistant", "code-assistant"]) == [
+            "hr-assistant"
+        ]
+
+    def test_filter_ids_empty_permissions_denies_everything(self):
+        enforcement.set_current_permissions(ResolvedPermissions(group_ids=(), groups=()))
+        assert enforcement.filter_ids("agents", ["a", "b"]) == []
+
+    def test_filter_agent_registry_applies_permissions(self, tmp_path):
+        perms = make_perms(tmp_path, {"g.yaml": "agents: [b]\n"}, "g")
+        enforcement.set_current_permissions(perms)
+        registry = {"a": "agent-a", "b": "agent-b"}
+        assert enforcement.filter_agent_registry(registry) == {"b": "agent-b"}
+
+
+# ===================================================================
+# 2. MCP tool surface (effective_tools cascade at planning time)
+# ===================================================================
+
+
+class TestEffectiveToolRegistry:
+    REGISTRY = {
+        "database-mcp": {
+            "get_records": {"description": "read"},
+            "update_records": {"description": "write"},
+            "delete_records": {"description": "delete"},
+        }
+    }
+
+    def test_group_wide_deny_removes_tools(self, tmp_path):
+        perms = make_perms(
+            tmp_path,
+            {
+                "g.yaml": (
+                    "agents: [assistant]\n"
+                    "mcp_servers:\n"
+                    "  database-mcp:\n"
+                    "    tools:\n"
+                    "      deny: [delete_*, update_*]\n"
+                )
+            },
+            "g",
+        )
+        enforcement.set_current_permissions(perms)
+        filtered = enforcement.effective_tool_registry("assistant", self.REGISTRY)
+        assert set(filtered["database-mcp"]) == {"get_records"}
+
+    def test_agent_scoped_allow_supersedes_inherited(self, tmp_path):
+        """An allow override expands against the catalog, not the inherited set."""
+        perms = make_perms(
+            tmp_path,
+            {
+                "g.yaml": (
+                    "agents:\n"
+                    "  - assistant:\n"
+                    "      database-mcp:\n"
+                    "        tools:\n"
+                    "          allow: [get_records, delete_records]\n"
+                )
+            },
+            "g",
+        )
+        enforcement.set_current_permissions(perms)
+        # Inherited view lacks delete_records (attachment narrowed), but the
+        # catalog has it -- the group override supersedes the attachment.
+        inherited = {"database-mcp": {"get_records": {}, "update_records": {}}}
+        filtered = enforcement.effective_tool_registry(
+            "assistant", inherited, catalogs=self.REGISTRY
+        )
+        assert set(filtered["database-mcp"]) == {"get_records", "delete_records"}
+
+    def test_denied_agent_has_empty_tool_surface(self, tmp_path):
+        perms = make_perms(tmp_path, {"g.yaml": "agents: [other-agent]\n"}, "g")
+        enforcement.set_current_permissions(perms)
+        filtered = enforcement.effective_tool_registry("assistant", self.REGISTRY)
+        assert filtered == {}
+
+    def test_hide_server_entirely(self, tmp_path):
+        perms = make_perms(
+            tmp_path,
+            {
+                "g.yaml": (
+                    "agents: [assistant]\n"
+                    "mcp_servers:\n"
+                    "  database-mcp:\n"
+                    "    tools:\n"
+                    '      deny: "*"\n'
+                )
+            },
+            "g",
+        )
+        enforcement.set_current_permissions(perms)
+        filtered = enforcement.effective_tool_registry("assistant", self.REGISTRY)
+        assert "database-mcp" not in filtered
+
+    def test_no_override_keeps_inherited_tools(self, tmp_path):
+        perms = make_perms(tmp_path, {"g.yaml": "agents: [assistant]\n"}, "g")
+        enforcement.set_current_permissions(perms)
+        filtered = enforcement.effective_tool_registry("assistant", self.REGISTRY)
+        assert set(filtered["database-mcp"]) == {
+            "get_records",
+            "update_records",
+            "delete_records",
+        }
+
+
+# ===================================================================
+# 3. Overlord permission gate (resolution + direct addressing)
+# ===================================================================
+
+
+def make_overlord_stub(resolver, agents: dict) -> Overlord:
+    """Bare Overlord with just the attributes _apply_permission_gate needs."""
+    overlord = Overlord.__new__(Overlord)
+    overlord._configured_services = {"permission_resolver": resolver}
+    overlord.agents = agents
+    overlord.formation_id = FORMATION_ID
+    return overlord
+
+
+class TestPermissionGate:
+    async def test_no_resolver_is_noop(self):
+        overlord = make_overlord_stub(None, {"a": object()})
+        assert await overlord._apply_permission_gate("alice", None) is None
+        assert enforcement.get_current_permissions() is None
+
+    async def test_no_user_id_is_noop(self, tmp_path):
+        perms = make_perms(tmp_path, {"g.yaml": "agents: [a]\n"}, "g")
+        resolver = FakeResolver(perms)
+        overlord = make_overlord_stub(resolver, {"a": object()})
+        assert await overlord._apply_permission_gate(None, None) is None
+        assert resolver.calls == 0
+        assert enforcement.get_current_permissions() is None
+
+    async def test_resolves_once_and_sets_context(self, tmp_path):
+        perms = make_perms(tmp_path, {"g.yaml": "agents: [a]\n"}, "g")
+        resolver = FakeResolver(perms)
+        overlord = make_overlord_stub(resolver, {"a": object(), "b": object()})
+
+        assert await overlord._apply_permission_gate("Alice@Example.COM ", None) is None
+        assert resolver.calls == 1
+        assert resolver.resolved_user_ids == ["alice@example.com"]
+        assert enforcement.get_current_permissions() is perms
+
+        # Enforcement sites read the context -- no further resolve() calls
+        assert enforcement.filter_ids("agents", ["a", "b"]) == ["a"]
+        assert enforcement.is_allowed("agents", "a")
+        assert resolver.calls == 1
+
+    async def test_denied_direct_address_matches_unknown_agent_error(self, tmp_path):
+        """Denied agent raises the exact error get_agent uses for unknown ids."""
+        perms = make_perms(tmp_path, {"g.yaml": "agents: [a]\n"}, "g")
+        overlord = make_overlord_stub(FakeResolver(perms), {"a": object(), "b": object()})
+
+        with pytest.raises(ValueError) as denied:
+            await overlord._apply_permission_gate("alice", "b")
+
+        # Compare against the real unknown-agent error from get_agent()
+        full_overlord = Overlord.__new__(Overlord)
+        full_overlord.agents = {"a": object()}
+        full_overlord.default_agent_id = "a"
+        with pytest.raises(ValueError) as unknown:
+            full_overlord.get_agent("b")
+
+        assert str(denied.value) == str(unknown.value)
+
+    async def test_no_permitted_agents_returns_graceful_response(self, tmp_path):
+        perms = ResolvedPermissions(group_ids=(), groups=())  # no memberships
+        overlord = make_overlord_stub(FakeResolver(perms), {"a": object(), "b": object()})
+
+        response = await overlord._apply_permission_gate("stranger", None)
+        assert isinstance(response, MuxiResponse)
+        assert response.role == "assistant"
+        assert response.content
+        assert response.metadata["reason"] == "no_capabilities"
+
+    async def test_gate_clears_stale_context_when_resolver_absent(self, tmp_path):
+        perms = make_perms(tmp_path, {"g.yaml": "agents: [a]\n"}, "g")
+        enforcement.set_current_permissions(perms)
+        overlord = make_overlord_stub(None, {"a": object()})
+        await overlord._apply_permission_gate("alice", None)
+        assert enforcement.get_current_permissions() is None
+
+
+# ===================================================================
+# 4. Agent routing
+# ===================================================================
+
+
+def make_router(agent_ids: list, metadata: Optional[dict] = None) -> AgentRouter:
+    overlord = SimpleNamespace(
+        agents={aid: object() for aid in agent_ids},
+        active_agent_tracker=ActiveAgentsTracker(),
+        formation_config={},
+        agent_metadata=metadata or {},
+        agent_descriptions={},
+        default_agent_id=None,
+        routing_model=None,
+    )
+    return AgentRouter(overlord)
+
+
+class TestAgentRouterFiltering:
+    async def test_routing_narrowed_to_single_permitted_agent(self, tmp_path):
+        """With one permitted agent the router returns it without any LLM."""
+        perms = make_perms(tmp_path, {"g.yaml": "agents: [hr-assistant]\n"}, "g")
+        enforcement.set_current_permissions(perms)
+        router = make_router(["hr-assistant", "code-assistant", "finance-assistant"])
+
+        selected = await router.select_agent_for_message("show me salaries")
+        assert selected == "hr-assistant"
+
+    async def test_all_agents_denied_raises_no_available_agents(self):
+        enforcement.set_current_permissions(ResolvedPermissions(group_ids=(), groups=()))
+        router = make_router(["a", "b"])
+        with pytest.raises(NoAvailableAgentsError):
+            await router.select_agent_for_message("hello")
+
+    async def test_no_permissions_behavior_unchanged(self):
+        router = make_router(["only-agent"])
+        assert await router.select_agent_for_message("hello") == "only-agent"
+
+    async def test_fallback_selection_respects_permissions(self, tmp_path):
+        perms = make_perms(tmp_path, {"g.yaml": "agents: [code-assistant]\n"}, "g")
+        enforcement.set_current_permissions(perms)
+        metadata = {
+            "hr-assistant": {"role": "specialist", "specialties": ["salaries"]},
+            "code-assistant": {"role": "specialist", "specialties": ["deployments"]},
+        }
+        router = make_router(["hr-assistant", "code-assistant"], metadata)
+        selected = await router._select_best_available_agent("tell me about salaries")
+        assert selected == "code-assistant"
+
+
+# ===================================================================
+# 5. SOP matching
+# ===================================================================
+
+
+def make_sop_overlord(sops: list) -> Overlord:
+    """Bare Overlord whose sop_system returns the given ranked SOP list."""
+    overlord = Overlord.__new__(Overlord)
+    captured = {}
+
+    async def find_relevant_sops(message, top_k=3):
+        captured["top_k"] = top_k
+        return sops[:top_k]
+
+    overlord.sop_system = SimpleNamespace(
+        enabled=True,
+        sops={sop["id"]: sop for sop in sops},
+        find_relevant_sops=find_relevant_sops,
+    )
+    overlord._sop_captured = captured
+    return overlord
+
+
+class TestSopFiltering:
+    SOPS = [
+        {"id": "payroll-review", "name": "Payroll Review", "relevance_score": 0.95},
+        {"id": "deploy-service", "name": "Deploy Service", "relevance_score": 0.85},
+    ]
+
+    async def test_denied_top_match_falls_through_to_permitted_sop(self, tmp_path):
+        perms = make_perms(tmp_path, {"g.yaml": "sops: [deploy-*]\n"}, "g")
+        enforcement.set_current_permissions(perms)
+        overlord = make_sop_overlord(self.SOPS)
+
+        sop = await overlord._find_relevant_sop("how do I deploy?")
+        assert sop is not None
+        assert sop["id"] == "deploy-service"
+        # Over-fetches candidates so a denied #1 can't hide a permitted #2
+        assert overlord._sop_captured["top_k"] > 1
+
+    async def test_all_matches_denied_returns_none(self, tmp_path):
+        perms = make_perms(tmp_path, {"g.yaml": "sops: [onboarding]\n"}, "g")
+        enforcement.set_current_permissions(perms)
+        overlord = make_sop_overlord(self.SOPS)
+        assert await overlord._find_relevant_sop("payroll?") is None
+
+    async def test_no_permissions_returns_top_match_with_topk_one(self):
+        overlord = make_sop_overlord(self.SOPS)
+        sop = await overlord._find_relevant_sop("payroll?")
+        assert sop["id"] == "payroll-review"
+        assert overlord._sop_captured["top_k"] == 1
+
+
+# ===================================================================
+# 6. Trigger route (API channel: 403 on denial)
+# ===================================================================
+
+
+def make_trigger_request(user_id: str) -> Request:
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/v1/triggers/hr-report",
+        "raw_path": b"/v1/triggers/hr-report",
+        "query_string": b"",
+        "headers": [(b"x-muxi-user-id", user_id.encode())],
+    }
+    return Request(scope)
+
+
+def make_trigger_formation(tmp_path, resolver) -> SimpleNamespace:
+    return SimpleNamespace(
+        formation_id=FORMATION_ID,
+        permission_resolver=resolver,
+        is_overlord_running=lambda: True,
+        get_formation_path=lambda: str(tmp_path),
+        _overlord=None,
+    )
+
+
+class TestTriggerRouteEnforcement:
+    async def test_denied_trigger_returns_403(self, tmp_path):
+        perms = make_perms(tmp_path, {"g.yaml": "triggers: [invoice-*]\n"}, "g")
+        formation = make_trigger_formation(tmp_path, FakeResolver(perms))
+        request = make_trigger_request("carol@example.com")
+        request.scope["app"] = SimpleNamespace(state=SimpleNamespace(formation=formation))
+
+        with pytest.raises(HTTPException) as exc_info:
+            await execute_trigger(
+                "hr-report",
+                request,
+                TriggerRequest(data={}),
+                BackgroundTasks(),
+            )
+        assert exc_info.value.status_code == 403
+        # Generic message: no resource enumeration in the detail
+        assert "hr-report" not in exc_info.value.detail
+
+    async def test_permitted_trigger_passes_gate(self, tmp_path):
+        """A permitted trigger clears the gate (then 404s on the missing file)."""
+        perms = make_perms(tmp_path, {"g.yaml": "triggers: [hr-report]\n"}, "g")
+        formation = make_trigger_formation(tmp_path, FakeResolver(perms))
+        request = make_trigger_request("alice@example.com")
+        request.scope["app"] = SimpleNamespace(state=SimpleNamespace(formation=formation))
+
+        with pytest.raises(HTTPException) as exc_info:
+            await execute_trigger(
+                "hr-report",
+                request,
+                TriggerRequest(data={}),
+                BackgroundTasks(),
+            )
+        assert exc_info.value.status_code == 404
+
+    async def test_no_resolver_skips_gate(self, tmp_path):
+        formation = make_trigger_formation(tmp_path, None)
+        request = make_trigger_request("anyone")
+        request.scope["app"] = SimpleNamespace(state=SimpleNamespace(formation=formation))
+
+        with pytest.raises(HTTPException) as exc_info:
+            await execute_trigger(
+                "hr-report",
+                request,
+                TriggerRequest(data={}),
+                BackgroundTasks(),
+            )
+        assert exc_info.value.status_code == 404
+
+
+# ===================================================================
+# 7. Workflow decomposition and task assignment
+# ===================================================================
+
+
+class TestWorkflowFiltering:
+    @staticmethod
+    def _agents():
+        return {
+            "hr-assistant": SimpleNamespace(
+                agent_id="hr-assistant",
+                name="HR Assistant",
+                description="Handles HR data",
+                role="specialist",
+                specialties=["hr"],
+            ),
+            "code-assistant": SimpleNamespace(
+                agent_id="code-assistant",
+                name="Code Assistant",
+                description="Handles engineering",
+                role="specialist",
+                specialties=["engineering"],
+            ),
+        }
+
+    def test_decomposer_capabilities_exclude_denied_agents(self, tmp_path):
+        perms = make_perms(tmp_path, {"g.yaml": "agents: [code-assistant]\n"}, "g")
+        enforcement.set_current_permissions(perms)
+        decomposer = TaskDecomposer(agent_registry=self._agents())
+
+        info = decomposer._get_available_capabilities_info()
+        assert "code-assistant" in info
+        assert "hr-assistant" not in info
+
+    def test_decomposer_unchanged_without_permissions(self):
+        decomposer = TaskDecomposer(agent_registry=self._agents())
+        info = decomposer._get_available_capabilities_info()
+        assert "code-assistant" in info
+        assert "hr-assistant" in info
+
+    def test_executor_never_assigns_denied_agent(self, tmp_path):
+        perms = make_perms(tmp_path, {"g.yaml": "agents: [code-assistant]\n"}, "g")
+        enforcement.set_current_permissions(perms)
+        executor = WorkflowExecutor(agent_registry=self._agents())
+
+        # Even a plan that explicitly names the denied agent can't reach it
+        task = SubTask(
+            id="task_1",
+            description="summarize salaries",
+            required_capabilities=["hr"],
+            assigned_agent_id="hr-assistant",
+        )
+        selected = executor._select_agent_for_task(task)
+        assert selected is not None
+        assert selected.agent_id == "code-assistant"
+
+        # Registry swap is restored after selection
+        assert set(executor.agent_registry) == {"hr-assistant", "code-assistant"}
+
+    def test_executor_unchanged_without_permissions(self):
+        executor = WorkflowExecutor(agent_registry=self._agents())
+        task = SubTask(
+            id="task_1",
+            description="summarize salaries",
+            required_capabilities=["hr"],
+            assigned_agent_id="hr-assistant",
+        )
+        selected = executor._select_agent_for_task(task)
+        assert selected.agent_id == "hr-assistant"


### PR DESCRIPTION
## Summary

Phase 3 of the group-based access control PRD (`prds/group-based-access-control.md`, 2026-07-06 revision): request-time **resource filtering enforcement**. Consumes Phase 2's `PermissionResolver` / `ResolvedPermissions` exactly as shipped — no resolver changes.

Enforcement is active **only** when `formation.permission_resolver` is not None (a `groups/` directory exists). Otherwise every new code path is a strict no-op — zero behavior change (regression-guarded by unit tests and the existing e2e suite).

## How it works

Permissions are resolved **once per request** in a gate at the top of `Overlord._process_sync_chat` and stored in a `ContextVar` (`services/gbac/enforcement.py`). Every enforcement site reads that context instead of re-resolving — no parameter threading through a dozen signatures, and the context propagates into the streaming/async execution tasks (the orchestrator already copies context into background tasks; `asyncio.create_task` copies it for the async path). Phase 2's TTL membership cache + LRU resolution cache keep the gate itself to a cached dict lookup after the first request — well under the PRD's <5ms budget; per-site filtering is fnmatch over small lists.

## Enforcement-site map

| Site | Where |
|------|-------|
| **Gate (resolve once + direct address + no-agents)** | `src/muxi/runtime/formation/overlord/overlord.py` — `_apply_permission_gate()` (L5426) called from `_process_sync_chat` (L6398) |
| **1. Agent routing** | `src/muxi/runtime/formation/overlord/agent_router.py` L301-308 (`select_agent_for_message`) and L609-613 (`_select_best_available_agent`) — the routing LLM never sees a denied agent |
| **1b. Workflow (multi-agent) paths** | `src/muxi/runtime/formation/workflow/decomposer.py` L461-467 (decomposition LLM's capability listing) and `src/muxi/runtime/formation/workflow/executor.py` L1066-1084 (`_with_permitted_registry` wrapping `_select_agent_for_task` / `_select_agent_for_spec`) — a plan naming a denied agent cannot reach it |
| **2. Triggers** | `src/muxi/runtime/formation/server/routes/client/triggers.py` L244-267 (`execute_trigger`) — 403 with a generic message per the PRD channel table |
| **3. SOPs** | `src/muxi/runtime/formation/overlord/overlord.py` — `_find_relevant_sop` (L1023, over-fetch + filter, covers all three matching call sites), analyzer `available_sops` (L7523), explicit-SOP-request path (L7732-7791, denied == not found) |
| **4. MCP tools** | `src/muxi/runtime/formation/agents/agent.py` L1473-1489 (`process_message` tool assembly) via `ResolvedPermissions.effective_tools` — `inherited_tools` = the agent's post-registry tool view, `catalog` = `mcp_service.tool_registry` (post-registry catalog), so group allow-overrides supersede rather than intersect. The filtered dict feeds both the planning prompt and the LLM tool schema, so a denied tool is neither visible nor callable in the turn |

## Mental-model compliance

- **No "permission denied" conversations.** Filtering removes resources from what the LLM can see; the model simply lacks the capability and answers naturally ("I don't have access to that").
- **Direct addressing leaks nothing.** A directly-addressed denied agent raises the *exact* error `get_agent()` uses for unknown agents (same type, same message) — verified byte-for-byte in unit and e2e tests.
- **Denied explicit SOP requests** take the same "not found" path as nonexistent SOPs, and the "available SOPs" list shown to the user is filtered.
- **Trigger 403 detail** is generic (does not echo or enumerate resources); the denial detail lands in observability, not the response.

## Edge cases defined

- **User with no groups ("registered but inactive"):** empty permissions → no agents → a graceful `"I'm sorry, but I'm not able to help with that request."` response (`metadata.reason = "no_capabilities"`), emitted through the normal completion path so streaming clients get a proper `completed` event. No crashes, no `NoAvailableAgentsError` 500s.
- **Open formation + groups (PRD's "unusual configuration"):** the PRD suggests users *not in the DB* get full access. Phase 2's resolver keys on `user_groups` rows only, so this PR resolves the ambiguity **fail-closed**: any user without memberships gets empty permissions, per the task spec's "registered-but-inactive" rule. Distinguishing "unknown to the DB" from "known but ungrouped" would need a users-table probe on every request; flagged as a possible Phase 4 refinement.
- **Single-user (SQLite) formations:** every chat request runs as user `"0"` by MUXI convention, so groups apply to user `"0"` (the PRD's "kid mode" story). Route-level gates (triggers, like the Phase 1 auth gate) key on the caller's header identity.
- **System flows without a requesting user** (`user_id=None` internal calls): gate no-ops and clears any inherited context — system principals are not restricted.
- **LLM hallucinating a denied agent id** during routing: the `selected not in available_agents` check falls back to the (filtered) heuristic; during workflow execution, `_with_permitted_registry` prevents assignment even when a plan names the agent explicitly.
- **Routing cache:** cached selections are validated against the *per-user filtered* available set, so one user's cached route can never hand another user a denied agent.
- **Trigger channel identity** is normalized (`lower().strip()`) identically to the chat path so membership lookups behave the same across entry points.

## Observability

- Hard denials → existing `ErrorEvents.AUTHORIZATION_FAILED` (trigger 403, denied direct address, denied explicit SOP, no-permitted-agents).
- Filtering decisions → new `SystemEvents.PERMISSION_FILTERED` (`gbac.permissions.filtered`, DEBUG) emitted only when filtering actually removed something, with the removed ids and the group combination.
- `scripts/validate_events.py`: **1234/1234 (100%)**.

## Tests

- **Unit:** `tests/unit/test_gbac_phase3.py` — 34 tests: context helpers + no-op guarantees, tool-cascade filtering (group-wide deny, agent-scoped allow superseding the attachment against the catalog, `deny: "*"` hides server, denied agent → empty surface), gate (single resolve per request, denied direct address == unknown-agent error compared against the real `get_agent` error, graceful no-agents response, stale-context clearing), router filtering (narrowed set, all-denied, unchanged without permissions), SOP matching (denied top match falls through to a permitted lower match, top_k unchanged without permissions), trigger route (403 denied / gate-pass / no-resolver), workflow decomposer + executor (denied agent excluded from the planning prompt and never assigned, registry restored after selection).
- **Full unit suite:** 1272 passed, 3 skipped.
- **Lint:** black / isort / ruff clean.

## E2E

- **New:** `e2e/tests/19_api/test_19x3_permission_enforcement.py` + `formation-api-enforcement/` fixture (2 agents, 2 groups, 1 trigger) reproducing the PRD Slack example — **PASS (exit 0, prints SUCCESS)**, all 8 checks:
  - hr-group user reaches `hr-assistant` (200)
  - engineering user directly addressing `hr-assistant` gets a byte-identical error to `ghost-agent` (no leak)
  - engineering user's HR question routes to `code-assistant`, never `hr-assistant` (asserted via the router's session-agent record, not response wording)
  - permitted trigger 200, denied trigger 403 with generic detail
  - no-groups user gets a graceful 200 (`no_capabilities`)
  - Note: local e2e runs on SQLite (single-user, chat identity is `"0"`), so the test moves user `"0"` between groups across phases with an explicit membership-cache invalidation (equivalent to the 60s TTL expiry); the trigger channel exercises two distinct header identities in one phase.
- **Existing GBAC e2e:** `test_19x2_group_permissions.py` re-run on final code — PASS (exit 0).
- **Regression:** `cd e2e && python run_random_tests.py 5` on the final code — **5/5 PASS**, no retries needed (`13a2_execute_simple_trigger`, `13a7_low_threshold_bypass`, `19v1_events_streaming`, `3b4`, `3c2`). An earlier 5/5 run mid-development also passed (`13a1`, `19b1_sop_endpoints`, `1a_5`, `4b2`, `7b1`).
- Worktree note: replicated the gitignored `.key`/`secrets.enc` files from the main checkout before running e2e (as hit by both prior phases); also added `.key` symlinks for the groups fixtures, mirroring `formation-api/.key -> ../../../assets/.key`.

## Out of scope (per task)

`memory.write` enforcement (memory-namespaces PRD), native_apps/Console gating, email channel, agent-level `tools:` attachment config (inherited_tools == current post-registry tool list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)