### PR TITLE
fix: require server.auth: required when groups are configured

### DIFF
--- a/e2e/tests/19_api/formation-api-enforcement/formation.yaml
+++ b/e2e/tests/19_api/formation-api-enforcement/formation.yaml
@@ -30,6 +30,7 @@ agents:
 server:
   enabled: true
   port: 8271
+  auth: required  # groups/ requires the auth gate (2026-07-07 ruling)
   api_keys:
     admin_key: test-admin-key-123
     client_key: test-client-key-456

--- a/e2e/tests/19_api/formation-api-groups-open/formation.yaml
+++ b/e2e/tests/19_api/formation-api-groups-open/formation.yaml
@@ -1,6 +1,6 @@
 schema: "1.0.0"
-id: api-test-groups-circular
-description: "Formation with a groups/ directory for GBAC circular inheritance failure testing"
+id: api-test-groups-open
+description: "Formation combining groups/ with default (open) auth -- must FAIL to load (2026-07-07 ruling)"
 
 llm:
   api_keys:
@@ -26,7 +26,8 @@ agents:
 server:
   enabled: true
   port: 8271
-  auth: required  # groups/ requires the auth gate (2026-07-07 ruling)
+  # auth deliberately absent (default: open) -- with groups/ present this
+  # formation must fail to load with a clear error
   api_keys:
     admin_key: test-admin-key-123
     client_key: test-client-key-456

--- a/e2e/tests/19_api/formation-api-groups-open/groups/analyst.yaml
+++ b/e2e/tests/19_api/formation-api-groups-open/groups/analyst.yaml
@@ -1,0 +1,3 @@
+name: "Analysts"
+agents:
+  - assistant

--- a/e2e/tests/19_api/formation-api-groups-open/secrets.enc
+++ b/e2e/tests/19_api/formation-api-groups-open/secrets.enc
@@ -1,0 +1,1 @@
+../formation-api/secrets.enc

--- a/e2e/tests/19_api/formation-api-groups/formation.yaml
+++ b/e2e/tests/19_api/formation-api-groups/formation.yaml
@@ -26,6 +26,7 @@ agents:
 server:
   enabled: true
   port: 8271
+  auth: required  # groups/ requires the auth gate (2026-07-07 ruling)
   api_keys:
     admin_key: test-admin-key-123
     client_key: test-client-key-456

--- a/e2e/tests/19_api/test_19x2_group_permissions.py
+++ b/e2e/tests/19_api/test_19x2_group_permissions.py
@@ -7,6 +7,12 @@ Covers GBAC Phase 2 end to end:
 - the PermissionResolver resolves seeded user_groups memberships with
   inheritance, deny-overrides, and empty-membership semantics
 - a formation with circular group inheritance FAILS to load with a clear error
