### PR TITLE
feat: memory event substrate

### DIFF
--- a/e2e/tests/2_memory/test_2s1_memory_event_substrate.py
+++ b/e2e/tests/2_memory/test_2s1_memory_event_substrate.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""Test 2S1: Memory Event Substrate
+
+This test validates:
+1. The memory event substrate is wired into the overlord and the
+   memory_events / projection_checkpoints tables are created alongside
+   the existing schema
+2. Conversation activity records immutable events with provenance
+   (interaction.turn plus extraction events linked via caused_by)
+3. The captain's log digest dual-writes a log.entry event
+4. Wipe-and-replay: wiping a projection and rebuilding it from the
+   event log reproduces the same queryable memory state (knowledge
+   graph, captain's log, flat facts)
+5. Existing memory behavior is intact after a full rebuild (flat-fact
+   recall still answers from persistent memory)
+"""
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+from base_memory_test import BaseMemoryTest
+
+
+def normalize_metadata(metadata):
+    """Drop storage-assigned write timestamps before state comparison."""
+    metadata = dict(metadata or {})
+    metadata.pop("timestamp", None)
+    return metadata
+
+
+async def snapshot_graph(knowledge_graph, user_id):
+    """Structural knowledge-graph state keyed by entity names."""
+    entities = await knowledge_graph.storage.list_entities(user_id, status=None, limit=1000)
+    names = {e["id"]: (e["type"], e["name"]) for e in entities}
+    relationships = await knowledge_graph.storage.list_relationships(
+        user_id, status=None, limit=1000
+    )
+    return (
+        {
+            names[e["id"]]: (
+                e["confidence"],
+                e["status"],
+                tuple(e["derived_from_event_ids"]),
+            )
+            for e in entities
+        },
+        {
+            (names[r["from_entity_id"]], r["type"], names[r["to_entity_id"]]): (
+                r["confidence"],
+                r["status"],
+                tuple(r["derived_from_event_ids"]),
+            )
+            for r in relationships
+        },
+    )
+
+
+async def snapshot_log(captains_log, user_id):
+    """Structural captain's-log state keyed by entry date."""
+    entries = await captains_log.storage.list_entries(user_id, limit=100)
+    sources = await captains_log.storage.get_sources_for_logs([e["id"] for e in entries])
+    return {
+        e["date"]: (
+            e["summary"],
+            tuple(e["decisions"]),
+            tuple(e["projects"]),
+            tuple(e["derived_from_event_ids"]),
+            tuple(sorted((s["source_type"], s["source_id"]) for s in sources.get(e["id"], []))),
+        )
+        for e in entries
+    }
+
+
+def snapshot_flat_facts(long_term_memory, internal_user_id):
+    """Extraction-derived flat-fact rows straight from the SQLite table."""
+    rows = long_term_memory.conn.execute(
+        f"""
+        SELECT text, collection, metadata FROM {long_term_memory.memories_table}
+        WHERE user_id = ? AND json_extract(metadata, '$.source') = 'extraction'
+        ORDER BY text
+        """,
+        (internal_user_id,),
+    ).fetchall()
+    import json
+
+    return [
+        (text, collection, tuple(sorted(normalize_metadata(json.loads(metadata or "{}")).items())))
+        for text, collection, metadata in rows
+    ]
+
+
+class TestMemoryEventSubstrate(BaseMemoryTest):
+    """Test event recording, provenance, and wipe-and-replay rebuilds."""
+
+    async def test_event_substrate(self):
+        """Events record with provenance; wipe-and-replay reproduces state."""
+        test_name = "2s1_memory_event_substrate"
+        self.print_test_header(
+            test_name, "Test memory event recording, provenance, and projection rebuild"
+        )
+
+        start_time = time.time()
+        checks_passed = []
+        transcript = []
+        all_passed = True
+        user_id = "event_test_user"
+
+        try:
+            # Start from a fresh database so schema and row assertions are
+            # deterministic (the sqlite formation stores memory_test.db in
+            # this test's working directory).
+            for suffix in ("", "-wal", "-shm"):
+                stale = Path.cwd() / f"memory_test.db{suffix}"
+                if stale.exists():
+                    stale.unlink()
+
+            print("\n📝 Phase 1: Recording conversation events...")
+            await self.setup_memory_formation("sqlite")
+
+            # SQLite runs in single-user mode: every external user id is
+            # normalized to "0" before extraction sees it.
+            effective_user_id = user_id if self.overlord.is_multi_user else "0"
+
+            # Check 1: substrate service is wired into the overlord
+            memory_events = getattr(self.overlord, "memory_events", None)
+            if memory_events is not None:
+                print("  ✓ Memory event substrate initialized")
+                checks_passed.append("Memory event substrate initialized")
+            else:
+                print("  ✗ Memory event substrate missing from overlord")
+                all_passed = False
+
+            # Check 2: substrate tables exist alongside the rest of the schema
+            if memory_events is not None:
+                from sqlalchemy import inspect
+
+                tables = inspect(memory_events.db_manager.engine).get_table_names()
+                expected = {"memory_events", "projection_checkpoints"}
+                if expected.issubset(set(tables)):
+                    print("  ✓ memory_events and projection_checkpoints tables created")
+                    checks_passed.append("Substrate tables created")
+                else:
+                    print(f"  ✗ Substrate tables missing (found: {tables})")
+                    all_passed = False
+
+                registered = sorted(memory_events.projectors)
+                if registered == ["captains_log", "flat_facts", "knowledge_graph"]:
+                    print(f"  ✓ Projectors registered: {registered}")
+                    checks_passed.append("All three projectors registered")
+                else:
+                    print(f"  ✗ Unexpected projector registry: {registered}")
+                    all_passed = False
+
+            # Conversation turns: graph-friendly and flat-fact-friendly facts
+            user_msg1 = (
+                "My name is Jordan. I founded a company called Automaze and I live in "
+                "London. Today we decided to launch the MUXI project next month."
+            )
+            response1 = await self.overlord.chat(
+                user_msg1, user_id=user_id, use_async=False, stream=False
+            )
+            response1_text = response1.content if hasattr(response1, "content") else str(response1)
+            transcript.append((user_msg1, response1_text))
+            print(f"User: {user_msg1}")
+            print(f"Assistant: {response1_text[:200]}...")
+
+            user_msg2 = "My favorite color is blue and I have two cats named Whiskers and Shadow."
+            response2 = await self.overlord.chat(
+                user_msg2, user_id=user_id, use_async=False, stream=False
+            )
+            response2_text = response2.content if hasattr(response2, "content") else str(response2)
+            transcript.append((user_msg2, response2_text))
+            print(f"User: {user_msg2}")
+            print(f"Assistant: {response2_text[:200]}...")
+
+            # Check 3: events recorded with provenance (extraction is
+            # fire-and-forget; poll until the passes have run)
+            events = []
+            if memory_events is not None:
+                for _ in range(12):
+                    await asyncio.sleep(5)
+                    events = await memory_events.list_events(effective_user_id)
+                    types = {e["event_type"] for e in events}
+                    if "interaction.turn" in types and "fact.extracted" in types:
+                        break
+
+                types = {e["event_type"] for e in events}
+                if "interaction.turn" in types:
+                    print(f"  ✓ Interaction turns recorded as events ({len(events)} total)")
+                    checks_passed.append("Interaction turns recorded")
+                else:
+                    print(f"  ✗ No interaction.turn events found (types: {types})")
+                    all_passed = False
+
+                derived = [e for e in events if e["event_type"] != "interaction.turn"]
+                linked = [e for e in derived if e["caused_by"] is not None]
+                if derived and linked:
+                    print(
+                        f"  ✓ Extraction events carry caused_by provenance "
+                        f"({len(linked)}/{len(derived)} linked)"
+                    )
+                    checks_passed.append("Events carry causation provenance")
+                else:
+                    print(f"  ✗ No extraction events with caused_by links ({len(derived)} derived)")
+                    all_passed = False
+
+                scoped = all(
+                    e["scope_type"] == "user" and e["scope_id"] == effective_user_id
+                    for e in events
+                )
+                if events and scoped:
+                    print("  ✓ Every event carries the forward-compatible user scope")
+                    checks_passed.append("Events carry scope columns")
+                else:
+                    print("  ✗ Events missing scope_type/scope_id values")
+                    all_passed = False
+
+            # Check 4: captain's log digest dual-writes a log.entry event
+            captains_log = getattr(self.overlord, "captains_log", None)
+            if memory_events is not None and captains_log is not None:
+                model = getattr(self.overlord, "extraction_model", None) or getattr(
+                    self.overlord, "default_model", None
+                )
+                totals = await captains_log.run_periodic_summarization(model)
+                print(f"  Digest totals: {totals}")
+                log_events = await memory_events.list_events(
+                    effective_user_id, event_types=["log.entry"]
+                )
+                if totals["entries"] >= 1 and log_events:
+                    print("  ✓ Digest recorded a log.entry event alongside the projection write")
+                    checks_passed.append("Digest dual-writes log.entry events")
+                else:
+                    print("  ✗ Digest produced no log.entry event")
+                    all_passed = False
+
+            # Give the fire-and-forget flat-fact extraction time to finish
+            # before snapshotting (2B1 pattern).
+            await asyncio.sleep(20)
+
+            print("\n🔄 Phase 2: Wipe-and-replay rebuild...")
+            knowledge_graph = getattr(self.overlord, "knowledge_graph", None)
+            long_term_memory = getattr(self.overlord, "long_term_memory", None)
+            internal_user_id = await long_term_memory.get_or_create_user(effective_user_id)
+
+            graph_before = await snapshot_graph(knowledge_graph, effective_user_id)
+            log_before = await snapshot_log(captains_log, effective_user_id)
+            facts_before = snapshot_flat_facts(long_term_memory, internal_user_id)
+            print(
+                f"  State before: {len(graph_before[0])} entities, "
+                f"{len(graph_before[1])} relationships, {len(log_before)} log entries, "
+                f"{len(facts_before)} extracted facts"
+            )
+            if graph_before[0] and facts_before and log_before:
+                checks_passed.append("All three projections populated")
+            else:
+                print("  ✗ Expected all projections to be populated before the rebuild")
+                all_passed = False
+
+            # Check 5: wiping a projection leaves it empty (proves the
+            # rebuild below starts from nothing, not from leftovers)
+            await memory_events.projectors["knowledge_graph"].reset(effective_user_id)
+            wiped = await snapshot_graph(knowledge_graph, effective_user_id)
+            if not wiped[0] and not wiped[1]:
+                print("  ✓ Knowledge graph projection wiped")
+                checks_passed.append("Projection wipe empties derived state")
+            else:
+                print(f"  ✗ Projection wipe left rows behind: {wiped}")
+                all_passed = False
+
+            # Check 6: full rebuild replays every projection from events
+            report = await memory_events.rebuild(effective_user_id)
+            print(f"  Rebuild report: {report}")
+            replayed = all(
+                section["applied"] > 0 and section["failed"] == 0 for section in report.values()
+            )
+            if set(report) == {"knowledge_graph", "captains_log", "flat_facts"} and replayed:
+                print("  ✓ Rebuild replayed events into all three projections")
+                checks_passed.append("Rebuild replays all projections")
+            else:
+                print("  ✗ Rebuild report incomplete or contains failures")
+                all_passed = False
+
+            graph_after = await snapshot_graph(knowledge_graph, effective_user_id)
+            log_after = await snapshot_log(captains_log, effective_user_id)
+            facts_after = snapshot_flat_facts(long_term_memory, internal_user_id)
+
+            if graph_after == graph_before:
+                print("  ✓ Knowledge graph state identical after replay")
+                checks_passed.append("Knowledge graph replay-equivalent")
+            else:
+                print(f"  ✗ Knowledge graph diverged:\n    {graph_before}\n    {graph_after}")
+                all_passed = False
+
+            if log_after == log_before:
+                print("  ✓ Captain's log state identical after replay")
+                checks_passed.append("Captain's log replay-equivalent")
+            else:
+                print(f"  ✗ Captain's log diverged:\n    {log_before}\n    {log_after}")
+                all_passed = False
+
+            if facts_after == facts_before:
+                print("  ✓ Flat-fact state identical after replay")
+                checks_passed.append("Flat facts replay-equivalent")
+            else:
+                print(f"  ✗ Flat facts diverged:\n    {facts_before}\n    {facts_after}")
+                all_passed = False
+
+            # Check 7: existing memory behavior intact after the rebuild
+            recall_msg = "What is my favorite color and what pets do I have?"
+            recall_response = await self.overlord.chat(
+                recall_msg, user_id=user_id, use_async=False, stream=False
+            )
+            recall_text = (
+                recall_response.content
+                if hasattr(recall_response, "content")
+                else str(recall_response)
+            )
+            transcript.append((recall_msg, recall_text))
+            print(f"\nUser: {recall_msg}")
+            print(f"Assistant: {recall_text[:300]}...")
+
+            recall_lower = recall_text.lower()
+            if any(marker in recall_lower for marker in ("blue", "whiskers", "shadow", "cat")):
+                print("  ✓ Flat-fact recall works from the rebuilt projections")
+                checks_passed.append("Recall intact after rebuild")
+            else:
+                print("  ✗ Recall failed after projection rebuild")
+                all_passed = False
+
+        except Exception as e:
+            import traceback
+
+            print(f"  ✗ Test failed with error: {e}")
+            traceback.print_exc()
+            all_passed = False
+
+        finally:
+            await self.cleanup()
+
+        duration = time.time() - start_time
+        self.print_test_result(test_name, all_passed, checks_passed, transcript, duration)
+
+        return all_passed
+
+    async def run_test(self):
+        """Run all test cases."""
+        print("\n" + "=" * 60)
+        print("🧾 AREA 2S1: MEMORY EVENT SUBSTRATE")
+        print("=" * 60)
+
+        all_passed = await self.test_event_substrate()
+
+        print("\n" + "=" * 60)
+        print(
+            f"🎯 OVERALL RESULT: {'✅ ALL TESTS PASSED' if all_passed else '❌ SOME TESTS FAILED'}"
+        )
+        print("=" * 60)
+
+        print("\n💡 KEY INSIGHTS:")
+        print("- Every memory write lands in the immutable event log first")
+        print("- Extraction events trace back to their interaction.turn via caused_by")
+        print("- Wipe-and-replay reproduces identical graph, log, and flat-fact state")
+
+        if all_passed:
+            print("SUCCESS", flush=True)
+        return all_passed
+
+
+def main():
+    """Main entry point."""
+    test = TestMemoryEventSubstrate()
+    result = asyncio.run(test.run_test())
+    os._exit(0 if result else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/muxi/runtime/datatypes/observability.py
+++ b/src/muxi/runtime/datatypes/observability.py
@@ -769,6 +769,34 @@ class ConversationEvents(Enum):
     MEMORY_LESSON_ARCHIVED = "memory.lesson.archived"
     # When lessons are archived by confidence decay
 
+    # Memory event substrate operations (Memory Platform Phase 2)
+    MEMORY_EVENT_APPENDED = "memory.event.appended"
+    # When a memory event is appended to the immutable event log
+
+    MEMORY_EVENT_APPEND_FAILED = "memory.event.append_failed"
+    # When a memory event append fails (isolated; projection writes continue)
+
+    MEMORY_EVENT_IDEMPOTENT_SKIP = "memory.event.idempotent_skip"
+    # When a duplicate (source, source_id) append is detected and skipped
+
+    MEMORY_PROJECTION_APPLIED = "memory.projection.applied"
+    # When an event is applied to a projection during replay
+
+    MEMORY_PROJECTION_FAILED = "memory.projection.failed"
+    # When applying an event to a projection fails during replay
+
+    MEMORY_REBUILD_STARTED = "memory.rebuild.started"
+    # When a projection rebuild from the event log is initiated
+
+    MEMORY_REBUILD_COMPLETED = "memory.rebuild.completed"
+    # When a projection rebuild finishes (report attached)
+
+    MEMORY_DELETION_REQUESTED = "memory.deletion.requested"
+    # When a user-initiated memory-event deletion is recorded
+
+    MEMORY_DELETION_HARD_PURGED = "memory.deletion.hard_purged"
+    # When the post-grace-period hard purge removes soft-deleted events
+
     USER_INFO_EXTRACTION_STARTED = "user.info.extraction.started"
     # When background user information extraction task is initiated
 

--- a/src/muxi/runtime/formation/formation.py
+++ b/src/muxi/runtime/formation/formation.py
@@ -1332,6 +1332,7 @@ class Formation:
                 "long_term_memory": getattr(self, "_long_term_memory", None),
                 "knowledge_graph": getattr(self, "_knowledge_graph", None),
                 "captains_log": getattr(self, "_captains_log", None),
+                "memory_events": getattr(self, "_memory_events", None),
                 "working_memory_config": getattr(self, "_working_memory_config", None),
                 "document_chunk_manager": getattr(self, "_document_chunk_manager", None),
                 "request_tracker": getattr(self, "_request_tracker", None),

--- a/src/muxi/runtime/formation/initialization.py
+++ b/src/muxi/runtime/formation/initialization.py
@@ -756,6 +756,11 @@ def initialize_memory_systems(formation) -> None:
                 embedding_dim = getattr(ltm, "dimension", 1536) if ltm else 1536
                 _create_all_database_tables(formation._db_manager, embedding_dim)
 
+                # Initialize the memory event substrate first: the knowledge
+                # graph and captain's log dual-write through it, so it must
+                # exist before they are constructed.
+                _initialize_memory_events(formation, memory_config.get("events", {}) or {})
+
                 # Initialize the knowledge graph service (Memory Revamp Phase 1).
                 # Placed after table creation (kg_entities/kg_relationships must
                 # exist) and after LLM configuration in the formation load order
@@ -767,6 +772,71 @@ def initialize_memory_systems(formation) -> None:
                 # extracted entities/relationships into it and register the
                 # captains_log_sources DAG on the shared algorithms layer.
                 _initialize_captains_log(formation, memory_config)
+
+                # Register the projection builders with the substrate now
+                # that every projection service exists. The registry is the
+                # extension point for later projections (Knowledge Index).
+                _register_memory_projectors(formation)
+
+
+def _initialize_memory_events(formation, events_config: Dict[str, Any]) -> None:
+    """Initialize the memory event substrate on top of persistent memory."""
+    if events_config.get("enabled", True) is False:
+        formation._memory_events = None
+        return
+
+    try:
+        from ..services.memory.events import MemoryEventService
+
+        formation_id = getattr(formation, "formation_id", "default-formation")
+        formation._memory_events = MemoryEventService(
+            db_manager=formation._db_manager,
+            formation_id=formation_id,
+            config=events_config,
+        )
+        print(
+            InitEventFormatter.format_ok(
+                "Initializing memory event substrate",
+                f"grace period {formation._memory_events.grace_period_days}d",
+            )
+        )
+    except Exception as e:
+        formation._memory_events = None
+        observability.observe(
+            event_type=observability.ErrorEvents.MEMORY_INITIALIZATION_FAILED,
+            level=observability.EventLevel.WARNING,
+            data={"error": str(e), "service": "memory_events"},
+            description=f"Failed to initialize memory event substrate: {str(e)}",
+        )
+        # Don't raise - the event substrate is additive to persistent memory
+
+
+def _register_memory_projectors(formation) -> None:
+    """Register the built-in projection builders with the event substrate."""
+    memory_events = getattr(formation, "_memory_events", None)
+    if memory_events is None:
+        return
+
+    try:
+        from ..services.memory.events import (
+            CaptainsLogProjector,
+            FlatFactProjector,
+            KnowledgeGraphProjector,
+        )
+
+        if getattr(formation, "_knowledge_graph", None) is not None:
+            memory_events.register_projector(KnowledgeGraphProjector(formation._knowledge_graph))
+        if getattr(formation, "_captains_log", None) is not None:
+            memory_events.register_projector(CaptainsLogProjector(formation._captains_log))
+        if getattr(formation, "_long_term_memory", None) is not None:
+            memory_events.register_projector(FlatFactProjector(formation._long_term_memory))
+    except Exception as e:
+        observability.observe(
+            event_type=observability.ErrorEvents.MEMORY_INITIALIZATION_FAILED,
+            level=observability.EventLevel.WARNING,
+            data={"error": str(e), "service": "memory_events"},
+            description=f"Failed to register memory projectors: {str(e)}",
+        )
 
 
 def _initialize_knowledge_graph(formation, graph_config: Dict[str, Any]) -> None:
@@ -783,6 +853,7 @@ def _initialize_knowledge_graph(formation, graph_config: Dict[str, Any]) -> None
             db_manager=formation._db_manager,
             formation_id=formation_id,
             config=graph_config,
+            event_log=getattr(formation, "_memory_events", None),
         )
         backend = "pgRouting" if formation._knowledge_graph.pgrouting_available else "NetworkX"
         print(InitEventFormatter.format_ok("Initializing knowledge graph", f"{backend} backend"))
@@ -816,6 +887,7 @@ def _initialize_captains_log(formation, memory_config: Dict[str, Any]) -> None:
             lessons_config=memory_config.get("lessons", {}) or {},
             knowledge_graph=getattr(formation, "_knowledge_graph", None),
             embedding_model=embedding_model,
+            event_log=getattr(formation, "_memory_events", None),
         )
         lessons_status = "lessons on" if formation._captains_log.lessons_enabled else "lessons off"
         print(InitEventFormatter.format_ok("Initializing captain's log", lessons_status))
@@ -1096,6 +1168,35 @@ def _migrate_add_meta_data_column(db_manager, table_name: str) -> None:
         pass  # Table may not exist yet on first run; create_tables handles it
 
 
