### PR TITLE
docs: remove duplicate v0.20260616.0 heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,8 +196,6 @@ Files touched:
 
 ## v0.20260616.0
 
-## v0.20260616.0
-
 ### SOP Skill Directives -- deterministic activation from SOP steps
 
 SOP steps can now declare skills that should be activated deterministically


### PR DESCRIPTION
Same pre-existing malformation Greptile flagged for v0.20260619.0 (fixed in #210) also existed for v0.20260616.0 — removes the duplicate heading. Verified no other version headings are duplicated. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)