+- a formation combining groups/ with open (default) auth FAILS to load
+  (2026-07-07 ruling: group files require server.auth: required)
+
+Formations with group files run with server.auth: required, so HTTP users
+are seeded into users/user_identifiers before chatting (same pattern as
+the 19x1 auth gate test).
 """
 
 import asyncio
@@ -24,6 +30,7 @@ from common import BaseE2ETest, TestOutputFormatter  # noqa: E402
 from muxi.runtime.datatypes.exceptions import ConfigurationValidationError  # noqa: E402
 from muxi.runtime.formation import Formation  # noqa: E402
 from muxi.runtime.services.memory.long_term import UserGroup  # noqa: E402
+from muxi.runtime.utils.user_resolution import resolve_user_identifier  # noqa: E402
 
 ANALYST_USER = "alice@example.com"
 UNGROUPED_USER = "stranger@example.com"
@@ -88,6 +95,15 @@ class TestGroupPermissions(BaseE2ETest):
             checks.append("groups auto-discovered from groups/ directory")
 
             print("\n3. Testing chat with groups loaded (zero behavior regression)...")
+            # groups/ requires server.auth: required, so register the user
+            # with the auth gate first (identity only -- no group membership)
+            await resolve_user_identifier(
+                identifier=UNGROUPED_USER,
+                formation_id=FORMATION_ID,
+                db_manager=self.formation._db_manager,
+                kv_cache=None,
+                create_if_missing=True,
+            )
             async with httpx.AsyncClient(timeout=90.0) as client:
                 r = await client.post(
                     f"{self.base_url}/chat",
@@ -143,6 +159,22 @@ class TestGroupPermissions(BaseE2ETest):
                 print("✅ Formation load failed with a clear circular-inheritance error")
                 checks.append("circular inheritance fails formation load")
             assert failed, "circular-inheritance formation loaded but should have failed"
+
+            # Phase C: groups/ with open (default) auth fails formation load
+            print("\n8. Loading formation combining groups/ with open auth...")
+            failed = False
+            try:
+                bad_formation = Formation()
+                await bad_formation.load(str(Path(__file__).parent / "formation-api-groups-open"))
+            except ConfigurationValidationError as e:
+                failed = True
+                message = str(e)
+                assert "server.auth" in message, message
+                assert "required" in message, message
+                assert "groups" in message, message
+                print("✅ Formation load failed: groups/ requires server.auth: required")
+                checks.append("groups/ with open auth fails formation load")
+            assert failed, "open-auth groups formation loaded but should have failed"
 
             formatter.print_test_result(
                 test_name="test_19x2_group_permissions",

--- a/e2e/tests/19_api/test_19x3_permission_enforcement.py
+++ b/e2e/tests/19_api/test_19x3_permission_enforcement.py
@@ -17,6 +17,10 @@ explicit membership-cache invalidation, mirroring the 60s TTL expiry a
 multi-user Postgres deployment would see). The trigger channel resolves
 the caller's header identity directly (same pattern as the Phase 1 auth
 gate), so it exercises two distinct users in a single phase.
+
+The formation runs with server.auth: required (groups/ demands it as of
+the 2026-07-07 ruling), so every HTTP identity is seeded into
+users/user_identifiers before the requests fire.
 """
 
 import asyncio
@@ -32,10 +36,12 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from common import BaseE2ETest, TestOutputFormatter  # noqa: E402
 
 from muxi.runtime.services.memory.long_term import UserGroup  # noqa: E402
+from muxi.runtime.utils.user_resolution import resolve_user_identifier  # noqa: E402
 
 CHAT_USER = "0"  # SQLite backend: all chat requests execute as user "0"
 HR_USER = "alice@example.com"
 ENG_USER = "carol@example.com"
+NO_GROUPS_USER = "stranger@example.com"
 FORMATION_ID = "api-test-enforcement"
 
 
@@ -98,14 +104,27 @@ class TestPermissionEnforcement(BaseE2ETest):
             print("✅ Formation loaded with groups: engineering, hr")
             checks.append("formation with enforcement groups loads")
 
-            print("\n2. Seeding memberships (chat user→hr, alice→hr, carol→engineering)...")
+            print("\n2. Registering HTTP identities with the auth gate...")
+            # groups/ requires server.auth: required, so every header
+            # identity must exist in users/user_identifiers to chat at all
+            for identity in (HR_USER, ENG_USER, NO_GROUPS_USER):
+                await resolve_user_identifier(
+                    identifier=identity,
+                    formation_id=FORMATION_ID,
+                    db_manager=self.formation._db_manager,
+                    kv_cache=None,
+                    create_if_missing=True,
+                )
+            print("✅ Identities registered (auth gate)")
+
+            print("\n3. Seeding memberships (chat user→hr, alice→hr, carol→engineering)...")
             await self._set_memberships(CHAT_USER, "hr")
             await self._set_memberships(HR_USER, "hr")
             await self._set_memberships(ENG_USER, "engineering")
             print("✅ Memberships seeded")
 
             async with httpx.AsyncClient(timeout=120.0) as client:
-                print("\n3. HR-group user directly addresses hr-assistant (permitted)...")
+                print("\n4. HR-group user directly addresses hr-assistant (permitted)...")
                 r = await client.post(
                     f"{self.base_url}/chat",
                     headers=self._user_headers(HR_USER),
@@ -119,7 +138,7 @@ class TestPermissionEnforcement(BaseE2ETest):
                 print("✅ Permitted direct address returns 200")
                 checks.append("group-A user reaches agent-A (direct address)")
 
-                print("\n4. Trigger channel: alice (hr) permitted, carol (engineering) denied...")
+                print("\n5. Trigger channel: alice (hr) permitted, carol (engineering) denied...")
                 r = await client.post(
                     f"{self.base_url}/triggers/hr-report",
                     headers=self._user_headers(HR_USER),
@@ -139,10 +158,10 @@ class TestPermissionEnforcement(BaseE2ETest):
                 print("✅ Denied trigger returns 403 with a generic message")
                 checks.append("denied trigger returns 403")
 
-                print("\n5. Switching chat user to group engineering...")
+                print("\n6. Switching chat user to group engineering...")
                 await self._set_memberships(CHAT_USER, "engineering")
 
-                print("\n6. Engineering user directly addresses hr-assistant (denied)...")
+                print("\n7. Engineering user directly addresses hr-assistant (denied)...")
                 r_denied = await client.post(
                     f"{self.base_url}/chat",
                     headers=self._user_headers(ENG_USER),
@@ -174,7 +193,7 @@ class TestPermissionEnforcement(BaseE2ETest):
                 print("✅ Denied agent is indistinguishable from a nonexistent one")
                 checks.append("denied direct address == unknown agent (no leak)")
 
-                print("\n7. Engineering user asks an HR question (routed)...")
+                print("\n8. Engineering user asks an HR question (routed)...")
                 r = await client.post(
                     f"{self.base_url}/chat",
                     headers=self._user_headers(ENG_USER),
@@ -197,11 +216,11 @@ class TestPermissionEnforcement(BaseE2ETest):
                 print(f"✅ hr-assistant never selected (selected: {selected or 'overlord-direct'})")
                 checks.append("denied agent never selected for group-B user")
 
-                print("\n8. User with no group memberships chats (graceful response)...")
+                print("\n9. User with no group memberships chats (graceful response)...")
                 await self._set_memberships(CHAT_USER)  # clear all memberships
                 r = await client.post(
                     f"{self.base_url}/chat",
-                    headers=self._user_headers("stranger@example.com"),
+                    headers=self._user_headers(NO_GROUPS_USER),
                     json={"message": "What is Dave's salary?", "stream": False},
                 )
                 assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text}"

--- a/src/muxi/runtime/formation/formation.py
+++ b/src/muxi/runtime/formation/formation.py
@@ -1421,7 +1421,11 @@ class Formation:
         the directory the feature is inert and nothing changes.
 
         Malformed group files, unknown inheritance parents, and circular
-        inheritance fail the formation load with a precise error.
+        inheritance fail the formation load with a precise error. Group
+        files also require ``server.auth: required`` (2026-07-07 ruling):
+        with open auth, unknown users would bypass the very restrictions
+        registered users are subject to, so that combination fails the
+        load too. An empty ``groups/`` directory stays inert.
 
         This method is idempotent -- _prepare_services() may run more than
         once (load() and start_overlord()); the resolver is built once so
@@ -1474,6 +1478,28 @@ class Formation:
                 ),
             )
             return
+
+        # Group permission filtering only makes sense behind the auth gate:
+        # with open auth, unknown users would bypass the very restrictions
+        # registered users are subject to (inverted trust). Fail the load.
+        auth_mode = (getattr(self, "_server_config", None) or {}).get("auth", "open")
+        if auth_mode != "required":
+            raise ConfigurationValidationError(
+                [
+                    f"groups/ directory at {groups_dir} requires server.auth: 'required' "
+                    f"(current auth: {auth_mode!r})"
+                ],
+                {
+                    "groups_dir": groups_dir,
+                    "current_value": auth_mode,
+                    "suggestion": (
+                        "Group permission filtering requires 'server.auth: required'. "
+                        "Set 'server.auth: required' in your formation.afs, or remove "
+                        "the groups/ directory"
+                    ),
+                    "example": {"server": {"auth": "required"}},
+                },
+            )
 
         runtime_config = self.config.get("runtime", {}) if self.config else {}
         membership_ttl = 60.0

--- a/tests/unit/test_gbac_auth_groups_validation.py
+++ b/tests/unit/test_gbac_auth_groups_validation.py
@@ -1,0 +1,114 @@
+"""Unit tests for the GBAC groups/auth coupling rule (2026-07-07 ruling).
+
+A ``groups/`` directory containing group files requires
+``server.auth: "required"``. The former "open formation with optional
+groups" configuration gave unknown users full access while registered
+users got filtered access (inverted trust), so the combination is now
+inexpressible: formation load fails with a clear, actionable error.
+
+Edge cases pinned here:
+- open auth + group files      -> ConfigurationValidationError at load
+- absent auth (default: open)  -> same error
+- required auth + group files  -> loads, resolver active
+- open auth + EMPTY groups/    -> inert (warning only, no error)
+- open auth + no groups/ dir   -> unchanged, fine
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from muxi.runtime.datatypes.exceptions import ConfigurationValidationError
+from muxi.runtime.formation.formation import Formation
+
+FORMATION_ID = "gbac-auth-groups-test"
+
+
+def formation_stub(tmp_path, auth: str | None) -> SimpleNamespace:
+    """Formation stub mirroring the state _setup_groups sees.
+
+    ``_setup_auth`` runs before ``_setup_groups`` in _prepare_services and
+    stores the effective auth mode in ``_server_config``; ``auth=None``
+    models the default (key absent -> open).
+    """
+    server_config = {"auth": auth} if auth is not None else {}
+    return SimpleNamespace(
+        _formation_path=str(tmp_path),
+        _permission_resolver=None,
+        _group_permissions={},
+        formation_id=FORMATION_ID,
+        config={"runtime": {}},
+        _server_config=server_config,
+    )
+
+
+def write_group_file(tmp_path) -> None:
+    (tmp_path / "groups").mkdir()
+    (tmp_path / "groups" / "analyst.yaml").write_text("agents: [researcher]\n")
+
+
+class TestGroupsRequireAuthRequired:
+    def test_open_auth_with_group_files_fails_load(self, tmp_path):
+        write_group_file(tmp_path)
+        stub = formation_stub(tmp_path, auth="open")
+        with pytest.raises(ConfigurationValidationError) as exc_info:
+            Formation._setup_groups(stub)
+        message = str(exc_info.value)
+        assert "server.auth" in message
+        assert "required" in message
+        assert "groups" in message
+        assert stub._permission_resolver is None
+
+    def test_default_auth_absent_with_group_files_fails_load(self, tmp_path):
+        """auth key absent means open -- the rule still applies."""
+        write_group_file(tmp_path)
+        stub = formation_stub(tmp_path, auth=None)
+        with pytest.raises(ConfigurationValidationError, match="server.auth"):
+            Formation._setup_groups(stub)
+
+    def test_error_names_the_groups_directory(self, tmp_path):
+        write_group_file(tmp_path)
+        stub = formation_stub(tmp_path, auth="open")
+        with pytest.raises(ConfigurationValidationError) as exc_info:
+            Formation._setup_groups(stub)
+        assert str(tmp_path / "groups") in str(exc_info.value)
+
+    def test_error_suggests_the_fix(self, tmp_path):
+        write_group_file(tmp_path)
+        stub = formation_stub(tmp_path, auth="open")
+        with pytest.raises(ConfigurationValidationError) as exc_info:
+            Formation._setup_groups(stub)
+        details = exc_info.value.details
+        assert details["current_value"] == "open"
+        assert "server.auth: required" in details["suggestion"]
+        assert details["example"] == {"server": {"auth": "required"}}
+
+    def test_required_auth_with_group_files_loads(self, tmp_path):
+        write_group_file(tmp_path)
+        stub = formation_stub(tmp_path, auth="required")
+        Formation._setup_groups(stub)
+        assert stub._permission_resolver is not None
+        assert stub._permission_resolver.group_ids == ("analyst",)
+
+
+class TestEdgeCasesStayInert:
+    def test_open_auth_with_empty_groups_dir_is_inert(self, tmp_path):
+        """Phase 2 behavior preserved: empty groups/ warns, never errors."""
+        (tmp_path / "groups").mkdir()
+        stub = formation_stub(tmp_path, auth="open")
+        Formation._setup_groups(stub)  # must not raise
+        assert stub._permission_resolver is None
+        assert stub._group_permissions == {}
+
+    def test_open_auth_without_groups_dir_is_fine(self, tmp_path):
+        stub = formation_stub(tmp_path, auth="open")
+        Formation._setup_groups(stub)  # must not raise
+        assert stub._permission_resolver is None
+
+    def test_required_auth_with_empty_groups_dir_is_inert(self, tmp_path):
+        (tmp_path / "groups").mkdir()
+        stub = formation_stub(tmp_path, auth="required")
+        Formation._setup_groups(stub)
+        assert stub._permission_resolver is None

--- a/tests/unit/test_gbac_phase2.py
+++ b/tests/unit/test_gbac_phase2.py
@@ -807,6 +807,9 @@ class TestFormationWiring:
             _group_permissions={},
             formation_id=FORMATION_ID,
             config={"runtime": {}},
+            # Group files require the auth gate (see
+            # test_gbac_auth_groups_validation.py for the rule itself)
+            _server_config={"auth": "required"},
         )
 
     def test_no_groups_dir_is_inert(self, tmp_path):
@@ -967,6 +970,7 @@ class TestGroupsLoadedEventDeferral:
             _group_permissions={},
             formation_id=FORMATION_ID,
             config={"runtime": {}},
+            _server_config={"auth": "required"},
         )
         Formation._setup_groups(stub)
         event = stub._groups_loaded_event


### PR DESCRIPTION
## Ruling (2026-07-07)

The GBAC **"Open Formation with Optional Groups"** configuration (`server.auth: open` + a `groups/` directory) is killed. Its PRD semantics gave unknown users full, unfiltered access while registered users got filtered access — inverted trust: registering a user *reduced* their capabilities. The combination is now inexpressible.

## The rule

A `groups/` directory containing group files requires `server.auth: "required"`. Otherwise formation load fails fast in `Formation._setup_groups()` with a `ConfigurationValidationError`:

```
Configuration validation failed: groups/ directory at <path>/groups requires server.auth: 'required' (current auth: 'open')
```

with details naming the groups directory, the offending value, the fix (`server.auth: required` in formation.afs, or remove `groups/`), and an example snippet.

## Edge cases

- **Empty `groups/` dir** → inert, warning only (Phase 2 behavior unchanged)
- **No `groups/` dir** → auth may be anything, unchanged
- **`auth: required` + groups** → unchanged
- **`auth` absent (default: open) + group files** → error, same as explicit `open`
- **Circular/malformed group files** keep error precedence (raised during parsing, before the auth check), so the existing circular-inheritance failure case is untouched

## Changes

- `Formation._setup_groups()`: the validation (after `load_groups()` succeeds and at least one group file was loaded, before the resolver is built)
- `tests/unit/test_gbac_auth_groups_validation.py`: new suite pinning the rule and its edges; existing `_setup_groups` stubs in `test_gbac_phase2.py` updated to run behind the gate
- e2e: `formation-api-groups`, `formation-api-groups-circular`, `formation-api-enforcement` now declare `auth: required`; 19x2/19x3 seed their HTTP identities into `users/user_identifiers` (19x1 pattern); new `formation-api-groups-open` + a phase C in `test_19x2` asserting the open+groups formation FAILS to load with the new error

## Test evidence

- Unit: `tests/unit/` — **1506 passed, 10 skipped** (full suite)
- `scripts/validate_events.py` — **100%** (1260/1260)

## E2E

- `test_19x1_auth_gate` — SUCCESS, exit 0
- `test_19x2_group_permissions` — SUCCESS, exit 0 (incl. new phase: "groups/ with open auth fails formation load")
- `test_19x3_permission_enforcement` — SUCCESS, exit 0
- Regression: `run_random_tests.py 5` — **5/5 passed**, no flakes (13_triggers/13b1, 19_api/19l1, 21_skills/21a1, 4_mcp/4c1, 4_mcp/4d3)

## Docs

The PRD (`prds/completed/group-based-access-control.md`) and spec-gaps doc (`prds/afs-spec-gaps.md`) were amended in the engineering repo (revision-header note, `auth` value table, invalid-combination section, §2 `server.auth` bullet) — left **uncommitted** there for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)