+def _migrate_add_derived_from_event_ids_column(db_manager, table_name: str) -> None:
+    """Add the provenance column to projection tables from older schema versions."""
+    from sqlalchemy import text
+
+    try:
+        with db_manager.engine.connect() as conn:
+            if db_manager.database_type == "postgresql":
+                conn.execute(
+                    text(
+                        f"ALTER TABLE {table_name} ADD COLUMN IF NOT EXISTS "
+                        f"derived_from_event_ids JSON NOT NULL DEFAULT '[]'"
+                    )
+                )
+            else:
+                # SQLite: check if column exists via PRAGMA, add if missing
+                result = conn.execute(text(f"PRAGMA table_info({table_name})"))
+                columns = [row[1] for row in result]
+                if "derived_from_event_ids" not in columns:
+                    conn.execute(
+                        text(
+                            f"ALTER TABLE {table_name} ADD COLUMN "
+                            f"derived_from_event_ids TEXT DEFAULT '[]'"
+                        )
+                    )
+            conn.commit()
+    except Exception:
+        pass  # Table may not exist yet on first run; create_tables handles it
+
+
 def _create_all_database_tables(db_manager, embedding_dimension: int = 1536) -> None:
     """
     Create all database tables for the MUXI runtime.
@@ -1115,6 +1216,10 @@ def _create_all_database_tables(db_manager, embedding_dimension: int = 1536) -> 
 
         # Get Base from db module
         from ..services.db import Base
+        from ..services.memory.events.models import (  # noqa: F401
+            MemoryEvent,
+            ProjectionCheckpoint,
+        )
         from ..services.memory.graph.models import KGEntity, KGRelationship  # noqa: F401
         from ..services.memory.log.models import (  # noqa: F401
             CaptainsLogEntry,
@@ -1156,6 +1261,10 @@ def _create_all_database_tables(db_manager, embedding_dimension: int = 1536) -> 
         # (CREATE TABLE IF NOT EXISTS won't add columns to existing tables)
         memories_table = f"memories_{embedding_dimension}"
         _migrate_add_meta_data_column(db_manager, memories_table)
+        # Migrate: ensure the provenance column exists on projection tables
+        # created before the memory event substrate shipped
+        for projection_table in ("kg_entities", "kg_relationships", "captains_log", "lessons"):
+            _migrate_add_derived_from_event_ids_column(db_manager, projection_table)
         ensure_memory_table_indexes(db_manager, embedding_dimension)
         table_names = [
             "users",
@@ -1163,6 +1272,8 @@ def _create_all_database_tables(db_manager, embedding_dimension: int = 1536) -> 
             "groups",
             "user_groups",  # Group-based access control tables
             memories_table,  # Memory system tables (dimension-specific)
+            "memory_events",
+            "projection_checkpoints",  # Memory event substrate tables
             "kg_entities",
             "kg_relationships",  # Knowledge graph tables
             "captains_log",

--- a/src/muxi/runtime/formation/memory/extraction_coordinator.py
+++ b/src/muxi/runtime/formation/memory/extraction_coordinator.py
@@ -106,13 +106,16 @@ class ExtractionCoordinator:
             caused_by_event_id = None
             memory_events = getattr(self.overlord, "memory_events", None)
             if memory_events is not None:
+                # agent_response is optional in the event schema: omit the
+                # key entirely when the agent has not responded yet rather
+                # than storing an empty string on every such turn.
+                payload = {"user_message": user_message}
+                if agent_response:
+                    payload["agent_response"] = agent_response
                 turn_event = await memory_events.record(
                     user_id=str(user_id),
                     event_type=EVENT_INTERACTION_TURN,
-                    payload={
-                        "user_message": user_message,
-                        "agent_response": agent_response or "",
-                    },
+                    payload=payload,
                     source=SOURCE_INTERACTION,
                     agent_id=agent_id,
                 )

--- a/src/muxi/runtime/formation/memory/extraction_coordinator.py
+++ b/src/muxi/runtime/formation/memory/extraction_coordinator.py
@@ -8,6 +8,7 @@ from conversations, including triggering extraction and managing the process.
 from typing import Any
 
 from ...datatypes import observability
+from ...services.memory.events.models import EVENT_INTERACTION_TURN, SOURCE_INTERACTION
 from ...services.memory.extractor import MemoryExtractor
 
 
@@ -96,6 +97,28 @@ class ExtractionCoordinator:
             # Use the provided extraction model or fall back to the overlord's default
             model_to_use = extraction_model or self.overlord.extraction_model
 
+            # Memory event substrate: record the raw turn as an
+            # interaction.turn event before any extraction pass runs. The
+            # event id links every extracted fact back to its originating
+            # turn (provenance), and the raw turn stays replayable through
+            # future extraction logic. record() is failure-isolated: a
+            # None return leaves extraction unaffected.
+            caused_by_event_id = None
+            memory_events = getattr(self.overlord, "memory_events", None)
+            if memory_events is not None:
+                turn_event = await memory_events.record(
+                    user_id=str(user_id),
+                    event_type=EVENT_INTERACTION_TURN,
+                    payload={
+                        "user_message": user_message,
+                        "agent_response": agent_response or "",
+                    },
+                    source=SOURCE_INTERACTION,
+                    agent_id=agent_id,
+                )
+                if turn_event is not None:
+                    caused_by_event_id = turn_event["id"]
+
             # Create a temporary extractor if needed or use the existing one
             if hasattr(self.overlord, "extractor") and self.overlord.extractor:
                 extractor = self.overlord.extractor
@@ -115,6 +138,7 @@ class ExtractionCoordinator:
                 agent_response=agent_response,
                 user_id=user_id,
                 message_count=1,  # We don't track message count here
+                caused_by_event_id=caused_by_event_id,
             )
 
             # Knowledge graph pass (Memory Revamp Phase 1): runs alongside the
@@ -128,6 +152,7 @@ class ExtractionCoordinator:
                     agent_response=agent_response,
                     user_id=user_id,
                     model=getattr(self.overlord, "default_model", None),
+                    caused_by_event_id=caused_by_event_id,
                 )
 
             # Captain's log intake (Memory Revamp Phase 2): buffer the turn

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -551,6 +551,13 @@ class Overlord:
         # Formation alongside persistent memory; None when disabled/unavailable.
         self.captains_log = configured_services.get("captains_log") if configured_services else None
 
+        # Memory event substrate - initialized by the Formation alongside
+        # persistent memory; None when disabled/unavailable. Every memory
+        # write path dual-writes through it (append event + direct write).
+        self.memory_events = (
+            configured_services.get("memory_events") if configured_services else None
+        )
+
         # Configure extraction settings (intelligence concerns)
         self.auto_extract_user_info = auto_extract_user_info
 
@@ -1494,6 +1501,10 @@ class Overlord:
                 lambda: getattr(self, "extraction_model", None)
                 or getattr(self, "default_model", None)
             )
+
+        # Start the memory event substrate's retention hard-purge loop.
+        if getattr(self, "memory_events", None):
+            self.memory_events.start()
 
         # Populate formation capabilities after all services are loaded
         self._populate_formation_capabilities()
@@ -4115,6 +4126,18 @@ Agent response: {raw_response}"""
                     level=observability.EventLevel.WARNING,
                     data={"error": str(e), "service": "captains_log"},
                     description=f"Error stopping captain's log service: {e}",
+                )
+
+        # Stop the memory event substrate's hard-purge loop if running
+        if getattr(self, "memory_events", None):
+            try:
+                await self.memory_events.stop()
+            except Exception as e:
+                observability.observe(
+                    event_type=observability.ErrorEvents.INTERNAL_ERROR,
+                    level=observability.EventLevel.WARNING,
+                    data={"error": str(e), "service": "memory_events"},
+                    description=f"Error stopping memory event service: {e}",
                 )
 
         observability.observe(

--- a/src/muxi/runtime/formation/server/routes/admin/memory.py
+++ b/src/muxi/runtime/formation/server/routes/admin/memory.py
@@ -37,6 +37,14 @@ class MemoryItemUpdate(BaseModel):
     value: Any
 
 
+class MemoryRebuildRequest(BaseModel):
+    """Model for a memory projection rebuild request."""
+
+    user_id: str
+    projection: Optional[str] = None
+    dry_run: bool = False
+
+
 @router.get("/memory", response_model=APIResponse)
 async def get_memory_config(request: Request) -> JSONResponse:
     """
@@ -132,6 +140,52 @@ async def get_buffer_stats(request: Request) -> JSONResponse:
         APIEventType.MEMORY_RETRIEVED,
         data,
         request_id,
+    )
+    return JSONResponse(content=response.model_dump(), status_code=200)
+
+
+@router.post("/memory/rebuild", response_model=APIResponse, operation_id="rebuild_memory")
+async def rebuild_memory_projections(
+    request: Request, rebuild: MemoryRebuildRequest
+) -> JSONResponse:
+    """
+    Rebuild memory projections from the event log (Memory Event Substrate).
+
+    Wipes the requested projection(s) for a user and replays that user's
+    memory events through the projection builders. Omit ``projection`` to
+    rebuild every registered projection; set ``dry_run`` to report the
+    event counts that would be replayed without touching derived state.
+    """
+    formation = request.app.state.formation
+    request_id = getattr(request.state, "request_id", None)
+
+    overlord = getattr(formation, "_overlord", None)
+    memory_events = getattr(overlord, "memory_events", None) if overlord else None
+    if memory_events is None:
+        response = create_error_response(
+            "SERVICE_UNAVAILABLE",
+            "Memory event substrate is not available",
+            None,
+            request_id,
+        )
+        return JSONResponse(content=response.model_dump(), status_code=503)
+
+    try:
+        report = await memory_events.rebuild(
+            rebuild.user_id, projection=rebuild.projection, dry_run=rebuild.dry_run
+        )
+    except ValueError as e:
+        response = create_error_response("INVALID_PARAMS", str(e), None, request_id)
+        return JSONResponse(content=response.model_dump(), status_code=422)
+    except Exception as e:
+        response = create_error_response(
+            "INTERNAL_ERROR", f"Failed to rebuild projections: {str(e)}", None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=500)
+
+    data = {"user_id": rebuild.user_id, "dry_run": rebuild.dry_run, "projections": report}
+    response = create_success_response(
+        APIObjectType.MEMORY, APIEventType.MEMORY_RETRIEVED, data, request_id
     )
     return JSONResponse(content=response.model_dump(), status_code=200)
 

--- a/src/muxi/runtime/services/memory/events/__init__.py
+++ b/src/muxi/runtime/services/memory/events/__init__.py
@@ -1,0 +1,45 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Memory Event Substrate Package
+# Description:  Immutable event log underneath every memory projection
+# Role:         Public surface for the memory event substrate
+# Usage:        from muxi.runtime.services.memory.events import MemoryEventService
+# Author:       Muxi Framework Team
+# =============================================================================
+
+from .models import (
+    EVENT_FACT_EXTRACTED,
+    EVENT_GRAPH_EXTRACTED,
+    EVENT_INTERACTION_TURN,
+    EVENT_LESSON_RECORDED,
+    EVENT_LOG_ENTRY,
+    EVENT_USER_DELETION,
+    MemoryEvent,
+    ProjectionCheckpoint,
+)
+from .projectors import (
+    CaptainsLogProjector,
+    FlatFactProjector,
+    KnowledgeGraphProjector,
+    apply_fact_event,
+)
+from .service import MemoryEventService
+from .storage import MemoryEventStorage
+
+__all__ = [
+    "EVENT_FACT_EXTRACTED",
+    "EVENT_GRAPH_EXTRACTED",
+    "EVENT_INTERACTION_TURN",
+    "EVENT_LESSON_RECORDED",
+    "EVENT_LOG_ENTRY",
+    "EVENT_USER_DELETION",
+    "MemoryEvent",
+    "ProjectionCheckpoint",
+    "CaptainsLogProjector",
+    "FlatFactProjector",
+    "KnowledgeGraphProjector",
+    "apply_fact_event",
+    "MemoryEventService",
+    "MemoryEventStorage",
+]

--- a/src/muxi/runtime/services/memory/events/__init__.py
+++ b/src/muxi/runtime/services/memory/events/__init__.py
@@ -17,6 +17,7 @@ from .models import (
     EVENT_USER_DELETION,
     MemoryEvent,
     ProjectionCheckpoint,
+    append_event_id,
 )
 from .projectors import (
     CaptainsLogProjector,
@@ -36,6 +37,7 @@ __all__ = [
     "EVENT_USER_DELETION",
     "MemoryEvent",
     "ProjectionCheckpoint",
+    "append_event_id",
     "CaptainsLogProjector",
     "FlatFactProjector",
     "KnowledgeGraphProjector",

--- a/src/muxi/runtime/services/memory/events/models.py
+++ b/src/muxi/runtime/services/memory/events/models.py
@@ -1,0 +1,299 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Memory Event Models - Immutable Event Log Tables
+# Description:  SQLAlchemy models for memory_events and projection_checkpoints
+# Role:         Defines the append-only substrate underneath every memory layer
+# Usage:        Registered with Base.metadata and created alongside all tables
+# Author:       Muxi Framework Team
+#
+# Memory Event Substrate (Memory Platform Phase 2). Every memory-producing
+# write first becomes a row in ``memory_events``; projections (knowledge
+# graph, captain's log + lessons, flat facts) are derived state that can be
+# rebuilt from the log. The schema is identical on PostgreSQL and SQLite:
+#
+# - Integer primary keys double as the replay cursor: ids are assigned in
+#   append order, so ``ORDER BY id`` is the canonical event ordering. This
+#   follows the kg_entities convention (Integer PK + String(21) ``public_id``
+#   Nano ID for external exposure) instead of the UUIDv7 TEXT key sketched
+#   in the PRD -- same time-ordered property, portable across both backends.
+# - ``scope_type`` / ``scope_id`` record the event's memory scope in the
+#   shape the memory-namespaces plan expects. Scoping is not built yet, so
+#   every event carries the implicit user scope (scope_type='user',
+#   scope_id=user_id); richer scopes can be added later without
+#   re-ingestion or schema changes.
+# - Events are immutable: the storage layer exposes no update path. The
+#   only mutation is the soft-delete pair (``deleted_at``/``deleted_reason``)
+#   that powers GDPR-style selective forgetting.
+# - ``EVENT_SCHEMAS`` is the versioned payload registry validated at write
+#   time. Adding a projection (e.g. the deferred Knowledge Index) means
+#   registering its event types here and its projector with the service --
+#   no schema migration.
+# =============================================================================
+
+from typing import Any, Dict
+
+from sqlalchemy import Column, DateTime, Float, Index, Integer, String, text
+
+from ....datatypes.json_type import JSONType
+from ....utils.datetime_utils import utc_now_naive
+from ....utils.id_generator import get_default_nanoid
+from ...db import AsyncModelMixin, Base
+
+# ---------------------------------------------------------------------------
+# Event type vocabulary (PRD "Event Types", restricted to the write paths
+# that exist today). Each type maps event_version -> payload schema.
+# ---------------------------------------------------------------------------
+
+# One conversation turn as seen by the extraction coordinator. Not consumed
+# by any projector today; recorded so future extraction logic can be replayed
+# over raw interactions and so downstream events can carry a causation link.
+EVENT_INTERACTION_TURN = "interaction.turn"
+
+# One flat fact extracted by the MemoryExtractor (vector-DB projection).
+EVENT_FACT_EXTRACTED = "fact.extracted"
+
+# One validated knowledge-graph extraction batch (entities + relationships).
+EVENT_GRAPH_EXTRACTED = "graph.extracted"
+
+# One captain's log digest result for a (user, date) entry.
+EVENT_LOG_ENTRY = "log.entry"
+
+# One lesson written through the digest or the record_lesson tool.
+EVENT_LESSON_RECORDED = "lesson.recorded"
+
+# A user-initiated deletion request (the audit-trail event; the referenced
+# events are soft-deleted, not removed).
+EVENT_USER_DELETION = "user.deletion"
+
+# Versioned payload schemas. "required" keys must be present; keys outside
+# required + optional are rejected -- schema evolution happens by adding a
+# new version, never by silently widening an existing one.
+EVENT_SCHEMAS: Dict[str, Dict[int, Dict[str, tuple]]] = {
+    EVENT_INTERACTION_TURN: {
+        1: {
+            "required": ("user_message",),
+            "optional": ("agent_response", "session_id"),
+        }
+    },
+    EVENT_FACT_EXTRACTED: {
+        1: {
+            "required": ("memory", "collection"),
+            "optional": ("metadata",),
+        }
+    },
+    EVENT_GRAPH_EXTRACTED: {
+        1: {
+            "required": ("entities", "relationships"),
+            "optional": (),
+        }
+    },
+    EVENT_LOG_ENTRY: {
+        1: {
+            "required": ("date", "summary"),
+            "optional": ("decisions", "projects", "context", "sources"),
+        }
+    },
+    EVENT_LESSON_RECORDED: {
+        1: {
+            "required": ("agent_id", "rule"),
+            "optional": ("context", "confidence", "source_log_date"),
+        }
+    },
+    EVENT_USER_DELETION: {
+        1: {
+            "required": ("reason",),
+            "optional": ("source", "target_event_ids"),
+        }
+    },
+}
+
+# Payload keys that must be lists when present (shape checks beyond presence).
+_LIST_KEYS = {"entities", "relationships", "decisions", "projects", "sources", "target_event_ids"}
+
+# Decay rates declared at write time (PRD "Decay Model"). Query-time decay
+# weighting is a later phase; the substrate records the declaration so old
+# events benefit when it lands.
+DECAY_STATIC = "static"
+DECAY_DECAYING = "decaying"
+DECAY_VOLATILE = "volatile"
+DECAY_RATES = {DECAY_STATIC, DECAY_DECAYING, DECAY_VOLATILE}
+
+# Source vocabulary used by the internal writers that exist today. External
+# ingestion sources (gmail, osint, ...) join this vocabulary in Phase 3.
+SOURCE_INTERACTION = "interaction"  # real-time chat-turn extraction passes
+SOURCE_PERIODIC = "periodic"  # the knowledge graph's periodic deep pass
+SOURCE_CAPTAINS_LOG = "captains_log"  # digest-derived writes (entries, lessons, graph facts)
+SOURCE_TOOL = "tool"  # the record_lesson agent tool
+SOURCE_USER_EDIT = "user_edit"  # user-initiated corrections/deletions
+
+# Scope shape recorded for forward compatibility with memory namespaces.
+SCOPE_TYPE_USER = "user"
+
+
+def validate_event_payload(event_type: str, payload: Any, event_version: int = 1) -> None:
+    """
+    Validate an event payload against the versioned schema registry.
+
+    Raises:
+        ValueError: On unknown event type/version, non-dict payload,
+            missing required keys, unknown keys, or mis-typed list fields.
+    """
+    versions = EVENT_SCHEMAS.get(event_type)
+    if versions is None:
+        raise ValueError(f"Unknown memory event type: {event_type!r}")
+    schema = versions.get(event_version)
+    if schema is None:
+        raise ValueError(f"Unknown version {event_version} for event type {event_type!r}")
+    if not isinstance(payload, dict):
+        raise ValueError(f"Payload for {event_type!r} must be a dict, got {type(payload).__name__}")
+
+    missing = [key for key in schema["required"] if key not in payload]
+    if missing:
+        raise ValueError(f"Payload for {event_type!r} is missing required keys: {missing}")
+
+    allowed = set(schema["required"]) | set(schema["optional"])
+    unknown = [key for key in payload if key not in allowed]
+    if unknown:
+        raise ValueError(f"Payload for {event_type!r} has unknown keys: {unknown}")
+
+    for key in _LIST_KEYS:
+        if key in payload and not isinstance(payload[key], list):
+            raise ValueError(f"Payload key {key!r} for {event_type!r} must be a list")
+
+
+class MemoryEvent(Base, AsyncModelMixin):
+    """One immutable row in the append-only memory event log."""
+
+    __tablename__ = "memory_events"
+
+    # Integer identity assigned in append order: the replay cursor.
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    # Nano ID for external exposure, matching the users table convention.
+    public_id = Column(String(21), nullable=False, unique=True, default=get_default_nanoid)
+    user_id = Column(String(255), nullable=False, index=True)
+    formation_id = Column(String(255), nullable=False, index=True)
+
+    # Forward-compatible scope columns (memory-namespaces cross-reference).
+    # Today every event is user-scoped; scope_id mirrors user_id.
+    scope_type = Column(String(20), nullable=False, default=SCOPE_TYPE_USER)
+    scope_id = Column(String(255), nullable=False)
+
+    # When the event happened vs when MUXI received it (differs on backfill).
+    occurred_at = Column(DateTime, nullable=False, default=utc_now_naive)
+    ingested_at = Column(DateTime, nullable=False, default=utc_now_naive)
+
+    event_type = Column(String(50), nullable=False)
+    event_version = Column(Integer, nullable=False, default=1)
+    payload = Column(JSONType, nullable=False, default={})
+
+    # Source tracking (what produced this event).
+    source = Column(String(50), nullable=False)
+    source_id = Column(String(255), nullable=True)
+    source_confidence = Column(Float, nullable=False, default=1.0)
+
+    # Causation link into this table (plain integer, not an FK, following
+    # the kg_entities cross-reference convention).
+    caused_by = Column(Integer, nullable=True)
+
+    # Decay declaration (applied at query time in a later phase).
+    decay_rate = Column(String(20), nullable=False, default=DECAY_STATIC)
+    expires_at = Column(DateTime, nullable=True)
+
+    # Soft delete for GDPR + selective forgetting. Replay skips soft-deleted
+    # events; a periodic hard-purge removes them after the grace period.
+    deleted_at = Column(DateTime, nullable=True)
+    deleted_reason = Column(String(50), nullable=True)
+
+    # Producing agent (NULL = overlord) and originating conversation.
+    agent_id = Column(String(255), nullable=True)
+    conversation_id = Column(String(255), nullable=True)
+
+    __table_args__ = (
+        # Idempotency: the same (source, source_id) cannot be written twice
+        # for a scope while live. Partial unique index works on both
+        # backends; soft-deleting an event re-allows its source_id.
+        Index(
+            "idx_memory_events_idempotency",
+            "formation_id",
+            "user_id",
+            "source",
+            "source_id",
+            unique=True,
+            postgresql_where=text("source_id IS NOT NULL AND deleted_at IS NULL"),
+            sqlite_where=text("source_id IS NOT NULL AND deleted_at IS NULL"),
+        ),
+        # Dominant access patterns (PRD "Multi-Tenancy & Performance").
+        Index("idx_memory_events_user_time", "formation_id", "user_id", "occurred_at"),
+        Index("idx_memory_events_user_type", "formation_id", "user_id", "event_type"),
+        Index("idx_memory_events_user_source", "formation_id", "user_id", "source"),
+        Index("idx_memory_events_caused_by", "caused_by"),
+        Index(
+            "idx_memory_events_expires",
+            "expires_at",
+            postgresql_where=text("expires_at IS NOT NULL"),
+            sqlite_where=text("expires_at IS NOT NULL"),
+        ),
+    )
+
+    def to_dict(self) -> dict:
+        """Return a plain-dict representation used by storage consumers."""
+        return {
+            "id": self.id,
+            "public_id": self.public_id,
+            "user_id": self.user_id,
+            "formation_id": self.formation_id,
+            "scope_type": self.scope_type,
+            "scope_id": self.scope_id,
+            "occurred_at": self.occurred_at.isoformat() if self.occurred_at else None,
+            "ingested_at": self.ingested_at.isoformat() if self.ingested_at else None,
+            "event_type": self.event_type,
+            "event_version": self.event_version,
+            "payload": self.payload or {},
+            "source": self.source,
+            "source_id": self.source_id,
+            "source_confidence": self.source_confidence,
+            "caused_by": self.caused_by,
+            "decay_rate": self.decay_rate,
+            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+            "deleted_at": self.deleted_at.isoformat() if self.deleted_at else None,
+            "deleted_reason": self.deleted_reason,
+            "agent_id": self.agent_id,
+            "conversation_id": self.conversation_id,
+        }
+
+
+class ProjectionCheckpoint(Base, AsyncModelMixin):
+    """Per-(projection, user) cursor into the memory event log."""
+
+    __tablename__ = "projection_checkpoints"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    projection_name = Column(String(50), nullable=False)
+    formation_id = Column(String(255), nullable=False)
+    user_id = Column(String(255), nullable=False)
+    last_event_id = Column(Integer, nullable=False)
+    last_applied_at = Column(DateTime, nullable=False, default=utc_now_naive)
+    schema_version = Column(Integer, nullable=False, default=1)
+
+    __table_args__ = (
+        Index(
+            "idx_projection_checkpoints_scope",
+            "projection_name",
+            "formation_id",
+            "user_id",
+            unique=True,
+        ),
+    )
+
+    def to_dict(self) -> dict:
+        """Return a plain-dict representation used by storage consumers."""
+        return {
+            "id": self.id,
+            "projection_name": self.projection_name,
+            "formation_id": self.formation_id,
+            "user_id": self.user_id,
+            "last_event_id": self.last_event_id,
+            "last_applied_at": (self.last_applied_at.isoformat() if self.last_applied_at else None),
+            "schema_version": self.schema_version,
+        }

--- a/src/muxi/runtime/services/memory/events/models.py
+++ b/src/muxi/runtime/services/memory/events/models.py
@@ -162,6 +162,21 @@ def validate_event_payload(event_type: str, payload: Any, event_version: int = 1
             raise ValueError(f"Payload key {key!r} for {event_type!r} must be a list")
 
 
+def append_event_id(current, event_id) -> list:
+    """
+    Return a ``derived_from_event_ids`` provenance list with ``event_id``
+    appended (idempotent; a None event_id or an already-present id leaves
+    the list unchanged).
+
+    Shared by every projection storage layer that maintains the provenance
+    bridge back into ``memory_events``.
+    """
+    ids = list(current or [])
+    if event_id is not None and event_id not in ids:
+        ids.append(event_id)
+    return ids
+
+
 class MemoryEvent(Base, AsyncModelMixin):
     """One immutable row in the append-only memory event log."""
 

--- a/src/muxi/runtime/services/memory/events/projectors.py
+++ b/src/muxi/runtime/services/memory/events/projectors.py
@@ -1,0 +1,140 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Memory Projectors - Event-to-Projection Builders
+# Description:  Projector registry contract and the three built-in projectors
+# Role:         Rebuild derived memory state (KG, log, flat facts) from events
+# Usage:        Registered with MemoryEventService during formation init
+# Author:       Muxi Framework Team
+#
+# Memory Event Substrate. A projector owns one projection: it knows which
+# event types feed it, how to apply one event, and how to wipe its derived
+# state for a user. ``MemoryEventService.rebuild`` drives the contract:
+# reset -> replay events in append order -> checkpoint.
+#
+# Determinism contract: ``apply`` must be a pure function of the event (no
+# LLM calls, no clock reads beyond what storage layers stamp identically on
+# the incremental path). Every projector routes through the exact same
+# storage upserts the live dual-write path uses, so a full replay converges
+# to the same state as incremental writes.
+#
+# Extensibility: adding a projection (e.g. the deferred Knowledge Index) is
+# a new class with these three members plus a service.register_projector
+# call -- no schema changes to the event log.
+# =============================================================================
+
+from typing import Any, Dict, Optional
+
+from .models import (
+    EVENT_FACT_EXTRACTED,
+    EVENT_GRAPH_EXTRACTED,
+    EVENT_LESSON_RECORDED,
+    EVENT_LOG_ENTRY,
+)
+
+# Metadata key linking a flat-fact memory row back to its originating event
+# (the provenance bridge for the vector projection, which has no dedicated
+# derived_from column -- metadata is its extension point).
+FACT_EVENT_METADATA_KEY = "derived_from_event_id"
+
+
+async def apply_fact_event(
+    long_term_memory,
+    user_id: str,
+    payload: Dict[str, Any],
+    event_id: Optional[int] = None,
+) -> str:
+    """
+    Apply one fact.extracted payload to the flat-fact (vector) projection.
+
+    Shared by the live extractor write path and the replay path so both
+    produce byte-identical rows. Returns the stored memory id.
+    """
+    metadata = dict(payload.get("metadata") or {})
+    if event_id is not None:
+        metadata[FACT_EVENT_METADATA_KEY] = event_id
+    return await long_term_memory.add(
+        content=payload["memory"],
+        metadata=metadata,
+        user_id=user_id,
+        collection=payload["collection"],
+    )
+
+
+class KnowledgeGraphProjector:
+    """Rebuilds kg_entities / kg_relationships from graph.extracted events."""
+
+    name = "knowledge_graph"
+    event_types = (EVENT_GRAPH_EXTRACTED,)
+
+    def __init__(self, knowledge_graph_service):
+        self.service = knowledge_graph_service
+
+    async def apply(self, event: Dict[str, Any]) -> None:
+        """Apply one extraction batch through the service's upsert path."""
+        await self.service.apply_extraction(
+            event["user_id"], event["payload"], event_id=event["id"]
+        )
+
+    async def reset(self, user_id: str) -> None:
+        """Wipe the user's graph and invalidate the algorithms cache."""
+        await self.service.storage.delete_all_for_user(user_id)
+        self.service.algorithms.invalidate(str(user_id))
+
+
+class CaptainsLogProjector:
+    """Rebuilds captains_log(+sources) and lessons from digest events."""
+
+    name = "captains_log"
+    event_types = (EVENT_LOG_ENTRY, EVENT_LESSON_RECORDED)
+
+    def __init__(self, captains_log_service):
+        self.service = captains_log_service
+
+    async def apply(self, event: Dict[str, Any]) -> None:
+        """Apply one log-entry or lesson event through the service."""
+        if event["event_type"] == EVENT_LOG_ENTRY:
+            await self.service.apply_log_entry_event(
+                event["user_id"], event["payload"], event_id=event["id"]
+            )
+        else:
+            await self.service.apply_lesson_event(
+                event["user_id"], event["payload"], event_id=event["id"]
+            )
+
+    async def reset(self, user_id: str) -> None:
+        """Wipe the user's lessons, log entries, and source lineage.
+
+        Lessons go first: their source_log_id FK references captains_log
+        rows, so the reverse order would violate the constraint on
+        PostgreSQL.
+        """
+        await self.service.lessons.delete_all_for_user(user_id)
+        await self.service.storage.delete_all_for_user(user_id)
+
+
+class FlatFactProjector:
+    """Rebuilds extraction-derived flat facts in the vector projection."""
+
+    name = "flat_facts"
+    event_types = (EVENT_FACT_EXTRACTED,)
+
+    def __init__(self, long_term_memory):
+        self.long_term_memory = long_term_memory
+
+    async def apply(self, event: Dict[str, Any]) -> None:
+        """Re-add one extracted fact through the shared write helper."""
+        await apply_fact_event(
+            self.long_term_memory, event["user_id"], event["payload"], event_id=event["id"]
+        )
+
+    async def reset(self, user_id: str) -> int:
+        """
+        Delete the user's extraction-derived memories.
+
+        Only rows written by the extractor (metadata source == 'extraction')
+        are touched: conversations, knowledge uploads, and manually created
+        memories are not event-sourced and must survive a rebuild.
+        Returns the number of memories deleted.
+        """
+        return await self.long_term_memory.delete_extracted_memories(str(user_id))

--- a/src/muxi/runtime/services/memory/events/service.py
+++ b/src/muxi/runtime/services/memory/events/service.py
@@ -1,0 +1,357 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Memory Event Service - Substrate Coordination
+# Description:  Failure-isolated event recording, projector registry, rebuild
+# Role:         Formation-level service owning the memory event substrate
+# Usage:        Created in formation initialization, driven by the Overlord
+# Author:       Muxi Framework Team
+#
+# Memory Event Substrate. Coordinates:
+#
+# 1. Recording: ``record`` is the failure-isolated append every memory write
+#    path calls alongside its existing direct projection write (the PRD's
+#    Phase A dual-write posture). An append failure is logged and swallowed
+#    -- the projection write and the chat turn are never affected.
+# 2. Projector registry: projections register a projector (apply + reset +
+#    event_types); the registry is the extension point for later
+#    projections (Knowledge Index) without event-schema changes.
+# 3. Rebuild: full re-projection per user -- wipe the projection, replay
+#    its events in append order through the same upsert code the live path
+#    uses, then checkpoint. This is the PRD's replay promise.
+# 4. Selective forgetting: ``forget_source`` soft-deletes every live event
+#    from a source and records the user.deletion audit event; a background
+#    hard-purge loop (Phase 1 lifecycle pattern: started by the Overlord
+#    next to the scheduler, cancelled on shutdown) removes soft-deleted
+#    events after the retention grace period.
+# =============================================================================
+
+import asyncio
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from ... import observability
+from .models import DECAY_STATIC, EVENT_USER_DELETION, SOURCE_USER_EDIT
+from .storage import MemoryEventStorage
+
+# PRD defaults (Configuration Reference -> memory.events.retention).
+DEFAULT_GRACE_PERIOD_DAYS = 30
+
+# Hard-purge cadence. Soft-deleted events only become purgeable after the
+# multi-day grace period, so a daily sweep is more than frequent enough.
+PURGE_INTERVAL_SECONDS = 86400.0
+
+
+class MemoryEventService:
+    """Owns the memory event log, projector registry, and rebuild path."""
+
+    def __init__(self, db_manager, formation_id: str, config: Optional[Dict[str, Any]] = None):
+        """
+        Initialize the memory event service.
+
+        Args:
+            db_manager: Shared DatabaseManager (PostgreSQL or SQLite).
+            formation_id: Formation identifier scoping all event rows.
+            config: The ``memory.events`` formation config section.
+        """
+        config = config or {}
+        retention = config.get("retention") or {}
+
+        self.formation_id = formation_id
+        self.enabled = config.get("enabled", True)
+        self.grace_period_days = int(retention.get("grace_period_days", DEFAULT_GRACE_PERIOD_DAYS))
+
+        self.db_manager = db_manager
+        self.storage = MemoryEventStorage(db_manager, formation_id)
+        self.projectors: Dict[str, Any] = {}
+        self._purge_task: Optional[asyncio.Task] = None
+
+    # ------------------------------------------------------------------
+    # Projector registry
+    # ------------------------------------------------------------------
+
+    def register_projector(self, projector) -> None:
+        """Register a projection builder under its ``name``."""
+        self.projectors[projector.name] = projector
+
+    # ------------------------------------------------------------------
+    # Recording (failure-isolated dual-write append)
+    # ------------------------------------------------------------------
+
+    async def record(
+        self,
+        user_id: Any,
+        event_type: str,
+        payload: Dict[str, Any],
+        source: str,
+        source_id: Optional[str] = None,
+        source_confidence: float = 1.0,
+        occurred_at: Optional[datetime] = None,
+        caused_by: Optional[int] = None,
+        decay_rate: str = DECAY_STATIC,
+        expires_at: Optional[datetime] = None,
+        agent_id: Optional[str] = None,
+        conversation_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Append one event to the log; never raises.
+
+        Returns the event dict (existing one on an idempotent duplicate),
+        or None when the substrate is disabled or the append failed. A
+        None return must never affect the caller's own write path.
+        """
+        if not self.enabled:
+            return None
+        try:
+            event, created = await self.storage.append(
+                user_id=str(user_id),
+                event_type=event_type,
+                payload=payload,
+                source=source,
+                source_id=source_id,
+                source_confidence=source_confidence,
+                occurred_at=occurred_at,
+                caused_by=caused_by,
+                decay_rate=decay_rate,
+                expires_at=expires_at,
+                agent_id=agent_id,
+                conversation_id=conversation_id,
+            )
+        except Exception as e:
+            observability.observe(
+                event_type=observability.ConversationEvents.MEMORY_EVENT_APPEND_FAILED,
+                level=observability.EventLevel.WARNING,
+                data={
+                    "user_id": str(user_id),
+                    "memory_event_type": event_type,
+                    "source": source,
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                },
+                description=f"Memory event append failed: {e}",
+            )
+            return None
+
+        if created:
+            observability.observe(
+                event_type=observability.ConversationEvents.MEMORY_EVENT_APPENDED,
+                level=observability.EventLevel.DEBUG,
+                data={
+                    "user_id": str(user_id),
+                    "memory_event_id": event["id"],
+                    "memory_event_type": event_type,
+                    "source": source,
+                },
+                description=f"Memory event appended: {event_type}",
+            )
+        else:
+            observability.observe(
+                event_type=observability.ConversationEvents.MEMORY_EVENT_IDEMPOTENT_SKIP,
+                level=observability.EventLevel.DEBUG,
+                data={
+                    "user_id": str(user_id),
+                    "memory_event_id": event["id"],
+                    "memory_event_type": event_type,
+                    "source": source,
+                    "source_id": source_id,
+                },
+                description=f"Duplicate memory event skipped: {event_type}",
+            )
+        return event
+
+    # ------------------------------------------------------------------
+    # Rebuild (full re-projection from the event log)
+    # ------------------------------------------------------------------
+
+    async def rebuild(
+        self,
+        user_id: Any,
+        projection: Optional[str] = None,
+        dry_run: bool = False,
+    ) -> Dict[str, Dict[str, Any]]:
+        """
+        Rebuild one or all projections for a user from the event log.
+
+        For each target projection: wipe the user's derived state, replay
+        the projection's events in append order through the same upsert
+        path the live dual-write uses, and record the checkpoint. With
+        ``dry_run`` the projection is untouched and only the event counts
+        that would be replayed are reported.
+
+        Returns:
+            {projection_name: {"events": n, "applied": n, "failed": n}}
+
+        Raises:
+            ValueError: When the substrate is disabled or the requested
+                projection is unknown.
+        """
+        if not self.enabled:
+            raise ValueError("Memory event substrate is disabled for this formation")
+        user_id = str(user_id)
+
+        if projection is not None and projection not in self.projectors:
+            raise ValueError(
+                f"Unknown projection {projection!r}; registered: {sorted(self.projectors)}"
+            )
+        names = [projection] if projection else sorted(self.projectors)
+
+        observability.observe(
+            event_type=observability.ConversationEvents.MEMORY_REBUILD_STARTED,
+            level=observability.EventLevel.INFO,
+            data={"user_id": user_id, "projections": names, "dry_run": dry_run},
+            description=f"Memory projection rebuild started for {', '.join(names)}",
+        )
+
+        report: Dict[str, Dict[str, Any]] = {}
+        for name in names:
+            projector = self.projectors[name]
+            events = await self.storage.list_events(
+                user_id, event_types=list(projector.event_types)
+            )
+            if dry_run:
+                report[name] = {"events": len(events), "applied": 0, "failed": 0, "dry_run": True}
+                continue
+
+            await projector.reset(user_id)
+            await self.storage.reset_checkpoint(name, user_id)
+
+            applied = 0
+            failed = 0
+            for event in events:
+                try:
+                    await projector.apply(event)
+                    applied += 1
+                    observability.observe(
+                        event_type=observability.ConversationEvents.MEMORY_PROJECTION_APPLIED,
+                        level=observability.EventLevel.DEBUG,
+                        data={
+                            "user_id": user_id,
+                            "projection": name,
+                            "memory_event_id": event["id"],
+                            "memory_event_type": event["event_type"],
+                        },
+                        description=f"Replayed event {event['id']} into {name}",
+                    )
+                except Exception as e:
+                    failed += 1
+                    observability.observe(
+                        event_type=observability.ConversationEvents.MEMORY_PROJECTION_FAILED,
+                        level=observability.EventLevel.WARNING,
+                        data={
+                            "user_id": user_id,
+                            "projection": name,
+                            "memory_event_id": event["id"],
+                            "error": str(e),
+                            "error_type": type(e).__name__,
+                        },
+                        description=f"Replay of event {event['id']} into {name} failed: {e}",
+                    )
+            if events:
+                await self.storage.set_checkpoint(name, user_id, last_event_id=events[-1]["id"])
+            report[name] = {"events": len(events), "applied": applied, "failed": failed}
+
+        observability.observe(
+            event_type=observability.ConversationEvents.MEMORY_REBUILD_COMPLETED,
+            level=observability.EventLevel.INFO,
+            data={"user_id": user_id, "report": report, "dry_run": dry_run},
+            description="Memory projection rebuild completed",
+        )
+        return report
+
+    # ------------------------------------------------------------------
+    # Selective forgetting (GDPR groundwork)
+    # ------------------------------------------------------------------
+
+    async def forget_source(
+        self, user_id: Any, source: str, reason: str = "user_request"
+    ) -> Dict[str, Any]:
+        """
+        Soft-delete every live event from a source for a user.
+
+        Records the ``user.deletion`` audit event, marks the targets
+        deleted, and reports which projections should be rebuilt for the
+        forgetting to take effect in derived state.
+        """
+        user_id = str(user_id)
+        events = await self.storage.list_events(user_id, source=source)
+        target_ids = [event["id"] for event in events]
+        deleted = await self.storage.soft_delete_events(user_id, target_ids, reason)
+        await self.record(
+            user_id=user_id,
+            event_type=EVENT_USER_DELETION,
+            payload={"reason": reason, "source": source, "target_event_ids": target_ids},
+            source=SOURCE_USER_EDIT,
+        )
+        observability.observe(
+            event_type=observability.ConversationEvents.MEMORY_DELETION_REQUESTED,
+            level=observability.EventLevel.INFO,
+            data={
+                "user_id": user_id,
+                "source": source,
+                "reason": reason,
+                "deleted_events": deleted,
+            },
+            description=f"Soft-deleted {deleted} memory events from source {source!r}",
+        )
+        return {
+            "deleted_events": deleted,
+            "rebuild_required": sorted(self.projectors),
+        }
+
+    # ------------------------------------------------------------------
+    # Hard-purge background loop (Phase 1 lifecycle pattern)
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the periodic hard-purge loop for soft-deleted events."""
+        if not self.enabled:
+            return
+        if self._purge_task is not None and not self._purge_task.done():
+            return
+        self._purge_task = asyncio.create_task(self._purge_loop())
+
+    async def stop(self) -> None:
+        """Cancel the hard-purge loop, if running."""
+        if self._purge_task is not None:
+            self._purge_task.cancel()
+            try:
+                await self._purge_task
+            except asyncio.CancelledError:
+                pass
+            self._purge_task = None
+
+    async def _purge_loop(self) -> None:
+        """Sleep-run loop for the retention hard purge."""
+        while True:
+            await asyncio.sleep(PURGE_INTERVAL_SECONDS)
+            try:
+                await self.run_hard_purge()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                observability.observe(
+                    event_type=observability.ErrorEvents.INTERNAL_ERROR,
+                    level=observability.EventLevel.WARNING,
+                    data={"error": str(e), "error_type": type(e).__name__, "pass": "hard_purge"},
+                    description=f"Memory event hard purge failed: {e}",
+                )
+
+    async def run_hard_purge(self) -> int:
+        """Hard-delete soft-deleted events past the grace period."""
+        purged = await self.storage.hard_purge(self.grace_period_days)
+        if purged:
+            observability.observe(
+                event_type=observability.ConversationEvents.MEMORY_DELETION_HARD_PURGED,
+                level=observability.EventLevel.INFO,
+                data={"purged_events": purged, "grace_period_days": self.grace_period_days},
+                description=f"Hard-purged {purged} soft-deleted memory events",
+            )
+        return purged
+
+    # ------------------------------------------------------------------
+    # Read surface (event listing for tests / provenance drill-down)
+    # ------------------------------------------------------------------
+
+    async def list_events(self, user_id: Any, **kwargs) -> List[Dict[str, Any]]:
+        """List a user's events in append order (see storage.list_events)."""
+        return await self.storage.list_events(str(user_id), **kwargs)

--- a/src/muxi/runtime/services/memory/events/storage.py
+++ b/src/muxi/runtime/services/memory/events/storage.py
@@ -1,0 +1,304 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Memory Event Storage - Append-Only Log Persistence
+# Description:  SQLAlchemy-backed storage for the memory event substrate
+# Role:         Event appends, idempotency, replay reads, and checkpoints
+# Usage:        Used by MemoryEventService
+# Author:       Muxi Framework Team
+#
+# Backend-agnostic persistence layer for the memory event log. The same ORM
+# models and queries run on PostgreSQL and SQLite through the shared
+# DatabaseManager async session factory. All rows are scoped by
+# (user_id, formation_id) exactly like the projection tables.
+#
+# Immutability contract: this class exposes append, read, soft-delete, and
+# hard-purge -- never update. An appended event's type, payload, source, and
+# timestamps are permanent; the only mutable columns are the soft-delete
+# pair, and hard purge physically removes rows only after the retention
+# grace period.
+#
+# Idempotency (PRD "Write Path"): when ``source_id`` is provided, a second
+# append with the same (formation, user, source, source_id) returns the
+# existing event instead of writing a duplicate. A partial unique index
+# backs this check so concurrent appenders cannot race past it.
+# =============================================================================
+
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+
+from sqlalchemy import delete as sql_delete, select
+from sqlalchemy.exc import IntegrityError
+
+from ....utils.datetime_utils import utc_now_naive
+from .models import (
+    DECAY_RATES,
+    DECAY_STATIC,
+    SCOPE_TYPE_USER,
+    MemoryEvent,
+    ProjectionCheckpoint,
+    validate_event_payload,
+)
+
+
+class MemoryEventStorage:
+    """Persistence layer for the append-only memory event log."""
+
+    def __init__(self, db_manager, formation_id: str):
+        """
+        Initialize event storage bound to a formation.
+
+        Args:
+            db_manager: Shared DatabaseManager (PostgreSQL or SQLite).
+            formation_id: Formation identifier used to scope all rows.
+        """
+        self.db_manager = db_manager
+        self.formation_id = formation_id
+
+    # ------------------------------------------------------------------
+    # Append (the only write)
+    # ------------------------------------------------------------------
+
+    async def append(
+        self,
+        user_id: str,
+        event_type: str,
+        payload: Dict[str, Any],
+        source: str,
+        source_id: Optional[str] = None,
+        source_confidence: float = 1.0,
+        event_version: int = 1,
+        occurred_at: Optional[datetime] = None,
+        caused_by: Optional[int] = None,
+        decay_rate: str = DECAY_STATIC,
+        expires_at: Optional[datetime] = None,
+        agent_id: Optional[str] = None,
+        conversation_id: Optional[str] = None,
+    ) -> Tuple[Dict[str, Any], bool]:
+        """
+        Append one event to the log after validating its payload.
+
+        Returns:
+            (event dict, created) -- created is False when an idempotent
+            duplicate was detected and the existing event is returned.
+
+        Raises:
+            ValueError: On schema validation failure or invalid decay rate.
+        """
+        user_id = str(user_id)
+        validate_event_payload(event_type, payload, event_version)
+        if decay_rate not in DECAY_RATES:
+            raise ValueError(f"Invalid decay_rate {decay_rate!r}; expected one of {DECAY_RATES}")
+        if not source or not str(source).strip():
+            raise ValueError("Memory events require a non-empty source")
+
+        if source_id is not None:
+            existing = await self._find_by_source_id(user_id, source, source_id)
+            if existing is not None:
+                return existing, False
+
+        try:
+            return await self._insert(
+                user_id=user_id,
+                event_type=event_type,
+                payload=payload,
+                source=source,
+                source_id=source_id,
+                source_confidence=source_confidence,
+                event_version=event_version,
+                occurred_at=occurred_at,
+                caused_by=caused_by,
+                decay_rate=decay_rate,
+                expires_at=expires_at,
+                agent_id=agent_id,
+                conversation_id=conversation_id,
+            )
+        except IntegrityError:
+            # Lost an idempotency race: another appender inserted the same
+            # (source, source_id) between our check and our insert.
+            if source_id is not None:
+                existing = await self._find_by_source_id(user_id, source, source_id)
+                if existing is not None:
+                    return existing, False
+            raise
+
+    async def _insert(self, user_id: str, **fields) -> Tuple[Dict[str, Any], bool]:
+        """Insert one event row; returns (event dict, True)."""
+        occurred_at = fields.pop("occurred_at") or utc_now_naive()
+        async with self.db_manager.get_async_session() as session:
+            event = MemoryEvent(
+                user_id=user_id,
+                formation_id=self.formation_id,
+                scope_type=SCOPE_TYPE_USER,
+                scope_id=user_id,
+                occurred_at=occurred_at,
+                **fields,
+            )
+            session.add(event)
+            await session.flush()
+            return event.to_dict(), True
+
+    async def _find_by_source_id(
+        self, user_id: str, source: str, source_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """Return the live event matching the idempotency key, or None."""
+        async with self.db_manager.get_async_session() as session:
+            stmt = (
+                select(MemoryEvent)
+                .filter_by(
+                    user_id=user_id,
+                    formation_id=self.formation_id,
+                    source=source,
+                    source_id=source_id,
+                )
+                .filter(MemoryEvent.deleted_at.is_(None))
+            )
+            event = (await session.execute(stmt)).scalars().first()
+            return event.to_dict() if event else None
+
+    # ------------------------------------------------------------------
+    # Reads (replay + provenance)
+    # ------------------------------------------------------------------
+
+    async def get_event(self, event_id: int) -> Optional[Dict[str, Any]]:
+        """Return the event with the given integer id, or None."""
+        async with self.db_manager.get_async_session() as session:
+            event = await session.get(MemoryEvent, event_id)
+            if event is None or event.formation_id != self.formation_id:
+                return None
+            return event.to_dict()
+
+    async def list_events(
+        self,
+        user_id: str,
+        event_types: Optional[List[str]] = None,
+        source: Optional[str] = None,
+        after_id: Optional[int] = None,
+        limit: Optional[int] = None,
+        include_deleted: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """
+        Return events in append order (the canonical replay ordering).
+
+        Soft-deleted events are excluded unless ``include_deleted`` is set,
+        so replaying the default listing yields the post-forgetting state.
+        """
+        async with self.db_manager.get_async_session() as session:
+            stmt = select(MemoryEvent).filter_by(
+                user_id=str(user_id), formation_id=self.formation_id
+            )
+            if event_types:
+                stmt = stmt.filter(MemoryEvent.event_type.in_(list(event_types)))
+            if source:
+                stmt = stmt.filter_by(source=source)
+            if after_id is not None:
+                stmt = stmt.filter(MemoryEvent.id > after_id)
+            if not include_deleted:
+                stmt = stmt.filter(MemoryEvent.deleted_at.is_(None))
+            stmt = stmt.order_by(MemoryEvent.id.asc())
+            if limit is not None:
+                stmt = stmt.limit(limit)
+            rows = (await session.execute(stmt)).scalars().all()
+            return [row.to_dict() for row in rows]
+
+    # ------------------------------------------------------------------
+    # Soft delete + hard purge (GDPR / selective forgetting)
+    # ------------------------------------------------------------------
+
+    async def soft_delete_events(self, user_id: str, event_ids: List[int], reason: str) -> int:
+        """Soft-delete the given events for a user; returns count marked."""
+        if not event_ids:
+            return 0
+        now = utc_now_naive()
+        marked = 0
+        async with self.db_manager.get_async_session() as session:
+            stmt = (
+                select(MemoryEvent)
+                .filter_by(user_id=str(user_id), formation_id=self.formation_id)
+                .filter(MemoryEvent.id.in_(event_ids), MemoryEvent.deleted_at.is_(None))
+            )
+            for event in (await session.execute(stmt)).scalars().all():
+                event.deleted_at = now
+                event.deleted_reason = reason
+                marked += 1
+            await session.flush()
+        return marked
+
+    async def hard_purge(self, grace_period_days: int) -> int:
+        """
+        Physically remove soft-deleted events older than the grace period.
+
+        Returns the number of rows purged.
+        """
+        cutoff = utc_now_naive() - timedelta(days=grace_period_days)
+        async with self.db_manager.get_async_session() as session:
+            stmt = (
+                sql_delete(MemoryEvent)
+                .where(MemoryEvent.formation_id == self.formation_id)
+                .where(MemoryEvent.deleted_at.is_not(None))
+                .where(MemoryEvent.deleted_at < cutoff)
+            )
+            result = await session.execute(stmt)
+            return int(result.rowcount or 0)
+
+    # ------------------------------------------------------------------
+    # Projection checkpoints
+    # ------------------------------------------------------------------
+
+    async def get_checkpoint(self, projection_name: str, user_id: str) -> Optional[Dict[str, Any]]:
+        """Return the checkpoint for (projection, user), or None."""
+        async with self.db_manager.get_async_session() as session:
+            stmt = select(ProjectionCheckpoint).filter_by(
+                projection_name=projection_name,
+                formation_id=self.formation_id,
+                user_id=str(user_id),
+            )
+            checkpoint = (await session.execute(stmt)).scalar_one_or_none()
+            return checkpoint.to_dict() if checkpoint else None
+
+    async def set_checkpoint(
+        self,
+        projection_name: str,
+        user_id: str,
+        last_event_id: int,
+        schema_version: int = 1,
+    ) -> Dict[str, Any]:
+        """Upsert the checkpoint cursor for (projection, user)."""
+        user_id = str(user_id)
+        now = utc_now_naive()
+        async with self.db_manager.get_async_session() as session:
+            stmt = select(ProjectionCheckpoint).filter_by(
+                projection_name=projection_name,
+                formation_id=self.formation_id,
+                user_id=user_id,
+            )
+            existing = (await session.execute(stmt)).scalar_one_or_none()
+            if existing is not None:
+                existing.last_event_id = last_event_id
+                existing.last_applied_at = now
+                existing.schema_version = schema_version
+                await session.flush()
+                return existing.to_dict()
+
+            checkpoint = ProjectionCheckpoint(
+                projection_name=projection_name,
+                formation_id=self.formation_id,
+                user_id=user_id,
+                last_event_id=last_event_id,
+                last_applied_at=now,
+                schema_version=schema_version,
+            )
+            session.add(checkpoint)
+            await session.flush()
+            return checkpoint.to_dict()
+
+    async def reset_checkpoint(self, projection_name: str, user_id: str) -> None:
+        """Remove the checkpoint for (projection, user), if present."""
+        async with self.db_manager.get_async_session() as session:
+            stmt = (
+                sql_delete(ProjectionCheckpoint)
+                .where(ProjectionCheckpoint.projection_name == projection_name)
+                .where(ProjectionCheckpoint.formation_id == self.formation_id)
+                .where(ProjectionCheckpoint.user_id == str(user_id))
+            )
+            await session.execute(stmt)

--- a/src/muxi/runtime/services/memory/extractor.py
+++ b/src/muxi/runtime/services/memory/extractor.py
@@ -39,6 +39,8 @@ from ...utils.fastjson import json
 from ...utils.redaction import DEFAULT_ENTITY_THRESHOLD, get_entity_detector
 from ...utils.sensitive_terms import SENSITIVE_KEY_TERMS
 from .. import observability
+from .events.models import EVENT_FACT_EXTRACTED, SOURCE_INTERACTION
+from .events.projectors import apply_fact_event
 
 
 class MemoryExtractor:
@@ -99,7 +101,7 @@ class MemoryExtractor:
         self._sensitive_key_patterns = SENSITIVE_KEY_TERMS
 
     async def process_conversation_turn(
-        self, user_message, agent_response, user_id, message_count=1
+        self, user_message, agent_response, user_id, message_count=1, caused_by_event_id=None
     ):
         """
         Process a conversation turn and extract information if needed.
@@ -113,6 +115,9 @@ class MemoryExtractor:
             agent_response: The response from the agent
             user_id: The user's ID
             message_count: Current message count for this user
+            caused_by_event_id: The interaction.turn memory event that
+                triggered this extraction (links extracted facts to their
+                originating turn in the event log)
         """
         if not self.auto_extract:
             return
@@ -151,7 +156,9 @@ class MemoryExtractor:
         extraction_results = await self._extract_user_information(conversation)
 
         # Process and store results if confidence threshold is met
-        await self._process_extraction_results(extraction_results, user_id)
+        await self._process_extraction_results(
+            extraction_results, user_id, caused_by_event_id=caused_by_event_id
+        )
 
     def opt_out_user(self, user_id: int) -> bool:
         """
@@ -392,7 +399,9 @@ class MemoryExtractor:
             "IMPORTANT: Always follow the extraction rules and age conversion rule above."
         )
 
-    async def _process_extraction_results(self, extraction_results, user_id):
+    async def _process_extraction_results(
+        self, extraction_results, user_id, caused_by_event_id=None
+    ):
         """
         Process extraction results and update context memory.
 
@@ -403,6 +412,8 @@ class MemoryExtractor:
         Args:
             extraction_results: Dictionary of extracted information
             user_id: The user's ID
+            caused_by_event_id: The interaction.turn memory event that
+                triggered this extraction, if any
         """
         if not extraction_results or "extracted_info" not in extraction_results:
             return
@@ -503,7 +514,10 @@ class MemoryExtractor:
 
         # Store all non-duplicate memories concurrently
         add_results = await asyncio.gather(
-            *(self._store_memory(memory_data, user_id) for memory_data in to_store),
+            *(
+                self._store_memory(memory_data, user_id, caused_by_event_id=caused_by_event_id)
+                for memory_data in to_store
+            ),
             return_exceptions=True,
         )
 
@@ -605,13 +619,20 @@ class MemoryExtractor:
         )
         return False
 
-    async def _store_memory(self, memory_data, user_id) -> None:
+    async def _store_memory(self, memory_data, user_id, caused_by_event_id=None) -> None:
         """
         Store a single extracted memory in long-term memory.
+
+        Dual-write (Memory Event Substrate): the fact becomes a
+        fact.extracted event first, then the flat-fact write goes through
+        the same apply helper the event replay uses. An event append
+        failure never blocks the memory write.
 
         Args:
             memory_data: The memory dict produced by extraction
             user_id: The user's ID
+            caused_by_event_id: The interaction.turn memory event that
+                triggered this extraction, if any
         """
         # Create metadata
         memory_metadata = {
@@ -624,15 +645,30 @@ class MemoryExtractor:
             "collection": memory_data["collection"],  # Keep in metadata for reference
         }
 
-        # Build add params - use user_id for both backends
-        add_params = {
-            "content": memory_data["memory"],
-            "metadata": memory_metadata,
-            "user_id": user_id,
+        payload = {
+            "memory": memory_data["memory"],
             "collection": memory_data["collection"],
+            "metadata": memory_metadata,
         }
+        event = None
+        memory_events = getattr(self.overlord, "memory_events", None)
+        if memory_events is not None:
+            event = await memory_events.record(
+                user_id=str(user_id),
+                event_type=EVENT_FACT_EXTRACTED,
+                payload=payload,
+                source=SOURCE_INTERACTION,
+                source_confidence=memory_data["confidence"],
+                caused_by=caused_by_event_id,
+                agent_id=memory_metadata["agent_id"],
+            )
 
-        await self.overlord.long_term_memory.add(**add_params)
+        await apply_fact_event(
+            self.overlord.long_term_memory,
+            user_id,
+            payload,
+            event_id=event["id"] if event else None,
+        )
 
     def _log_memory_storage_failure(
         self, error, memory_data, user_id, operation: str = "long_term_memory_add"

--- a/src/muxi/runtime/services/memory/graph/models.py
+++ b/src/muxi/runtime/services/memory/graph/models.py
@@ -95,6 +95,9 @@ class KGEntity(Base, AsyncModelMixin):
     # bookkeeping never fights the schema over insertion order).
     contradicted_by = Column(Integer, nullable=True)
     superseded_by = Column(Integer, nullable=True)
+    # Provenance bridge (Memory Event Substrate): the memory_events ids this
+    # row was derived from, appended on every contributing upsert.
+    derived_from_event_ids = Column(JSONType, nullable=False, default=[])
     created_at = Column(DateTime, nullable=False, default=utc_now_naive)
     updated_at = Column(DateTime, default=utc_now_naive, onupdate=utc_now_naive)
 
@@ -120,6 +123,7 @@ class KGEntity(Base, AsyncModelMixin):
             "status": self.status,
             "contradicted_by": self.contradicted_by,
             "superseded_by": self.superseded_by,
+            "derived_from_event_ids": self.derived_from_event_ids or [],
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }
@@ -143,6 +147,9 @@ class KGRelationship(Base, AsyncModelMixin):
     status = Column(String(20), nullable=False, default=STATUS_ACTIVE)
     contradicted_by = Column(Integer, nullable=True)
     superseded_by = Column(Integer, nullable=True)
+    # Provenance bridge (Memory Event Substrate): the memory_events ids this
+    # row was derived from, appended on every contributing upsert.
+    derived_from_event_ids = Column(JSONType, nullable=False, default=[])
     created_at = Column(DateTime, nullable=False, default=utc_now_naive)
     updated_at = Column(DateTime, default=utc_now_naive, onupdate=utc_now_naive)
 
@@ -167,6 +174,7 @@ class KGRelationship(Base, AsyncModelMixin):
             "status": self.status,
             "contradicted_by": self.contradicted_by,
             "superseded_by": self.superseded_by,
+            "derived_from_event_ids": self.derived_from_event_ids or [],
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }

--- a/src/muxi/runtime/services/memory/graph/service.py
+++ b/src/muxi/runtime/services/memory/graph/service.py
@@ -30,6 +30,7 @@ from typing import Any, Deque, Dict, List, Optional, Tuple
 from sqlalchemy import text
 
 from ... import observability
+from ..events.models import EVENT_GRAPH_EXTRACTED, SOURCE_INTERACTION, SOURCE_PERIODIC
 from .algorithms import NetworkXAlgorithms, PgRoutingAlgorithms
 from .extractor import USER_ENTITY_NAME, USER_ENTITY_TYPE, KnowledgeGraphExtractor
 from .storage import KnowledgeGraphStorage, normalize_type
@@ -48,7 +49,13 @@ _SCHEDULE_SECONDS = {"hourly": 3600, "daily": 86400}
 class KnowledgeGraphService:
     """Owns knowledge graph storage, extraction, and query surface."""
 
-    def __init__(self, db_manager, formation_id: str, config: Optional[Dict[str, Any]] = None):
+    def __init__(
+        self,
+        db_manager,
+        formation_id: str,
+        config: Optional[Dict[str, Any]] = None,
+        event_log=None,
+    ):
         """
         Initialize the knowledge graph service.
 
@@ -56,6 +63,11 @@ class KnowledgeGraphService:
             db_manager: Shared DatabaseManager (PostgreSQL or SQLite).
             formation_id: Formation identifier scoping all graph rows.
             config: The ``memory.graph`` formation config section.
+            event_log: MemoryEventService (or None). When present, every
+                extraction batch is appended to the memory event log before
+                the projection write (dual-write; append failures are
+                isolated inside the event service and never block the
+                graph write).
         """
         config = config or {}
         extraction_config = config.get("extraction") or {}
@@ -77,6 +89,7 @@ class KnowledgeGraphService:
         self.db_manager = db_manager
         self.storage = KnowledgeGraphStorage(db_manager, formation_id)
         self.extractor = KnowledgeGraphExtractor(confidence_threshold=self.realtime_confidence)
+        self.event_log = event_log
 
         # Backend selection: pgRouting on PostgreSQL when the extension is
         # installable, NetworkX on SQLite and as the safe fallback when the
@@ -126,12 +139,14 @@ class KnowledgeGraphService:
         agent_response: str,
         user_id: Any,
         model,
+        caused_by_event_id: Optional[int] = None,
     ) -> None:
         """
         Run the real-time graph extraction pass for one conversation turn.
 
         Never raises: extraction or storage failures are logged and the
-        chat turn continues unaffected.
+        chat turn continues unaffected. ``caused_by_event_id`` links the
+        recorded graph.extracted event to its interaction.turn event.
         """
         if not self.enabled or model is None:
             return
@@ -147,7 +162,9 @@ class KnowledgeGraphService:
             result = await self.extractor.extract(
                 conversation, model, confidence_threshold=self.realtime_confidence
             )
-            stored = await self._store_extraction(user_id, result)
+            stored = await self.store_extraction(
+                user_id, result, source=SOURCE_INTERACTION, caused_by=caused_by_event_id
+            )
             if stored["entities"] or stored["relationships"]:
                 observability.observe(
                     event_type=observability.ConversationEvents.MEMORY_AUTO_EXTRACTED,
@@ -177,21 +194,46 @@ class KnowledgeGraphService:
             )
 
     async def store_extraction(
-        self, user_id: Any, result: Dict[str, List[Dict[str, Any]]]
+        self,
+        user_id: Any,
+        result: Dict[str, List[Dict[str, Any]]],
+        source: str = SOURCE_INTERACTION,
+        caused_by: Optional[int] = None,
     ) -> Dict[str, int]:
-        """Persist an externally-produced extraction result.
+        """Record and persist an extraction result (dual-write path).
 
-        Public entry point for the Captain's Log digest integration
-        (Memory Revamp Phase 2): the digest response's entity/relationship
-        fields are validated with this service's extractor contract and
-        stored through the same upsert path as the built-in passes.
+        Public entry point for the built-in extraction passes and the
+        Captain's Log digest integration. Appends a ``graph.extracted``
+        event to the memory event log first (failure-isolated inside the
+        event service), then applies the same result through the upsert
+        path the replay rebuild uses.
         """
-        return await self._store_extraction(user_id, result)
+        event = None
+        if self.event_log is not None and (result.get("entities") or result.get("relationships")):
+            event = await self.event_log.record(
+                user_id=str(user_id),
+                event_type=EVENT_GRAPH_EXTRACTED,
+                payload={
+                    "entities": result.get("entities", []),
+                    "relationships": result.get("relationships", []),
+                },
+                source=source,
+                caused_by=caused_by,
+            )
+        return await self.apply_extraction(user_id, result, event_id=event["id"] if event else None)
 
-    async def _store_extraction(
-        self, user_id: Any, result: Dict[str, List[Dict[str, Any]]]
+    async def apply_extraction(
+        self,
+        user_id: Any,
+        result: Dict[str, List[Dict[str, Any]]],
+        event_id: Optional[int] = None,
     ) -> Dict[str, int]:
-        """Persist one extraction result; returns stored counts."""
+        """Persist one extraction result; returns stored counts.
+
+        Deterministic projection write shared by the live dual-write path
+        and the event-replay rebuild: given the same result batches in the
+        same order it converges to the same graph state.
+        """
         user_id = str(user_id)
         entity_ids: Dict[Tuple[str, str], int] = {}
         stored_entities = 0
@@ -204,16 +246,22 @@ class KnowledgeGraphService:
                 name=item["name"],
                 attributes=item.get("attributes"),
                 confidence=item["confidence"],
+                event_id=event_id,
             )
             entity_ids[(entity["type"], _name_key(entity["name"]))] = entity["id"]
             stored_entities += 1
 
         for item in result.get("relationships", []):
             from_id = await self._resolve_endpoint(
-                user_id, item["from"], item.get("from_type"), item["confidence"], entity_ids
+                user_id,
+                item["from"],
+                item.get("from_type"),
+                item["confidence"],
+                entity_ids,
+                event_id,
             )
             to_id = await self._resolve_endpoint(
-                user_id, item["to"], item.get("to_type"), item["confidence"], entity_ids
+                user_id, item["to"], item.get("to_type"), item["confidence"], entity_ids, event_id
             )
             if from_id is None or to_id is None or from_id == to_id:
                 continue
@@ -224,6 +272,7 @@ class KnowledgeGraphService:
                 rel_type=item["type"],
                 attributes=item.get("attributes"),
                 confidence=item["confidence"],
+                event_id=event_id,
             )
             stored_relationships += 1
 
@@ -239,6 +288,7 @@ class KnowledgeGraphService:
         entity_type: Optional[str],
         confidence: float,
         entity_ids: Dict[Tuple[str, str], int],
+        event_id: Optional[int] = None,
     ) -> Optional[int]:
         """Resolve a relationship endpoint to an entity id, creating it if typed."""
         key_name = _name_key(name)
@@ -253,6 +303,7 @@ class KnowledgeGraphService:
                 entity_type=normalized,
                 name=name,
                 confidence=confidence,
+                event_id=event_id,
             )
             entity_ids[(entity["type"], key_name)] = entity["id"]
             return entity["id"]
@@ -336,7 +387,7 @@ class KnowledgeGraphService:
                 result = await self.extractor.extract(
                     conversation, model, confidence_threshold=self.periodic_confidence
                 )
-                stored = await self._store_extraction(user_id, result)
+                stored = await self.store_extraction(user_id, result, source=SOURCE_PERIODIC)
                 totals["entities"] += stored["entities"]
                 totals["relationships"] += stored["relationships"]
             except Exception as e:

--- a/src/muxi/runtime/services/memory/graph/storage.py
+++ b/src/muxi/runtime/services/memory/graph/storage.py
@@ -25,7 +25,7 @@
 
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import select
+from sqlalchemy import delete as sql_delete, select
 
 from .models import (
     EXCLUSIVE_RELATIONSHIP_TYPES,
@@ -63,12 +63,14 @@ class KnowledgeGraphStorage:
         name: str,
         attributes: Optional[Dict[str, Any]] = None,
         confidence: float = 0.5,
+        event_id: Optional[int] = None,
     ) -> Dict[str, Any]:
         """
         Insert or update an entity keyed by (user, formation, type, name).
 
         Existing entities merge the new attributes over the old ones and
-        keep the highest confidence seen.
+        keep the highest confidence seen. When ``event_id`` is provided it
+        is appended to the row's provenance list (idempotently).
 
         Returns:
             Dict representation of the stored entity.
@@ -91,6 +93,9 @@ class KnowledgeGraphStorage:
                 merged.update(attributes or {})
                 existing.attributes = merged
                 existing.confidence = max(existing.confidence or 0.0, confidence)
+                existing.derived_from_event_ids = _append_event_id(
+                    existing.derived_from_event_ids, event_id
+                )
                 if existing.status == STATUS_SUPERSEDED:
                     # A fresh observation revives a previously superseded entity.
                     existing.status = STATUS_ACTIVE
@@ -105,6 +110,7 @@ class KnowledgeGraphStorage:
                 name=name,
                 attributes=attributes or {},
                 confidence=confidence,
+                derived_from_event_ids=_append_event_id([], event_id),
             )
             session.add(entity)
             await session.flush()
@@ -190,6 +196,7 @@ class KnowledgeGraphStorage:
         rel_type: str,
         attributes: Optional[Dict[str, Any]] = None,
         confidence: float = 0.5,
+        event_id: Optional[int] = None,
     ) -> Dict[str, Any]:
         """
         Insert or update a relationship with contradiction detection.
@@ -198,6 +205,8 @@ class KnowledgeGraphStorage:
         exclusive predicates a different object either supersedes the old
         fact (confidence delta above SUPERSEDE_CONFIDENCE_DELTA) or marks
         both facts conflicted. Old facts are retained, never deleted.
+        When ``event_id`` is provided it is appended to the row's
+        provenance list (idempotently).
 
         Returns:
             Dict representation of the stored relationship.
@@ -221,6 +230,9 @@ class KnowledgeGraphStorage:
                     merged.update(attributes or {})
                     existing.attributes = merged
                     existing.confidence = max(existing.confidence or 0.0, confidence)
+                    existing.derived_from_event_ids = _append_event_id(
+                        existing.derived_from_event_ids, event_id
+                    )
                     if existing.status == STATUS_SUPERSEDED:
                         existing.status = STATUS_ACTIVE
                         existing.superseded_by = None
@@ -235,6 +247,7 @@ class KnowledgeGraphStorage:
                 type=rel_type,
                 attributes=attributes or {},
                 confidence=confidence,
+                derived_from_event_ids=_append_event_id([], event_id),
             )
 
             # Contradiction detection on exclusive predicates.
@@ -320,7 +333,45 @@ class KnowledgeGraphStorage:
             rows = (await session.execute(stmt)).scalars().all()
             return [row.to_dict() for row in rows]
 
+    # ------------------------------------------------------------------
+    # Rebuild support (Memory Event Substrate)
+    # ------------------------------------------------------------------
+
+    async def delete_all_for_user(self, user_id: str) -> Dict[str, int]:
+        """
+        Delete the user's entire subgraph (relationships first, then
+        entities). Only the projection rebuild path may call this: the
+        knowledge graph is derived state and is repopulated by replaying
+        graph.extracted events.
+
+        Returns:
+            {"entities": n, "relationships": n} deleted counts.
+        """
+        user_id = str(user_id)
+        async with self.db_manager.get_async_session() as session:
+            rel_stmt = (
+                sql_delete(KGRelationship)
+                .where(KGRelationship.user_id == user_id)
+                .where(KGRelationship.formation_id == self.formation_id)
+            )
+            relationships = int((await session.execute(rel_stmt)).rowcount or 0)
+            entity_stmt = (
+                sql_delete(KGEntity)
+                .where(KGEntity.user_id == user_id)
+                .where(KGEntity.formation_id == self.formation_id)
+            )
+            entities = int((await session.execute(entity_stmt)).rowcount or 0)
+            return {"entities": entities, "relationships": relationships}
+
 
 def normalize_type(value: str) -> str:
     """Normalize an entity/relationship type to the storage form."""
     return value.strip().lower().replace(" ", "_")[:50]
+
+
+def _append_event_id(current, event_id: Optional[int]) -> list:
+    """Return the provenance list with ``event_id`` appended (idempotent)."""
+    ids = list(current or [])
+    if event_id is not None and event_id not in ids:
+        ids.append(event_id)
+    return ids

--- a/src/muxi/runtime/services/memory/graph/storage.py
+++ b/src/muxi/runtime/services/memory/graph/storage.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, List, Optional
 
 from sqlalchemy import delete as sql_delete, select
 
+from ..events.models import append_event_id
 from .models import (
     EXCLUSIVE_RELATIONSHIP_TYPES,
     STATUS_ACTIVE,
@@ -93,7 +94,7 @@ class KnowledgeGraphStorage:
                 merged.update(attributes or {})
                 existing.attributes = merged
                 existing.confidence = max(existing.confidence or 0.0, confidence)
-                existing.derived_from_event_ids = _append_event_id(
+                existing.derived_from_event_ids = append_event_id(
                     existing.derived_from_event_ids, event_id
                 )
                 if existing.status == STATUS_SUPERSEDED:
@@ -110,7 +111,7 @@ class KnowledgeGraphStorage:
                 name=name,
                 attributes=attributes or {},
                 confidence=confidence,
-                derived_from_event_ids=_append_event_id([], event_id),
+                derived_from_event_ids=append_event_id([], event_id),
             )
             session.add(entity)
             await session.flush()
@@ -230,7 +231,7 @@ class KnowledgeGraphStorage:
                     merged.update(attributes or {})
                     existing.attributes = merged
                     existing.confidence = max(existing.confidence or 0.0, confidence)
-                    existing.derived_from_event_ids = _append_event_id(
+                    existing.derived_from_event_ids = append_event_id(
                         existing.derived_from_event_ids, event_id
                     )
                     if existing.status == STATUS_SUPERSEDED:
@@ -247,7 +248,7 @@ class KnowledgeGraphStorage:
                 type=rel_type,
                 attributes=attributes or {},
                 confidence=confidence,
-                derived_from_event_ids=_append_event_id([], event_id),
+                derived_from_event_ids=append_event_id([], event_id),
             )
 
             # Contradiction detection on exclusive predicates.
@@ -367,11 +368,3 @@ class KnowledgeGraphStorage:
 def normalize_type(value: str) -> str:
     """Normalize an entity/relationship type to the storage form."""
     return value.strip().lower().replace(" ", "_")[:50]
-
-
-def _append_event_id(current, event_id: Optional[int]) -> list:
-    """Return the provenance list with ``event_id`` appended (idempotent)."""
-    ids = list(current or [])
-    if event_id is not None and event_id not in ids:
-        ids.append(event_id)
-    return ids

--- a/src/muxi/runtime/services/memory/log/models.py
+++ b/src/muxi/runtime/services/memory/log/models.py
@@ -70,6 +70,9 @@ class CaptainsLogEntry(Base, AsyncModelMixin):
     decisions = Column(JSONType, nullable=False, default=[])
     projects = Column(JSONType, nullable=False, default=[])
     context = Column(Text, nullable=True)
+    # Provenance bridge (Memory Event Substrate): the memory_events ids this
+    # entry was derived from, appended on every contributing digest upsert.
+    derived_from_event_ids = Column(JSONType, nullable=False, default=[])
     created_at = Column(DateTime, nullable=False, default=utc_now_naive)
     updated_at = Column(DateTime, default=utc_now_naive, onupdate=utc_now_naive)
 
@@ -90,6 +93,7 @@ class CaptainsLogEntry(Base, AsyncModelMixin):
             "decisions": self.decisions or [],
             "projects": self.projects or [],
             "context": self.context,
+            "derived_from_event_ids": self.derived_from_event_ids or [],
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }
@@ -141,6 +145,9 @@ class Lesson(Base, AsyncModelMixin):
     # backends without a dialect-specific type.
     rule_hash = Column(String(64), nullable=False)
     source_log_id = Column(Integer, ForeignKey("captains_log.id"), nullable=True)
+    # Provenance bridge (Memory Event Substrate): the memory_events ids this
+    # lesson was derived from, appended on every write/confirmation.
+    derived_from_event_ids = Column(JSONType, nullable=False, default=[])
     confidence = Column(Float, nullable=False, default=0.5)
     hits = Column(Integer, nullable=False, default=1)
     last_applied_at = Column(DateTime, nullable=True)
@@ -171,6 +178,7 @@ class Lesson(Base, AsyncModelMixin):
             "context": self.context,
             "rule_hash": self.rule_hash,
             "source_log_id": self.source_log_id,
+            "derived_from_event_ids": self.derived_from_event_ids or [],
             "confidence": self.confidence,
             "hits": self.hits,
             "last_applied_at": (self.last_applied_at.isoformat() if self.last_applied_at else None),

--- a/src/muxi/runtime/services/memory/log/service.py
+++ b/src/muxi/runtime/services/memory/log/service.py
@@ -29,11 +29,18 @@
 import asyncio
 import time
 from collections import OrderedDict, deque
+from datetime import date as date_type
 from typing import Any, Deque, Dict, List, Optional, Tuple
 
 from ....utils.datetime_utils import utc_now_naive
 from ... import observability
 from ..embedding import DEFAULT_EMBEDDING_MODEL, embed
+from ..events.models import (
+    EVENT_LESSON_RECORDED,
+    EVENT_LOG_ENTRY,
+    SOURCE_CAPTAINS_LOG,
+    SOURCE_TOOL,
+)
 from ..graph.extractor import KnowledgeGraphExtractor
 from ..graph.service import _schedule_to_seconds
 from .models import SOURCE_TYPE_BUFFER_ITEM
@@ -84,6 +91,7 @@ class CaptainsLogService:
         lessons_config: Optional[Dict[str, Any]] = None,
         knowledge_graph=None,
         embedding_model: Optional[str] = None,
+        event_log=None,
     ):
         """
         Initialize the captain's log service.
@@ -97,6 +105,10 @@ class CaptainsLogService:
                 for the digest's entity/relationship integration.
             embedding_model: Slug used for lesson-consolidation clustering;
                 defaults to the shared memory embedding default.
+            event_log: MemoryEventService (or None). When present, digest
+                entries and lessons are appended to the memory event log
+                before the projection writes (dual-write; append failures
+                are isolated inside the event service).
         """
         config = config or {}
         lessons_config = lessons_config or {}
@@ -126,6 +138,7 @@ class CaptainsLogService:
         self.graph_extractor = KnowledgeGraphExtractor(confidence_threshold=DIGEST_GRAPH_CONFIDENCE)
         self.knowledge_graph = knowledge_graph
         self.embedding_model = embedding_model or DEFAULT_EMBEDDING_MODEL
+        self.event_log = event_log
 
         # Turns accumulated per user since the last run, with the capture
         # timestamp used as the buffer_item source key.
@@ -296,27 +309,36 @@ class CaptainsLogService:
         if digest is None:
             return {"entries": 0, "sources": 0, "lessons": 0}
 
-        entry = await self.storage.upsert_entry(
-            user_id,
-            entry_date,
-            summary=digest["summary"],
-            decisions=digest["decisions"],
-            projects=digest["projects"],
-            context=digest["context"],
-        )
-        source_counts = await self.storage.add_sources(
-            user_id,
-            entry["id"],
-            [
+        # Dual-write (Memory Event Substrate): the digest result becomes a
+        # log.entry event first, then the projection write goes through the
+        # same apply path the event replay uses.
+        entry_payload = {
+            "date": entry_date.isoformat(),
+            "summary": digest["summary"],
+            "decisions": digest["decisions"],
+            "projects": digest["projects"],
+            "context": digest["context"],
+            "sources": [
                 {"source_type": SOURCE_TYPE_BUFFER_ITEM, "source_id": timestamp_key}
                 for timestamp_key, _ in turns
             ],
+        }
+        event = None
+        if self.event_log is not None:
+            event = await self.event_log.record(
+                user_id=user_id,
+                event_type=EVENT_LOG_ENTRY,
+                payload=entry_payload,
+                source=SOURCE_CAPTAINS_LOG,
+            )
+        entry, source_counts = await self.apply_log_entry_event(
+            user_id, entry_payload, event_id=event["id"] if event else None
         )
 
         lessons_stored = 0
         if extract_lessons:
             lessons_stored = await self._store_lessons(
-                user_id, digest["lessons"], source_log_id=entry["id"]
+                user_id, digest["lessons"], source_log_date=entry_payload["date"]
             )
 
         # Knowledge graph integration: the same digest response carries
@@ -328,7 +350,9 @@ class CaptainsLogService:
                 extraction = self.graph_extractor.parse_response(
                     raw_response, DIGEST_GRAPH_CONFIDENCE
                 )
-                stored = await self.knowledge_graph.store_extraction(user_id, extraction)
+                stored = await self.knowledge_graph.store_extraction(
+                    user_id, extraction, source=SOURCE_CAPTAINS_LOG
+                )
                 if stored["entities"] or stored["relationships"]:
                     observability.observe(
                         event_type=observability.ConversationEvents.MEMORY_AUTO_EXTRACTED,
@@ -370,18 +394,33 @@ class CaptainsLogService:
         self,
         user_id: str,
         lessons: List[Dict[str, Optional[str]]],
-        source_log_id: Optional[int] = None,
+        source_log_date: Optional[str] = None,
         agent_id: str = "overlord",
     ) -> int:
-        """Upsert digest-extracted lessons; returns stored count."""
+        """Upsert digest-extracted lessons; returns stored count.
+
+        Lessons reference their source entry by date (the stable digest
+        key) rather than by integer id so replayed events resolve against
+        the rebuilt entry rows.
+        """
         stored = 0
         for item in lessons:
-            lesson, created = await self.lessons.upsert_lesson(
-                user_id=user_id,
-                agent_id=agent_id,
-                rule=item["rule"],
-                context=item.get("context"),
-                source_log_id=source_log_id,
+            payload = {
+                "agent_id": agent_id,
+                "rule": item["rule"],
+                "context": item.get("context"),
+                "source_log_date": source_log_date,
+            }
+            event = None
+            if self.event_log is not None:
+                event = await self.event_log.record(
+                    user_id=user_id,
+                    event_type=EVENT_LESSON_RECORDED,
+                    payload=payload,
+                    source=SOURCE_CAPTAINS_LOG,
+                )
+            lesson, created = await self.apply_lesson_event(
+                user_id, payload, event_id=event["id"] if event else None
             )
             stored += 1
             observability.observe(
@@ -398,6 +437,61 @@ class CaptainsLogService:
                 description="Lesson recorded from captain's log digest",
             )
         return stored
+
+    # ------------------------------------------------------------------
+    # Event apply path (shared by dual-write and replay rebuild)
+    # ------------------------------------------------------------------
+
+    async def apply_log_entry_event(
+        self, user_id: str, payload: Dict[str, Any], event_id: Optional[int] = None
+    ) -> Tuple[Dict[str, Any], Dict[str, int]]:
+        """
+        Apply one log.entry payload to the captains_log projection.
+
+        Deterministic write shared by the live digest path and the event
+        replay: upserts the (user, date) entry and attaches its source
+        lineage rows. Returns (entry dict, source counts).
+        """
+        entry = await self.storage.upsert_entry(
+            str(user_id),
+            date_type.fromisoformat(payload["date"]),
+            summary=payload.get("summary"),
+            decisions=payload.get("decisions"),
+            projects=payload.get("projects"),
+            context=payload.get("context"),
+            event_id=event_id,
+        )
+        counts = await self.storage.add_sources(
+            str(user_id), entry["id"], payload.get("sources") or []
+        )
+        return entry, counts
+
+    async def apply_lesson_event(
+        self, user_id: str, payload: Dict[str, Any], event_id: Optional[int] = None
+    ) -> Tuple[Dict[str, Any], bool]:
+        """
+        Apply one lesson.recorded payload to the lessons projection.
+
+        Resolves the source entry by date at apply time so the same event
+        links to the rebuilt entry row after a replay. Returns
+        (lesson dict, created).
+        """
+        user_id = str(user_id)
+        source_log_id = None
+        source_log_date = payload.get("source_log_date")
+        if source_log_date:
+            entry = await self.storage.get_entry(user_id, date_type.fromisoformat(source_log_date))
+            if entry is not None:
+                source_log_id = entry["id"]
+        return await self.lessons.upsert_lesson(
+            user_id=user_id,
+            agent_id=payload["agent_id"],
+            rule=payload["rule"],
+            context=payload.get("context"),
+            confidence=payload.get("confidence", 0.5),
+            source_log_id=source_log_id,
+            event_id=event_id,
+        )
 
     # ------------------------------------------------------------------
     # Lessons: write path (agent tool) and read path (prompt injection)
@@ -421,8 +515,18 @@ class CaptainsLogService:
         if not rule or not rule.strip():
             raise ValueError("record_lesson requires a non-empty rule")
 
-        lesson, created = await self.lessons.upsert_lesson(
-            user_id=str(user_id), agent_id=agent_id, rule=rule, context=context
+        payload = {"agent_id": str(agent_id), "rule": rule.strip(), "context": context}
+        event = None
+        if self.event_log is not None:
+            event = await self.event_log.record(
+                user_id=str(user_id),
+                event_type=EVENT_LESSON_RECORDED,
+                payload=payload,
+                source=SOURCE_TOOL,
+                agent_id=str(agent_id),
+            )
+        lesson, created = await self.apply_lesson_event(
+            str(user_id), payload, event_id=event["id"] if event else None
         )
         observability.observe(
             event_type=observability.ConversationEvents.MEMORY_LESSON_RECORDED,

--- a/src/muxi/runtime/services/memory/log/storage.py
+++ b/src/muxi/runtime/services/memory/log/storage.py
@@ -36,6 +36,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from sqlalchemy import delete as sql_delete, func, select
 
 from ....utils.datetime_utils import utc_now_naive
+from ..events.models import append_event_id
 from ..graph.algorithms import lexicographic_topological_sort
 from .models import SOURCE_TYPE_LOG_ENTRY, SOURCE_TYPES, CaptainsLogEntry, CaptainsLogSource, Lesson
 
@@ -97,7 +98,7 @@ class CaptainsLogStorage:
                 existing.decisions = decisions or []
                 existing.projects = projects or []
                 existing.context = context
-                existing.derived_from_event_ids = _append_event_id(
+                existing.derived_from_event_ids = append_event_id(
                     existing.derived_from_event_ids, event_id
                 )
                 await session.flush()
@@ -111,7 +112,7 @@ class CaptainsLogStorage:
                 decisions=decisions or [],
                 projects=projects or [],
                 context=context,
-                derived_from_event_ids=_append_event_id([], event_id),
+                derived_from_event_ids=append_event_id([], event_id),
             )
             session.add(entry)
             await session.flush()
@@ -359,7 +360,7 @@ class LessonStorage:
                     existing.context = context
                 if source_log_id is not None:
                     existing.source_log_id = source_log_id
-                existing.derived_from_event_ids = _append_event_id(
+                existing.derived_from_event_ids = append_event_id(
                     existing.derived_from_event_ids, event_id
                 )
                 if existing.archived:
@@ -375,7 +376,7 @@ class LessonStorage:
                 context=context,
                 rule_hash=digest,
                 source_log_id=source_log_id,
-                derived_from_event_ids=_append_event_id([], event_id),
+                derived_from_event_ids=append_event_id([], event_id),
                 confidence=confidence,
                 hits=hits,
             )
@@ -509,11 +510,3 @@ def normalize_rule(rule: str) -> str:
 def rule_hash(rule: str) -> str:
     """Return the hex sha256 of the normalized rule text."""
     return hashlib.sha256(normalize_rule(rule).encode("utf-8")).hexdigest()
-
-
-def _append_event_id(current, event_id: Optional[int]) -> list:
-    """Return the provenance list with ``event_id`` appended (idempotent)."""
-    ids = list(current or [])
-    if event_id is not None and event_id not in ids:
-        ids.append(event_id)
-    return ids

--- a/src/muxi/runtime/services/memory/log/storage.py
+++ b/src/muxi/runtime/services/memory/log/storage.py
@@ -33,7 +33,7 @@ import hashlib
 from datetime import date as date_type, datetime
 from typing import Any, Dict, List, Optional, Tuple
 
-from sqlalchemy import func, select
+from sqlalchemy import delete as sql_delete, func, select
 
 from ....utils.datetime_utils import utc_now_naive
 from ..graph.algorithms import lexicographic_topological_sort
@@ -72,13 +72,16 @@ class CaptainsLogStorage:
         decisions: Optional[List[str]] = None,
         projects: Optional[List[str]] = None,
         context: Optional[str] = None,
+        event_id: Optional[int] = None,
     ) -> Dict[str, Any]:
         """
         Insert or update the entry keyed by (user, formation, date).
 
         The caller passes the full merged section content (the digest
         prompt already folds the previous entry in), so an update
-        replaces the stored sections rather than appending.
+        replaces the stored sections rather than appending. When
+        ``event_id`` is provided it is appended to the entry's provenance
+        list (idempotently).
 
         Returns:
             Dict representation of the stored entry.
@@ -94,6 +97,9 @@ class CaptainsLogStorage:
                 existing.decisions = decisions or []
                 existing.projects = projects or []
                 existing.context = context
+                existing.derived_from_event_ids = _append_event_id(
+                    existing.derived_from_event_ids, event_id
+                )
                 await session.flush()
                 return existing.to_dict()
 
@@ -105,6 +111,7 @@ class CaptainsLogStorage:
                 decisions=decisions or [],
                 projects=projects or [],
                 context=context,
+                derived_from_event_ids=_append_event_id([], event_id),
             )
             session.add(entry)
             await session.flush()
@@ -257,6 +264,40 @@ class CaptainsLogStorage:
                     continue  # malformed source_id: not part of the DAG
             return edges
 
+    # ------------------------------------------------------------------
+    # Rebuild support (Memory Event Substrate)
+    # ------------------------------------------------------------------
+
+    async def delete_all_for_user(self, user_id: str) -> Dict[str, int]:
+        """
+        Delete the user's log entries and their source lineage rows.
+
+        Only the projection rebuild path may call this: the captain's log
+        is derived state and is repopulated by replaying log.entry events.
+
+        Returns:
+            {"entries": n, "sources": n} deleted counts.
+        """
+        user_id = str(user_id)
+        async with self.db_manager.get_async_session() as session:
+            id_stmt = select(CaptainsLogEntry.id).filter_by(
+                user_id=user_id, formation_id=self.formation_id
+            )
+            log_ids = [int(row[0]) for row in (await session.execute(id_stmt)).all()]
+            sources = 0
+            if log_ids:
+                source_stmt = sql_delete(CaptainsLogSource).where(
+                    CaptainsLogSource.log_id.in_(log_ids)
+                )
+                sources = int((await session.execute(source_stmt)).rowcount or 0)
+            entry_stmt = (
+                sql_delete(CaptainsLogEntry)
+                .where(CaptainsLogEntry.user_id == user_id)
+                .where(CaptainsLogEntry.formation_id == self.formation_id)
+            )
+            entries = int((await session.execute(entry_stmt)).rowcount or 0)
+            return {"entries": entries, "sources": sources}
+
 
 class LessonStorage:
     """Persistence layer for the lessons self-improvement loop."""
@@ -281,13 +322,16 @@ class LessonStorage:
         confidence: float = 0.5,
         source_log_id: Optional[int] = None,
         hits: int = 1,
+        event_id: Optional[int] = None,
     ) -> Tuple[Dict[str, Any], bool]:
         """
         Insert a lesson or confirm an existing one.
 
         Dedup key is sha256(normalize(rule)) per (user, agent, formation).
         On conflict the write is a confirmation: hits increments, confidence
-        is bumped, and a previously archived lesson is revived.
+        is bumped, and a previously archived lesson is revived. When
+        ``event_id`` is provided it is appended to the lesson's provenance
+        list (idempotently).
 
         Returns:
             (lesson dict, created) where created is False on confirmation.
@@ -315,6 +359,9 @@ class LessonStorage:
                     existing.context = context
                 if source_log_id is not None:
                     existing.source_log_id = source_log_id
+                existing.derived_from_event_ids = _append_event_id(
+                    existing.derived_from_event_ids, event_id
+                )
                 if existing.archived:
                     existing.archived = False  # re-confirmation revives it
                 await session.flush()
@@ -328,6 +375,7 @@ class LessonStorage:
                 context=context,
                 rule_hash=digest,
                 source_log_id=source_log_id,
+                derived_from_event_ids=_append_event_id([], event_id),
                 confidence=confidence,
                 hits=hits,
             )
@@ -431,6 +479,27 @@ class LessonStorage:
             rows = (await session.execute(stmt)).all()
             return [(row[0], row[1], int(row[2])) for row in rows]
 
+    # ------------------------------------------------------------------
+    # Rebuild support (Memory Event Substrate)
+    # ------------------------------------------------------------------
+
+    async def delete_all_for_user(self, user_id: str) -> int:
+        """
+        Delete every lesson for a user (all agents, archived included).
+
+        Only the projection rebuild path may call this: lessons are derived
+        state and are repopulated by replaying lesson.recorded events.
+        Returns the number of lessons deleted.
+        """
+        async with self.db_manager.get_async_session() as session:
+            stmt = (
+                sql_delete(Lesson)
+                .where(Lesson.user_id == str(user_id))
+                .where(Lesson.formation_id == self.formation_id)
+            )
+            result = await session.execute(stmt)
+            return int(result.rowcount or 0)
+
 
 def normalize_rule(rule: str) -> str:
     """Normalize a rule for hashing: lowercase, collapsed whitespace."""
@@ -440,3 +509,11 @@ def normalize_rule(rule: str) -> str:
 def rule_hash(rule: str) -> str:
     """Return the hex sha256 of the normalized rule text."""
     return hashlib.sha256(normalize_rule(rule).encode("utf-8")).hexdigest()
+
+
+def _append_event_id(current, event_id: Optional[int]) -> list:
+    """Return the provenance list with ``event_id`` appended (idempotent)."""
+    ids = list(current or [])
+    if event_id is not None and event_id not in ids:
+        ids.append(event_id)
+    return ids

--- a/src/muxi/runtime/services/memory/long_term.py
+++ b/src/muxi/runtime/services/memory/long_term.py
@@ -1483,6 +1483,30 @@ class LongTermMemory:
                 for m in memories
             ]
 
+    async def delete_extracted_memories(self, external_user_id: Optional[str] = None) -> int:
+        """
+        Delete every extraction-derived memory for a user (all collections).
+
+        Rebuild support for the memory event substrate: only rows written
+        by the extractor (metadata ``source == 'extraction'``) are removed,
+        so conversations, knowledge uploads, and manually created memories
+        survive a flat-fact projection rebuild.
+
+        Returns:
+            The number of memories deleted.
+        """
+        internal_user_id = await self._resolve_user_id_async(external_user_id)
+        deleted = 0
+        async with self.AsyncSession() as session:
+            query = select(self.MemoryModel).where(self.MemoryModel.user_id == internal_user_id)
+            rows = (await session.execute(query)).scalars().all()
+            for memory in rows:
+                if (memory.meta_data or {}).get("source") == "extraction":
+                    await session.delete(memory)
+                    deleted += 1
+            await session.commit()
+        return deleted
+
     # Async collection methods removed - using simple column-based collections
 
     async def _search_internal_async(

--- a/src/muxi/runtime/services/memory/long_term.py
+++ b/src/muxi/runtime/services/memory/long_term.py
@@ -36,6 +36,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import numpy as np
 from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
+    JSON,
     Column,
     DateTime,
     ForeignKey,
@@ -43,9 +44,11 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    delete as sql_delete,
     desc,
     func,
     select,
+    type_coerce,
 )
 
 from ...datatypes.json_type import JSONType
@@ -1496,16 +1499,20 @@ class LongTermMemory:
             The number of memories deleted.
         """
         internal_user_id = await self._resolve_user_id_async(external_user_id)
-        deleted = 0
+        # type_coerce gives the JSONType column a JSON-typed expression so
+        # the path operator compiles per dialect (``meta_data ->> 'source'``
+        # on PostgreSQL, ``JSON_EXTRACT`` elsewhere) instead of failing on
+        # the decorator's TEXT impl.
+        source_marker = type_coerce(self.MemoryModel.meta_data, JSON)["source"].as_string()
+        stmt = (
+            sql_delete(self.MemoryModel)
+            .where(self.MemoryModel.user_id == internal_user_id)
+            .where(source_marker == "extraction")
+        )
         async with self.AsyncSession() as session:
-            query = select(self.MemoryModel).where(self.MemoryModel.user_id == internal_user_id)
-            rows = (await session.execute(query)).scalars().all()
-            for memory in rows:
-                if (memory.meta_data or {}).get("source") == "extraction":
-                    await session.delete(memory)
-                    deleted += 1
+            result = await session.execute(stmt)
             await session.commit()
-        return deleted
+            return int(result.rowcount or 0)
 
     # Async collection methods removed - using simple column-based collections
 

--- a/src/muxi/runtime/services/memory/memobase.py
+++ b/src/muxi/runtime/services/memory/memobase.py
@@ -486,6 +486,24 @@ class Memobase:
             )
             raise
 
+    async def delete_extracted_memories(self, external_user_id: Optional[str] = None) -> int:
+        """
+        Delete every extraction-derived memory for a user (all collections).
+
+        Rebuild support for the memory event substrate; delegates to the
+        wrapped LongTermMemory. Anonymous users store nothing, so the call
+        is a no-op for them.
+
+        Returns:
+            The number of memories deleted.
+        """
+        external_user_id = (
+            external_user_id if external_user_id is not None else self.default_external_user_id
+        )
+        if external_user_id in ["default", "anonymous", "0"]:
+            return 0
+        return await self.long_term_memory.delete_extracted_memories(external_user_id)
+
     def clear_user_memory(self, external_user_id: Optional[str] = None) -> None:
         """
         Clear memory for a specific user by recreating their collection.

--- a/src/muxi/runtime/services/memory/sqlite.py
+++ b/src/muxi/runtime/services/memory/sqlite.py
@@ -582,6 +582,35 @@ class SQLiteMemory(BaseMemory):
 
         return memory_id
 
+    async def delete_extracted_memories(self, user_id: Optional[str] = None) -> int:
+        """
+        Delete every extraction-derived memory for a user (all collections).
+
+        Rebuild support for the memory event substrate: only rows written
+        by the extractor (metadata ``source == 'extraction'``) are removed,
+        so conversations, knowledge uploads, and manually created memories
+        survive a flat-fact projection rebuild. The FTS mirror rows are
+        removed by the table's delete trigger.
+
+        Returns:
+            The number of memories deleted.
+        """
+        await self._ensure_dim()
+        if user_id:
+            internal_user_id = await self.get_or_create_user(str(user_id))
+        else:
+            internal_user_id = self.default_user_id
+        cursor = self.conn.execute(
+            f"""
+            DELETE FROM {self.memories_table}
+            WHERE user_id = ?
+              AND json_extract(metadata, '$.source') = 'extraction'
+            """,
+            (internal_user_id,),
+        )
+        self.conn.commit()
+        return int(cursor.rowcount or 0)
+
     async def search(
         self,
         query: str,

--- a/tests/unit/test_captains_log_schema.py
+++ b/tests/unit/test_captains_log_schema.py
@@ -69,6 +69,7 @@ class TestTableCreation:
             "decisions",
             "projects",
             "context",
+            "derived_from_event_ids",
             "created_at",
             "updated_at",
         }
@@ -89,6 +90,7 @@ class TestTableCreation:
             "context",
             "rule_hash",
             "source_log_id",
+            "derived_from_event_ids",
             "confidence",
             "hits",
             "last_applied_at",

--- a/tests/unit/test_knowledge_graph_schema.py
+++ b/tests/unit/test_knowledge_graph_schema.py
@@ -66,6 +66,7 @@ class TestTableCreation:
             "status",
             "contradicted_by",
             "superseded_by",
+            "derived_from_event_ids",
             "created_at",
             "updated_at",
         }
@@ -85,6 +86,7 @@ class TestTableCreation:
             "status",
             "contradicted_by",
             "superseded_by",
+            "derived_from_event_ids",
             "created_at",
             "updated_at",
         }

--- a/tests/unit/test_long_term_delete_extracted.py
+++ b/tests/unit/test_long_term_delete_extracted.py
@@ -1,0 +1,119 @@
+"""Unit tests for LongTermMemory.delete_extracted_memories.
+
+The flat-fact projection reset must be one bulk DELETE filtered on the
+JSON extraction-source marker -- rows are never loaded into memory and
+never deleted one-by-one (Greptile review of the memory event substrate:
+a per-row sweep is RAM-hungry and slow during a rebuild for an active
+user). Covers both the statement shape (single bulk DELETE, no memories
+SELECT) and the behavior (only the user's extraction-derived rows go;
+conversations and other users survive).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import event, select
+
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.long_term import LongTermMemory, get_memory_model
+
+FORMATION_ID = "ltm-delete-test-formation"
+
+
+@pytest.fixture
+def ltm(tmp_path):
+    """Single-user LongTermMemory backed by a file SQLite database."""
+    db_manager = DatabaseManager(f"sqlite:///{tmp_path}/ltm.db")
+    get_memory_model(1536)  # ensure the dim table is registered with Base
+    db_manager.create_tables(Base.metadata)
+    memory = LongTermMemory(
+        db_manager=db_manager,
+        formation_id=FORMATION_ID,
+        embedding_model="openai/text-embedding-3-small",
+    )
+    yield memory
+    db_manager.engine.dispose()
+
+
+def seed_memory(ltm, user_id: int, text: str, source: str) -> str:
+    """Insert one memory row directly (no embedding round-trip)."""
+    model = ltm.MemoryModel
+    with ltm.Session() as session:
+        row = model(
+            user_id=user_id,
+            text=text,
+            meta_data={"source": source, "collection": "context"},
+            collection="context",
+        )
+        session.add(row)
+        session.commit()
+        return row.id
+
+
+class TestDeleteExtractedMemories:
+    async def test_only_extraction_rows_for_the_user_are_deleted(self, ltm):
+        internal_user_id = await ltm._resolve_user_id_async(None)
+        seed_memory(ltm, internal_user_id, "Likes tea", "extraction")
+        seed_memory(ltm, internal_user_id, "Works at Automaze", "extraction")
+        seed_memory(ltm, internal_user_id, "raw conversation text", "conversation")
+
+        # A second user's extraction row must survive the reset.
+        from muxi.runtime.services.memory.long_term import User
+        from muxi.runtime.utils.id_generator import get_default_nanoid
+
+        with ltm.Session() as session:
+            other = User(public_id=get_default_nanoid(), formation_id=FORMATION_ID)
+            session.add(other)
+            session.commit()
+            other_id = other.id
+        seed_memory(ltm, other_id, "Other user's fact", "extraction")
+
+        deleted = await ltm.delete_extracted_memories()
+        assert deleted == 2
+
+        with ltm.Session() as session:
+            remaining = session.execute(select(ltm.MemoryModel.text)).scalars().all()
+        assert sorted(remaining) == ["Other user's fact", "raw conversation text"]
+
+    async def test_no_rows_returns_zero(self, ltm):
+        assert await ltm.delete_extracted_memories() == 0
+
+    async def test_reset_is_a_single_bulk_delete(self, ltm):
+        internal_user_id = await ltm._resolve_user_id_async(None)
+        for index in range(5):
+            seed_memory(ltm, internal_user_id, f"fact {index}", "extraction")
+        seed_memory(ltm, internal_user_id, "conversation", "conversation")
+
+        statements = []
+        sync_engine = ltm.db_manager.async_engine.sync_engine
+
+        def record_statement(conn, cursor, statement, parameters, context, executemany):
+            statements.append(statement)
+
+        event.listen(sync_engine, "before_cursor_execute", record_statement)
+        try:
+            deleted = await ltm.delete_extracted_memories()
+        finally:
+            event.remove(sync_engine, "before_cursor_execute", record_statement)
+
+        assert deleted == 5
+        deletes = [s for s in statements if s.lstrip().upper().startswith("DELETE")]
+        assert len(deletes) == 1  # one bulk statement, not one per memory
+        assert "json_extract" in deletes[0].lower()  # filtered in SQL, not in Python
+        # The memories table is never SELECTed: rows stay out of process memory.
+        table = ltm.MemoryModel.__tablename__
+        selects = [
+            s for s in statements if s.lstrip().upper().startswith("SELECT") and table in s.lower()
+        ]
+        assert selects == []
+
+    def test_postgres_dialect_compiles_to_json_path_operator(self, ltm):
+        """The same expression renders meta_data ->> 'source' on PostgreSQL."""
+        from sqlalchemy import JSON, delete, type_coerce
+        from sqlalchemy.dialects import postgresql
+
+        model = ltm.MemoryModel
+        marker = type_coerce(model.meta_data, JSON)["source"].as_string()
+        stmt = delete(model).where(model.user_id == 1).where(marker == "extraction")
+        compiled = str(stmt.compile(dialect=postgresql.dialect()))
+        assert "meta_data ->> " in compiled

--- a/tests/unit/test_memory_events_replay.py
+++ b/tests/unit/test_memory_events_replay.py
@@ -1,0 +1,565 @@
+"""Replay-equivalence tests for the Memory Event Substrate.
+
+The substrate's core promise: for every projection, write -> wipe ->
+replay produces the same queryable state as the incremental writes did.
+Each projection is exercised through its REAL dual-write path (the same
+code a live formation runs), snapshotted, wiped by its projector, rebuilt
+from the event log, and compared under a normalization that ignores only
+storage-assigned identity (integer ids, public ids, row timestamps).
+
+Also covers append-failure isolation: when the event log is down, every
+projection write path must still succeed (PRD Phase A dual-write posture).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.events import (
+    CaptainsLogProjector,
+    FlatFactProjector,
+    KnowledgeGraphProjector,
+    MemoryEventService,
+)
+from muxi.runtime.services.memory.events.models import (
+    EVENT_FACT_EXTRACTED,
+    EVENT_GRAPH_EXTRACTED,
+    EVENT_LESSON_RECORDED,
+    EVENT_LOG_ENTRY,
+)
+from muxi.runtime.services.memory.extractor import MemoryExtractor
+from muxi.runtime.services.memory.graph.service import KnowledgeGraphService
+from muxi.runtime.services.memory.log.service import CaptainsLogService
+
+FORMATION_ID = "replay-test-formation"
+USER = "u1"
+
+DIGEST_RESPONSE = (
+    "{"
+    '"summary": "The user finalized the memory PRD and founded Automaze.",'
+    '"decisions": ["Knowledge graph over flat facts"],'
+    '"projects": ["MUXI"],'
+    '"context": "Focused on the launch.",'
+    '"lessons": [{"rule": "Prefer reportlab over fpdf", "context": "PDF generation"}],'
+    '"entities": [],'
+    '"relationships": []'
+    "}"
+)
+
+
+class FakeModel:
+    """Digest LLM double returning a canned response."""
+
+    def __init__(self, response=DIGEST_RESPONSE):
+        self.response = response
+
+    async def generate_text(self, prompt, caching=True):
+        return self.response
+
+
+class FakeLongTermMemory:
+    """Vector-store double implementing the flat-fact projection contract."""
+
+    def __init__(self):
+        self.rows = {}
+        self._counter = 0
+
+    async def add(self, content, metadata=None, user_id=None, collection=None):
+        self._counter += 1
+        memory_id = f"m{self._counter}"
+        self.rows[memory_id] = {
+            "content": content,
+            "metadata": dict(metadata or {}),
+            "user_id": str(user_id),
+            "collection": collection,
+        }
+        return memory_id
+
+    async def delete_extracted_memories(self, user_id):
+        doomed = [
+            memory_id
+            for memory_id, row in self.rows.items()
+            if row["user_id"] == str(user_id) and row["metadata"].get("source") == "extraction"
+        ]
+        for memory_id in doomed:
+            del self.rows[memory_id]
+        return len(doomed)
+
+
+class FakeOverlord:
+    """Just enough overlord surface for MemoryExtractor writes."""
+
+    def __init__(self, memory_events):
+        self.is_multi_user = True
+        self.long_term_memory = FakeLongTermMemory()
+        self.memory_events = memory_events
+        self.current_agent = "overlord"
+
+
+@pytest.fixture
+def db_manager(tmp_path):
+    manager = DatabaseManager(f"sqlite:///{tmp_path}/replay.db")
+    manager.create_tables(Base.metadata)
+    yield manager
+    manager.engine.dispose()
+
+
+@pytest.fixture
+def events(db_manager):
+    return MemoryEventService(db_manager, FORMATION_ID)
+
+
+@pytest.fixture
+def broken_events(db_manager, monkeypatch):
+    """An event service whose appends always fail (database down)."""
+    service = MemoryEventService(db_manager, FORMATION_ID)
+
+    async def broken_append(**kwargs):
+        raise RuntimeError("event log unavailable")
+
+    monkeypatch.setattr(service.storage, "append", broken_append)
+    return service
+
+
+# ----------------------------------------------------------------------
+# Normalized snapshots: structural state keyed by natural identity, with
+# storage-assigned ids and row timestamps excluded.
+# ----------------------------------------------------------------------
+
+
+async def snapshot_graph(graph, user_id=USER):
+    """Snapshot the full subgraph (all statuses) keyed by names."""
+    entities = await graph.storage.list_entities(user_id, status=None, limit=1000)
+    entity_key = {e["id"]: (e["type"], e["name"]) for e in entities}
+    entity_state = {
+        entity_key[e["id"]]: {
+            "attributes": e["attributes"],
+            "confidence": e["confidence"],
+            "status": e["status"],
+            "contradicted_by": entity_key.get(e["contradicted_by"]),
+            "superseded_by": entity_key.get(e["superseded_by"]),
+            "events": e["derived_from_event_ids"],
+        }
+        for e in entities
+    }
+    relationships = await graph.storage.list_relationships(user_id, status=None, limit=1000)
+    rel_key = {
+        r["id"]: (entity_key[r["from_entity_id"]], r["type"], entity_key[r["to_entity_id"]])
+        for r in relationships
+    }
+    rel_state = {
+        rel_key[r["id"]]: {
+            "attributes": r["attributes"],
+            "confidence": r["confidence"],
+            "status": r["status"],
+            "contradicted_by": rel_key.get(r["contradicted_by"]),
+            "superseded_by": rel_key.get(r["superseded_by"]),
+            "events": r["derived_from_event_ids"],
+        }
+        for r in relationships
+    }
+    return entity_state, rel_state
+
+
+async def snapshot_log(log, user_id=USER):
+    """Snapshot entries (+ lineage) and lessons keyed by natural identity."""
+    entries = await log.storage.list_entries(user_id, limit=1000)
+    date_by_id = {e["id"]: e["date"] for e in entries}
+    sources_by_log = await log.storage.get_sources_for_logs([e["id"] for e in entries])
+    entry_state = {
+        e["date"]: {
+            "summary": e["summary"],
+            "decisions": e["decisions"],
+            "projects": e["projects"],
+            "context": e["context"],
+            "events": e["derived_from_event_ids"],
+            "sources": sorted(
+                (s["source_type"], s["source_id"]) for s in sources_by_log.get(e["id"], [])
+            ),
+        }
+        for e in entries
+    }
+    lessons = await log.lessons.list_active(user_id, limit=1000)
+    lesson_state = {
+        (lesson["agent_id"], lesson["rule_hash"]): {
+            "rule": lesson["rule"],
+            "context": lesson["context"],
+            "confidence": lesson["confidence"],
+            "hits": lesson["hits"],
+            "archived": lesson["archived"],
+            "source_log_date": date_by_id.get(lesson["source_log_id"]),
+            "events": lesson["derived_from_event_ids"],
+        }
+        for lesson in lessons
+    }
+    return entry_state, lesson_state
+
+
+def snapshot_flat(long_term_memory, user_id=USER):
+    """Snapshot flat-fact rows without their storage-assigned ids."""
+    rows = [row for row in long_term_memory.rows.values() if row["user_id"] == str(user_id)]
+    return sorted(rows, key=lambda row: (row["collection"], row["content"]))
+
+
+# ----------------------------------------------------------------------
+# Knowledge graph projection
+# ----------------------------------------------------------------------
+
+
+class TestKnowledgeGraphReplay:
+    async def seed(self, graph):
+        """Drive the real dual-write path, covering merge, conflict, supersede."""
+        await graph.store_extraction(
+            USER,
+            {
+                "entities": [
+                    {"name": "User", "type": "person", "confidence": 0.95},
+                    {
+                        "name": "London",
+                        "type": "location",
+                        "confidence": 0.9,
+                        "attributes": {"country": "UK"},
+                    },
+                ],
+                "relationships": [
+                    {
+                        "from": "User",
+                        "from_type": "person",
+                        "to": "London",
+                        "to_type": "location",
+                        "type": "lives_in",
+                        "confidence": 0.9,
+                    }
+                ],
+            },
+        )
+        # Conflicting fact on an exclusive predicate (delta below threshold).
+        await graph.store_extraction(
+            USER,
+            {
+                "entities": [{"name": "Berlin", "type": "location", "confidence": 0.9}],
+                "relationships": [
+                    {
+                        "from": "User",
+                        "from_type": "person",
+                        "to": "Berlin",
+                        "to_type": "location",
+                        "type": "lives_in",
+                        "confidence": 0.92,
+                    }
+                ],
+            },
+            source="periodic",
+        )
+        # Superseding fact (delta above threshold) + duplicate entity merge.
+        await graph.store_extraction(
+            USER,
+            {
+                "entities": [
+                    {
+                        "name": "User",
+                        "type": "person",
+                        "confidence": 0.9,
+                        "attributes": {"role": "founder"},
+                    },
+                    {"name": "Acme", "type": "company", "confidence": 0.5},
+                ],
+                "relationships": [
+                    {
+                        "from": "User",
+                        "from_type": "person",
+                        "to": "Acme",
+                        "to_type": "company",
+                        "type": "works_at",
+                        "confidence": 0.5,
+                    }
+                ],
+            },
+        )
+        await graph.store_extraction(
+            USER,
+            {
+                "entities": [{"name": "Beta", "type": "company", "confidence": 0.9}],
+                "relationships": [
+                    {
+                        "from": "User",
+                        "from_type": "person",
+                        "to": "Beta",
+                        "to_type": "company",
+                        "type": "works_at",
+                        "confidence": 0.9,
+                    }
+                ],
+            },
+        )
+
+    async def test_wipe_and_replay_reproduces_identical_state(self, db_manager, events):
+        graph = KnowledgeGraphService(db_manager, FORMATION_ID, event_log=events)
+        events.register_projector(KnowledgeGraphProjector(graph))
+        await self.seed(graph)
+
+        before = await snapshot_graph(graph)
+        entity_state, rel_state = before
+        # Sanity: the seed produced the full contradiction-detection shape.
+        assert (
+            rel_state[(("person", "User"), "lives_in", ("location", "Berlin"))]["status"]
+            == "conflicted"
+        )
+        assert (
+            rel_state[(("person", "User"), "works_at", ("company", "Acme"))]["status"]
+            == "superseded"
+        )
+        assert entity_state[("person", "User")]["attributes"] == {"role": "founder"}
+        assert all(state["events"] for state in entity_state.values())
+
+        report = await events.rebuild(USER, projection="knowledge_graph")
+        assert report["knowledge_graph"]["events"] == 4
+        assert report["knowledge_graph"]["failed"] == 0
+
+        after = await snapshot_graph(graph)
+        assert after == before
+
+        checkpoint = await events.storage.get_checkpoint("knowledge_graph", USER)
+        graph_events = await events.list_events(USER, event_types=[EVENT_GRAPH_EXTRACTED])
+        assert checkpoint["last_event_id"] == graph_events[-1]["id"]
+
+    async def test_replay_is_idempotent_across_repeated_rebuilds(self, db_manager, events):
+        graph = KnowledgeGraphService(db_manager, FORMATION_ID, event_log=events)
+        events.register_projector(KnowledgeGraphProjector(graph))
+        await self.seed(graph)
+
+        await events.rebuild(USER, projection="knowledge_graph")
+        first = await snapshot_graph(graph)
+        await events.rebuild(USER, projection="knowledge_graph")
+        second = await snapshot_graph(graph)
+        assert second == first
+
+    async def test_rebuild_scoped_to_one_user(self, db_manager, events):
+        graph = KnowledgeGraphService(db_manager, FORMATION_ID, event_log=events)
+        events.register_projector(KnowledgeGraphProjector(graph))
+        await self.seed(graph)
+        await graph.store_extraction(
+            "u2",
+            {
+                "entities": [{"name": "Oslo", "type": "location", "confidence": 0.9}],
+                "relationships": [],
+            },
+        )
+        other_before = await snapshot_graph(graph, "u2")
+
+        await events.rebuild(USER, projection="knowledge_graph")
+        assert await snapshot_graph(graph, "u2") == other_before
+
+    async def test_append_failure_never_blocks_graph_writes(self, db_manager, broken_events):
+        graph = KnowledgeGraphService(db_manager, FORMATION_ID, event_log=broken_events)
+        await graph.store_extraction(
+            USER,
+            {
+                "entities": [{"name": "Acme", "type": "company", "confidence": 0.9}],
+                "relationships": [],
+            },
+        )
+        stored = await graph.storage.get_entity(USER, "company", "Acme")
+        assert stored is not None
+        assert stored["derived_from_event_ids"] == []  # no event, write still landed
+
+
+# ----------------------------------------------------------------------
+# Captain's log projection (entries + lineage + lessons)
+# ----------------------------------------------------------------------
+
+
+class TestCaptainsLogReplay:
+    async def seed(self, log):
+        """Drive the real digest and record_lesson dual-write paths."""
+        log.queue_turn("We founded Automaze today.", "Congratulations.", USER)
+        log.queue_turn("Decided to launch MUXI next month.", "Noted.", USER)
+        totals = await log.run_periodic_summarization(FakeModel())
+        assert totals["entries"] == 1
+        # Tool path, including a duplicate write (confirmation: hits bump).
+        await log.record_lesson(USER, "memory_agent", "Always confirm before deleting")
+        await log.record_lesson(USER, "memory_agent", "Always confirm before deleting")
+
+    async def test_wipe_and_replay_reproduces_identical_state(self, db_manager, events):
+        log = CaptainsLogService(db_manager, FORMATION_ID, event_log=events)
+        events.register_projector(CaptainsLogProjector(log))
+        await self.seed(log)
+
+        before = await snapshot_log(log)
+        entry_state, lesson_state = before
+        assert len(entry_state) == 1
+        (entry,) = entry_state.values()
+        assert len(entry["sources"]) == 2  # both buffered turns in the lineage
+        assert entry["events"]  # provenance recorded
+        # Digest lesson links to its entry by date; confirmation doubled hits.
+        digest_lesson = next(
+            state for state in lesson_state.values() if state["rule"].startswith("Prefer")
+        )
+        assert digest_lesson["source_log_date"] in entry_state
+        tool_lesson = next(
+            state for state in lesson_state.values() if state["rule"].startswith("Always")
+        )
+        assert tool_lesson["hits"] == 2
+
+        report = await events.rebuild(USER, projection="captains_log")
+        assert report["captains_log"]["events"] == 4  # 1 entry + 3 lesson events
+        assert report["captains_log"]["failed"] == 0
+
+        after = await snapshot_log(log)
+        assert after == before
+
+        log_events = await events.list_events(
+            USER, event_types=[EVENT_LOG_ENTRY, EVENT_LESSON_RECORDED]
+        )
+        checkpoint = await events.storage.get_checkpoint("captains_log", USER)
+        assert checkpoint["last_event_id"] == log_events[-1]["id"]
+
+    async def test_append_failure_never_blocks_digest(self, db_manager, broken_events):
+        log = CaptainsLogService(db_manager, FORMATION_ID, event_log=broken_events)
+        log.queue_turn("We founded Automaze today.", "Congratulations.", USER)
+        totals = await log.run_periodic_summarization(FakeModel())
+        assert totals["entries"] == 1
+        entries = await log.storage.list_entries(USER)
+        assert entries[0]["derived_from_event_ids"] == []
+
+    async def test_append_failure_never_blocks_record_lesson(self, db_manager, broken_events):
+        log = CaptainsLogService(db_manager, FORMATION_ID, event_log=broken_events)
+        lesson = await log.record_lesson(USER, "memory_agent", "Stay calm")
+        assert lesson["rule"] == "Stay calm"
+
+
+# ----------------------------------------------------------------------
+# Flat-fact (vector) projection
+# ----------------------------------------------------------------------
+
+EXTRACTION_RESULTS = {
+    "extracted_info": [
+        {
+            "memory": "The user's favorite color is blue",
+            "confidence": 0.9,
+            "importance": 0.7,
+            "collection": "preferences",
+        },
+        {
+            "memory": "Works at Automaze",
+            "confidence": 0.85,
+            "importance": 0.8,
+            "collection": "user_identity",
+        },
+    ]
+}
+
+
+class TestFlatFactReplay:
+    async def seed(self, events):
+        overlord = FakeOverlord(events)
+        extractor = MemoryExtractor(overlord=overlord)
+        turn = await events.record(
+            user_id=USER,
+            event_type="interaction.turn",
+            payload={"user_message": "My favorite color is blue and I work at Automaze."},
+            source="interaction",
+        )
+        await extractor._process_extraction_results(
+            EXTRACTION_RESULTS, USER, caused_by_event_id=turn["id"]
+        )
+        # A non-extraction row (conversation) that must survive rebuilds.
+        await overlord.long_term_memory.add(
+            content="raw conversation text",
+            metadata={"source": "conversation"},
+            user_id=USER,
+            collection="conversations",
+        )
+        return overlord
+
+    async def test_wipe_and_replay_reproduces_identical_state(self, events):
+        overlord = await self.seed(events)
+        events.register_projector(FlatFactProjector(overlord.long_term_memory))
+
+        before = snapshot_flat(overlord.long_term_memory)
+        extracted = [row for row in before if row["metadata"].get("source") == "extraction"]
+        assert len(extracted) == 2
+        fact_events = await events.list_events(USER, event_types=[EVENT_FACT_EXTRACTED])
+        assert len(fact_events) == 2
+        # Provenance chain: fact -> interaction.turn, and the row -> fact event.
+        assert all(e["caused_by"] is not None for e in fact_events)
+        assert {row["metadata"]["derived_from_event_id"] for row in extracted} == {
+            e["id"] for e in fact_events
+        }
+
+        report = await events.rebuild(USER, projection="flat_facts")
+        assert report["flat_facts"]["events"] == 2
+        assert report["flat_facts"]["failed"] == 0
+
+        after = snapshot_flat(overlord.long_term_memory)
+        assert after == before
+
+    async def test_rebuild_preserves_non_extraction_memories(self, events):
+        overlord = await self.seed(events)
+        events.register_projector(FlatFactProjector(overlord.long_term_memory))
+
+        await events.rebuild(USER, projection="flat_facts")
+        conversations = [
+            row
+            for row in overlord.long_term_memory.rows.values()
+            if row["collection"] == "conversations"
+        ]
+        assert len(conversations) == 1
+
+    async def test_append_failure_never_blocks_fact_storage(self, broken_events):
+        overlord = FakeOverlord(broken_events)
+        extractor = MemoryExtractor(overlord=overlord)
+        await extractor._process_extraction_results(EXTRACTION_RESULTS, USER)
+        stored = snapshot_flat(overlord.long_term_memory)
+        assert len(stored) == 2
+        assert all("derived_from_event_id" not in row["metadata"] for row in stored)
+
+    async def test_no_event_service_keeps_legacy_behavior(self):
+        overlord = FakeOverlord(None)
+        overlord.memory_events = None
+        extractor = MemoryExtractor(overlord=overlord)
+        await extractor._process_extraction_results(EXTRACTION_RESULTS, USER)
+        assert len(snapshot_flat(overlord.long_term_memory)) == 2
+
+
+# ----------------------------------------------------------------------
+# All three projections in one rebuild pass
+# ----------------------------------------------------------------------
+
+
+class TestFullRebuild:
+    async def test_rebuild_all_registered_projections(self, db_manager, events):
+        graph = KnowledgeGraphService(db_manager, FORMATION_ID, event_log=events)
+        log = CaptainsLogService(db_manager, FORMATION_ID, event_log=events)
+        overlord = FakeOverlord(events)
+        events.register_projector(KnowledgeGraphProjector(graph))
+        events.register_projector(CaptainsLogProjector(log))
+        events.register_projector(FlatFactProjector(overlord.long_term_memory))
+
+        await graph.store_extraction(
+            USER,
+            {
+                "entities": [{"name": "Acme", "type": "company", "confidence": 0.9}],
+                "relationships": [],
+            },
+        )
+        log.queue_turn("We founded Automaze today.", "Congratulations.", USER)
+        await log.run_periodic_summarization(FakeModel())
+        extractor = MemoryExtractor(overlord=overlord)
+        await extractor._process_extraction_results(EXTRACTION_RESULTS, USER)
+
+        before = (
+            await snapshot_graph(graph),
+            await snapshot_log(log),
+            snapshot_flat(overlord.long_term_memory),
+        )
+        report = await events.rebuild(USER)
+        assert set(report) == {"knowledge_graph", "captains_log", "flat_facts"}
+        assert all(section["failed"] == 0 for section in report.values())
+        after = (
+            await snapshot_graph(graph),
+            await snapshot_log(log),
+            snapshot_flat(overlord.long_term_memory),
+        )
+        assert after == before

--- a/tests/unit/test_memory_events_schema.py
+++ b/tests/unit/test_memory_events_schema.py
@@ -1,0 +1,258 @@
+"""Unit tests for the Memory Event Substrate schema.
+
+Covers table creation on both database backends (exercised through SQLite,
+which shares the SQLAlchemy models and metadata with PostgreSQL; set
+MUXI_TEST_POSTGRES_DSN to also run the suite against a live PostgreSQL),
+the event/checkpoint column sets, the partial unique idempotency index,
+and the versioned payload schema registry.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+from muxi.runtime.services.db import Base
+from muxi.runtime.services.memory.events.models import (
+    EVENT_FACT_EXTRACTED,
+    EVENT_GRAPH_EXTRACTED,
+    EVENT_INTERACTION_TURN,
+    EVENT_LESSON_RECORDED,
+    EVENT_LOG_ENTRY,
+    EVENT_SCHEMAS,
+    EVENT_USER_DELETION,
+    MemoryEvent,
+    ProjectionCheckpoint,
+    validate_event_payload,
+)
+
+FORMATION_ID = "events-test-formation"
+
+EVENT_TABLES = [MemoryEvent.__table__, ProjectionCheckpoint.__table__]
+
+POSTGRES_DSN = os.environ.get("MUXI_TEST_POSTGRES_DSN")
+
+BACKENDS = ["sqlite"] + (["postgresql"] if POSTGRES_DSN else [])
+
+
+@pytest.fixture(params=BACKENDS)
+def engine(request):
+    """Engine per backend with the substrate tables created."""
+    if request.param == "postgresql":
+        engine = create_engine(POSTGRES_DSN)
+        Base.metadata.drop_all(engine, tables=EVENT_TABLES)
+    else:
+        engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=EVENT_TABLES)
+    yield engine
+    if request.param == "postgresql":
+        Base.metadata.drop_all(engine, tables=EVENT_TABLES)
+    engine.dispose()
+
+
+@pytest.fixture
+def session(engine):
+    """Session bound to the backend engine."""
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+def make_event(**overrides) -> MemoryEvent:
+    """Build a minimal valid event row."""
+    fields = {
+        "user_id": "u1",
+        "formation_id": FORMATION_ID,
+        "scope_type": "user",
+        "scope_id": "u1",
+        "event_type": EVENT_INTERACTION_TURN,
+        "payload": {"user_message": "hello"},
+        "source": "interaction",
+    }
+    fields.update(overrides)
+    return MemoryEvent(**fields)
+
+
+class TestTableCreation:
+    """Both substrate tables create cleanly with the PRD columns."""
+
+    def test_tables_exist(self, engine):
+        tables = inspect(engine).get_table_names()
+        assert "memory_events" in tables
+        assert "projection_checkpoints" in tables
+
+    def test_event_columns(self, engine):
+        columns = {c["name"] for c in inspect(engine).get_columns("memory_events")}
+        assert columns == {
+            "id",
+            "public_id",
+            "user_id",
+            "formation_id",
+            "scope_type",
+            "scope_id",
+            "occurred_at",
+            "ingested_at",
+            "event_type",
+            "event_version",
+            "payload",
+            "source",
+            "source_id",
+            "source_confidence",
+            "caused_by",
+            "decay_rate",
+            "expires_at",
+            "deleted_at",
+            "deleted_reason",
+            "agent_id",
+            "conversation_id",
+        }
+
+    def test_checkpoint_columns(self, engine):
+        columns = {c["name"] for c in inspect(engine).get_columns("projection_checkpoints")}
+        assert columns == {
+            "id",
+            "projection_name",
+            "formation_id",
+            "user_id",
+            "last_event_id",
+            "last_applied_at",
+            "schema_version",
+        }
+
+    def test_event_indexes(self, engine):
+        indexes = {index["name"] for index in inspect(engine).get_indexes("memory_events")}
+        assert "idx_memory_events_idempotency" in indexes
+        assert "idx_memory_events_user_time" in indexes
+        assert "idx_memory_events_user_type" in indexes
+        assert "idx_memory_events_user_source" in indexes
+        assert "idx_memory_events_caused_by" in indexes
+
+
+class TestScopeAndDefaults:
+    """Forward-compatible scope columns and column defaults."""
+
+    def test_user_scope_recorded(self, session):
+        event = make_event()
+        session.add(event)
+        session.commit()
+        assert event.scope_type == "user"
+        assert event.scope_id == event.user_id
+
+    def test_defaults(self, session):
+        event = make_event()
+        session.add(event)
+        session.commit()
+        assert event.event_version == 1
+        assert event.source_confidence == 1.0
+        assert event.decay_rate == "static"
+        assert event.deleted_at is None
+        assert event.occurred_at is not None
+        assert event.ingested_at is not None
+        assert len(event.public_id) == 21
+
+
+class TestIdempotencyIndex:
+    """The partial unique index enforces (scope, source, source_id) once."""
+
+    def test_duplicate_source_id_rejected(self, session):
+        session.add(make_event(source_id="turn/1"))
+        session.commit()
+        session.add(make_event(source_id="turn/1"))
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+    def test_null_source_id_unconstrained(self, session):
+        session.add(make_event())
+        session.add(make_event())
+        session.commit()
+        assert session.query(MemoryEvent).count() == 2
+
+    def test_other_user_unconstrained(self, session):
+        session.add(make_event(source_id="turn/1"))
+        session.add(make_event(user_id="u2", scope_id="u2", source_id="turn/1"))
+        session.commit()
+        assert session.query(MemoryEvent).count() == 2
+
+
+class TestCheckpointUniqueness:
+    """One checkpoint row per (projection, formation, user)."""
+
+    def test_duplicate_scope_rejected(self, session):
+        session.add(
+            ProjectionCheckpoint(
+                projection_name="knowledge_graph",
+                formation_id=FORMATION_ID,
+                user_id="u1",
+                last_event_id=1,
+            )
+        )
+        session.commit()
+        session.add(
+            ProjectionCheckpoint(
+                projection_name="knowledge_graph",
+                formation_id=FORMATION_ID,
+                user_id="u1",
+                last_event_id=2,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+
+class TestPayloadSchemaRegistry:
+    """Versioned payload validation at write time."""
+
+    def test_every_event_type_has_a_v1_schema(self):
+        for event_type in (
+            EVENT_INTERACTION_TURN,
+            EVENT_FACT_EXTRACTED,
+            EVENT_GRAPH_EXTRACTED,
+            EVENT_LOG_ENTRY,
+            EVENT_LESSON_RECORDED,
+            EVENT_USER_DELETION,
+        ):
+            assert 1 in EVENT_SCHEMAS[event_type]
+
+    def test_valid_payloads_pass(self):
+        validate_event_payload(EVENT_INTERACTION_TURN, {"user_message": "hi"})
+        validate_event_payload(
+            EVENT_FACT_EXTRACTED,
+            {"memory": "Likes tea", "collection": "preferences", "metadata": {}},
+        )
+        validate_event_payload(EVENT_GRAPH_EXTRACTED, {"entities": [], "relationships": []})
+        validate_event_payload(
+            EVENT_LOG_ENTRY,
+            {"date": "2026-07-07", "summary": "Did things", "decisions": [], "sources": []},
+        )
+        validate_event_payload(EVENT_LESSON_RECORDED, {"agent_id": "overlord", "rule": "Be brief"})
+        validate_event_payload(EVENT_USER_DELETION, {"reason": "gdpr", "target_event_ids": [1]})
+
+    def test_unknown_event_type_rejected(self):
+        with pytest.raises(ValueError, match="Unknown memory event type"):
+            validate_event_payload("nope.event", {})
+
+    def test_unknown_version_rejected(self):
+        with pytest.raises(ValueError, match="Unknown version"):
+            validate_event_payload(EVENT_INTERACTION_TURN, {"user_message": "hi"}, 2)
+
+    def test_missing_required_key_rejected(self):
+        with pytest.raises(ValueError, match="missing required keys"):
+            validate_event_payload(EVENT_FACT_EXTRACTED, {"memory": "Likes tea"})
+
+    def test_unknown_key_rejected(self):
+        with pytest.raises(ValueError, match="unknown keys"):
+            validate_event_payload(EVENT_INTERACTION_TURN, {"user_message": "hi", "extra": 1})
+
+    def test_non_dict_payload_rejected(self):
+        with pytest.raises(ValueError, match="must be a dict"):
+            validate_event_payload(EVENT_INTERACTION_TURN, ["hi"])
+
+    def test_list_key_type_enforced(self):
+        with pytest.raises(ValueError, match="must be a list"):
+            validate_event_payload(EVENT_GRAPH_EXTRACTED, {"entities": "Acme", "relationships": []})

--- a/tests/unit/test_memory_events_service.py
+++ b/tests/unit/test_memory_events_service.py
@@ -1,0 +1,256 @@
+"""Unit tests for the MemoryEventService coordination layer.
+
+Covers failure-isolated recording (an append failure or a disabled
+substrate never raises into the caller's write path), the projector
+registry, the rebuild driver (reset -> ordered replay -> checkpoint,
+dry-run, per-event failure containment), selective forgetting, and the
+hard-purge lifecycle.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.events.models import (
+    EVENT_FACT_EXTRACTED,
+    EVENT_INTERACTION_TURN,
+    EVENT_USER_DELETION,
+)
+from muxi.runtime.services.memory.events.service import MemoryEventService
+
+FORMATION_ID = "events-test-formation"
+
+
+@pytest.fixture
+def service(tmp_path):
+    """Event service backed by a file SQLite database."""
+    db_manager = DatabaseManager(f"sqlite:///{tmp_path}/events.db")
+    db_manager.create_tables(Base.metadata)
+    yield MemoryEventService(db_manager, FORMATION_ID)
+    db_manager.engine.dispose()
+
+
+class RecordingProjector:
+    """Test double implementing the projector contract."""
+
+    def __init__(self, name="test_projection", event_types=(EVENT_FACT_EXTRACTED,)):
+        self.name = name
+        self.event_types = event_types
+        self.applied = []
+        self.resets = []
+        self.fail_on_event_ids = set()
+
+    async def apply(self, event):
+        if event["id"] in self.fail_on_event_ids:
+            raise RuntimeError("projector exploded")
+        self.applied.append(event["id"])
+
+    async def reset(self, user_id):
+        self.resets.append(str(user_id))
+        self.applied = []
+
+
+async def record_fact(service, memory="Likes tea", **kwargs):
+    return await service.record(
+        user_id="u1",
+        event_type=EVENT_FACT_EXTRACTED,
+        payload={"memory": memory, "collection": "preferences"},
+        source="interaction",
+        **kwargs,
+    )
+
+
+class TestRecord:
+    async def test_record_appends_and_returns_event(self, service):
+        event = await record_fact(service)
+        assert event is not None
+        assert event["event_type"] == EVENT_FACT_EXTRACTED
+        assert [e["id"] for e in await service.list_events("u1")] == [event["id"]]
+
+    async def test_record_idempotent_duplicate_returns_existing(self, service):
+        first = await record_fact(service, source_id="conv/1")
+        second = await record_fact(service, memory="other", source_id="conv/1")
+        assert second["id"] == first["id"]
+        assert len(await service.list_events("u1")) == 1
+
+    async def test_record_never_raises_on_append_failure(self, service, monkeypatch):
+        async def broken_append(**kwargs):
+            raise RuntimeError("database down")
+
+        monkeypatch.setattr(service.storage, "append", broken_append)
+        assert await record_fact(service) is None  # swallowed, not raised
+
+    async def test_record_never_raises_on_invalid_payload(self, service):
+        event = await service.record(
+            user_id="u1",
+            event_type=EVENT_FACT_EXTRACTED,
+            payload={"memory": "missing collection"},
+            source="interaction",
+        )
+        assert event is None
+
+    async def test_record_disabled_returns_none(self, service):
+        service.enabled = False
+        assert await record_fact(service) is None
+        service.enabled = True
+        assert await service.list_events("u1") == []
+
+
+class TestRebuild:
+    async def test_rebuild_resets_replays_and_checkpoints(self, service):
+        projector = RecordingProjector()
+        service.register_projector(projector)
+
+        first = await record_fact(service, memory="one")
+        second = await record_fact(service, memory="two")
+        # An event outside the projector's types must not be replayed.
+        await service.record(
+            user_id="u1",
+            event_type=EVENT_INTERACTION_TURN,
+            payload={"user_message": "hello"},
+            source="interaction",
+        )
+
+        report = await service.rebuild("u1")
+        assert report == {"test_projection": {"events": 2, "applied": 2, "failed": 0}}
+        assert projector.resets == ["u1"]
+        assert projector.applied == [first["id"], second["id"]]
+
+        checkpoint = await service.storage.get_checkpoint("test_projection", "u1")
+        assert checkpoint["last_event_id"] == second["id"]
+
+    async def test_rebuild_specific_projection_only(self, service):
+        target = RecordingProjector(name="target")
+        bystander = RecordingProjector(name="bystander")
+        service.register_projector(target)
+        service.register_projector(bystander)
+        await record_fact(service)
+
+        report = await service.rebuild("u1", projection="target")
+        assert list(report) == ["target"]
+        assert bystander.resets == []
+
+    async def test_rebuild_unknown_projection_raises(self, service):
+        with pytest.raises(ValueError, match="Unknown projection"):
+            await service.rebuild("u1", projection="nope")
+
+    async def test_rebuild_disabled_raises(self, service):
+        service.enabled = False
+        with pytest.raises(ValueError, match="disabled"):
+            await service.rebuild("u1")
+
+    async def test_rebuild_dry_run_touches_nothing(self, service):
+        projector = RecordingProjector()
+        service.register_projector(projector)
+        await record_fact(service)
+
+        report = await service.rebuild("u1", dry_run=True)
+        assert report["test_projection"] == {
+            "events": 1,
+            "applied": 0,
+            "failed": 0,
+            "dry_run": True,
+        }
+        assert projector.resets == []
+        assert projector.applied == []
+        assert await service.storage.get_checkpoint("test_projection", "u1") is None
+
+    async def test_rebuild_contains_per_event_failures(self, service):
+        projector = RecordingProjector()
+        service.register_projector(projector)
+        bad = await record_fact(service, memory="bad")
+        good = await record_fact(service, memory="good")
+        projector.fail_on_event_ids = {bad["id"]}
+
+        report = await service.rebuild("u1")
+        assert report["test_projection"] == {"events": 2, "applied": 1, "failed": 1}
+        assert projector.applied == [good["id"]]
+
+    async def test_rebuild_skips_soft_deleted_events(self, service):
+        projector = RecordingProjector()
+        service.register_projector(projector)
+        forgotten = await record_fact(service, memory="forgotten")
+        kept = await record_fact(service, memory="kept")
+        await service.storage.soft_delete_events("u1", [forgotten["id"]], "user_request")
+
+        report = await service.rebuild("u1")
+        assert report["test_projection"]["events"] == 1
+        assert projector.applied == [kept["id"]]
+
+
+class TestForgetSource:
+    async def test_forget_source_soft_deletes_and_audits(self, service):
+        projector = RecordingProjector()
+        service.register_projector(projector)
+        await record_fact(service, memory="one")
+        await record_fact(service, memory="two")
+
+        result = await service.forget_source("u1", "interaction", reason="gdpr")
+        assert result["deleted_events"] == 2
+        assert result["rebuild_required"] == ["test_projection"]
+
+        live = await service.list_events("u1")
+        assert [e["event_type"] for e in live] == [EVENT_USER_DELETION]
+        assert live[0]["payload"]["reason"] == "gdpr"
+        assert len(live[0]["payload"]["target_event_ids"]) == 2
+
+    async def test_forget_source_leaves_other_sources(self, service):
+        await record_fact(service)
+        await service.record(
+            user_id="u1",
+            event_type=EVENT_FACT_EXTRACTED,
+            payload={"memory": "periodic fact", "collection": "context"},
+            source="periodic",
+        )
+        result = await service.forget_source("u1", "interaction")
+        assert result["deleted_events"] == 1
+        sources = {e["source"] for e in await service.list_events("u1")}
+        assert "periodic" in sources
+
+
+class TestPurgeLifecycle:
+    async def test_start_and_stop_purge_loop(self, service):
+        service.start()
+        assert service._purge_task is not None
+        first_task = service._purge_task
+        service.start()  # idempotent while running
+        assert service._purge_task is first_task
+        await service.stop()
+        assert service._purge_task is None
+        await service.stop()  # idempotent when stopped
+
+    async def test_start_disabled_is_noop(self, service):
+        service.enabled = False
+        service.start()
+        assert service._purge_task is None
+
+    async def test_run_hard_purge_empty_log(self, service):
+        assert await service.run_hard_purge() == 0
+
+
+class TestConfig:
+    def test_defaults(self, service):
+        assert service.enabled is True
+        assert service.grace_period_days == 30
+
+    def test_config_overrides(self, tmp_path):
+        db_manager = DatabaseManager(f"sqlite:///{tmp_path}/cfg.db")
+        db_manager.create_tables(Base.metadata)
+        configured = MemoryEventService(
+            db_manager,
+            FORMATION_ID,
+            config={"enabled": True, "retention": {"grace_period_days": 7}},
+        )
+        assert configured.grace_period_days == 7
+        db_manager.engine.dispose()
+
+    def test_invalid_grace_period_fails_fast(self, tmp_path):
+        db_manager = DatabaseManager(f"sqlite:///{tmp_path}/bad.db")
+        with pytest.raises(ValueError):
+            MemoryEventService(
+                db_manager,
+                FORMATION_ID,
+                config={"retention": {"grace_period_days": "forever"}},
+            )
+        db_manager.engine.dispose()

--- a/tests/unit/test_memory_events_storage.py
+++ b/tests/unit/test_memory_events_storage.py
@@ -1,0 +1,299 @@
+"""Unit tests for the Memory Event Substrate storage layer.
+
+Covers append (validation, ordering, causation, decay declaration),
+idempotency, immutability (no update surface), soft delete + hard purge,
+replay listing filters, user/formation isolation, and the projection
+checkpoint cursor. Runs on SQLite; set MUXI_TEST_POSTGRES_DSN to run the
+same suite against a live PostgreSQL.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import timedelta
+
+import pytest
+
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.events.models import (
+    EVENT_FACT_EXTRACTED,
+    EVENT_INTERACTION_TURN,
+    MemoryEvent,
+    ProjectionCheckpoint,
+)
+from muxi.runtime.services.memory.events.storage import MemoryEventStorage
+from muxi.runtime.utils.datetime_utils import utc_now_naive
+
+FORMATION_ID = "events-test-formation"
+POSTGRES_DSN = os.environ.get("MUXI_TEST_POSTGRES_DSN")
+BACKENDS = ["sqlite"] + (["postgresql"] if POSTGRES_DSN else [])
+
+EVENT_TABLES = [MemoryEvent.__table__, ProjectionCheckpoint.__table__]
+
+
+@pytest.fixture(params=BACKENDS)
+def storage(request, tmp_path):
+    """Event storage backed by a per-test database.
+
+    SQLite uses a file (not :memory:) because the DatabaseManager keeps
+    separate sync and async engines; both must see the same tables.
+    """
+    if request.param == "postgresql":
+        db_manager = DatabaseManager(POSTGRES_DSN)
+        Base.metadata.drop_all(db_manager.engine, tables=EVENT_TABLES)
+    else:
+        db_manager = DatabaseManager(f"sqlite:///{tmp_path}/events.db")
+    db_manager.create_tables(Base.metadata, tables=EVENT_TABLES)
+    yield MemoryEventStorage(db_manager, FORMATION_ID)
+    if request.param == "postgresql":
+        Base.metadata.drop_all(db_manager.engine, tables=EVENT_TABLES)
+    db_manager.engine.dispose()
+
+
+async def append_turn(storage, user_id="u1", message="hello", **kwargs):
+    """Append a minimal interaction.turn event."""
+    return await storage.append(
+        user_id=user_id,
+        event_type=EVENT_INTERACTION_TURN,
+        payload={"user_message": message},
+        source="interaction",
+        **kwargs,
+    )
+
+
+class TestAppend:
+    async def test_append_returns_full_event(self, storage):
+        event, created = await append_turn(storage, agent_id="assistant")
+        assert created is True
+        assert event["id"] > 0
+        assert len(event["public_id"]) == 21
+        assert event["user_id"] == "u1"
+        assert event["formation_id"] == FORMATION_ID
+        assert event["scope_type"] == "user"
+        assert event["scope_id"] == "u1"
+        assert event["event_type"] == EVENT_INTERACTION_TURN
+        assert event["event_version"] == 1
+        assert event["payload"] == {"user_message": "hello"}
+        assert event["source"] == "interaction"
+        assert event["source_confidence"] == 1.0
+        assert event["decay_rate"] == "static"
+        assert event["agent_id"] == "assistant"
+        assert event["occurred_at"] is not None
+        assert event["ingested_at"] is not None
+        assert event["deleted_at"] is None
+
+    async def test_append_order_is_the_replay_cursor(self, storage):
+        first, _ = await append_turn(storage, message="one")
+        second, _ = await append_turn(storage, message="two")
+        third, _ = await append_turn(storage, message="three")
+        assert first["id"] < second["id"] < third["id"]
+
+        events = await storage.list_events("u1")
+        assert [e["payload"]["user_message"] for e in events] == ["one", "two", "three"]
+
+    async def test_causation_link(self, storage):
+        turn, _ = await append_turn(storage)
+        fact, _ = await storage.append(
+            user_id="u1",
+            event_type=EVENT_FACT_EXTRACTED,
+            payload={"memory": "Likes tea", "collection": "preferences"},
+            source="interaction",
+            caused_by=turn["id"],
+        )
+        assert fact["caused_by"] == turn["id"]
+
+    async def test_explicit_occurred_at_preserved(self, storage):
+        backfill_time = utc_now_naive() - timedelta(days=30)
+        event, _ = await append_turn(storage, occurred_at=backfill_time)
+        assert event["occurred_at"] == backfill_time.isoformat()
+        assert event["ingested_at"] != event["occurred_at"]
+
+    async def test_invalid_payload_rejected(self, storage):
+        with pytest.raises(ValueError, match="missing required keys"):
+            await storage.append(
+                user_id="u1",
+                event_type=EVENT_FACT_EXTRACTED,
+                payload={"memory": "no collection"},
+                source="interaction",
+            )
+        assert await storage.list_events("u1") == []
+
+    async def test_unknown_event_type_rejected(self, storage):
+        with pytest.raises(ValueError, match="Unknown memory event type"):
+            await storage.append(
+                user_id="u1", event_type="bogus.type", payload={}, source="interaction"
+            )
+
+    async def test_invalid_decay_rate_rejected(self, storage):
+        with pytest.raises(ValueError, match="Invalid decay_rate"):
+            await append_turn(storage, decay_rate="sometimes")
+
+    async def test_empty_source_rejected(self, storage):
+        with pytest.raises(ValueError, match="non-empty source"):
+            await storage.append(
+                user_id="u1",
+                event_type=EVENT_INTERACTION_TURN,
+                payload={"user_message": "hi"},
+                source=" ",
+            )
+
+
+class TestIdempotency:
+    async def test_duplicate_source_id_returns_existing(self, storage):
+        first, created_first = await append_turn(storage, source_id="conv/1/turn/1")
+        second, created_second = await append_turn(
+            storage, message="different body", source_id="conv/1/turn/1"
+        )
+        assert created_first is True
+        assert created_second is False
+        assert second["id"] == first["id"]
+        assert second["payload"] == first["payload"]  # original write wins
+        assert len(await storage.list_events("u1")) == 1
+
+    async def test_same_source_id_different_user_both_stored(self, storage):
+        await append_turn(storage, user_id="u1", source_id="turn/1")
+        await append_turn(storage, user_id="u2", source_id="turn/1")
+        assert len(await storage.list_events("u1")) == 1
+        assert len(await storage.list_events("u2")) == 1
+
+    async def test_soft_deleted_source_id_can_be_rewritten(self, storage):
+        first, _ = await append_turn(storage, source_id="turn/1")
+        await storage.soft_delete_events("u1", [first["id"]], "user_request")
+        second, created = await append_turn(storage, source_id="turn/1")
+        assert created is True
+        assert second["id"] != first["id"]
+
+
+class TestImmutability:
+    def test_storage_exposes_no_update_surface(self, storage):
+        mutators = [
+            name
+            for name in dir(storage)
+            if not name.startswith("_") and callable(getattr(storage, name))
+        ]
+        assert sorted(mutators) == [
+            "append",
+            "get_checkpoint",
+            "get_event",
+            "hard_purge",
+            "list_events",
+            "reset_checkpoint",
+            "set_checkpoint",
+            "soft_delete_events",
+        ]
+
+    async def test_soft_delete_preserves_event_content(self, storage):
+        event, _ = await append_turn(storage)
+        await storage.soft_delete_events("u1", [event["id"]], "gdpr")
+        stored = await storage.get_event(event["id"])
+        assert stored["payload"] == event["payload"]
+        assert stored["deleted_at"] is not None
+        assert stored["deleted_reason"] == "gdpr"
+
+
+class TestListing:
+    async def test_filters_by_event_type(self, storage):
+        await append_turn(storage)
+        await storage.append(
+            user_id="u1",
+            event_type=EVENT_FACT_EXTRACTED,
+            payload={"memory": "Likes tea", "collection": "preferences"},
+            source="interaction",
+        )
+        facts = await storage.list_events("u1", event_types=[EVENT_FACT_EXTRACTED])
+        assert [e["event_type"] for e in facts] == [EVENT_FACT_EXTRACTED]
+
+    async def test_filters_by_source(self, storage):
+        await append_turn(storage)
+        await storage.append(
+            user_id="u1",
+            event_type=EVENT_FACT_EXTRACTED,
+            payload={"memory": "Fact", "collection": "context"},
+            source="periodic",
+        )
+        periodic = await storage.list_events("u1", source="periodic")
+        assert [e["source"] for e in periodic] == ["periodic"]
+
+    async def test_after_id_cursor_and_limit(self, storage):
+        first, _ = await append_turn(storage, message="one")
+        await append_turn(storage, message="two")
+        await append_turn(storage, message="three")
+        after = await storage.list_events("u1", after_id=first["id"], limit=1)
+        assert [e["payload"]["user_message"] for e in after] == ["two"]
+
+    async def test_soft_deleted_excluded_by_default(self, storage):
+        keep, _ = await append_turn(storage, message="keep")
+        drop, _ = await append_turn(storage, message="drop")
+        await storage.soft_delete_events("u1", [drop["id"]], "user_request")
+
+        visible = await storage.list_events("u1")
+        assert [e["id"] for e in visible] == [keep["id"]]
+
+        everything = await storage.list_events("u1", include_deleted=True)
+        assert [e["id"] for e in everything] == [keep["id"], drop["id"]]
+
+    async def test_user_isolation(self, storage):
+        await append_turn(storage, user_id="u1")
+        await append_turn(storage, user_id="u2")
+        assert {e["user_id"] for e in await storage.list_events("u1")} == {"u1"}
+        assert {e["user_id"] for e in await storage.list_events("u2")} == {"u2"}
+
+    async def test_get_event_scoped_to_formation(self, storage):
+        event, _ = await append_turn(storage)
+        assert (await storage.get_event(event["id"]))["id"] == event["id"]
+        assert await storage.get_event(999999) is None
+
+
+class TestSoftDeleteAndPurge:
+    async def test_soft_delete_counts_only_live_rows(self, storage):
+        event, _ = await append_turn(storage)
+        assert await storage.soft_delete_events("u1", [event["id"]], "user_request") == 1
+        assert await storage.soft_delete_events("u1", [event["id"]], "user_request") == 0
+        assert await storage.soft_delete_events("u1", [], "user_request") == 0
+
+    async def test_hard_purge_honors_grace_period(self, storage):
+        fresh, _ = await append_turn(storage, message="fresh")
+        aged, _ = await append_turn(storage, message="aged")
+        live, _ = await append_turn(storage, message="live")
+        await storage.soft_delete_events("u1", [fresh["id"], aged["id"]], "user_request")
+
+        # Age one soft-delete past the grace period.
+        async with storage.db_manager.get_async_session() as session:
+            row = await session.get(MemoryEvent, aged["id"])
+            row.deleted_at = utc_now_naive() - timedelta(days=31)
+
+        purged = await storage.hard_purge(grace_period_days=30)
+        assert purged == 1
+        remaining = await storage.list_events("u1", include_deleted=True)
+        assert {e["id"] for e in remaining} == {fresh["id"], live["id"]}
+
+
+class TestCheckpoints:
+    async def test_get_missing_checkpoint(self, storage):
+        assert await storage.get_checkpoint("knowledge_graph", "u1") is None
+
+    async def test_set_and_update_checkpoint(self, storage):
+        created = await storage.set_checkpoint("knowledge_graph", "u1", last_event_id=5)
+        assert created["last_event_id"] == 5
+        assert created["schema_version"] == 1
+
+        updated = await storage.set_checkpoint("knowledge_graph", "u1", last_event_id=9)
+        assert updated["last_event_id"] == 9
+        assert updated["id"] == created["id"]  # upsert, not a second row
+
+        fetched = await storage.get_checkpoint("knowledge_graph", "u1")
+        assert fetched["last_event_id"] == 9
+
+    async def test_checkpoints_scoped_per_projection_and_user(self, storage):
+        await storage.set_checkpoint("knowledge_graph", "u1", last_event_id=1)
+        await storage.set_checkpoint("captains_log", "u1", last_event_id=2)
+        await storage.set_checkpoint("knowledge_graph", "u2", last_event_id=3)
+        assert (await storage.get_checkpoint("knowledge_graph", "u1"))["last_event_id"] == 1
+        assert (await storage.get_checkpoint("captains_log", "u1"))["last_event_id"] == 2
+        assert (await storage.get_checkpoint("knowledge_graph", "u2"))["last_event_id"] == 3
+
+    async def test_reset_checkpoint(self, storage):
+        await storage.set_checkpoint("knowledge_graph", "u1", last_event_id=5)
+        await storage.reset_checkpoint("knowledge_graph", "u1")
+        assert await storage.get_checkpoint("knowledge_graph", "u1") is None
+        await storage.reset_checkpoint("knowledge_graph", "u1")  # idempotent


### PR DESCRIPTION
## Summary

Implements the Memory Event Substrate (PRD: `memory-event-substrate.md`): an immutable, append-only `memory_events` log underneath every memory projection, with a projector registry and a full wipe-and-replay rebuild path. Every memory-producing write now dual-writes: the validated result is appended to the event log first, then applied to its projection through the exact same code the replay rebuild uses.

### Scope amendment (Option 1, decided 2026-07-07)

The PRD lists the Knowledge Index among the projections the substrate rebuilds. The revamp's Layer 4 (Knowledge Index) is deferred, so this PR builds the substrate over the projections that exist today:

- **Knowledge graph** (`kg_entities` / `kg_relationships`, merged in #208)
- **Captain's log + lessons** (`captains_log`, `captains_log_sources`, `lessons`, merged in #209)
- **Flat facts** (extractor writes into the `memories_{dim}` vector tables)

The projection registry is the extension point: a Knowledge Index projector later means one new event type in the versioned schema registry plus one `register_projector` call. No schema changes to the event log.

## Schema

Two new tables on both backends (PostgreSQL and SQLite), created via `_create_all_database_tables` like all others:

**`memory_events`** - integer PK in append order (the replay cursor) + `public_id` Nano ID, following the kg_entities convention instead of the PRD's UUIDv7 sketch (same time-ordered property, portable across both backends). Columns per the PRD: `occurred_at`/`ingested_at`, `event_type`/`event_version`, JSON `payload`, source tracking (`source`, `source_id`, `source_confidence`), `caused_by` causation link, decay declaration (`decay_rate`, `expires_at`), soft delete (`deleted_at`, `deleted_reason`), `agent_id`/`conversation_id`. Partial unique idempotency index on `(formation_id, user_id, source, source_id) WHERE source_id IS NOT NULL AND deleted_at IS NULL` plus the PRD's query-pattern indexes.

**`projection_checkpoints`** - per-(projection, formation, user) cursor into the log.

**Forward-compatible scoping** (memory-namespaces cross-ref): every event carries `scope_type` / `scope_id`. Scoping is not built, so events record the implicit user scope (`scope_type='user'`, `scope_id=user_id`); richer scopes can be added later without re-ingestion or schema changes.

**Event types (v1)**: `interaction.turn`, `fact.extracted`, `graph.extracted`, `log.entry`, `lesson.recorded`, `user.deletion`. Payloads are validated at write time against a versioned schema registry (`EVENT_SCHEMAS`); unknown keys are rejected so schema evolution happens via `event_version`, never silent widening.

**Provenance bridge**: `kg_entities`, `kg_relationships`, `captains_log`, and `lessons` gain a `derived_from_event_ids` JSON column (appended idempotently on every contributing upsert; ALTER-TABLE migration included for existing databases). Flat-fact rows carry `derived_from_event_id` in their metadata. Extraction events link back to their `interaction.turn` event via `caused_by`.

## Write path (PRD Phase A: dual-write)

Per the PRD's migration strategy, this PR ships Phase A - additive and backward compatible. New writes append an event AND perform the direct projection write; the PRD's Phase C (event-first only, direct writes removed) is an explicit later cutover. Consequently:

- `MemoryEventService.record()` is failure-isolated: an append failure (or a disabled substrate) is logged and swallowed, and the projection write proceeds unchanged. Nothing in the substrate can break a chat turn - verified by dedicated tests for all three write paths.
- The extraction coordinator records one `interaction.turn` event per turn and threads its id as `caused_by` into the flat-fact and knowledge-graph passes.
- KG extraction (`store_extraction`), the captain's log digest (`log.entry` + `lesson.recorded`), the `record_lesson` tool, and the flat-fact extractor all record their validated results as events, then apply them through shared apply methods (`apply_extraction`, `apply_log_entry_event`, `apply_lesson_event`, `apply_fact_event`) - the same functions the replay rebuild calls, which is what makes replay equivalence structural rather than coincidental.

## Replay / rebuild design

`MemoryEventService.rebuild(user_id, projection=None, dry_run=False)`:

1. wipe the user's derived state via the projector's `reset()` (graph rows, log entries + lineage + lessons, or extraction-derived vector rows - non-event-sourced rows like conversations and knowledge uploads survive)
2. replay the projection's events in append order (`ORDER BY id`, soft-deleted events excluded - which is how selective forgetting materializes)
3. checkpoint the last applied event id; per-event failures are contained and reported

Payloads store post-LLM validated results, so projectors are deterministic (no LLM calls during replay). Cross-row references use stable natural keys (lessons reference their source entry by date, resolved at apply time) so replays link against rebuilt rows.

Exposed as an admin API endpoint: `POST /v1/memory/rebuild` (`{user_id, projection?, dry_run?}`) - the runtime-side surface for the PRD's `muxi memory rebuild` CLI command.

GDPR groundwork per the PRD: `forget_source()` soft-deletes a source's events and records the `user.deletion` audit event; a daily hard-purge background loop (started/stopped by the Overlord beside the scheduler, KG/captain's-log lifecycle pattern) removes soft-deleted events past the retention grace period (`memory.events.retention.grace_period_days`, default 30).

Observability: nine new `ConversationEvents` members (`memory.event.appended`, `memory.event.append_failed`, `memory.event.idempotent_skip`, `memory.projection.applied/failed`, `memory.rebuild.started/completed`, `memory.deletion.requested/hard_purged`). `scripts/validate_events.py` stays at 100%.

## Design decisions beyond the PRD

- **Integer PK + Nano `public_id` instead of UUIDv7 TEXT PK** - follows the merged kg/log convention; append-ordered integer ids double as the replay cursor.
- **`graph.extracted` event type** - the PRD's `fact.extracted` payload sketch (subject/predicate/object) predates the actual Phase 1 shape. Flat facts use `fact.extracted` ({memory, collection, metadata}); KG batches use `graph.extracted` ({entities, relationships}) so each event replays through its own projector.
- **Lessons reference entries by date, not integer id** - integer FKs change across rebuilds; the digest date is the stable key, resolved at apply time.
- **`delete_extracted_memories()` added to SQLiteMemory, LongTermMemory, and Memobase** - the flat-fact projector's reset must remove only extractor-derived rows; each backend implements it against its own schema.
- **Checkpoints are written by rebuilds** - in Phase A dual-write, projections are maintained by the direct writes; the checkpoint records replay progress. Async incremental consumers arrive with the Phase C cutover.

## Deferred (later phases, per PRD/roadmap)

- Knowledge Index projector (Option 1 amendment above)
- Event-first writes / removal of direct writes (PRD Phase C) and async projection workers
- Legacy backfill of pre-substrate data (PRD Phase B)
- Query-time decay weighting and volatile expiry filtering (decay declarations are recorded on every event now, so historical events benefit when it lands)
- Entity-resolution/merge/correction event types (`entity.resolved`, `entity.merged`, `user.correction`) - no writers exist yet
- Postgres time partitioning, interaction compaction, per-user size budgets
- Lesson maintenance passes (decay, consolidation, `last_applied_at`) remain projection-side runtime state, re-derivable after a rebuild

## Tests

- `tests/unit/test_memory_events_schema.py` - tables/columns/indexes, partial unique idempotency index, checkpoint uniqueness, payload schema registry (parametrized to also run on PostgreSQL via `MUXI_TEST_POSTGRES_DSN`)
- `tests/unit/test_memory_events_storage.py` - append ordering/causation/backfill timestamps, idempotency (incl. soft-delete re-allow), immutability (no update surface, soft delete preserves content), listing filters, isolation, purge grace period, checkpoints (same backend parametrization)
- `tests/unit/test_memory_events_service.py` - failure-isolated record, registry, rebuild driver (dry-run, per-event failure containment, soft-delete skipping), forget_source, purge lifecycle, fail-fast config
- `tests/unit/test_memory_events_replay.py` - **replay equivalence**: each projection driven through its real dual-write path (KG incl. contradiction/supersede shapes, digest + record_lesson incl. confirmation hits, extractor flat facts), snapshotted, wiped, rebuilt from events, compared. Plus append-failure isolation for every write path.
- Full unit suite: **1573 passed, 10 skipped**. `ruff check src/` and `black --check src/` clean. `tests/integration`: 26 passed, 8 skipped.

## E2E

New standalone test `e2e/tests/2_memory/test_2s1_memory_event_substrate.py` (sqlite formation, real LLM): substrate wired + tables created; conversation turns recorded as `interaction.turn` events; extraction events carry `caused_by` provenance and user-scope columns; digest dual-writes `log.entry`; knowledge-graph projection wiped then full rebuild replays all three projections to **identical state** (graph, log, flat facts); flat-fact recall still answers after the rebuild. Result: **SUCCESS, all 14 checks, exit 0** (73s).

Regression: `cd e2e && uv run python run_random_tests.py 5` - **5/5 passed, 0 failed, no re-runs needed** (19_api/test_19k1_jobs, 3_multimodal/test_3c1, 3_multimodal/test_3g4, 5_artifacts/test_5_9, 6_knowledge/test_6a1_chat_knowledge_loading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
