### PR TITLE
feat: memory benchmarking harness (tier 1)

### DIFF
--- a/bench/__init__.py
+++ b/bench/__init__.py
@@ -1,0 +1,7 @@
+"""MUXI Runtime benchmark harnesses.
+
+Package marker so benchmark modules can be imported as ``bench.*``
+from the repository root (unit tests, ``python -m bench.memory...``).
+The standalone microbench scripts in this directory remain directly
+runnable and are not affected.
+"""

--- a/bench/memory/README.md
+++ b/bench/memory/README.md
@@ -1,0 +1,150 @@
+# Memory Benchmarking Harness (Tier 1)
+
+Runs the standard academic long-term-memory benchmarks against a REAL
+MUXI formation — no mocks. This is Tier 1 of the memory benchmarking
+PRD (`engineering/prds/memory-benchmarking.md`): directly comparable
+scores on LongMemEval, LoCoMo, and ConvoMem.
+
+## What it measures
+
+For every question the harness reports two numbers:
+
+1. **Retrieval recall (R@K)** — is the evidence in the top-K retrieved
+   results? Session-level R@K is the headline (comparable to published
+   Mem0 / Mastra / Zep / MemPalace numbers); turn-level R@K is also
+   reported when the dataset labels evidence turns. Coverage@K and MRR
+   are included for diagnosis.
+2. **QA accuracy** (optional, `--qa`) — does the full stack (retrieval
+   + LLM) answer the question correctly? Scored by an LLM judge
+   against the ground truth.
+
+Abstention questions (LongMemEval `_abs` ids, LoCoMo adversarial) have
+no evidence by design: they are excluded from retrieval aggregates and
+counted separately, but still scored for QA (correct = declining).
+
+## Retrieval modes
+
+| Mode         | What it tests                                        |
+|--------------|------------------------------------------------------|
+| `working`    | FAISS working-memory search only                     |
+| `persistent` | SQLite (sqlite-vec) persistent-memory search only    |
+| `combined`   | Both backends, merged with Reciprocal Rank Fusion    |
+
+RRF is used for `combined` because the two backends score on
+different scales; rank fusion is scale-free and deterministic. The
+PRD's fourth mode (combined + KG routing) is not part of Tier 1: it
+depends on per-turn KG extraction (one LLM call per turn, which turns
+a $0 retrieval run into a multi-dollar one) and is deferred to the
+Tier 2 structured-recall work where the KG is the subject under test.
+
+## Cheap-model configuration
+
+`formation/formation.yaml` is the run template:
+
+- **Embeddings:** `local/nomic-ai/nomic-embed-text-v1.5` (ONNX,
+  on-box, free). Retrieval-only runs make **zero** API calls.
+- **Text model:** `openai/gpt-4o-mini` — only used with `--qa`
+  (one answer + one judge call per question). The fixture run costs
+  well under $0.01; a full LongMemEval `--qa` run is on the order of
+  $1-2 at current list prices.
+- **Persistent memory:** SQLite + sqlite-vec, in a per-run temp
+  directory. Every run is isolated; per-case `user_id` scoping keeps
+  haystacks from bleeding into each other.
+
+Every report includes the run's LLM request count, token totals per
+model, and an estimated cost, so spend is always visible.
+
+Secrets: the harness reuses the e2e secrets pair. It looks for
+`.key`/`secrets.enc` in `e2e/assets/` (override with `--secrets-dir`).
+`secrets.enc` is committed; `.key` is gitignored — copy it from your
+main checkout as for the e2e suite.
+
+## Running
+
+```bash
+# Committed fixture samples (CI-safe, no downloads, ~1 min each)
+uv run python -m bench.memory.longmemeval_runner --fixture --qa
+uv run python -m bench.memory.locomo_runner --fixture --qa
+uv run python -m bench.memory.convomem_runner --fixture --qa
+
+# Full datasets
+uv run python -m bench.memory.download_datasets --data-dir ~/datasets/membench
+export MUXI_BENCH_DATA_DIR=~/datasets/membench
+
+# Dev split (50 questions, for tuning) vs holdout (for publishing)
+uv run python -m bench.memory.longmemeval_runner --split dev --mode combined
+uv run python -m bench.memory.longmemeval_runner --split holdout --mode combined --qa
+
+# Full mode matrix for one benchmark
+for mode in working persistent combined; do
+    uv run python -m bench.memory.longmemeval_runner --split holdout --mode "$mode"
+done
+```
+
+Useful flags: `--limit N` (smoke runs), `--k`, `--fetch-limit`,
+`--seed` (split shuffle), `--output`, `--run-dir` (keep the rendered
+formation, SQLite DB, and the run's `membench-events.jsonl` event
+log). Exit code is 0 only when every question completed without a
+harness error.
+
+## Datasets and licensing
+
+The committed files under `fixtures/` are small **synthetic** samples
+that follow each dataset's published schema — no third-party data is
+committed. The full datasets are for local benchmarking only:
+
+| Dataset     | Source                                        | License |
+|-------------|-----------------------------------------------|---------|
+| LongMemEval | HF `xiaowu0162/longmemeval-cleaned`           | See upstream repo (research release, ICLR 2025) |
+| LoCoMo      | GitHub `snap-research/locomo`                 | CC-BY-NC-4.0 |
+| ConvoMem    | HF `Salesforce/ConvoMem`                      | CC-BY-NC-4.0 |
+
+CC-BY-NC datasets must never be committed to this repository or
+redistributed with MUXI artifacts.
+
+## Methodology notes
+
+- **Indexing granularity:** one memory item per conversation turn,
+  rendered as `[session date] role: content`. Session-level rankings
+  are derived from the turn ranking (a session's rank is its best
+  turn's rank).
+- **Isolation:** each case runs under its own `user_id`; working
+  memory is cleared between cases (its FIFO capacity is global).
+- **Determinism:** retrieval is deterministic (exact FAISS/sqlite-vec
+  search, `recency_bias=0`, seeded splits); QA runs at temperature 0.
+  Reports are written with sorted keys so runs diff cleanly.
+- **Truncation:** turns longer than `--max-embed-chars` (default
+  6000) are clipped before embedding; the count is reported under
+  `usage.truncated_turns`.
+- **ConvoMem evidence:** located by exact text match of
+  `message_evidences` inside the item's conversations, so scoring is
+  conversation-level R@K plus turn-level for the matched messages.
+
+## Results
+
+`results/` holds committed fixture-run reports (one per benchmark and
+mode) so the harness output format is pinned and regressions in the
+retrieval path show up as diffs. Full-dataset reports are timestamped
+and can be committed alongside published numbers.
+
+## Layout
+
+```
+bench/memory/
+├── datasets.py            # Normalized model + LongMemEval/LoCoMo/ConvoMem loaders
+├── scoring.py             # R@K, coverage@K, MRR, RRF, aggregation
+├── split.py               # Seeded dev/holdout split (PRD: 50 dev)
+├── report.py              # JSON report + human summary + cost estimation
+├── adapter.py             # Real-formation adapter (ingest/search/QA)
+├── runner.py              # Shared run loop + CLI
+├── longmemeval_runner.py  # Entry point (K=5)
+├── locomo_runner.py       # Entry point (K=10)
+├── convomem_runner.py     # Entry point (K=5)
+├── download_datasets.py   # Full-dataset fetch instructions/downloads
+├── formation/             # Benchmark formation template (cheap-model config)
+├── fixtures/              # Committed synthetic samples (CI-safe)
+└── results/               # Committed fixture-run reports
+```
+
+Unit tests: `tests/unit/bench_memory/` (loaders, metrics, split,
+report, adapter logic — `uv run python -m pytest tests/unit/bench_memory/`).

--- a/bench/memory/README.md
+++ b/bench/memory/README.md
@@ -82,10 +82,12 @@ done
 ```
 
 Useful flags: `--limit N` (smoke runs), `--k`, `--fetch-limit`,
-`--seed` (split shuffle), `--output`, `--run-dir` (keep the rendered
-formation, SQLite DB, and the run's `membench-events.jsonl` event
-log). Exit code is 0 only when every question completed without a
-harness error.
+`--seed` (split shuffle), `--output`. The per-run temp dir (rendered
+formation, SQLite DB, `membench-events.jsonl` event log) is removed
+after the run — the JSON report is the durable artifact. To inspect
+it, pass `--keep-run-dir` (or set `MUXI_BENCH_KEEP_RUN_DIR=1`), or
+supply an explicit `--run-dir`, which is never deleted. Exit code is
+0 only when every question completed without a harness error.
 
 ## Datasets and licensing
 

--- a/bench/memory/__init__.py
+++ b/bench/memory/__init__.py
@@ -1,0 +1,8 @@
+"""Memory benchmarking harness (Tier 1).
+
+Runs the standard academic long-term-memory benchmarks (LongMemEval,
+LoCoMo, ConvoMem) against a REAL MUXI formation — no mocks — and
+reports retrieval recall plus optional end-to-end QA accuracy.
+
+See ``bench/memory/README.md`` for the reproduction guide.
+"""

--- a/bench/memory/adapter.py
+++ b/bench/memory/adapter.py
@@ -30,6 +30,8 @@ scope for Tier 1 (it depends on per-turn KG extraction; see README).
 
 from __future__ import annotations
 
+import asyncio
+import os
 import shutil
 import uuid
 from dataclasses import dataclass
@@ -98,6 +100,7 @@ class MuxiMemoryAdapter:
         run_dir: Optional[Path] = None,
         secrets_dir: Optional[Path] = None,
         max_embed_chars: int = DEFAULT_MAX_EMBED_CHARS,
+        keep_run_dir: bool = False,
     ):
         if mode not in MODES:
             raise ValueError(f"Unknown mode: {mode} (expected one of {MODES})")
@@ -106,10 +109,13 @@ class MuxiMemoryAdapter:
         self.run_dir = Path(run_dir) if run_dir else None
         self.secrets_dir = Path(secrets_dir or DEFAULT_SECRETS_DIR)
         self.max_embed_chars = max_embed_chars
+        self.keep_run_dir = keep_run_dir
 
         self.formation = None
         self.overlord = None
         self._token_context = None
+        self._created_run_dir = False
+        self._stopped = False
         self.llm_requests = 0
         self.ingested_turns = 0
         self.truncated_turns = 0
@@ -123,6 +129,7 @@ class MuxiMemoryAdapter:
             import tempfile
 
             self.run_dir = Path(tempfile.mkdtemp(prefix="muxi-membench-"))
+            self._created_run_dir = True
         self.run_dir.mkdir(parents=True, exist_ok=True)
 
         with open(self.formation_yaml, "r", encoding="utf-8") as handle:
@@ -189,8 +196,61 @@ class MuxiMemoryAdapter:
         set_request_context(self._token_context)
 
     async def stop(self) -> None:
+        """Tear down the formation and remove the temp run directory.
+
+        Idempotent and safe on a never- or partially-started adapter
+        (e.g. when ``start()`` failed mid-load), so the runner can call
+        it unconditionally in a ``finally`` block.
+
+        Teardown mirrors the e2e suite's canonical sequence
+        (``e2e/tests/common/base.py::cleanup_formation``): the runtime
+        has no single fuller shutdown than these three steps combined —
+        ``stop_overlord()`` drains agents, disconnects MCP servers, and
+        disposes the database engine; the observability manager stop
+        releases its background tasks/stream transports; and
+        ``Formation.stop()`` clears remaining service references
+        without exiting the process.
+        """
+        if self._stopped:
+            return
+        self._stopped = True
+
         if self.formation is not None:
-            await self.formation.stop_overlord()
+            try:
+                await asyncio.wait_for(self.formation.stop_overlord(), timeout=30.0)
+            except Exception:
+                pass  # partially-started formation; continue teardown
+            manager = getattr(self.formation, "_observability_manager", None)
+            if manager is not None:
+                try:
+                    await manager.stop()
+                except Exception:
+                    pass
+            try:
+                self.formation.stop()
+            except Exception:
+                pass
+
+        self.formation = None
+        self.overlord = None
+        self._cleanup_run_dir()
+
+    def _cleanup_run_dir(self) -> None:
+        """Remove the adapter-created temp run dir.
+
+        The JSON report under ``results/`` is the durable artifact; the
+        run dir (SQLite DB, rendered formation, event log) is scratch.
+        Kept when: the caller supplied ``--run-dir`` (never deleted),
+        ``keep_run_dir=True`` (``--keep-run-dir``), or the
+        ``MUXI_BENCH_KEEP_RUN_DIR`` environment variable is set.
+        """
+        if not self._created_run_dir or self.run_dir is None:
+            return
+        if self.keep_run_dir:
+            return
+        if os.environ.get("MUXI_BENCH_KEEP_RUN_DIR", "").lower() not in ("", "0", "false"):
+            return
+        shutil.rmtree(self.run_dir, ignore_errors=True)
 
     # -- ingestion ---------------------------------------------------------
 

--- a/bench/memory/adapter.py
+++ b/bench/memory/adapter.py
@@ -1,0 +1,409 @@
+"""Real-formation adapter for the memory benchmarks.
+
+The harness never mocks the memory stack: every run boots an actual
+:class:`muxi.runtime.formation.Formation` (SQLite persistent memory,
+FAISS working memory, local ONNX embeddings by default) and drives it
+through the same public APIs the runtime uses in production.
+
+Isolation model
+---------------
+- Each benchmark case is ingested under its own ``user_id``
+  (``bench-{benchmark}-{case_id}``), so persistent-memory rows from
+  one case can never surface in another case's retrieval.
+- Working memory is cleared between cases (``WorkingMemory.clear()``)
+  because its FIFO capacity is global; per-case ingestion + clearing
+  keeps every haystack fully resident during its questions.
+- Each run gets a fresh run directory (temp dir by default) holding a
+  rendered ``formation.yaml`` with a run-local SQLite path, so runs
+  never see each other's databases.
+
+Retrieval modes
+---------------
+- ``working``      — FAISS working-memory search only.
+- ``persistent``   — SQLite (sqlite-vec) persistent-memory search only.
+- ``combined``     — both backends, merged with Reciprocal Rank Fusion
+  (scores are on different scales across backends; RRF is scale-free).
+
+The "combined + KG routing" mode from the PRD's mode table is out of
+scope for Tier 1 (it depends on per-turn KG extraction; see README).
+"""
+
+from __future__ import annotations
+
+import shutil
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+import yaml
+
+from .datasets import Question, Session
+from .scoring import ranked_unique, reciprocal_rank_fusion
+
+MODES = ("working", "persistent", "combined")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FORMATION_YAML = Path(__file__).resolve().parent / "formation" / "formation.yaml"
+DEFAULT_SECRETS_DIR = REPO_ROOT / "e2e" / "assets"
+
+# Local embedding inputs are capped defensively; the default local
+# model (nomic v1.5) has an 8k-token context. Truncations are counted
+# and reported so silent clipping never skews published numbers.
+DEFAULT_MAX_EMBED_CHARS = 6000
+
+_ANSWER_SYSTEM_PROMPT = (
+    "You answer questions about a user's past conversations. Base your "
+    "answer ONLY on the provided conversation excerpts. If the question "
+    "asks for advice, a plan, or a recommendation, give one that honors "
+    "what the excerpts say about the user (preferences, restrictions, "
+    "facts). If the excerpts lack the information needed, say you do not "
+    "know. Answer concisely."
+)
+
+_JUDGE_PROMPT = """You are grading a memory system's answer against the ground truth.
+
+Question: {question}
+Ground-truth answer: {gold}
+System answer: {predicted}
+
+Reply with exactly one word: CORRECT if the system answer conveys the same
+information as the ground truth (wording may differ), otherwise INCORRECT.
+If the ground truth states a requirement or preference the answer must
+respect (for example a dietary restriction), the system answer is CORRECT
+when it satisfies that requirement. If the ground truth indicates the
+question is unanswerable or that there is no information, the system answer
+is CORRECT only if it also declines or states the information is
+unavailable."""
+
+
+@dataclass
+class RetrievedItem:
+    """One retrieval result mapped back to benchmark ids."""
+
+    turn_id: str
+    session_id: str
+    text: str
+    score: float
+    source: str
+
+
+class MuxiMemoryAdapter:
+    """Drives a real MUXI formation through ingest / search / QA."""
+
+    def __init__(
+        self,
+        mode: str,
+        formation_yaml: Optional[Path] = None,
+        run_dir: Optional[Path] = None,
+        secrets_dir: Optional[Path] = None,
+        max_embed_chars: int = DEFAULT_MAX_EMBED_CHARS,
+    ):
+        if mode not in MODES:
+            raise ValueError(f"Unknown mode: {mode} (expected one of {MODES})")
+        self.mode = mode
+        self.formation_yaml = Path(formation_yaml or DEFAULT_FORMATION_YAML)
+        self.run_dir = Path(run_dir) if run_dir else None
+        self.secrets_dir = Path(secrets_dir or DEFAULT_SECRETS_DIR)
+        self.max_embed_chars = max_embed_chars
+
+        self.formation = None
+        self.overlord = None
+        self._token_context = None
+        self.llm_requests = 0
+        self.ingested_turns = 0
+        self.truncated_turns = 0
+        self.searches = 0
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def _prepare_run_dir(self) -> Path:
+        """Render the benchmark formation into an isolated run directory."""
+        if self.run_dir is None:
+            import tempfile
+
+            self.run_dir = Path(tempfile.mkdtemp(prefix="muxi-membench-"))
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+
+        with open(self.formation_yaml, "r", encoding="utf-8") as handle:
+            config = yaml.safe_load(handle)
+
+        # Run-local SQLite database so concurrent/consecutive runs never
+        # share state.
+        persistent = config.setdefault("memory", {}).setdefault("persistent", {})
+        persistent["connection_string"] = str(self.run_dir / "membench.db")
+
+        # Run-local conversation event log (keeps stdout readable and
+        # leaves an auditable JSONL trail per run).
+        streams = config.get("logging", {}).get("conversation", {}).get("streams", [])
+        for stream in streams:
+            if stream.get("transport") == "file":
+                stream["destination"] = str(self.run_dir / "membench-events.jsonl")
+
+        rendered = self.run_dir / "formation.yaml"
+        with open(rendered, "w", encoding="utf-8") as handle:
+            yaml.safe_dump(config, handle, sort_keys=False)
+
+        # Secrets: same symlink strategy as the e2e suite (the .key file
+        # is gitignored; secrets.enc is committed under e2e/assets).
+        for name in (".key", "secrets.enc"):
+            source = self.secrets_dir / name
+            target = self.run_dir / name
+            if target.exists() or target.is_symlink():
+                continue
+            if source.exists():
+                try:
+                    target.symlink_to(source)
+                except OSError:
+                    shutil.copy2(source, target)
+        return rendered
+
+    async def start(self) -> None:
+        """Load the formation, boot the overlord, and arm token tracking."""
+        from muxi.runtime.datatypes.observability import RequestContext
+        from muxi.runtime.formation import Formation
+        from muxi.runtime.services.observability.context import set_request_context
+
+        rendered = self._prepare_run_dir()
+        self.formation = Formation()
+        await self.formation.load(str(rendered))
+        self.overlord = await self.formation.start_overlord()
+
+        # In server mode this is called after startup; the harness runs
+        # the formation bare, so activate the configured file stream
+        # here. Conversation events (model.request.*, memory.*) then go
+        # to the run-local JSONL instead of stdout.
+        from muxi.runtime.formation.initialization import enable_conversation_logging
+
+        enable_conversation_logging(self.formation)
+
+        if self.mode in ("working", "combined") and self.overlord.buffer_memory is None:
+            raise RuntimeError("Working memory is not configured on the benchmark formation")
+        if self.mode in ("persistent", "combined") and self.overlord.long_term_memory is None:
+            raise RuntimeError("Persistent memory is not configured on the benchmark formation")
+
+        # Cumulative token tally: every LLM call made by this task
+        # (QA answers, judging, cloud embeddings if configured) lands in
+        # this context's TokenUsage.
+        self._token_context = RequestContext(id=f"membench-{uuid.uuid4().hex[:12]}")
+        set_request_context(self._token_context)
+
+    async def stop(self) -> None:
+        if self.formation is not None:
+            await self.formation.stop_overlord()
+
+    # -- ingestion ---------------------------------------------------------
+
+    def _render_turn_text(self, session: Session, turn) -> str:
+        prefix = f"[{session.date}] " if session.date else ""
+        text = f"{prefix}{turn.role}: {turn.content}"
+        if len(text) > self.max_embed_chars:
+            self.truncated_turns += 1
+            text = text[: self.max_embed_chars]
+        return text
+
+    async def ingest_session(self, user_id: str, session: Session) -> None:
+        """Ingest one session turn-by-turn into the mode's backends."""
+        for turn in session.turns:
+            text = self._render_turn_text(session, turn)
+            if not text.strip():
+                continue
+            metadata = {
+                "user_id": user_id,
+                "bench_session_id": session.session_id,
+                "bench_turn_id": turn.turn_id,
+                "role": turn.role,
+            }
+            if self.mode in ("working", "combined"):
+                await self.overlord.buffer_memory.add(text, metadata=dict(metadata))
+            if self.mode in ("persistent", "combined"):
+                await self.overlord.long_term_memory.add(
+                    content=text,
+                    metadata=dict(metadata),
+                    user_id=user_id,
+                    collection="conversations",
+                )
+            self.ingested_turns += 1
+
+    def clear_case(self) -> None:
+        """Reset working memory between cases (FIFO capacity is global)."""
+        if self.overlord is not None and self.overlord.buffer_memory is not None:
+            self.overlord.buffer_memory.clear()
+
+    # -- retrieval ---------------------------------------------------------
+
+    @staticmethod
+    def _items_from_working(results: Sequence[Dict[str, Any]]) -> List[RetrievedItem]:
+        items = []
+        for result in results:
+            metadata = result.get("metadata") or {}
+            turn_id = metadata.get("bench_turn_id")
+            session_id = metadata.get("bench_session_id")
+            if not turn_id or not session_id:
+                continue
+            items.append(
+                RetrievedItem(
+                    turn_id=str(turn_id),
+                    session_id=str(session_id),
+                    text=str(result.get("text", "")),
+                    score=float(result.get("score", 0.0)),
+                    source="working",
+                )
+            )
+        return items
+
+    @staticmethod
+    def _items_from_persistent(results: Sequence[Dict[str, Any]]) -> List[RetrievedItem]:
+        items = []
+        for result in results:
+            metadata = result.get("metadata") or {}
+            turn_id = metadata.get("bench_turn_id")
+            session_id = metadata.get("bench_session_id")
+            if not turn_id or not session_id:
+                continue
+            items.append(
+                RetrievedItem(
+                    turn_id=str(turn_id),
+                    session_id=str(session_id),
+                    text=str(result.get("text", "")),
+                    score=float(result.get("score", 0.0)),
+                    source="persistent",
+                )
+            )
+        return items
+
+    async def search(self, user_id: str, query: str, fetch_limit: int) -> List[RetrievedItem]:
+        """Turn-level retrieval, ranked best-first, for one question."""
+        self.searches += 1
+        working_items: List[RetrievedItem] = []
+        persistent_items: List[RetrievedItem] = []
+
+        if self.mode in ("working", "combined"):
+            raw = await self.overlord.buffer_memory.search(
+                query,
+                limit=fetch_limit,
+                filter_metadata={"user_id": user_id},
+                recency_bias=0.0,
+                namespace="buffer",
+            )
+            working_items = self._items_from_working(raw)
+
+        if self.mode in ("persistent", "combined"):
+            raw = await self.overlord.long_term_memory.search(
+                query,
+                limit=fetch_limit,
+                user_id=user_id,
+                scopes=["user"],
+            )
+            persistent_items = self._items_from_persistent(raw)
+
+        if self.mode == "working":
+            return working_items
+        if self.mode == "persistent":
+            return persistent_items
+
+        # Combined: scale-free rank fusion over turn ids, then map the
+        # fused ranking back to items (working copy preferred for text).
+        by_turn: Dict[str, RetrievedItem] = {}
+        for item in persistent_items + working_items:
+            by_turn[item.turn_id] = item
+        fused = reciprocal_rank_fusion(
+            [
+                [item.turn_id for item in working_items],
+                [item.turn_id for item in persistent_items],
+            ]
+        )
+        return [by_turn[turn_id] for turn_id in fused[:fetch_limit]]
+
+    @staticmethod
+    def ranked_session_ids(items: Sequence[RetrievedItem]) -> List[str]:
+        """Session ranking derived from the turn ranking (best turn wins)."""
+        return ranked_unique(item.session_id for item in items)
+
+    @staticmethod
+    def ranked_turn_ids(items: Sequence[RetrievedItem]) -> List[str]:
+        return ranked_unique(item.turn_id for item in items)
+
+    # -- QA (end-to-end answer accuracy) ------------------------------------
+
+    async def answer_question(
+        self, question: Question, items: Sequence[RetrievedItem], context_limit: int
+    ) -> str:
+        """Answer ``question`` from the top retrieved excerpts."""
+        model = await self.overlord.get_model_for_capability("text")
+        context = "\n".join(f"- {item.text}" for item in items[:context_limit] if item.text.strip())
+        if not context:
+            context = "(no relevant excerpts were retrieved)"
+        user_message = (
+            f"Conversation excerpts (most relevant first):\n{context}\n\n"
+            f"Question: {question.question}"
+        )
+        self.llm_requests += 1
+        response = await model.chat(
+            messages=[
+                {"role": "system", "content": _ANSWER_SYSTEM_PROMPT},
+                {"role": "user", "content": user_message},
+            ],
+            temperature=0.0,
+        )
+        return str(response).strip()
+
+    async def judge_answer(self, question: Question, predicted: str) -> bool:
+        """LLM-as-judge: does ``predicted`` match the gold answer?"""
+        model = await self.overlord.get_model_for_capability("text")
+        prompt = _JUDGE_PROMPT.format(
+            question=question.question,
+            gold=question.answer if question.answer is not None else "(unanswerable)",
+            predicted=predicted,
+        )
+        self.llm_requests += 1
+        response = await model.chat(
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.0,
+            max_tokens=8,
+        )
+        return str(response).strip().upper().startswith("CORRECT")
+
+    # -- usage reporting -----------------------------------------------------
+
+    def usage_snapshot(self) -> Dict[str, Any]:
+        """Token/cost usage for the run (from the request-context tally)."""
+        from .report import estimate_cost_usd
+
+        tokens = {"total": 0, "in": 0, "out": 0}
+        breakdown: Dict[str, List[int]] = {}
+        if self._token_context is not None:
+            usage = self._token_context.tokens
+            tokens = {
+                "total": usage.total[0],
+                "in": usage.total[1],
+                "out": usage.total[2],
+                "total_cached": usage.total[3],
+            }
+            breakdown = {model: list(fields) for model, fields in usage.breakdown.items()}
+        return {
+            "llm_requests": self.llm_requests,
+            "tokens": tokens,
+            "tokens_by_model": breakdown,
+            "cost": estimate_cost_usd(breakdown),
+            "ingested_turns": self.ingested_turns,
+            "truncated_turns": self.truncated_turns,
+            "searches": self.searches,
+        }
+
+    def config_snapshot(self) -> Dict[str, Any]:
+        """Echo the effective configuration into the report."""
+        from .report import relativize
+
+        config: Dict[str, Any] = {
+            "mode": self.mode,
+            "formation_yaml": relativize(self.formation_yaml, REPO_ROOT),
+            "max_embed_chars": self.max_embed_chars,
+        }
+        if self.overlord is not None and self.overlord.buffer_memory is not None:
+            config["working_embedding_model"] = self.overlord.buffer_memory.embedding_model_name
+        capability_models = getattr(self.formation, "_capability_models", None) or {}
+        text_model = capability_models.get("text") or {}
+        if isinstance(text_model, dict) and text_model.get("model"):
+            config["text_model"] = text_model["model"]
+        return config

--- a/bench/memory/convomem_runner.py
+++ b/bench/memory/convomem_runner.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""ConvoMem benchmark runner (Tier 1, secondary).
+
+Salesforce/ConvoMem evidence files (75K+ QA pairs across 6 evidence
+categories); the PRD target is >= 85%. Evidence conversations are
+located by matching ``message_evidences`` texts, so scoring is
+session(conversation)-level. Defaults: K=5.
+
+The full dataset is CC-BY-NC-4.0 — do not commit it; see
+bench/memory/README.md for download instructions.
+
+Usage
+-----
+::
+
+    uv run python -m bench.memory.convomem_runner --fixture
+    uv run python -m bench.memory.convomem_runner --dataset ~/datasets/membench/convomem.json
+"""
+
+import sys
+from pathlib import Path
+
+if __package__ in (None, ""):  # direct script invocation
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from bench.memory.runner import main  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(main("convomem", default_k=5))

--- a/bench/memory/datasets.py
+++ b/bench/memory/datasets.py
@@ -1,0 +1,427 @@
+"""Dataset loaders for the Tier 1 memory benchmarks.
+
+Every benchmark is normalized into the same shape so a single runner
+can score all of them:
+
+- ``BenchmarkDataset``  — a named collection of independent cases.
+- ``BenchmarkCase``     — one isolated haystack (sessions) plus the
+  questions asked against it. Cases never share memory: the runner
+  ingests each case under its own user id and clears working memory
+  between cases.
+- ``Session`` / ``Turn`` — the conversation history, with stable ids
+  so retrieval results can be mapped back to evidence.
+
+Loaders are schema-faithful to the published datasets:
+
+- LongMemEval (``longmemeval_s*.json``): one case per question
+  instance; each instance carries its own haystack of sessions.
+- LoCoMo (``locomo10.json``): one case per sample; all QA pairs in a
+  sample share the sample's multi-session conversation.
+- ConvoMem (Salesforce/ConvoMem evidence files): one case per
+  evidence item; evidence conversations are located by matching the
+  ``message_evidences`` texts inside the item's conversations.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+# LoCoMo question categories, per the paper (snap-research/locomo).
+LOCOMO_CATEGORIES = {
+    1: "multi-hop",
+    2: "temporal",
+    3: "open-domain",
+    4: "single-hop",
+    5: "adversarial",
+}
+
+
+@dataclass(frozen=True)
+class Turn:
+    """A single conversation turn."""
+
+    turn_id: str
+    role: str
+    content: str
+    has_answer: bool = False
+
+
+@dataclass(frozen=True)
+class Session:
+    """A conversation session: an ordered list of turns."""
+
+    session_id: str
+    turns: Tuple[Turn, ...]
+    date: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class Question:
+    """A benchmark question with its ground-truth evidence."""
+
+    question_id: str
+    question: str
+    answer: Optional[str]
+    question_type: str
+    evidence_session_ids: Tuple[str, ...] = ()
+    evidence_turn_ids: Tuple[str, ...] = ()
+    question_date: Optional[str] = None
+    is_abstention: bool = False
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    """One isolated haystack plus the questions asked against it."""
+
+    case_id: str
+    sessions: Tuple[Session, ...]
+    questions: Tuple[Question, ...]
+
+    @property
+    def turn_count(self) -> int:
+        return sum(len(session.turns) for session in self.sessions)
+
+
+@dataclass(frozen=True)
+class BenchmarkDataset:
+    """A named collection of independent benchmark cases."""
+
+    name: str
+    cases: Tuple[BenchmarkCase, ...] = field(default_factory=tuple)
+
+    @property
+    def question_count(self) -> int:
+        return sum(len(case.questions) for case in self.cases)
+
+    @property
+    def session_count(self) -> int:
+        return sum(len(case.sessions) for case in self.cases)
+
+    def iter_questions(self):
+        """Yield ``(case, question)`` pairs in dataset order."""
+        for case in self.cases:
+            for question in case.questions:
+                yield case, question
+
+
+def _read_json(path: Union[str, Path]) -> Any:
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Dataset file not found: {path}")
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+# ---------------------------------------------------------------------------
+# LongMemEval
+# ---------------------------------------------------------------------------
+
+
+def load_longmemeval(path: Union[str, Path]) -> BenchmarkDataset:
+    """Load a LongMemEval file (``longmemeval_s.json`` or the cleaned variant).
+
+    Each instance becomes one :class:`BenchmarkCase` (per-question
+    haystack). Abstention questions (ids ending in ``_abs``) carry no
+    evidence sessions and are excluded from retrieval aggregates by
+    the scorer.
+    """
+    data = _read_json(path)
+    _require(isinstance(data, list), "LongMemEval file must be a JSON list of instances")
+
+    cases: List[BenchmarkCase] = []
+    for idx, instance in enumerate(data):
+        _require(isinstance(instance, dict), f"LongMemEval instance {idx} is not an object")
+        question_id = str(instance.get("question_id", idx))
+        haystack_sessions = instance.get("haystack_sessions")
+        haystack_session_ids = instance.get("haystack_session_ids")
+        _require(
+            isinstance(haystack_sessions, list) and isinstance(haystack_session_ids, list),
+            f"LongMemEval instance {question_id}: missing haystack sessions/ids",
+        )
+        _require(
+            len(haystack_sessions) == len(haystack_session_ids),
+            f"LongMemEval instance {question_id}: haystack sessions/ids length mismatch",
+        )
+        haystack_dates = instance.get("haystack_dates") or [None] * len(haystack_sessions)
+
+        sessions: List[Session] = []
+        evidence_turn_ids: List[str] = []
+        answer_session_ids = {str(sid) for sid in (instance.get("answer_session_ids") or [])}
+        for session_id, session_turns, date in zip(
+            haystack_session_ids, haystack_sessions, haystack_dates
+        ):
+            session_id = str(session_id)
+            turns: List[Turn] = []
+            for turn_idx, raw_turn in enumerate(session_turns or []):
+                turn_id = f"{session_id}:{turn_idx}"
+                has_answer = bool(raw_turn.get("has_answer", False))
+                if has_answer:
+                    evidence_turn_ids.append(turn_id)
+                turns.append(
+                    Turn(
+                        turn_id=turn_id,
+                        role=str(raw_turn.get("role", "user")),
+                        content=str(raw_turn.get("content", "")),
+                        has_answer=has_answer,
+                    )
+                )
+            sessions.append(
+                Session(
+                    session_id=session_id,
+                    turns=tuple(turns),
+                    date=str(date) if date is not None else None,
+                )
+            )
+
+        is_abstention = question_id.endswith("_abs") or not answer_session_ids
+        question = Question(
+            question_id=question_id,
+            question=str(instance.get("question", "")),
+            answer=(str(instance["answer"]) if instance.get("answer") is not None else None),
+            question_type=str(instance.get("question_type", "unknown")),
+            evidence_session_ids=tuple(sorted(answer_session_ids)),
+            evidence_turn_ids=tuple(evidence_turn_ids),
+            question_date=(
+                str(instance["question_date"]) if instance.get("question_date") else None
+            ),
+            is_abstention=is_abstention,
+        )
+        cases.append(
+            BenchmarkCase(
+                case_id=question_id,
+                sessions=tuple(sessions),
+                questions=(question,),
+            )
+        )
+
+    return BenchmarkDataset(name="longmemeval", cases=tuple(cases))
+
+
+# ---------------------------------------------------------------------------
+# LoCoMo
+# ---------------------------------------------------------------------------
+
+
+def _locomo_session_id_from_dia(dia_id: str) -> Optional[str]:
+    """Map a LoCoMo dialog id (``D1:3``) to its session id (``session_1``)."""
+    dia_id = str(dia_id).strip()
+    if not dia_id.startswith("D"):
+        return None
+    head = dia_id[1:].split(":", 1)[0]
+    if not head.isdigit():
+        return None
+    return f"session_{head}"
+
+
+def load_locomo(path: Union[str, Path]) -> BenchmarkDataset:
+    """Load a LoCoMo file (``locomo10.json``).
+
+    One case per sample. Evidence is turn-level (dialog ids like
+    ``D1:3``); session-level evidence is derived from the dialog ids.
+    Adversarial questions (category 5) are unanswerable by design and
+    marked as abstention questions.
+    """
+    data = _read_json(path)
+    _require(isinstance(data, list), "LoCoMo file must be a JSON list of samples")
+
+    cases: List[BenchmarkCase] = []
+    for idx, sample in enumerate(data):
+        _require(isinstance(sample, dict), f"LoCoMo sample {idx} is not an object")
+        sample_id = str(sample.get("sample_id", idx))
+        conversation = sample.get("conversation")
+        _require(
+            isinstance(conversation, dict),
+            f"LoCoMo sample {sample_id}: missing conversation object",
+        )
+
+        sessions: List[Session] = []
+        session_numbers = []
+        for key in conversation:
+            if key.startswith("session_") and not key.endswith("_date_time"):
+                suffix = key.removeprefix("session_")
+                if suffix.isdigit() and isinstance(conversation[key], list):
+                    session_numbers.append(int(suffix))
+        for number in sorted(session_numbers):
+            key = f"session_{number}"
+            date = conversation.get(f"{key}_date_time")
+            turns: List[Turn] = []
+            for turn_idx, raw_turn in enumerate(conversation[key]):
+                dia_id = str(raw_turn.get("dia_id", f"D{number}:{turn_idx}"))
+                speaker = str(raw_turn.get("speaker", "speaker"))
+                text = str(raw_turn.get("text", ""))
+                turns.append(
+                    Turn(
+                        turn_id=dia_id,
+                        role=speaker,
+                        content=text,
+                    )
+                )
+            sessions.append(
+                Session(
+                    session_id=key,
+                    turns=tuple(turns),
+                    date=str(date) if date is not None else None,
+                )
+            )
+
+        questions: List[Question] = []
+        for q_idx, qa in enumerate(sample.get("qa") or []):
+            category = qa.get("category")
+            category_name = LOCOMO_CATEGORIES.get(category, str(category))
+            evidence_dia_ids = [str(e) for e in (qa.get("evidence") or [])]
+            evidence_session_ids = sorted(
+                {
+                    session_id
+                    for session_id in (
+                        _locomo_session_id_from_dia(dia_id) for dia_id in evidence_dia_ids
+                    )
+                    if session_id is not None
+                }
+            )
+            answer = qa.get("answer")
+            if answer is None:
+                answer = qa.get("adversarial_answer")
+            is_adversarial = category_name == "adversarial"
+            questions.append(
+                Question(
+                    question_id=f"{sample_id}:q{q_idx}",
+                    question=str(qa.get("question", "")),
+                    answer=(str(answer) if answer is not None else None),
+                    question_type=category_name,
+                    evidence_session_ids=tuple(evidence_session_ids),
+                    evidence_turn_ids=tuple(evidence_dia_ids),
+                    is_abstention=is_adversarial or not evidence_dia_ids,
+                )
+            )
+
+        cases.append(
+            BenchmarkCase(
+                case_id=sample_id,
+                sessions=tuple(sessions),
+                questions=tuple(questions),
+            )
+        )
+
+    return BenchmarkDataset(name="locomo", cases=tuple(cases))
+
+
+# ---------------------------------------------------------------------------
+# ConvoMem
+# ---------------------------------------------------------------------------
+
+
+def _convomem_items(data: Any) -> List[Dict[str, Any]]:
+    """Normalize a ConvoMem file into a flat list of evidence items.
+
+    Accepts either a bare list of evidence items or an object whose
+    values are lists of evidence items (the published dataset groups
+    items by evidence category).
+    """
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    if isinstance(data, dict):
+        items: List[Dict[str, Any]] = []
+        for value in data.values():
+            if isinstance(value, list):
+                items.extend(item for item in value if isinstance(item, dict))
+        return items
+    raise ValueError("ConvoMem file must be a JSON list or an object of lists")
+
+
+def load_convomem(path: Union[str, Path]) -> BenchmarkDataset:
+    """Load a ConvoMem evidence file (Salesforce/ConvoMem).
+
+    One case per evidence item. Evidence conversations/messages are
+    located by exact text match of ``message_evidences`` entries
+    inside the item's conversations.
+    """
+    data = _read_json(path)
+    items = _convomem_items(data)
+    _require(bool(items), "ConvoMem file contains no evidence items")
+
+    cases: List[BenchmarkCase] = []
+    for item_idx, item in enumerate(items):
+        case_id = str(item.get("id", item_idx))
+        conversations = item.get("conversations")
+        _require(
+            isinstance(conversations, list) and conversations,
+            f"ConvoMem item {case_id}: missing conversations",
+        )
+        evidences = item.get("message_evidences") or []
+        evidence_keys = {
+            (str(ev.get("speaker", "")).lower(), str(ev.get("text", "")))
+            for ev in evidences
+            if isinstance(ev, dict)
+        }
+
+        sessions: List[Session] = []
+        evidence_session_ids: List[str] = []
+        evidence_turn_ids: List[str] = []
+        for conv_idx, conversation in enumerate(conversations):
+            session_id = f"conv_{conv_idx}"
+            messages = conversation.get("messages", []) if isinstance(conversation, dict) else []
+            turns: List[Turn] = []
+            session_has_evidence = False
+            for msg_idx, message in enumerate(messages):
+                if not isinstance(message, dict):
+                    continue
+                speaker = str(message.get("speaker", "user"))
+                text = str(message.get("text", ""))
+                turn_id = f"{session_id}:{msg_idx}"
+                has_answer = (speaker.lower(), text) in evidence_keys
+                if has_answer:
+                    session_has_evidence = True
+                    evidence_turn_ids.append(turn_id)
+                turns.append(
+                    Turn(
+                        turn_id=turn_id,
+                        role=speaker,
+                        content=text,
+                        has_answer=has_answer,
+                    )
+                )
+            if session_has_evidence:
+                evidence_session_ids.append(session_id)
+            sessions.append(Session(session_id=session_id, turns=tuple(turns)))
+
+        question = Question(
+            question_id=case_id,
+            question=str(item.get("question", "")),
+            answer=(str(item["answer"]) if item.get("answer") is not None else None),
+            question_type=str(item.get("category", "convomem")),
+            evidence_session_ids=tuple(evidence_session_ids),
+            evidence_turn_ids=tuple(evidence_turn_ids),
+            is_abstention=not evidence_turn_ids,
+        )
+        cases.append(
+            BenchmarkCase(
+                case_id=case_id,
+                sessions=tuple(sessions),
+                questions=(question,),
+            )
+        )
+
+    return BenchmarkDataset(name="convomem", cases=tuple(cases))
+
+
+LOADERS = {
+    "longmemeval": load_longmemeval,
+    "locomo": load_locomo,
+    "convomem": load_convomem,
+}
+
+
+def load_dataset(benchmark: str, path: Union[str, Path]) -> BenchmarkDataset:
+    """Load ``path`` with the loader registered for ``benchmark``."""
+    loader = LOADERS.get(benchmark)
+    if loader is None:
+        raise ValueError(f"Unknown benchmark: {benchmark} (expected one of {sorted(LOADERS)})")
+    return loader(path)

--- a/bench/memory/download_datasets.py
+++ b/bench/memory/download_datasets.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Download the full Tier 1 benchmark datasets (NOT committed to git).
+
+The committed fixtures under ``bench/memory/fixtures/`` are small
+SYNTHETIC samples that follow each dataset's published schema — they
+exist so CI and the self-run never depend on downloads or licensing.
+Publishable numbers require the full datasets:
+
+- LongMemEval (cleaned): HuggingFace ``xiaowu0162/longmemeval-cleaned``
+  — released with the LongMemEval paper (ICLR 2025); check the
+  repository license before redistribution.
+- LoCoMo: ``snap-research/locomo`` on GitHub — released under
+  CC-BY-NC-4.0 (non-commercial research use).
+- ConvoMem: HuggingFace ``Salesforce/ConvoMem`` — CC-BY-NC-4.0
+  (non-commercial). Download requires the ``huggingface_hub`` /
+  ``datasets`` tooling; see the printed instructions.
+
+Licensing note: CC-BY-NC datasets must never be committed to this
+repository or redistributed with MUXI artifacts. They are downloaded
+to a local data directory for benchmarking only.
+
+Usage
+-----
+::
+
+    uv run python -m bench.memory.download_datasets --data-dir ~/datasets/membench
+    export MUXI_BENCH_DATA_DIR=~/datasets/membench
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import urllib.request
+from pathlib import Path
+
+DOWNLOADS = {
+    "longmemeval_s_cleaned.json": (
+        "https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/"
+        "resolve/main/longmemeval_s_cleaned.json"
+    ),
+    "locomo10.json": (
+        "https://raw.githubusercontent.com/snap-research/locomo/main/data/locomo10.json"
+    ),
+}
+
+CONVOMEM_INSTRUCTIONS = """\
+ConvoMem (Salesforce/ConvoMem, CC-BY-NC-4.0) is distributed via the
+HuggingFace Hub and is not fetched automatically. To download:
+
+    pip install huggingface_hub
+    hf download Salesforce/ConvoMem --repo-type dataset --local-dir {data_dir}/convomem_raw
+
+Then point --dataset at an evidence JSON file (or export a combined
+{data_dir}/convomem.json). The loader accepts either a JSON list of
+evidence items or an object grouping items by category.
+"""
+
+
+def download(url: str, target: Path) -> None:
+    print(f"Downloading {url}")
+    request = urllib.request.Request(url, headers={"User-Agent": "muxi-membench/1.0"})
+    with urllib.request.urlopen(request, timeout=120) as response:
+        target.write_bytes(response.read())
+    print(f"  -> {target} ({target.stat().st_size / 1_048_576:.1f} MB)")
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--data-dir",
+        required=True,
+        help="Directory to store the datasets (export as MUXI_BENCH_DATA_DIR).",
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="Re-download files that already exist."
+    )
+    args = parser.parse_args(argv)
+
+    data_dir = Path(args.data_dir).expanduser()
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    failures = 0
+    for filename, url in DOWNLOADS.items():
+        target = data_dir / filename
+        if target.exists() and not args.force:
+            print(f"Already present: {target} (use --force to re-download)")
+            continue
+        try:
+            download(url, target)
+        except Exception as exc:
+            failures += 1
+            print(f"  FAILED: {type(exc).__name__}: {exc}", file=sys.stderr)
+
+    print()
+    print(CONVOMEM_INSTRUCTIONS.format(data_dir=data_dir))
+    print(f'Set the environment variable:\n    export MUXI_BENCH_DATA_DIR="{data_dir}"')
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/memory/fixtures/convomem_sample.json
+++ b/bench/memory/fixtures/convomem_sample.json
@@ -1,0 +1,89 @@
+[
+  {
+    "id": "fixture_user_evidence_1",
+    "category": "user_evidence",
+    "question": "What instrument does the user play?",
+    "answer": "The cello",
+    "message_evidences": [
+      {"speaker": "user", "text": "I've played the cello since I was nine, and I still practice every evening after work."}
+    ],
+    "conversations": [
+      {
+        "messages": [
+          {"speaker": "user", "text": "Can you help me plan a productive morning routine?"},
+          {"speaker": "assistant", "text": "Sure - start with a consistent wake time, ten minutes of stretching, and plan your top three tasks before checking email."},
+          {"speaker": "user", "text": "I like that. I'll try it next week."}
+        ]
+      },
+      {
+        "messages": [
+          {"speaker": "user", "text": "I've played the cello since I was nine, and I still practice every evening after work."},
+          {"speaker": "assistant", "text": "That's wonderful dedication. Daily practice after work is a great way to keep your cello skills sharp."},
+          {"speaker": "user", "text": "Do you have suggestions for pieces to learn next?"},
+          {"speaker": "assistant", "text": "If you enjoy romantic repertoire, try Saint-Saens' 'The Swan' or Faure's 'Elegie'."}
+        ]
+      },
+      {
+        "messages": [
+          {"speaker": "user", "text": "What's the best way to store fresh basil?"},
+          {"speaker": "assistant", "text": "Treat it like flowers: trim the stems and keep it in a glass of water at room temperature, loosely covered."}
+        ]
+      }
+    ]
+  },
+  {
+    "id": "fixture_assistant_evidence_1",
+    "category": "assistant_evidence",
+    "question": "Which city did the assistant recommend for a first solo trip to Japan?",
+    "answer": "Kyoto",
+    "message_evidences": [
+      {"speaker": "assistant", "text": "For a first solo trip to Japan I'd recommend Kyoto: it's walkable, safe, packed with temples, and easy to navigate by bus."}
+    ],
+    "conversations": [
+      {
+        "messages": [
+          {"speaker": "user", "text": "I'm thinking about a solo trip to Japan this autumn. Where should I go?"},
+          {"speaker": "assistant", "text": "For a first solo trip to Japan I'd recommend Kyoto: it's walkable, safe, packed with temples, and easy to navigate by bus."},
+          {"speaker": "user", "text": "How many days should I spend there?"},
+          {"speaker": "assistant", "text": "Four to five days covers the main temples, Arashiyama, and a day trip to Nara."}
+        ]
+      },
+      {
+        "messages": [
+          {"speaker": "user", "text": "My sourdough starter smells like acetone. Is it dead?"},
+          {"speaker": "assistant", "text": "Not dead - that smell means it's hungry. Feed it twice daily for a few days and the aroma should return to pleasantly sour."}
+        ]
+      }
+    ]
+  },
+  {
+    "id": "fixture_user_evidence_2",
+    "category": "user_evidence",
+    "question": "What is the name of the user's startup?",
+    "answer": "Fernweh Labs",
+    "message_evidences": [
+      {"speaker": "user", "text": "My startup, Fernweh Labs, builds route-planning software for cycling tour companies."}
+    ],
+    "conversations": [
+      {
+        "messages": [
+          {"speaker": "user", "text": "My startup, Fernweh Labs, builds route-planning software for cycling tour companies."},
+          {"speaker": "assistant", "text": "Fernweh Labs sounds like a great niche - cycling tour operators have very specific routing needs like elevation limits and cafe stops."},
+          {"speaker": "user", "text": "Exactly. We're onboarding our first three customers this month."}
+        ]
+      },
+      {
+        "messages": [
+          {"speaker": "user", "text": "Explain the difference between a lease and a loan for a car."},
+          {"speaker": "assistant", "text": "A loan buys the car over time so you own it; a lease rents it for a term with mileage limits and no equity at the end."}
+        ]
+      },
+      {
+        "messages": [
+          {"speaker": "user", "text": "Give me a 20-minute bodyweight workout."},
+          {"speaker": "assistant", "text": "Four rounds: 10 push-ups, 15 squats, 10 lunges per leg, 30-second plank, 30 seconds rest between rounds."}
+        ]
+      }
+    ]
+  }
+]

--- a/bench/memory/fixtures/locomo_sample.json
+++ b/bench/memory/fixtures/locomo_sample.json
@@ -1,0 +1,71 @@
+[
+  {
+    "sample_id": "fixture_1",
+    "conversation": {
+      "speaker_a": "Nadia",
+      "speaker_b": "Omar",
+      "session_1_date_time": "1:15 pm on 8 January, 2023",
+      "session_1": [
+        {"speaker": "Nadia", "dia_id": "D1:1", "text": "Omar! Guess what - I finally signed up for the pottery class at the community studio."},
+        {"speaker": "Omar", "dia_id": "D1:2", "text": "That's awesome, Nadia! You've been talking about pottery for months. When does it start?"},
+        {"speaker": "Nadia", "dia_id": "D1:3", "text": "First class is next Tuesday evening. It runs for eight weeks."},
+        {"speaker": "Omar", "dia_id": "D1:4", "text": "Nice. I've been busy too - I adopted a grey tabby cat last weekend. Named him Biscuit."},
+        {"speaker": "Nadia", "dia_id": "D1:5", "text": "Biscuit! That's adorable. Is he settling in okay?"},
+        {"speaker": "Omar", "dia_id": "D1:6", "text": "He hid under the couch for two days but now he owns the apartment."}
+      ],
+      "session_2_date_time": "7:40 pm on 25 February, 2023",
+      "session_2": [
+        {"speaker": "Nadia", "dia_id": "D2:1", "text": "I made my first proper bowl in pottery class! It's lopsided but I love it."},
+        {"speaker": "Omar", "dia_id": "D2:2", "text": "Ha! Lopsided bowls have character. I have news too - I got promoted to senior data analyst at the logistics company."},
+        {"speaker": "Nadia", "dia_id": "D2:3", "text": "Congratulations! Does that mean more travel?"},
+        {"speaker": "Omar", "dia_id": "D2:4", "text": "A bit. I'll be visiting the Rotterdam office in April for two weeks."},
+        {"speaker": "Nadia", "dia_id": "D2:5", "text": "Rotterdam in spring sounds lovely. Take pictures of the architecture for me."}
+      ],
+      "session_3_date_time": "11:05 am on 30 April, 2023",
+      "session_3": [
+        {"speaker": "Omar", "dia_id": "D3:1", "text": "Back from Rotterdam! The office visit went well and I tried herring from a street stall. Biscuit sulked the whole time I was gone, according to my sister."},
+        {"speaker": "Nadia", "dia_id": "D3:2", "text": "Poor Biscuit. While you were away I finished the pottery course - our final projects were glazed last week. I made a full dinner set, six plates and six bowls."},
+        {"speaker": "Omar", "dia_id": "D3:3", "text": "A whole dinner set! You went from lopsided bowl to production line in two months."},
+        {"speaker": "Nadia", "dia_id": "D3:4", "text": "I'm signing up for the intermediate wheel-throwing course in May."}
+      ]
+    },
+    "qa": [
+      {
+        "question": "What is the name of Omar's cat?",
+        "answer": "Biscuit",
+        "evidence": ["D1:4"],
+        "category": 4
+      },
+      {
+        "question": "What did Nadia make for her pottery final project?",
+        "answer": "A full dinner set with six plates and six bowls",
+        "evidence": ["D3:2"],
+        "category": 4
+      },
+      {
+        "question": "What job title did Omar hold when he traveled to Rotterdam?",
+        "answer": "Senior data analyst",
+        "evidence": ["D2:2", "D2:4", "D3:1"],
+        "category": 1
+      },
+      {
+        "question": "How long after signing up for the pottery class did Nadia finish the course?",
+        "answer": "About three and a half months (signed up in early January, finished in late April)",
+        "evidence": ["D1:1", "D3:2"],
+        "category": 2
+      },
+      {
+        "question": "When did Omar adopt his cat?",
+        "answer": "The first weekend of January 2023",
+        "evidence": ["D1:4"],
+        "category": 2
+      },
+      {
+        "question": "What color is Nadia's car?",
+        "adversarial_answer": "Nadia never mentioned owning a car.",
+        "evidence": [],
+        "category": 5
+      }
+    ]
+  }
+]

--- a/bench/memory/fixtures/longmemeval_sample.json
+++ b/bench/memory/fixtures/longmemeval_sample.json
@@ -1,0 +1,205 @@
+[
+  {
+    "question_id": "fixture_ssu_001",
+    "question_type": "single-session-user",
+    "question": "What breed is my dog?",
+    "answer": "A border collie",
+    "question_date": "2023/05/20 (Sat) 10:00",
+    "haystack_dates": [
+      "2023/04/02 (Sun) 09:12",
+      "2023/04/11 (Tue) 18:45",
+      "2023/04/29 (Sat) 14:30",
+      "2023/05/06 (Sat) 11:05"
+    ],
+    "haystack_session_ids": [
+      "fixture_ssu_001_s1",
+      "fixture_ssu_001_s2",
+      "fixture_ssu_001_s3",
+      "fixture_ssu_001_s4"
+    ],
+    "haystack_sessions": [
+      [
+        {"role": "user", "content": "Can you suggest a good pasta recipe for a weeknight dinner?"},
+        {"role": "assistant", "content": "A simple aglio e olio works well: garlic, olive oil, chili flakes, and spaghetti, ready in about 20 minutes."},
+        {"role": "user", "content": "Great, I'll try that tonight."}
+      ],
+      [
+        {"role": "user", "content": "I just adopted a dog! She's a two-year-old border collie named Pixel.", "has_answer": true},
+        {"role": "assistant", "content": "Congratulations on adopting Pixel! Border collies are highly intelligent and need plenty of exercise and mental stimulation."},
+        {"role": "user", "content": "Any toy recommendations for her?"},
+        {"role": "assistant", "content": "Puzzle feeders and frisbees are excellent choices for border collies."}
+      ],
+      [
+        {"role": "user", "content": "How do I fix a leaky kitchen faucet?"},
+        {"role": "assistant", "content": "Usually you need to replace the cartridge or the O-ring. Turn off the water supply under the sink first."}
+      ],
+      [
+        {"role": "user", "content": "What's a good beginner workout plan for building strength?"},
+        {"role": "assistant", "content": "Three full-body sessions per week with squats, push-ups, rows, and planks is a solid start."}
+      ]
+    ],
+    "answer_session_ids": ["fixture_ssu_001_s2"]
+  },
+  {
+    "question_id": "fixture_ssa_001",
+    "question_type": "single-session-assistant",
+    "question": "What internal temperature did you tell me chicken should reach to be safe?",
+    "answer": "165 degrees Fahrenheit (74 degrees Celsius)",
+    "question_date": "2023/06/12 (Mon) 09:30",
+    "haystack_dates": [
+      "2023/05/14 (Sun) 17:20",
+      "2023/05/21 (Sun) 12:10",
+      "2023/06/01 (Thu) 19:40"
+    ],
+    "haystack_session_ids": [
+      "fixture_ssa_001_s1",
+      "fixture_ssa_001_s2",
+      "fixture_ssa_001_s3"
+    ],
+    "haystack_sessions": [
+      [
+        {"role": "user", "content": "I'm roasting a whole chicken on Sunday. How do I know when it's done?"},
+        {"role": "assistant", "content": "Use a meat thermometer: chicken is safe to eat when the thickest part of the thigh reaches 165 degrees Fahrenheit, which is 74 degrees Celsius.", "has_answer": true},
+        {"role": "user", "content": "Perfect, thanks!"}
+      ],
+      [
+        {"role": "user", "content": "Recommend some podcasts about space exploration."},
+        {"role": "assistant", "content": "Try 'Houston We Have a Podcast' by NASA and 'Planetary Radio' by The Planetary Society."}
+      ],
+      [
+        {"role": "user", "content": "My laptop battery drains fast. Any tips?"},
+        {"role": "assistant", "content": "Lower screen brightness, disable background apps, and check battery health in your OS settings."}
+      ]
+    ],
+    "answer_session_ids": ["fixture_ssa_001_s1"]
+  },
+  {
+    "question_id": "fixture_ssp_001",
+    "question_type": "single-session-preference",
+    "question": "Plan a dinner party menu for me. Remember my dietary restriction when you do.",
+    "answer": "The user is allergic to shellfish, so the menu must avoid shrimp, crab, lobster, and other shellfish.",
+    "question_date": "2023/07/03 (Mon) 16:00",
+    "haystack_dates": [
+      "2023/06/10 (Sat) 13:25",
+      "2023/06/18 (Sun) 10:50",
+      "2023/06/25 (Sun) 20:15"
+    ],
+    "haystack_session_ids": [
+      "fixture_ssp_001_s1",
+      "fixture_ssp_001_s2",
+      "fixture_ssp_001_s3"
+    ],
+    "haystack_sessions": [
+      [
+        {"role": "user", "content": "What are some good books on habit formation?"},
+        {"role": "assistant", "content": "'Atomic Habits' by James Clear and 'Tiny Habits' by BJ Fogg are both excellent."}
+      ],
+      [
+        {"role": "user", "content": "I had a scary reaction at a restaurant last night. Turns out I'm severely allergic to shellfish - shrimp, crab, lobster, all of it.", "has_answer": true},
+        {"role": "assistant", "content": "That sounds frightening. With a severe shellfish allergy you should always mention it when dining out, and consider carrying an epinephrine auto-injector after consulting your doctor."},
+        {"role": "user", "content": "Yes, my doctor prescribed an EpiPen today."}
+      ],
+      [
+        {"role": "user", "content": "Help me plan a weekend trip to Portland."},
+        {"role": "assistant", "content": "Visit Powell's Books, the Japanese Garden, and food carts downtown. Two days is enough for the highlights."}
+      ]
+    ],
+    "answer_session_ids": ["fixture_ssp_001_s2"]
+  },
+  {
+    "question_id": "fixture_ms_001",
+    "question_type": "multi-session",
+    "question": "How many marathons have I mentioned running this year in total?",
+    "answer": "Two: the Chicago Marathon in April and the Berlin Marathon in September",
+    "question_date": "2023/10/15 (Sun) 08:45",
+    "haystack_dates": [
+      "2023/04/24 (Mon) 07:30",
+      "2023/06/05 (Mon) 12:00",
+      "2023/09/26 (Tue) 21:10",
+      "2023/10/01 (Sun) 15:40"
+    ],
+    "haystack_session_ids": [
+      "fixture_ms_001_s1",
+      "fixture_ms_001_s2",
+      "fixture_ms_001_s3",
+      "fixture_ms_001_s4"
+    ],
+    "haystack_sessions": [
+      [
+        {"role": "user", "content": "I finished the Chicago Marathon yesterday! My time was 3:58, my first sub-four marathon.", "has_answer": true},
+        {"role": "assistant", "content": "Congratulations on breaking four hours at the Chicago Marathon! That's a huge milestone."}
+      ],
+      [
+        {"role": "user", "content": "What's the difference between trail running shoes and road running shoes?"},
+        {"role": "assistant", "content": "Trail shoes have deeper lugs for grip and stiffer soles for rocky terrain; road shoes are lighter with more cushioning."}
+      ],
+      [
+        {"role": "user", "content": "Just got back from Germany - I ran the Berlin Marathon on Sunday and set a personal best of 3:51!", "has_answer": true},
+        {"role": "assistant", "content": "A personal best of 3:51 at the Berlin Marathon is fantastic - that course is famously fast."}
+      ],
+      [
+        {"role": "user", "content": "Can you recommend recovery stretches for tight calves?"},
+        {"role": "assistant", "content": "Wall calf stretches, downward dog, and foam rolling are effective for tight calves."}
+      ]
+    ],
+    "answer_session_ids": ["fixture_ms_001_s1", "fixture_ms_001_s3"]
+  },
+  {
+    "question_id": "fixture_ku_001",
+    "question_type": "knowledge-update",
+    "question": "Which team do I work on now?",
+    "answer": "The platform infrastructure team",
+    "question_date": "2023/09/09 (Sat) 11:20",
+    "haystack_dates": [
+      "2023/03/15 (Wed) 09:00",
+      "2023/05/30 (Tue) 17:35",
+      "2023/08/21 (Mon) 10:05"
+    ],
+    "haystack_session_ids": [
+      "fixture_ku_001_s1",
+      "fixture_ku_001_s2",
+      "fixture_ku_001_s3"
+    ],
+    "haystack_sessions": [
+      [
+        {"role": "user", "content": "I work on the mobile apps team and we're debating React Native versus native development."},
+        {"role": "assistant", "content": "For a small mobile apps team, React Native speeds up cross-platform delivery; go native if you need heavy platform-specific features."}
+      ],
+      [
+        {"role": "user", "content": "What are good practices for sprint retrospectives?"},
+        {"role": "assistant", "content": "Keep them under an hour, rotate facilitators, and end with one or two concrete action items."}
+      ],
+      [
+        {"role": "user", "content": "Big news - I transferred from the mobile apps team to the platform infrastructure team last week. Now I'm learning Kubernetes.", "has_answer": true},
+        {"role": "assistant", "content": "Congratulations on the move to platform infrastructure! For Kubernetes, start with pods, deployments, and services before diving into operators."}
+      ]
+    ],
+    "answer_session_ids": ["fixture_ku_001_s3"]
+  },
+  {
+    "question_id": "fixture_tr_001_abs",
+    "question_type": "temporal-reasoning",
+    "question": "What color did I paint my garage in August?",
+    "answer": "The user never mentioned painting a garage.",
+    "question_date": "2023/09/30 (Sat) 14:00",
+    "haystack_dates": [
+      "2023/08/05 (Sat) 10:30",
+      "2023/08/19 (Sat) 16:45"
+    ],
+    "haystack_session_ids": [
+      "fixture_tr_001_s1",
+      "fixture_tr_001_s2"
+    ],
+    "haystack_sessions": [
+      [
+        {"role": "user", "content": "I repainted my bedroom a calming sage green this weekend."},
+        {"role": "assistant", "content": "Sage green is a great choice for bedrooms - it pairs well with warm wood tones and white trim."}
+      ],
+      [
+        {"role": "user", "content": "What vegetables can I still plant in late August?"},
+        {"role": "assistant", "content": "Spinach, radishes, lettuce, and kale all do well when planted in late August for a fall harvest."}
+      ]
+    ],
+    "answer_session_ids": []
+  }
+]

--- a/bench/memory/formation/formation.yaml
+++ b/bench/memory/formation/formation.yaml
@@ -1,0 +1,69 @@
+# Memory benchmarking formation (Tier 1).
+#
+# Cheap-model configuration by design:
+#   - Embeddings: local Nomic v1.5 (ONNX, free, 768-dim) — retrieval-only
+#     runs cost $0 in API spend.
+#   - Text model: openai/gpt-4o-mini — only called with --qa (answer +
+#     judge); roughly $0.15/$0.60 per 1M tokens in/out.
+#   - Persistent memory: SQLite + sqlite-vec. The connection_string is
+#     rewritten to a run-local path by the harness, so this file is a
+#     template; do not point it at a shared database.
+#
+# The buffer must hold the largest single case (LongMemEval-S haystacks
+# reach ~2,500 turns); the harness clears the buffer between cases.
+
+schema: "1.0.0"
+id: "membench"
+description: "Formation used by the Tier 1 memory benchmark harness"
+
+runtime:
+  built_in_mcps: false
+
+llm:
+  settings:
+    temperature: 0.0
+    max_tokens: 400
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+    - embedding: "local/nomic-ai/nomic-embed-text-v1.5"
+
+agents:
+  - id: "membench-agent"
+    name: "MemBench Agent"
+    description: "Answers questions from retrieved conversation excerpts"
+    model: "openai/gpt-4o-mini"
+    system_message: |
+      You answer questions about a user's past conversations using only
+      the provided excerpts. If the excerpts do not contain the answer,
+      say you do not know.
+
+overlord:
+  clarification:
+    enabled: false
+
+memory:
+  buffer:
+    size: 400
+    multiplier: 10
+    vector_search: true
+
+  persistent:
+    provider: "sqlite"
+    connection_string: "membench.db"
+
+# Conversation events (model.request.*, memory.*) go to a run-local
+# JSONL file (path rewritten by the harness) so stdout stays readable
+# and every run leaves an auditable event log.
+logging:
+  system:
+    level: "warning"
+    destination: "stdout"
+  conversation:
+    enabled: true
+    streams:
+      - transport: "file"
+        destination: "membench-events.jsonl"
+        level: "info"
+        format: "jsonl"

--- a/bench/memory/locomo_runner.py
+++ b/bench/memory/locomo_runner.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""LoCoMo benchmark runner (Tier 1, secondary).
+
+1,986 multi-hop QA pairs over 10 long conversations; the PRD target
+is R@10 >= 85% (turn-level evidence, no rerank). Defaults: K=10.
+Adversarial questions (category 5) are unanswerable by design and are
+excluded from retrieval aggregates (counted as abstentions).
+
+Usage
+-----
+::
+
+    uv run python -m bench.memory.locomo_runner --fixture
+    MUXI_BENCH_DATA_DIR=~/datasets/membench \\
+        uv run python -m bench.memory.locomo_runner --mode combined
+"""
+
+import sys
+from pathlib import Path
+
+if __package__ in (None, ""):  # direct script invocation
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from bench.memory.runner import main  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(main("locomo", default_k=10))

--- a/bench/memory/longmemeval_runner.py
+++ b/bench/memory/longmemeval_runner.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""LongMemEval benchmark runner (Tier 1, primary).
+
+500 questions across 6 types; the PRD target is R@5 >= 94% in
+combined mode. Defaults: K=5, session-level scoring is the headline.
+
+Usage
+-----
+::
+
+    # Committed fixture sample (CI-safe, no dataset download)
+    uv run python -m bench.memory.longmemeval_runner --fixture
+
+    # Full dataset (see bench/memory/README.md for the download)
+    export MUXI_BENCH_DATA_DIR=~/datasets/membench
+    uv run python -m bench.memory.longmemeval_runner --mode combined --split holdout
+"""
+
+import sys
+from pathlib import Path
+
+if __package__ in (None, ""):  # direct script invocation
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from bench.memory.runner import main  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(main("longmemeval", default_k=5))

--- a/bench/memory/report.py
+++ b/bench/memory/report.py
@@ -1,0 +1,217 @@
+"""Report generation for the memory benchmarks.
+
+Every run produces one structured JSON report (machine-comparable
+across runs) and a human summary printed to stdout. Reports are
+written with sorted keys and stable list ordering so that two runs
+with identical results produce byte-identical ``results`` /
+``metrics`` blocks (only the ``run`` metadata differs).
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import subprocess
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+from .scoring import QuestionResult
+
+REPORT_SCHEMA_VERSION = "1.0"
+
+# Published list prices (USD per 1M tokens), used ONLY for the
+# estimated-cost line in reports. Estimates as of 2026-07; update as
+# providers change pricing. Unknown models report ``null`` cost.
+MODEL_PRICES_USD_PER_MTOK: Dict[str, Dict[str, float]] = {
+    "openai/gpt-4o-mini": {"in": 0.15, "out": 0.60},
+    "openai/gpt-4o": {"in": 2.50, "out": 10.00},
+    "openai/gpt-4.1-mini": {"in": 0.40, "out": 1.60},
+    "openai/gpt-4.1-nano": {"in": 0.10, "out": 0.40},
+    "openai/text-embedding-3-small": {"in": 0.02, "out": 0.0},
+    "openai/text-embedding-3-large": {"in": 0.13, "out": 0.0},
+    "anthropic/claude-3-5-haiku-20241022": {"in": 0.80, "out": 4.00},
+}
+
+# Local (ONNX) embedding models run on-box and are free.
+_FREE_MODEL_PREFIX = "local/"
+
+
+def estimate_cost_usd(model_breakdown: Dict[str, Sequence[int]]) -> Dict[str, Any]:
+    """Estimate the run's LLM spend from a per-model token breakdown.
+
+    ``model_breakdown`` maps a provider-prefixed model slug to the
+    ``TokenUsage.FIELDS`` array (``[total, in, out, total_cached,
+    in_cached, out_cached]``). Models with no price entry contribute
+    ``null`` and are listed under ``unpriced_models``.
+    """
+    total_cost: float = 0.0
+    priced_any = False
+    unpriced: List[str] = []
+    per_model: Dict[str, Optional[float]] = {}
+    for model, fields in sorted(model_breakdown.items()):
+        tokens_in = fields[1] if len(fields) > 1 else 0
+        tokens_out = fields[2] if len(fields) > 2 else 0
+        if model.startswith(_FREE_MODEL_PREFIX):
+            per_model[model] = 0.0
+            priced_any = True
+            continue
+        price = MODEL_PRICES_USD_PER_MTOK.get(model)
+        if price is None:
+            per_model[model] = None
+            unpriced.append(model)
+            continue
+        cost = (tokens_in * price["in"] + tokens_out * price["out"]) / 1_000_000
+        per_model[model] = round(cost, 6)
+        total_cost += cost
+        priced_any = True
+    return {
+        "estimated_usd": round(total_cost, 6) if priced_any or not unpriced else None,
+        "per_model_usd": per_model,
+        "unpriced_models": unpriced,
+        "note": "List-price estimate for reporting only; local/* models are free.",
+    }
+
+
+def relativize(path: Union[str, Path], repo_root: Optional[Union[str, Path]]) -> str:
+    """Render ``path`` relative to ``repo_root`` when it lives inside it.
+
+    Committed reports must not leak machine-specific absolute paths;
+    paths outside the repo (e.g. ``$MUXI_BENCH_DATA_DIR``) stay as-is.
+    """
+    path = Path(path)
+    if repo_root is not None:
+        try:
+            return str(path.resolve().relative_to(Path(repo_root).resolve()))
+        except ValueError:
+            pass
+    return str(path)
+
+
+def _git_commit(repo_root: Union[str, Path]) -> Optional[str]:
+    try:
+        output = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return output.stdout.strip() or None
+    except Exception:
+        return None
+
+
+def build_report(
+    *,
+    benchmark: str,
+    mode: str,
+    k: int,
+    dataset_path: str,
+    dataset_stats: Dict[str, int],
+    config: Dict[str, Any],
+    metrics: Dict[str, Any],
+    results: Sequence[QuestionResult],
+    usage: Dict[str, Any],
+    wall_seconds: float,
+    repo_root: Optional[Union[str, Path]] = None,
+) -> Dict[str, Any]:
+    """Assemble the structured report for one benchmark run."""
+    sorted_results = sorted(results, key=lambda result: result.question_id)
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "benchmark": benchmark,
+        "mode": mode,
+        "k": k,
+        "run": {
+            "started_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "wall_seconds": round(wall_seconds, 2),
+            "python": platform.python_version(),
+            "git_commit": _git_commit(repo_root) if repo_root else None,
+        },
+        "dataset": {"path": relativize(dataset_path, repo_root), **dataset_stats},
+        "config": config,
+        "usage": usage,
+        "metrics": metrics,
+        "results": [asdict(result) for result in sorted_results],
+    }
+
+
+def write_report(report: Dict[str, Any], path: Union[str, Path]) -> Path:
+    """Write ``report`` as deterministic, sorted-key JSON."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(report, handle, indent=2, sort_keys=True, ensure_ascii=False)
+        handle.write("\n")
+    return path
+
+
+def _format_pct(value: Optional[float]) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value * 100:.1f}%"
+
+
+def render_summary(report: Dict[str, Any]) -> str:
+    """Render the human-readable stdout summary for one run."""
+    metrics = report["metrics"]
+    k = report["k"]
+    lines: List[str] = []
+    lines.append("=" * 64)
+    lines.append(f"Memory benchmark: {report['benchmark']}  (mode={report['mode']}, k={k})")
+    lines.append("=" * 64)
+    dataset = report["dataset"]
+    lines.append(
+        f"Dataset: {dataset['path']}  "
+        f"(cases={dataset.get('cases', '?')}, questions={dataset.get('questions', '?')})"
+    )
+    lines.append(
+        f"Scored: {metrics['questions_scored']}  "
+        f"abstention: {metrics['questions_abstention']}  "
+        f"errors: {metrics['questions_errored']}"
+    )
+
+    for level_name, label in (("session_level", "Session"), ("turn_level", "Turn")):
+        level = metrics["retrieval"].get(level_name)
+        if not level:
+            continue
+        overall = level["overall"]
+        lines.append("")
+        lines.append(
+            f"{label}-level retrieval:  R@{k}={_format_pct(overall[f'recall@{k}'])}  "
+            f"coverage@{k}={_format_pct(overall[f'coverage@{k}'])}  "
+            f"MRR={overall['mrr']:.3f}  (n={overall['questions']})"
+        )
+        for question_type, stats in level["by_question_type"].items():
+            lines.append(
+                f"  {question_type:<28} R@{k}={_format_pct(stats[f'recall@{k}']):>7}  "
+                f"n={stats['questions']}"
+            )
+
+    qa = metrics.get("qa")
+    if qa:
+        lines.append("")
+        lines.append(
+            f"QA accuracy (end-to-end): {_format_pct(qa['overall']['accuracy'])}  "
+            f"(n={qa['overall']['questions']})"
+        )
+        for question_type, stats in qa["by_question_type"].items():
+            lines.append(
+                f"  {question_type:<28} acc={_format_pct(stats['accuracy']):>7}  "
+                f"n={stats['questions']}"
+            )
+
+    usage = report.get("usage") or {}
+    tokens = usage.get("tokens") or {}
+    cost = usage.get("cost") or {}
+    lines.append("")
+    lines.append(
+        f"LLM usage: requests={usage.get('llm_requests', 0)}  "
+        f"tokens_in={tokens.get('in', 0)}  tokens_out={tokens.get('out', 0)}  "
+        f"est_cost=${cost.get('estimated_usd') if cost.get('estimated_usd') is not None else 'n/a'}"
+    )
+    lines.append(f"Wall time: {report['run']['wall_seconds']}s")
+    lines.append("=" * 64)
+    return "\n".join(lines)

--- a/bench/memory/report.py
+++ b/bench/memory/report.py
@@ -116,6 +116,9 @@ def build_report(
     usage: Dict[str, Any],
     wall_seconds: float,
     started_at: Optional[datetime] = None,
+    partial: bool = False,
+    abort_reason: Optional[str] = None,
+    case_stats: Optional[Dict[str, int]] = None,
     repo_root: Optional[Union[str, Path]] = None,
 ) -> Dict[str, Any]:
     """Assemble the structured report for one benchmark run.
@@ -124,27 +127,39 @@ def build_report(
     the runner alongside its monotonic timer so ``started_at +
     wall_seconds`` equals the real finish time. Falls back to "now"
     only for callers that do not time a run of their own.
+
+    ``partial=True`` marks a run that was cut short (start failure,
+    crash, systematic-failure early stop) and records ``abort_reason``;
+    a complete run carries neither key. ``case_stats`` (completed /
+    failed / skipped counts) is included whenever provided.
     """
     if started_at is None:
         started_at = datetime.now(timezone.utc)
     sorted_results = sorted(results, key=lambda result: result.question_id)
-    return {
+    run_block: Dict[str, Any] = {
+        "started_at": started_at.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "wall_seconds": round(wall_seconds, 2),
+        "python": platform.python_version(),
+        "git_commit": _git_commit(repo_root) if repo_root else None,
+    }
+    if case_stats is not None:
+        run_block["cases"] = dict(case_stats)
+    report: Dict[str, Any] = {
         "schema_version": REPORT_SCHEMA_VERSION,
         "benchmark": benchmark,
         "mode": mode,
         "k": k,
-        "run": {
-            "started_at": started_at.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "wall_seconds": round(wall_seconds, 2),
-            "python": platform.python_version(),
-            "git_commit": _git_commit(repo_root) if repo_root else None,
-        },
+        "run": run_block,
         "dataset": {"path": relativize(dataset_path, repo_root), **dataset_stats},
         "config": config,
         "usage": usage,
         "metrics": metrics,
         "results": [asdict(result) for result in sorted_results],
     }
+    if partial:
+        report["partial"] = True
+        run_block["abort_reason"] = abort_reason
+    return report
 
 
 def write_report(report: Dict[str, Any], path: Union[str, Path]) -> Path:
@@ -181,6 +196,16 @@ def render_summary(report: Dict[str, Any]) -> str:
         f"abstention: {metrics['questions_abstention']}  "
         f"errors: {metrics['questions_errored']}"
     )
+    case_stats = report["run"].get("cases")
+    if case_stats:
+        lines.append(
+            f"Cases: {case_stats.get('completed', 0)} completed, "
+            f"{case_stats.get('failed', 0)} failed, "
+            f"{case_stats.get('skipped', 0)} skipped"
+        )
+    if report.get("partial"):
+        lines.append("")
+        lines.append(f"PARTIAL RUN — aborted: {report['run'].get('abort_reason')}")
 
     for level_name, label in (("session_level", "Session"), ("turn_level", "Turn")):
         level = metrics["retrieval"].get(level_name)

--- a/bench/memory/report.py
+++ b/bench/memory/report.py
@@ -115,9 +115,18 @@ def build_report(
     results: Sequence[QuestionResult],
     usage: Dict[str, Any],
     wall_seconds: float,
+    started_at: Optional[datetime] = None,
     repo_root: Optional[Union[str, Path]] = None,
 ) -> Dict[str, Any]:
-    """Assemble the structured report for one benchmark run."""
+    """Assemble the structured report for one benchmark run.
+
+    ``started_at`` is the wall-clock moment the run began, captured by
+    the runner alongside its monotonic timer so ``started_at +
+    wall_seconds`` equals the real finish time. Falls back to "now"
+    only for callers that do not time a run of their own.
+    """
+    if started_at is None:
+        started_at = datetime.now(timezone.utc)
     sorted_results = sorted(results, key=lambda result: result.question_id)
     return {
         "schema_version": REPORT_SCHEMA_VERSION,
@@ -125,7 +134,7 @@ def build_report(
         "mode": mode,
         "k": k,
         "run": {
-            "started_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "started_at": started_at.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "wall_seconds": round(wall_seconds, 2),
             "python": platform.python_version(),
             "git_commit": _git_commit(repo_root) if repo_root else None,

--- a/bench/memory/results/convomem_fixture_combined.json
+++ b/bench/memory/results/convomem_fixture_combined.json
@@ -1,0 +1,218 @@
+{
+  "benchmark": "convomem",
+  "config": {
+    "fetch_limit": 25,
+    "formation_yaml": "bench/memory/formation/formation.yaml",
+    "max_embed_chars": 6000,
+    "mode": "combined",
+    "qa": true,
+    "text_model": "openai/gpt-4o-mini",
+    "working_embedding_model": "local/nomic-ai/nomic-embed-text-v1.5"
+  },
+  "dataset": {
+    "cases": 3,
+    "fixture": true,
+    "path": "bench/memory/fixtures/convomem_sample.json",
+    "questions": 3,
+    "seed": 42,
+    "sessions": 8,
+    "split": "all"
+  },
+  "k": 5,
+  "metrics": {
+    "k": 5,
+    "qa": {
+      "by_question_type": {
+        "assistant_evidence": {
+          "accuracy": 1.0,
+          "questions": 1
+        },
+        "user_evidence": {
+          "accuracy": 1.0,
+          "questions": 2
+        }
+      },
+      "overall": {
+        "accuracy": 1.0,
+        "questions": 3
+      }
+    },
+    "questions_abstention": 0,
+    "questions_errored": 0,
+    "questions_scored": 3,
+    "questions_total": 3,
+    "retrieval": {
+      "session_level": {
+        "by_question_type": {
+          "assistant_evidence": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "user_evidence": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 2,
+            "recall@5": 1.0
+          }
+        },
+        "overall": {
+          "coverage@5": 1.0,
+          "mrr": 1.0,
+          "questions": 3,
+          "recall@5": 1.0
+        }
+      },
+      "turn_level": {
+        "by_question_type": {
+          "assistant_evidence": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "user_evidence": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 2,
+            "recall@5": 1.0
+          }
+        },
+        "overall": {
+          "coverage@5": 1.0,
+          "mrr": 1.0,
+          "questions": 3,
+          "recall@5": 1.0
+        }
+      }
+    }
+  },
+  "mode": "combined",
+  "results": [
+    {
+      "elapsed_seconds": 2.125,
+      "error": null,
+      "evidence_session_ids": [
+        "conv_0"
+      ],
+      "evidence_turn_ids": [
+        "conv_0:1"
+      ],
+      "is_abstention": false,
+      "qa_answer": "The assistant recommended Kyoto for a first solo trip to Japan.",
+      "qa_correct": true,
+      "question_id": "fixture_assistant_evidence_1",
+      "question_type": "assistant_evidence",
+      "retrieved_session_ids": [
+        "conv_0",
+        "conv_1"
+      ],
+      "retrieved_turn_ids": [
+        "conv_0:1",
+        "conv_0:0",
+        "conv_0:3",
+        "conv_1:1",
+        "conv_0:2",
+        "conv_1:0"
+      ]
+    },
+    {
+      "elapsed_seconds": 2.152,
+      "error": null,
+      "evidence_session_ids": [
+        "conv_1"
+      ],
+      "evidence_turn_ids": [
+        "conv_1:0"
+      ],
+      "is_abstention": false,
+      "qa_answer": "The user plays the cello.",
+      "qa_correct": true,
+      "question_id": "fixture_user_evidence_1",
+      "question_type": "user_evidence",
+      "retrieved_session_ids": [
+        "conv_1",
+        "conv_0",
+        "conv_2"
+      ],
+      "retrieved_turn_ids": [
+        "conv_1:0",
+        "conv_1:3",
+        "conv_0:2",
+        "conv_1:1",
+        "conv_1:2",
+        "conv_2:1",
+        "conv_0:1",
+        "conv_0:0",
+        "conv_2:0"
+      ]
+    },
+    {
+      "elapsed_seconds": 2.05,
+      "error": null,
+      "evidence_session_ids": [
+        "conv_0"
+      ],
+      "evidence_turn_ids": [
+        "conv_0:0"
+      ],
+      "is_abstention": false,
+      "qa_answer": "The user's startup is called Fernweh Labs.",
+      "qa_correct": true,
+      "question_id": "fixture_user_evidence_2",
+      "question_type": "user_evidence",
+      "retrieved_session_ids": [
+        "conv_0",
+        "conv_1",
+        "conv_2"
+      ],
+      "retrieved_turn_ids": [
+        "conv_0:0",
+        "conv_0:2",
+        "conv_0:1",
+        "conv_1:1",
+        "conv_2:1",
+        "conv_2:0",
+        "conv_1:0"
+      ]
+    }
+  ],
+  "run": {
+    "git_commit": "3b8fb6f2e5c03e094dbfe8b617ac090de10fa389",
+    "python": "3.11.13",
+    "started_at": "2026-07-07T20:44:53Z",
+    "wall_seconds": 28.93
+  },
+  "schema_version": "1.0",
+  "usage": {
+    "cost": {
+      "estimated_usd": 0.000205,
+      "note": "List-price estimate for reporting only; local/* models are free.",
+      "per_model_usd": {
+        "openai/gpt-4o-mini": 0.000205
+      },
+      "unpriced_models": []
+    },
+    "ingested_turns": 22,
+    "llm_requests": 6,
+    "searches": 3,
+    "tokens": {
+      "in": 1237,
+      "out": 33,
+      "total": 1270,
+      "total_cached": 0
+    },
+    "tokens_by_model": {
+      "openai/gpt-4o-mini": [
+        1270,
+        1237,
+        33,
+        0,
+        0,
+        0
+      ]
+    },
+    "truncated_turns": 0
+  }
+}

--- a/bench/memory/results/convomem_fixture_combined.json
+++ b/bench/memory/results/convomem_fixture_combined.json
@@ -91,7 +91,7 @@
   "mode": "combined",
   "results": [
     {
-      "elapsed_seconds": 2.125,
+      "elapsed_seconds": 2.08,
       "error": null,
       "evidence_session_ids": [
         "conv_0"
@@ -118,7 +118,7 @@
       ]
     },
     {
-      "elapsed_seconds": 2.152,
+      "elapsed_seconds": 1.927,
       "error": null,
       "evidence_session_ids": [
         "conv_1"
@@ -149,7 +149,7 @@
       ]
     },
     {
-      "elapsed_seconds": 2.05,
+      "elapsed_seconds": 2.011,
       "error": null,
       "evidence_session_ids": [
         "conv_0"
@@ -179,10 +179,15 @@
     }
   ],
   "run": {
-    "git_commit": "3b8fb6f2e5c03e094dbfe8b617ac090de10fa389",
+    "cases": {
+      "completed": 3,
+      "failed": 0,
+      "skipped": 0
+    },
+    "git_commit": "192b6cbd91a35f99bf6d63ba640028ce0dccd58e",
     "python": "3.11.13",
-    "started_at": "2026-07-07T20:44:53Z",
-    "wall_seconds": 28.93
+    "started_at": "2026-07-07T21:33:53Z",
+    "wall_seconds": 34.82
   },
   "schema_version": "1.0",
   "usage": {

--- a/bench/memory/results/locomo_fixture_combined.json
+++ b/bench/memory/results/locomo_fixture_combined.json
@@ -28,7 +28,7 @@
           "questions": 1
         },
         "multi-hop": {
-          "accuracy": 1.0,
+          "accuracy": 0.0,
           "questions": 1
         },
         "single-hop": {
@@ -36,7 +36,7 @@
           "questions": 2
         },
         "temporal": {
-          "accuracy": 0.5,
+          "accuracy": 1.0,
           "questions": 2
         }
       },
@@ -111,7 +111,7 @@
   "mode": "combined",
   "results": [
     {
-      "elapsed_seconds": 2.479,
+      "elapsed_seconds": 3.697,
       "error": null,
       "evidence_session_ids": [
         "session_1"
@@ -148,7 +148,7 @@
       ]
     },
     {
-      "elapsed_seconds": 2.782,
+      "elapsed_seconds": 2.557,
       "error": null,
       "evidence_session_ids": [
         "session_3"
@@ -185,7 +185,7 @@
       ]
     },
     {
-      "elapsed_seconds": 2.51,
+      "elapsed_seconds": 2.264,
       "error": null,
       "evidence_session_ids": [
         "session_2",
@@ -197,8 +197,8 @@
         "D3:1"
       ],
       "is_abstention": false,
-      "qa_answer": "Omar was a data analyst when he traveled to Rotterdam, and he was later promoted to senior data analyst.",
-      "qa_correct": true,
+      "qa_answer": "Omar was a data analyst when he traveled to Rotterdam.",
+      "qa_correct": false,
       "question_id": "fixture_1:q2",
       "question_type": "multi-hop",
       "retrieved_session_ids": [
@@ -225,7 +225,7 @@
       ]
     },
     {
-      "elapsed_seconds": 2.667,
+      "elapsed_seconds": 2.914,
       "error": null,
       "evidence_session_ids": [
         "session_1",
@@ -236,8 +236,8 @@
         "D3:2"
       ],
       "is_abstention": false,
-      "qa_answer": "Nadia finished the pottery course on 30 April 2023, which is approximately four months and two weeks after she signed up on 8 January 2023.",
-      "qa_correct": false,
+      "qa_answer": "Nadia signed up for the pottery class on 8 January 2023 and finished the course on 30 April 2023. This means she finished the course approximately 3 months and 22 days after signing up.",
+      "qa_correct": true,
       "question_id": "fixture_1:q3",
       "question_type": "temporal",
       "retrieved_session_ids": [
@@ -264,7 +264,7 @@
       ]
     },
     {
-      "elapsed_seconds": 2.75,
+      "elapsed_seconds": 4.764,
       "error": null,
       "evidence_session_ids": [
         "session_1"
@@ -301,7 +301,7 @@
       ]
     },
     {
-      "elapsed_seconds": 2.411,
+      "elapsed_seconds": 2.22,
       "error": null,
       "evidence_session_ids": [],
       "evidence_turn_ids": [],
@@ -335,18 +335,23 @@
     }
   ],
   "run": {
-    "git_commit": "3b8fb6f2e5c03e094dbfe8b617ac090de10fa389",
+    "cases": {
+      "completed": 1,
+      "failed": 0,
+      "skipped": 0
+    },
+    "git_commit": "192b6cbd91a35f99bf6d63ba640028ce0dccd58e",
     "python": "3.11.13",
-    "started_at": "2026-07-07T20:44:23Z",
-    "wall_seconds": 37.4
+    "started_at": "2026-07-07T21:33:04Z",
+    "wall_seconds": 39.31
   },
   "schema_version": "1.0",
   "usage": {
     "cost": {
-      "estimated_usd": 0.000639,
+      "estimated_usd": 0.00064,
       "note": "List-price estimate for reporting only; local/* models are free.",
       "per_model_usd": {
-        "openai/gpt-4o-mini": 0.000639
+        "openai/gpt-4o-mini": 0.00064
       },
       "unpriced_models": []
     },
@@ -354,16 +359,16 @@
     "llm_requests": 12,
     "searches": 6,
     "tokens": {
-      "in": 3761,
-      "out": 125,
-      "total": 3886,
+      "in": 3762,
+      "out": 126,
+      "total": 3888,
       "total_cached": 0
     },
     "tokens_by_model": {
       "openai/gpt-4o-mini": [
-        3886,
-        3761,
-        125,
+        3888,
+        3762,
+        126,
         0,
         0,
         0

--- a/bench/memory/results/locomo_fixture_combined.json
+++ b/bench/memory/results/locomo_fixture_combined.json
@@ -1,0 +1,374 @@
+{
+  "benchmark": "locomo",
+  "config": {
+    "fetch_limit": 50,
+    "formation_yaml": "bench/memory/formation/formation.yaml",
+    "max_embed_chars": 6000,
+    "mode": "combined",
+    "qa": true,
+    "text_model": "openai/gpt-4o-mini",
+    "working_embedding_model": "local/nomic-ai/nomic-embed-text-v1.5"
+  },
+  "dataset": {
+    "cases": 1,
+    "fixture": true,
+    "path": "bench/memory/fixtures/locomo_sample.json",
+    "questions": 6,
+    "seed": 42,
+    "sessions": 3,
+    "split": "all"
+  },
+  "k": 10,
+  "metrics": {
+    "k": 10,
+    "qa": {
+      "by_question_type": {
+        "adversarial": {
+          "accuracy": 1.0,
+          "questions": 1
+        },
+        "multi-hop": {
+          "accuracy": 1.0,
+          "questions": 1
+        },
+        "single-hop": {
+          "accuracy": 1.0,
+          "questions": 2
+        },
+        "temporal": {
+          "accuracy": 0.5,
+          "questions": 2
+        }
+      },
+      "overall": {
+        "accuracy": 0.8333333333333334,
+        "questions": 6
+      }
+    },
+    "questions_abstention": 1,
+    "questions_errored": 0,
+    "questions_scored": 5,
+    "questions_total": 6,
+    "retrieval": {
+      "session_level": {
+        "by_question_type": {
+          "multi-hop": {
+            "coverage@10": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@10": 1.0
+          },
+          "single-hop": {
+            "coverage@10": 1.0,
+            "mrr": 1.0,
+            "questions": 2,
+            "recall@10": 1.0
+          },
+          "temporal": {
+            "coverage@10": 1.0,
+            "mrr": 1.0,
+            "questions": 2,
+            "recall@10": 1.0
+          }
+        },
+        "overall": {
+          "coverage@10": 1.0,
+          "mrr": 1.0,
+          "questions": 5,
+          "recall@10": 1.0
+        }
+      },
+      "turn_level": {
+        "by_question_type": {
+          "multi-hop": {
+            "coverage@10": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@10": 1.0
+          },
+          "single-hop": {
+            "coverage@10": 1.0,
+            "mrr": 1.0,
+            "questions": 2,
+            "recall@10": 1.0
+          },
+          "temporal": {
+            "coverage@10": 1.0,
+            "mrr": 1.0,
+            "questions": 2,
+            "recall@10": 1.0
+          }
+        },
+        "overall": {
+          "coverage@10": 1.0,
+          "mrr": 1.0,
+          "questions": 5,
+          "recall@10": 1.0
+        }
+      }
+    }
+  },
+  "mode": "combined",
+  "results": [
+    {
+      "elapsed_seconds": 2.479,
+      "error": null,
+      "evidence_session_ids": [
+        "session_1"
+      ],
+      "evidence_turn_ids": [
+        "D1:4"
+      ],
+      "is_abstention": false,
+      "qa_answer": "Omar's cat is named Biscuit.",
+      "qa_correct": true,
+      "question_id": "fixture_1:q0",
+      "question_type": "single-hop",
+      "retrieved_session_ids": [
+        "session_1",
+        "session_3",
+        "session_2"
+      ],
+      "retrieved_turn_ids": [
+        "D1:4",
+        "D3:3",
+        "D1:6",
+        "D2:2",
+        "D3:1",
+        "D1:1",
+        "D2:4",
+        "D1:2",
+        "D1:5",
+        "D3:2",
+        "D2:1",
+        "D2:3",
+        "D1:3",
+        "D3:4",
+        "D2:5"
+      ]
+    },
+    {
+      "elapsed_seconds": 2.782,
+      "error": null,
+      "evidence_session_ids": [
+        "session_3"
+      ],
+      "evidence_turn_ids": [
+        "D3:2"
+      ],
+      "is_abstention": false,
+      "qa_answer": "Nadia made a full dinner set, which included six plates and six bowls, for her pottery final project.",
+      "qa_correct": true,
+      "question_id": "fixture_1:q1",
+      "question_type": "single-hop",
+      "retrieved_session_ids": [
+        "session_3",
+        "session_2",
+        "session_1"
+      ],
+      "retrieved_turn_ids": [
+        "D3:2",
+        "D2:1",
+        "D1:1",
+        "D1:2",
+        "D3:4",
+        "D2:5",
+        "D1:3",
+        "D2:3",
+        "D1:5",
+        "D3:3",
+        "D2:2",
+        "D3:1",
+        "D2:4",
+        "D1:4",
+        "D1:6"
+      ]
+    },
+    {
+      "elapsed_seconds": 2.51,
+      "error": null,
+      "evidence_session_ids": [
+        "session_2",
+        "session_3"
+      ],
+      "evidence_turn_ids": [
+        "D2:2",
+        "D2:4",
+        "D3:1"
+      ],
+      "is_abstention": false,
+      "qa_answer": "Omar was a data analyst when he traveled to Rotterdam, and he was later promoted to senior data analyst.",
+      "qa_correct": true,
+      "question_id": "fixture_1:q2",
+      "question_type": "multi-hop",
+      "retrieved_session_ids": [
+        "session_2",
+        "session_3",
+        "session_1"
+      ],
+      "retrieved_turn_ids": [
+        "D2:4",
+        "D3:1",
+        "D2:2",
+        "D1:6",
+        "D2:5",
+        "D3:3",
+        "D1:1",
+        "D1:4",
+        "D1:2",
+        "D2:3",
+        "D1:3",
+        "D3:2",
+        "D3:4",
+        "D2:1",
+        "D1:5"
+      ]
+    },
+    {
+      "elapsed_seconds": 2.667,
+      "error": null,
+      "evidence_session_ids": [
+        "session_1",
+        "session_3"
+      ],
+      "evidence_turn_ids": [
+        "D1:1",
+        "D3:2"
+      ],
+      "is_abstention": false,
+      "qa_answer": "Nadia finished the pottery course on 30 April 2023, which is approximately four months and two weeks after she signed up on 8 January 2023.",
+      "qa_correct": false,
+      "question_id": "fixture_1:q3",
+      "question_type": "temporal",
+      "retrieved_session_ids": [
+        "session_1",
+        "session_2",
+        "session_3"
+      ],
+      "retrieved_turn_ids": [
+        "D1:1",
+        "D2:1",
+        "D1:3",
+        "D3:2",
+        "D3:4",
+        "D1:2",
+        "D2:5",
+        "D2:3",
+        "D1:5",
+        "D3:3",
+        "D2:4",
+        "D2:2",
+        "D3:1",
+        "D1:6",
+        "D1:4"
+      ]
+    },
+    {
+      "elapsed_seconds": 2.75,
+      "error": null,
+      "evidence_session_ids": [
+        "session_1"
+      ],
+      "evidence_turn_ids": [
+        "D1:4"
+      ],
+      "is_abstention": false,
+      "qa_answer": "Omar adopted his cat, Biscuit, on the weekend before 8 January 2023.",
+      "qa_correct": true,
+      "question_id": "fixture_1:q4",
+      "question_type": "temporal",
+      "retrieved_session_ids": [
+        "session_1",
+        "session_3",
+        "session_2"
+      ],
+      "retrieved_turn_ids": [
+        "D1:4",
+        "D1:6",
+        "D3:3",
+        "D2:2",
+        "D2:4",
+        "D1:1",
+        "D3:1",
+        "D1:2",
+        "D1:5",
+        "D2:3",
+        "D2:1",
+        "D3:2",
+        "D1:3",
+        "D3:4",
+        "D2:5"
+      ]
+    },
+    {
+      "elapsed_seconds": 2.411,
+      "error": null,
+      "evidence_session_ids": [],
+      "evidence_turn_ids": [],
+      "is_abstention": true,
+      "qa_answer": "I do not know.",
+      "qa_correct": true,
+      "question_id": "fixture_1:q5",
+      "question_type": "adversarial",
+      "retrieved_session_ids": [
+        "session_1",
+        "session_2",
+        "session_3"
+      ],
+      "retrieved_turn_ids": [
+        "D1:1",
+        "D2:3",
+        "D3:4",
+        "D2:5",
+        "D1:3",
+        "D2:1",
+        "D3:2",
+        "D1:5",
+        "D1:2",
+        "D1:4",
+        "D2:2",
+        "D1:6",
+        "D2:4",
+        "D3:3",
+        "D3:1"
+      ]
+    }
+  ],
+  "run": {
+    "git_commit": "3b8fb6f2e5c03e094dbfe8b617ac090de10fa389",
+    "python": "3.11.13",
+    "started_at": "2026-07-07T20:44:23Z",
+    "wall_seconds": 37.4
+  },
+  "schema_version": "1.0",
+  "usage": {
+    "cost": {
+      "estimated_usd": 0.000639,
+      "note": "List-price estimate for reporting only; local/* models are free.",
+      "per_model_usd": {
+        "openai/gpt-4o-mini": 0.000639
+      },
+      "unpriced_models": []
+    },
+    "ingested_turns": 15,
+    "llm_requests": 12,
+    "searches": 6,
+    "tokens": {
+      "in": 3761,
+      "out": 125,
+      "total": 3886,
+      "total_cached": 0
+    },
+    "tokens_by_model": {
+      "openai/gpt-4o-mini": [
+        3886,
+        3761,
+        125,
+        0,
+        0,
+        0
+      ]
+    },
+    "truncated_turns": 0
+  }
+}

--- a/bench/memory/results/longmemeval_fixture_combined.json
+++ b/bench/memory/results/longmemeval_fixture_combined.json
@@ -143,7 +143,7 @@
   "mode": "combined",
   "results": [
     {
-      "elapsed_seconds": 2.67,
+      "elapsed_seconds": 3.939,
       "error": null,
       "evidence_session_ids": [
         "fixture_ku_001_s3"
@@ -171,7 +171,7 @@
       ]
     },
     {
-      "elapsed_seconds": 2.257,
+      "elapsed_seconds": 2.397,
       "error": null,
       "evidence_session_ids": [
         "fixture_ms_001_s1",
@@ -204,7 +204,7 @@
       ]
     },
     {
-      "elapsed_seconds": 2.999,
+      "elapsed_seconds": 2.44,
       "error": null,
       "evidence_session_ids": [
         "fixture_ssa_001_s1"
@@ -233,7 +233,7 @@
       ]
     },
     {
-      "elapsed_seconds": 4.556,
+      "elapsed_seconds": 3.693,
       "error": null,
       "evidence_session_ids": [
         "fixture_ssp_001_s2"
@@ -242,7 +242,7 @@
         "fixture_ssp_001_s2:0"
       ],
       "is_abstention": false,
-      "qa_answer": "For your dinner party menu, consider the following options that avoid shellfish:\n\n**Appetizers:**\n- Caprese skewers (mozzarella, cherry tomatoes, and basil)\n- Stuffed mushrooms with cream cheese and herbs\n\n**Main Course:**\n- Grilled chicken with lemon and herbs\n- Vegetarian pasta primavera with seasonal vegetables\n\n**Side Dishes:**\n- Quinoa salad with cucumbers, bell peppers, and a lemon vinaigrette\n- Roasted seasonal vegetables\n\n**Dessert:**\n- Chocolate mousse or fruit salad\n\nMake sure to communicate your shellfish allergy to your guests to ensure everyone's safety. Enjoy your dinner party!",
+      "qa_answer": "For your dinner party menu, consider the following options that avoid shellfish:\n\n**Appetizers:**\n- Caprese skewers (mozzarella, cherry tomatoes, and basil)\n- Stuffed mushrooms (filled with cream cheese, herbs, and breadcrumbs)\n\n**Main Course:**\n- Grilled chicken with lemon and herbs\n- Vegetarian pasta primavera (with seasonal vegetables)\n\n**Side Dishes:**\n- Roasted seasonal vegetables\n- Quinoa salad with cucumbers, tomatoes, and a lemon vinaigrette\n\n**Dessert:**\n- Chocolate mousse or fruit salad\n\nMake sure to communicate your shellfish allergy to your guests to ensure everyone's safety. Enjoy your dinner party!",
       "qa_correct": true,
       "question_id": "fixture_ssp_001",
       "question_type": "single-session-preference",
@@ -262,7 +262,7 @@
       ]
     },
     {
-      "elapsed_seconds": 2.8,
+      "elapsed_seconds": 2.343,
       "error": null,
       "evidence_session_ids": [
         "fixture_ssu_001_s2"
@@ -296,7 +296,7 @@
       ]
     },
     {
-      "elapsed_seconds": 1.91,
+      "elapsed_seconds": 2.224,
       "error": null,
       "evidence_session_ids": [],
       "evidence_turn_ids": [],
@@ -318,18 +318,18 @@
     }
   ],
   "run": {
-    "git_commit": "3b8fb6f2e5c03e094dbfe8b617ac090de10fa389",
+    "git_commit": "6d380d46f532424bdada54fcb91e7494a3ab4803",
     "python": "3.11.13",
-    "started_at": "2026-07-07T20:42:37Z",
-    "wall_seconds": 51.3
+    "started_at": "2026-07-07T21:10:31Z",
+    "wall_seconds": 42.78
   },
   "schema_version": "1.0",
   "usage": {
     "cost": {
-      "estimated_usd": 0.000615,
+      "estimated_usd": 0.000618,
       "note": "List-price estimate for reporting only; local/* models are free.",
       "per_model_usd": {
-        "openai/gpt-4o-mini": 0.000615
+        "openai/gpt-4o-mini": 0.000618
       },
       "unpriced_models": []
     },
@@ -337,16 +337,16 @@
     "llm_requests": 12,
     "searches": 6,
     "tokens": {
-      "in": 3241,
-      "out": 214,
-      "total": 3455,
+      "in": 3246,
+      "out": 219,
+      "total": 3465,
       "total_cached": 0
     },
     "tokens_by_model": {
       "openai/gpt-4o-mini": [
-        3455,
-        3241,
-        214,
+        3465,
+        3246,
+        219,
         0,
         0,
         0

--- a/bench/memory/results/longmemeval_fixture_combined.json
+++ b/bench/memory/results/longmemeval_fixture_combined.json
@@ -143,7 +143,7 @@
   "mode": "combined",
   "results": [
     {
-      "elapsed_seconds": 3.939,
+      "elapsed_seconds": 2.194,
       "error": null,
       "evidence_session_ids": [
         "fixture_ku_001_s3"
@@ -152,7 +152,7 @@
         "fixture_ku_001_s3:0"
       ],
       "is_abstention": false,
-      "qa_answer": "You work on the platform infrastructure team now.",
+      "qa_answer": "You work on the platform infrastructure team.",
       "qa_correct": true,
       "question_id": "fixture_ku_001",
       "question_type": "knowledge-update",
@@ -171,7 +171,7 @@
       ]
     },
     {
-      "elapsed_seconds": 2.397,
+      "elapsed_seconds": 2.375,
       "error": null,
       "evidence_session_ids": [
         "fixture_ms_001_s1",
@@ -204,7 +204,7 @@
       ]
     },
     {
-      "elapsed_seconds": 2.44,
+      "elapsed_seconds": 2.374,
       "error": null,
       "evidence_session_ids": [
         "fixture_ssa_001_s1"
@@ -233,7 +233,7 @@
       ]
     },
     {
-      "elapsed_seconds": 3.693,
+      "elapsed_seconds": 4.336,
       "error": null,
       "evidence_session_ids": [
         "fixture_ssp_001_s2"
@@ -242,7 +242,7 @@
         "fixture_ssp_001_s2:0"
       ],
       "is_abstention": false,
-      "qa_answer": "For your dinner party menu, consider the following options that avoid shellfish:\n\n**Appetizers:**\n- Caprese skewers (mozzarella, cherry tomatoes, and basil)\n- Stuffed mushrooms (filled with cream cheese, herbs, and breadcrumbs)\n\n**Main Course:**\n- Grilled chicken with lemon and herbs\n- Vegetarian pasta primavera (with seasonal vegetables)\n\n**Side Dishes:**\n- Roasted seasonal vegetables\n- Quinoa salad with cucumbers, tomatoes, and a lemon vinaigrette\n\n**Dessert:**\n- Chocolate mousse or fruit salad\n\nMake sure to communicate your shellfish allergy to your guests to ensure everyone's safety. Enjoy your dinner party!",
+      "qa_answer": "For your dinner party menu, consider the following options that avoid shellfish:\n\n**Appetizers:**\n- Caprese skewers (mozzarella, tomatoes, basil)\n- Stuffed mushrooms (with cream cheese and herbs)\n\n**Main Course:**\n- Grilled chicken with lemon and herbs\n- Vegetarian pasta primavera (with seasonal vegetables)\n\n**Side Dishes:**\n- Roasted vegetables (carrots, zucchini, bell peppers)\n- Quinoa salad with cucumbers, tomatoes, and a lemon vinaigrette\n\n**Dessert:**\n- Chocolate mousse or fruit salad\n\nMake sure to inform your guests about your shellfish allergy to ensure a safe dining experience!",
       "qa_correct": true,
       "question_id": "fixture_ssp_001",
       "question_type": "single-session-preference",
@@ -262,7 +262,7 @@
       ]
     },
     {
-      "elapsed_seconds": 2.343,
+      "elapsed_seconds": 2.444,
       "error": null,
       "evidence_session_ids": [
         "fixture_ssu_001_s2"
@@ -296,7 +296,7 @@
       ]
     },
     {
-      "elapsed_seconds": 2.224,
+      "elapsed_seconds": 2.125,
       "error": null,
       "evidence_session_ids": [],
       "evidence_turn_ids": [],
@@ -318,18 +318,23 @@
     }
   ],
   "run": {
-    "git_commit": "6d380d46f532424bdada54fcb91e7494a3ab4803",
+    "cases": {
+      "completed": 6,
+      "failed": 0,
+      "skipped": 0
+    },
+    "git_commit": "192b6cbd91a35f99bf6d63ba640028ce0dccd58e",
     "python": "3.11.13",
-    "started_at": "2026-07-07T21:10:31Z",
-    "wall_seconds": 42.78
+    "started_at": "2026-07-07T21:30:34Z",
+    "wall_seconds": 42.32
   },
   "schema_version": "1.0",
   "usage": {
     "cost": {
-      "estimated_usd": 0.000618,
+      "estimated_usd": 0.000616,
       "note": "List-price estimate for reporting only; local/* models are free.",
       "per_model_usd": {
-        "openai/gpt-4o-mini": 0.000618
+        "openai/gpt-4o-mini": 0.000616
       },
       "unpriced_models": []
     },
@@ -337,16 +342,16 @@
     "llm_requests": 12,
     "searches": 6,
     "tokens": {
-      "in": 3246,
-      "out": 219,
-      "total": 3465,
+      "in": 3243,
+      "out": 216,
+      "total": 3459,
       "total_cached": 0
     },
     "tokens_by_model": {
       "openai/gpt-4o-mini": [
-        3465,
-        3246,
-        219,
+        3459,
+        3243,
+        216,
         0,
         0,
         0

--- a/bench/memory/results/longmemeval_fixture_combined.json
+++ b/bench/memory/results/longmemeval_fixture_combined.json
@@ -1,0 +1,357 @@
+{
+  "benchmark": "longmemeval",
+  "config": {
+    "fetch_limit": 25,
+    "formation_yaml": "bench/memory/formation/formation.yaml",
+    "max_embed_chars": 6000,
+    "mode": "combined",
+    "qa": true,
+    "text_model": "openai/gpt-4o-mini",
+    "working_embedding_model": "local/nomic-ai/nomic-embed-text-v1.5"
+  },
+  "dataset": {
+    "cases": 6,
+    "fixture": true,
+    "path": "bench/memory/fixtures/longmemeval_sample.json",
+    "questions": 6,
+    "seed": 42,
+    "sessions": 19,
+    "split": "all"
+  },
+  "k": 5,
+  "metrics": {
+    "k": 5,
+    "qa": {
+      "by_question_type": {
+        "knowledge-update": {
+          "accuracy": 1.0,
+          "questions": 1
+        },
+        "multi-session": {
+          "accuracy": 1.0,
+          "questions": 1
+        },
+        "single-session-assistant": {
+          "accuracy": 1.0,
+          "questions": 1
+        },
+        "single-session-preference": {
+          "accuracy": 1.0,
+          "questions": 1
+        },
+        "single-session-user": {
+          "accuracy": 1.0,
+          "questions": 1
+        },
+        "temporal-reasoning": {
+          "accuracy": 1.0,
+          "questions": 1
+        }
+      },
+      "overall": {
+        "accuracy": 1.0,
+        "questions": 6
+      }
+    },
+    "questions_abstention": 1,
+    "questions_errored": 0,
+    "questions_scored": 5,
+    "questions_total": 6,
+    "retrieval": {
+      "session_level": {
+        "by_question_type": {
+          "knowledge-update": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "multi-session": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "single-session-assistant": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "single-session-preference": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "single-session-user": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          }
+        },
+        "overall": {
+          "coverage@5": 1.0,
+          "mrr": 1.0,
+          "questions": 5,
+          "recall@5": 1.0
+        }
+      },
+      "turn_level": {
+        "by_question_type": {
+          "knowledge-update": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "multi-session": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "single-session-assistant": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "single-session-preference": {
+            "coverage@5": 1.0,
+            "mrr": 0.5,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "single-session-user": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          }
+        },
+        "overall": {
+          "coverage@5": 1.0,
+          "mrr": 0.9,
+          "questions": 5,
+          "recall@5": 1.0
+        }
+      }
+    }
+  },
+  "mode": "combined",
+  "results": [
+    {
+      "elapsed_seconds": 2.67,
+      "error": null,
+      "evidence_session_ids": [
+        "fixture_ku_001_s3"
+      ],
+      "evidence_turn_ids": [
+        "fixture_ku_001_s3:0"
+      ],
+      "is_abstention": false,
+      "qa_answer": "You work on the platform infrastructure team now.",
+      "qa_correct": true,
+      "question_id": "fixture_ku_001",
+      "question_type": "knowledge-update",
+      "retrieved_session_ids": [
+        "fixture_ku_001_s3",
+        "fixture_ku_001_s1",
+        "fixture_ku_001_s2"
+      ],
+      "retrieved_turn_ids": [
+        "fixture_ku_001_s3:0",
+        "fixture_ku_001_s1:0",
+        "fixture_ku_001_s3:1",
+        "fixture_ku_001_s1:1",
+        "fixture_ku_001_s2:1",
+        "fixture_ku_001_s2:0"
+      ]
+    },
+    {
+      "elapsed_seconds": 2.257,
+      "error": null,
+      "evidence_session_ids": [
+        "fixture_ms_001_s1",
+        "fixture_ms_001_s3"
+      ],
+      "evidence_turn_ids": [
+        "fixture_ms_001_s1:0",
+        "fixture_ms_001_s3:0"
+      ],
+      "is_abstention": false,
+      "qa_answer": "You have mentioned running two marathons this year: the Chicago Marathon and the Berlin Marathon.",
+      "qa_correct": true,
+      "question_id": "fixture_ms_001",
+      "question_type": "multi-session",
+      "retrieved_session_ids": [
+        "fixture_ms_001_s1",
+        "fixture_ms_001_s3",
+        "fixture_ms_001_s2",
+        "fixture_ms_001_s4"
+      ],
+      "retrieved_turn_ids": [
+        "fixture_ms_001_s1:0",
+        "fixture_ms_001_s1:1",
+        "fixture_ms_001_s3:1",
+        "fixture_ms_001_s3:0",
+        "fixture_ms_001_s2:1",
+        "fixture_ms_001_s2:0",
+        "fixture_ms_001_s4:1",
+        "fixture_ms_001_s4:0"
+      ]
+    },
+    {
+      "elapsed_seconds": 2.999,
+      "error": null,
+      "evidence_session_ids": [
+        "fixture_ssa_001_s1"
+      ],
+      "evidence_turn_ids": [
+        "fixture_ssa_001_s1:1"
+      ],
+      "is_abstention": false,
+      "qa_answer": "I told you that chicken is safe to eat when the thickest part of the thigh reaches 165 degrees Fahrenheit, which is 74 degrees Celsius.",
+      "qa_correct": true,
+      "question_id": "fixture_ssa_001",
+      "question_type": "single-session-assistant",
+      "retrieved_session_ids": [
+        "fixture_ssa_001_s1",
+        "fixture_ssa_001_s3",
+        "fixture_ssa_001_s2"
+      ],
+      "retrieved_turn_ids": [
+        "fixture_ssa_001_s1:1",
+        "fixture_ssa_001_s1:0",
+        "fixture_ssa_001_s1:2",
+        "fixture_ssa_001_s3:1",
+        "fixture_ssa_001_s2:0",
+        "fixture_ssa_001_s2:1",
+        "fixture_ssa_001_s3:0"
+      ]
+    },
+    {
+      "elapsed_seconds": 4.556,
+      "error": null,
+      "evidence_session_ids": [
+        "fixture_ssp_001_s2"
+      ],
+      "evidence_turn_ids": [
+        "fixture_ssp_001_s2:0"
+      ],
+      "is_abstention": false,
+      "qa_answer": "For your dinner party menu, consider the following options that avoid shellfish:\n\n**Appetizers:**\n- Caprese skewers (mozzarella, cherry tomatoes, and basil)\n- Stuffed mushrooms with cream cheese and herbs\n\n**Main Course:**\n- Grilled chicken with lemon and herbs\n- Vegetarian pasta primavera with seasonal vegetables\n\n**Side Dishes:**\n- Quinoa salad with cucumbers, bell peppers, and a lemon vinaigrette\n- Roasted seasonal vegetables\n\n**Dessert:**\n- Chocolate mousse or fruit salad\n\nMake sure to communicate your shellfish allergy to your guests to ensure everyone's safety. Enjoy your dinner party!",
+      "qa_correct": true,
+      "question_id": "fixture_ssp_001",
+      "question_type": "single-session-preference",
+      "retrieved_session_ids": [
+        "fixture_ssp_001_s2",
+        "fixture_ssp_001_s1",
+        "fixture_ssp_001_s3"
+      ],
+      "retrieved_turn_ids": [
+        "fixture_ssp_001_s2:1",
+        "fixture_ssp_001_s2:0",
+        "fixture_ssp_001_s1:1",
+        "fixture_ssp_001_s3:1",
+        "fixture_ssp_001_s2:2",
+        "fixture_ssp_001_s3:0",
+        "fixture_ssp_001_s1:0"
+      ]
+    },
+    {
+      "elapsed_seconds": 2.8,
+      "error": null,
+      "evidence_session_ids": [
+        "fixture_ssu_001_s2"
+      ],
+      "evidence_turn_ids": [
+        "fixture_ssu_001_s2:0"
+      ],
+      "is_abstention": false,
+      "qa_answer": "Your dog is a border collie.",
+      "qa_correct": true,
+      "question_id": "fixture_ssu_001",
+      "question_type": "single-session-user",
+      "retrieved_session_ids": [
+        "fixture_ssu_001_s2",
+        "fixture_ssu_001_s1",
+        "fixture_ssu_001_s3",
+        "fixture_ssu_001_s4"
+      ],
+      "retrieved_turn_ids": [
+        "fixture_ssu_001_s2:0",
+        "fixture_ssu_001_s2:1",
+        "fixture_ssu_001_s2:3",
+        "fixture_ssu_001_s2:2",
+        "fixture_ssu_001_s1:2",
+        "fixture_ssu_001_s3:1",
+        "fixture_ssu_001_s1:1",
+        "fixture_ssu_001_s4:0",
+        "fixture_ssu_001_s4:1",
+        "fixture_ssu_001_s1:0",
+        "fixture_ssu_001_s3:0"
+      ]
+    },
+    {
+      "elapsed_seconds": 1.91,
+      "error": null,
+      "evidence_session_ids": [],
+      "evidence_turn_ids": [],
+      "is_abstention": true,
+      "qa_answer": "I do not know.",
+      "qa_correct": true,
+      "question_id": "fixture_tr_001_abs",
+      "question_type": "temporal-reasoning",
+      "retrieved_session_ids": [
+        "fixture_tr_001_s1",
+        "fixture_tr_001_s2"
+      ],
+      "retrieved_turn_ids": [
+        "fixture_tr_001_s1:0",
+        "fixture_tr_001_s2:1",
+        "fixture_tr_001_s1:1",
+        "fixture_tr_001_s2:0"
+      ]
+    }
+  ],
+  "run": {
+    "git_commit": "3b8fb6f2e5c03e094dbfe8b617ac090de10fa389",
+    "python": "3.11.13",
+    "started_at": "2026-07-07T20:42:37Z",
+    "wall_seconds": 51.3
+  },
+  "schema_version": "1.0",
+  "usage": {
+    "cost": {
+      "estimated_usd": 0.000615,
+      "note": "List-price estimate for reporting only; local/* models are free.",
+      "per_model_usd": {
+        "openai/gpt-4o-mini": 0.000615
+      },
+      "unpriced_models": []
+    },
+    "ingested_turns": 43,
+    "llm_requests": 12,
+    "searches": 6,
+    "tokens": {
+      "in": 3241,
+      "out": 214,
+      "total": 3455,
+      "total_cached": 0
+    },
+    "tokens_by_model": {
+      "openai/gpt-4o-mini": [
+        3455,
+        3241,
+        214,
+        0,
+        0,
+        0
+      ]
+    },
+    "truncated_turns": 0
+  }
+}

--- a/bench/memory/results/longmemeval_fixture_persistent.json
+++ b/bench/memory/results/longmemeval_fixture_persistent.json
@@ -1,0 +1,315 @@
+{
+  "benchmark": "longmemeval",
+  "config": {
+    "fetch_limit": 25,
+    "formation_yaml": "bench/memory/formation/formation.yaml",
+    "max_embed_chars": 6000,
+    "mode": "persistent",
+    "qa": false,
+    "text_model": "openai/gpt-4o-mini",
+    "working_embedding_model": "local/nomic-ai/nomic-embed-text-v1.5"
+  },
+  "dataset": {
+    "cases": 6,
+    "fixture": true,
+    "path": "bench/memory/fixtures/longmemeval_sample.json",
+    "questions": 6,
+    "seed": 42,
+    "sessions": 19,
+    "split": "all"
+  },
+  "k": 5,
+  "metrics": {
+    "k": 5,
+    "qa": null,
+    "questions_abstention": 1,
+    "questions_errored": 0,
+    "questions_scored": 5,
+    "questions_total": 6,
+    "retrieval": {
+      "session_level": {
+        "by_question_type": {
+          "knowledge-update": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "multi-session": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "single-session-assistant": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "single-session-preference": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "single-session-user": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          }
+        },
+        "overall": {
+          "coverage@5": 1.0,
+          "mrr": 1.0,
+          "questions": 5,
+          "recall@5": 1.0
+        }
+      },
+      "turn_level": {
+        "by_question_type": {
+          "knowledge-update": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "multi-session": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "single-session-assistant": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "single-session-preference": {
+            "coverage@5": 1.0,
+            "mrr": 0.5,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "single-session-user": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          }
+        },
+        "overall": {
+          "coverage@5": 1.0,
+          "mrr": 0.9,
+          "questions": 5,
+          "recall@5": 1.0
+        }
+      }
+    }
+  },
+  "mode": "persistent",
+  "results": [
+    {
+      "elapsed_seconds": 0.07,
+      "error": null,
+      "evidence_session_ids": [
+        "fixture_ku_001_s3"
+      ],
+      "evidence_turn_ids": [
+        "fixture_ku_001_s3:0"
+      ],
+      "is_abstention": false,
+      "qa_answer": null,
+      "qa_correct": null,
+      "question_id": "fixture_ku_001",
+      "question_type": "knowledge-update",
+      "retrieved_session_ids": [
+        "fixture_ku_001_s3",
+        "fixture_ku_001_s1",
+        "fixture_ku_001_s2"
+      ],
+      "retrieved_turn_ids": [
+        "fixture_ku_001_s3:0",
+        "fixture_ku_001_s1:0",
+        "fixture_ku_001_s3:1",
+        "fixture_ku_001_s1:1",
+        "fixture_ku_001_s2:1",
+        "fixture_ku_001_s2:0"
+      ]
+    },
+    {
+      "elapsed_seconds": 0.076,
+      "error": null,
+      "evidence_session_ids": [
+        "fixture_ms_001_s1",
+        "fixture_ms_001_s3"
+      ],
+      "evidence_turn_ids": [
+        "fixture_ms_001_s1:0",
+        "fixture_ms_001_s3:0"
+      ],
+      "is_abstention": false,
+      "qa_answer": null,
+      "qa_correct": null,
+      "question_id": "fixture_ms_001",
+      "question_type": "multi-session",
+      "retrieved_session_ids": [
+        "fixture_ms_001_s1",
+        "fixture_ms_001_s3",
+        "fixture_ms_001_s2",
+        "fixture_ms_001_s4"
+      ],
+      "retrieved_turn_ids": [
+        "fixture_ms_001_s1:0",
+        "fixture_ms_001_s1:1",
+        "fixture_ms_001_s3:1",
+        "fixture_ms_001_s3:0",
+        "fixture_ms_001_s2:1",
+        "fixture_ms_001_s2:0",
+        "fixture_ms_001_s4:1",
+        "fixture_ms_001_s4:0"
+      ]
+    },
+    {
+      "elapsed_seconds": 0.065,
+      "error": null,
+      "evidence_session_ids": [
+        "fixture_ssa_001_s1"
+      ],
+      "evidence_turn_ids": [
+        "fixture_ssa_001_s1:1"
+      ],
+      "is_abstention": false,
+      "qa_answer": null,
+      "qa_correct": null,
+      "question_id": "fixture_ssa_001",
+      "question_type": "single-session-assistant",
+      "retrieved_session_ids": [
+        "fixture_ssa_001_s1",
+        "fixture_ssa_001_s3",
+        "fixture_ssa_001_s2"
+      ],
+      "retrieved_turn_ids": [
+        "fixture_ssa_001_s1:1",
+        "fixture_ssa_001_s1:0",
+        "fixture_ssa_001_s1:2",
+        "fixture_ssa_001_s3:1",
+        "fixture_ssa_001_s2:0",
+        "fixture_ssa_001_s2:1",
+        "fixture_ssa_001_s3:0"
+      ]
+    },
+    {
+      "elapsed_seconds": 0.084,
+      "error": null,
+      "evidence_session_ids": [
+        "fixture_ssp_001_s2"
+      ],
+      "evidence_turn_ids": [
+        "fixture_ssp_001_s2:0"
+      ],
+      "is_abstention": false,
+      "qa_answer": null,
+      "qa_correct": null,
+      "question_id": "fixture_ssp_001",
+      "question_type": "single-session-preference",
+      "retrieved_session_ids": [
+        "fixture_ssp_001_s2",
+        "fixture_ssp_001_s1",
+        "fixture_ssp_001_s3"
+      ],
+      "retrieved_turn_ids": [
+        "fixture_ssp_001_s2:1",
+        "fixture_ssp_001_s2:0",
+        "fixture_ssp_001_s1:1",
+        "fixture_ssp_001_s3:1",
+        "fixture_ssp_001_s2:2",
+        "fixture_ssp_001_s3:0",
+        "fixture_ssp_001_s1:0"
+      ]
+    },
+    {
+      "elapsed_seconds": 0.061,
+      "error": null,
+      "evidence_session_ids": [
+        "fixture_ssu_001_s2"
+      ],
+      "evidence_turn_ids": [
+        "fixture_ssu_001_s2:0"
+      ],
+      "is_abstention": false,
+      "qa_answer": null,
+      "qa_correct": null,
+      "question_id": "fixture_ssu_001",
+      "question_type": "single-session-user",
+      "retrieved_session_ids": [
+        "fixture_ssu_001_s2",
+        "fixture_ssu_001_s1",
+        "fixture_ssu_001_s3",
+        "fixture_ssu_001_s4"
+      ],
+      "retrieved_turn_ids": [
+        "fixture_ssu_001_s2:0",
+        "fixture_ssu_001_s2:1",
+        "fixture_ssu_001_s2:3",
+        "fixture_ssu_001_s2:2",
+        "fixture_ssu_001_s1:2",
+        "fixture_ssu_001_s3:1",
+        "fixture_ssu_001_s1:1",
+        "fixture_ssu_001_s4:0",
+        "fixture_ssu_001_s4:1",
+        "fixture_ssu_001_s1:0",
+        "fixture_ssu_001_s3:0"
+      ]
+    },
+    {
+      "elapsed_seconds": 0.065,
+      "error": null,
+      "evidence_session_ids": [],
+      "evidence_turn_ids": [],
+      "is_abstention": true,
+      "qa_answer": null,
+      "qa_correct": null,
+      "question_id": "fixture_tr_001_abs",
+      "question_type": "temporal-reasoning",
+      "retrieved_session_ids": [
+        "fixture_tr_001_s1",
+        "fixture_tr_001_s2"
+      ],
+      "retrieved_turn_ids": [
+        "fixture_tr_001_s1:0",
+        "fixture_tr_001_s2:1",
+        "fixture_tr_001_s1:1",
+        "fixture_tr_001_s2:0"
+      ]
+    }
+  ],
+  "run": {
+    "git_commit": "3b8fb6f2e5c03e094dbfe8b617ac090de10fa389",
+    "python": "3.11.13",
+    "started_at": "2026-07-07T20:43:44Z",
+    "wall_seconds": 26.37
+  },
+  "schema_version": "1.0",
+  "usage": {
+    "cost": {
+      "estimated_usd": 0.0,
+      "note": "List-price estimate for reporting only; local/* models are free.",
+      "per_model_usd": {},
+      "unpriced_models": []
+    },
+    "ingested_turns": 43,
+    "llm_requests": 0,
+    "searches": 6,
+    "tokens": {
+      "in": 0,
+      "out": 0,
+      "total": 0,
+      "total_cached": 0
+    },
+    "tokens_by_model": {},
+    "truncated_turns": 0
+  }
+}

--- a/bench/memory/results/longmemeval_fixture_persistent.json
+++ b/bench/memory/results/longmemeval_fixture_persistent.json
@@ -112,7 +112,7 @@
   "mode": "persistent",
   "results": [
     {
-      "elapsed_seconds": 0.07,
+      "elapsed_seconds": 0.066,
       "error": null,
       "evidence_session_ids": [
         "fixture_ku_001_s3"
@@ -140,7 +140,7 @@
       ]
     },
     {
-      "elapsed_seconds": 0.076,
+      "elapsed_seconds": 0.087,
       "error": null,
       "evidence_session_ids": [
         "fixture_ms_001_s1",
@@ -173,7 +173,7 @@
       ]
     },
     {
-      "elapsed_seconds": 0.065,
+      "elapsed_seconds": 0.066,
       "error": null,
       "evidence_session_ids": [
         "fixture_ssa_001_s1"
@@ -202,7 +202,7 @@
       ]
     },
     {
-      "elapsed_seconds": 0.084,
+      "elapsed_seconds": 0.07,
       "error": null,
       "evidence_session_ids": [
         "fixture_ssp_001_s2"
@@ -265,7 +265,7 @@
       ]
     },
     {
-      "elapsed_seconds": 0.065,
+      "elapsed_seconds": 0.07,
       "error": null,
       "evidence_session_ids": [],
       "evidence_turn_ids": [],
@@ -287,10 +287,15 @@
     }
   ],
   "run": {
-    "git_commit": "3b8fb6f2e5c03e094dbfe8b617ac090de10fa389",
+    "cases": {
+      "completed": 6,
+      "failed": 0,
+      "skipped": 0
+    },
+    "git_commit": "192b6cbd91a35f99bf6d63ba640028ce0dccd58e",
     "python": "3.11.13",
-    "started_at": "2026-07-07T20:43:44Z",
-    "wall_seconds": 26.37
+    "started_at": "2026-07-07T21:32:28Z",
+    "wall_seconds": 24.15
   },
   "schema_version": "1.0",
   "usage": {

--- a/bench/memory/results/longmemeval_fixture_working.json
+++ b/bench/memory/results/longmemeval_fixture_working.json
@@ -1,0 +1,315 @@
+{
+  "benchmark": "longmemeval",
+  "config": {
+    "fetch_limit": 25,
+    "formation_yaml": "bench/memory/formation/formation.yaml",
+    "max_embed_chars": 6000,
+    "mode": "working",
+    "qa": false,
+    "text_model": "openai/gpt-4o-mini",
+    "working_embedding_model": "local/nomic-ai/nomic-embed-text-v1.5"
+  },
+  "dataset": {
+    "cases": 6,
+    "fixture": true,
+    "path": "bench/memory/fixtures/longmemeval_sample.json",
+    "questions": 6,
+    "seed": 42,
+    "sessions": 19,
+    "split": "all"
+  },
+  "k": 5,
+  "metrics": {
+    "k": 5,
+    "qa": null,
+    "questions_abstention": 1,
+    "questions_errored": 0,
+    "questions_scored": 5,
+    "questions_total": 6,
+    "retrieval": {
+      "session_level": {
+        "by_question_type": {
+          "knowledge-update": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "multi-session": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "single-session-assistant": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "single-session-preference": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "single-session-user": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          }
+        },
+        "overall": {
+          "coverage@5": 1.0,
+          "mrr": 1.0,
+          "questions": 5,
+          "recall@5": 1.0
+        }
+      },
+      "turn_level": {
+        "by_question_type": {
+          "knowledge-update": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "multi-session": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "single-session-assistant": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "single-session-preference": {
+            "coverage@5": 1.0,
+            "mrr": 0.5,
+            "questions": 1,
+            "recall@5": 1.0
+          },
+          "single-session-user": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 1,
+            "recall@5": 1.0
+          }
+        },
+        "overall": {
+          "coverage@5": 1.0,
+          "mrr": 0.9,
+          "questions": 5,
+          "recall@5": 1.0
+        }
+      }
+    }
+  },
+  "mode": "working",
+  "results": [
+    {
+      "elapsed_seconds": 0.069,
+      "error": null,
+      "evidence_session_ids": [
+        "fixture_ku_001_s3"
+      ],
+      "evidence_turn_ids": [
+        "fixture_ku_001_s3:0"
+      ],
+      "is_abstention": false,
+      "qa_answer": null,
+      "qa_correct": null,
+      "question_id": "fixture_ku_001",
+      "question_type": "knowledge-update",
+      "retrieved_session_ids": [
+        "fixture_ku_001_s3",
+        "fixture_ku_001_s1",
+        "fixture_ku_001_s2"
+      ],
+      "retrieved_turn_ids": [
+        "fixture_ku_001_s3:0",
+        "fixture_ku_001_s1:0",
+        "fixture_ku_001_s3:1",
+        "fixture_ku_001_s1:1",
+        "fixture_ku_001_s2:1",
+        "fixture_ku_001_s2:0"
+      ]
+    },
+    {
+      "elapsed_seconds": 0.069,
+      "error": null,
+      "evidence_session_ids": [
+        "fixture_ms_001_s1",
+        "fixture_ms_001_s3"
+      ],
+      "evidence_turn_ids": [
+        "fixture_ms_001_s1:0",
+        "fixture_ms_001_s3:0"
+      ],
+      "is_abstention": false,
+      "qa_answer": null,
+      "qa_correct": null,
+      "question_id": "fixture_ms_001",
+      "question_type": "multi-session",
+      "retrieved_session_ids": [
+        "fixture_ms_001_s1",
+        "fixture_ms_001_s3",
+        "fixture_ms_001_s2",
+        "fixture_ms_001_s4"
+      ],
+      "retrieved_turn_ids": [
+        "fixture_ms_001_s1:0",
+        "fixture_ms_001_s1:1",
+        "fixture_ms_001_s3:1",
+        "fixture_ms_001_s3:0",
+        "fixture_ms_001_s2:1",
+        "fixture_ms_001_s2:0",
+        "fixture_ms_001_s4:1",
+        "fixture_ms_001_s4:0"
+      ]
+    },
+    {
+      "elapsed_seconds": 0.061,
+      "error": null,
+      "evidence_session_ids": [
+        "fixture_ssa_001_s1"
+      ],
+      "evidence_turn_ids": [
+        "fixture_ssa_001_s1:1"
+      ],
+      "is_abstention": false,
+      "qa_answer": null,
+      "qa_correct": null,
+      "question_id": "fixture_ssa_001",
+      "question_type": "single-session-assistant",
+      "retrieved_session_ids": [
+        "fixture_ssa_001_s1",
+        "fixture_ssa_001_s3",
+        "fixture_ssa_001_s2"
+      ],
+      "retrieved_turn_ids": [
+        "fixture_ssa_001_s1:1",
+        "fixture_ssa_001_s1:0",
+        "fixture_ssa_001_s1:2",
+        "fixture_ssa_001_s3:1",
+        "fixture_ssa_001_s2:0",
+        "fixture_ssa_001_s2:1",
+        "fixture_ssa_001_s3:0"
+      ]
+    },
+    {
+      "elapsed_seconds": 0.072,
+      "error": null,
+      "evidence_session_ids": [
+        "fixture_ssp_001_s2"
+      ],
+      "evidence_turn_ids": [
+        "fixture_ssp_001_s2:0"
+      ],
+      "is_abstention": false,
+      "qa_answer": null,
+      "qa_correct": null,
+      "question_id": "fixture_ssp_001",
+      "question_type": "single-session-preference",
+      "retrieved_session_ids": [
+        "fixture_ssp_001_s2",
+        "fixture_ssp_001_s1",
+        "fixture_ssp_001_s3"
+      ],
+      "retrieved_turn_ids": [
+        "fixture_ssp_001_s2:1",
+        "fixture_ssp_001_s2:0",
+        "fixture_ssp_001_s1:1",
+        "fixture_ssp_001_s3:1",
+        "fixture_ssp_001_s2:2",
+        "fixture_ssp_001_s3:0",
+        "fixture_ssp_001_s1:0"
+      ]
+    },
+    {
+      "elapsed_seconds": 0.069,
+      "error": null,
+      "evidence_session_ids": [
+        "fixture_ssu_001_s2"
+      ],
+      "evidence_turn_ids": [
+        "fixture_ssu_001_s2:0"
+      ],
+      "is_abstention": false,
+      "qa_answer": null,
+      "qa_correct": null,
+      "question_id": "fixture_ssu_001",
+      "question_type": "single-session-user",
+      "retrieved_session_ids": [
+        "fixture_ssu_001_s2",
+        "fixture_ssu_001_s1",
+        "fixture_ssu_001_s3",
+        "fixture_ssu_001_s4"
+      ],
+      "retrieved_turn_ids": [
+        "fixture_ssu_001_s2:0",
+        "fixture_ssu_001_s2:1",
+        "fixture_ssu_001_s2:3",
+        "fixture_ssu_001_s2:2",
+        "fixture_ssu_001_s1:2",
+        "fixture_ssu_001_s3:1",
+        "fixture_ssu_001_s1:1",
+        "fixture_ssu_001_s4:0",
+        "fixture_ssu_001_s4:1",
+        "fixture_ssu_001_s1:0",
+        "fixture_ssu_001_s3:0"
+      ]
+    },
+    {
+      "elapsed_seconds": 0.068,
+      "error": null,
+      "evidence_session_ids": [],
+      "evidence_turn_ids": [],
+      "is_abstention": true,
+      "qa_answer": null,
+      "qa_correct": null,
+      "question_id": "fixture_tr_001_abs",
+      "question_type": "temporal-reasoning",
+      "retrieved_session_ids": [
+        "fixture_tr_001_s1",
+        "fixture_tr_001_s2"
+      ],
+      "retrieved_turn_ids": [
+        "fixture_tr_001_s1:0",
+        "fixture_tr_001_s2:1",
+        "fixture_tr_001_s1:1",
+        "fixture_tr_001_s2:0"
+      ]
+    }
+  ],
+  "run": {
+    "git_commit": "3b8fb6f2e5c03e094dbfe8b617ac090de10fa389",
+    "python": "3.11.13",
+    "started_at": "2026-07-07T20:52:17Z",
+    "wall_seconds": 23.8
+  },
+  "schema_version": "1.0",
+  "usage": {
+    "cost": {
+      "estimated_usd": 0.0,
+      "note": "List-price estimate for reporting only; local/* models are free.",
+      "per_model_usd": {},
+      "unpriced_models": []
+    },
+    "ingested_turns": 43,
+    "llm_requests": 0,
+    "searches": 6,
+    "tokens": {
+      "in": 0,
+      "out": 0,
+      "total": 0,
+      "total_cached": 0
+    },
+    "tokens_by_model": {},
+    "truncated_turns": 0
+  }
+}

--- a/bench/memory/results/longmemeval_fixture_working.json
+++ b/bench/memory/results/longmemeval_fixture_working.json
@@ -140,7 +140,7 @@
       ]
     },
     {
-      "elapsed_seconds": 0.069,
+      "elapsed_seconds": 0.09,
       "error": null,
       "evidence_session_ids": [
         "fixture_ms_001_s1",
@@ -173,7 +173,7 @@
       ]
     },
     {
-      "elapsed_seconds": 0.061,
+      "elapsed_seconds": 0.069,
       "error": null,
       "evidence_session_ids": [
         "fixture_ssa_001_s1"
@@ -202,7 +202,7 @@
       ]
     },
     {
-      "elapsed_seconds": 0.072,
+      "elapsed_seconds": 0.088,
       "error": null,
       "evidence_session_ids": [
         "fixture_ssp_001_s2"
@@ -231,7 +231,7 @@
       ]
     },
     {
-      "elapsed_seconds": 0.069,
+      "elapsed_seconds": 0.06,
       "error": null,
       "evidence_session_ids": [
         "fixture_ssu_001_s2"
@@ -265,7 +265,7 @@
       ]
     },
     {
-      "elapsed_seconds": 0.068,
+      "elapsed_seconds": 0.063,
       "error": null,
       "evidence_session_ids": [],
       "evidence_turn_ids": [],
@@ -287,10 +287,15 @@
     }
   ],
   "run": {
-    "git_commit": "3b8fb6f2e5c03e094dbfe8b617ac090de10fa389",
+    "cases": {
+      "completed": 6,
+      "failed": 0,
+      "skipped": 0
+    },
+    "git_commit": "192b6cbd91a35f99bf6d63ba640028ce0dccd58e",
     "python": "3.11.13",
-    "started_at": "2026-07-07T20:52:17Z",
-    "wall_seconds": 23.8
+    "started_at": "2026-07-07T21:31:41Z",
+    "wall_seconds": 23.88
   },
   "schema_version": "1.0",
   "usage": {

--- a/bench/memory/runner.py
+++ b/bench/memory/runner.py
@@ -13,6 +13,7 @@ import asyncio
 import os
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
 
@@ -122,7 +123,18 @@ def build_arg_parser(benchmark: str, default_k: int) -> argparse.ArgumentParser:
     parser.add_argument(
         "--run-dir",
         default=None,
-        help="Run directory for the rendered formation + SQLite DB (default: temp dir).",
+        help=(
+            "Run directory for the rendered formation + SQLite DB (default: a temp "
+            "dir removed after the run; an explicit --run-dir is never deleted)."
+        ),
+    )
+    parser.add_argument(
+        "--keep-run-dir",
+        action="store_true",
+        help=(
+            "Keep the temp run dir (SQLite DB, rendered formation, event log) for "
+            "debugging. Also honored via MUXI_BENCH_KEEP_RUN_DIR=1."
+        ),
     )
     parser.add_argument(
         "--secrets-dir",
@@ -190,6 +202,7 @@ async def run_benchmark(benchmark: str, args: argparse.Namespace) -> int:
         formation_yaml=Path(args.formation),
         run_dir=Path(args.run_dir) if args.run_dir else None,
         secrets_dir=Path(args.secrets_dir) if args.secrets_dir else None,
+        keep_run_dir=args.keep_run_dir,
     )
 
     print(
@@ -198,10 +211,14 @@ async def run_benchmark(benchmark: str, args: argparse.Namespace) -> int:
         f"fixture={used_fixture})"
     )
 
+    started_at = datetime.now(timezone.utc)
     started = time.monotonic()
     results: List[QuestionResult] = []
-    await adapter.start()
+    # start() inside the try: a formation-load failure must still reach
+    # stop(), which tears down partial state and removes the temp run
+    # dir (stop() is idempotent and tolerates a never-started adapter).
     try:
+        await adapter.start()
         for case_index, case in enumerate(dataset.cases, start=1):
             adapter.clear_case()
             user_id = f"bench-{benchmark}-{case.case_id}"
@@ -261,6 +278,7 @@ async def run_benchmark(benchmark: str, args: argparse.Namespace) -> int:
         metrics=metrics,
         results=results,
         usage=usage,
+        started_at=started_at,
         wall_seconds=time.monotonic() - started,
         repo_root=REPO_ROOT,
     )

--- a/bench/memory/runner.py
+++ b/bench/memory/runner.py
@@ -29,6 +29,12 @@ RESULTS_DIR = Path(__file__).resolve().parent / "results"
 
 DATA_DIR_ENV = "MUXI_BENCH_DATA_DIR"
 
+# Early-stop threshold for systematic environment failures: when this
+# many cases in a row fail INGESTION (embedding model unavailable,
+# database unwritable, ...), the run aborts and writes a partial
+# report instead of burning hours failing every remaining case.
+MAX_CONSECUTIVE_CASE_FAILURES = 3
+
 DATASET_FILENAMES = {
     "longmemeval": "longmemeval_s_cleaned.json",
     "locomo": "locomo10.json",
@@ -214,16 +220,68 @@ async def run_benchmark(benchmark: str, args: argparse.Namespace) -> int:
     started_at = datetime.now(timezone.utc)
     started = time.monotonic()
     results: List[QuestionResult] = []
-    # start() inside the try: a formation-load failure must still reach
-    # stop(), which tears down partial state and removes the temp run
-    # dir (stop() is idempotent and tolerates a never-started adapter).
+    partial = False
+    abort_reason: Optional[str] = None
+    cases_completed = 0
+    cases_failed = 0
+    consecutive_failures = 0
+    usage: dict = {}
+    config: dict = {}
+    metrics: dict = {}
+
+    # Everything after this point runs under one try/finally:
+    # - start() inside the try, so a formation-load failure still
+    #   reaches stop() (idempotent; tears down partial state and
+    #   removes the temp run dir).
+    # - The report is built and written in the finally path, so EVERY
+    #   exit — clean finish, early abort, unexpected crash, even
+    #   KeyboardInterrupt — leaves a report with whatever completed
+    #   (marked ``partial`` when the run was cut short).
     try:
         await adapter.start()
         for case_index, case in enumerate(dataset.cases, start=1):
             adapter.clear_case()
             user_id = f"bench-{benchmark}-{case.case_id}"
-            for session in case.sessions:
-                await adapter.ingest_session(user_id, session)
+
+            # Ingestion failures are isolated per case: the case is
+            # recorded as failed (its questions carry the error) and
+            # the run moves on — a broken haystack must not throw away
+            # hours of completed work.
+            try:
+                for session in case.sessions:
+                    await adapter.ingest_session(user_id, session)
+            except Exception as exc:
+                cases_failed += 1
+                consecutive_failures += 1
+                error = f"case ingestion failed: {type(exc).__name__}: {exc}"
+                for question in case.questions:
+                    results.append(
+                        QuestionResult(
+                            question_id=question.question_id,
+                            question_type=question.question_type,
+                            is_abstention=question.is_abstention,
+                            evidence_session_ids=list(question.evidence_session_ids),
+                            evidence_turn_ids=list(question.evidence_turn_ids),
+                            error=error,
+                        )
+                    )
+                print(
+                    f"[membench] case {case_index}/{len(dataset.cases)} FAILED "
+                    f"({case.case_id}): {error}",
+                    file=sys.stderr,
+                )
+                # A failure storm means the environment is broken
+                # (embedding model missing, database unwritable, ...):
+                # stop early instead of burning hours failing every case.
+                if consecutive_failures >= MAX_CONSECUTIVE_CASE_FAILURES:
+                    partial = True
+                    abort_reason = (
+                        f"aborted after {consecutive_failures} consecutive case "
+                        f"ingestion failures (systematic environment failure); "
+                        f"last error: {error}"
+                    )
+                    break
+                continue
 
             for question in case.questions:
                 q_started = time.monotonic()
@@ -249,50 +307,73 @@ async def run_benchmark(benchmark: str, args: argparse.Namespace) -> int:
                 result.elapsed_seconds = round(time.monotonic() - q_started, 3)
                 results.append(result)
 
+            cases_completed += 1
+            consecutive_failures = 0
             print(
                 f"[membench] case {case_index}/{len(dataset.cases)} done "
                 f"({case.case_id}: {len(case.sessions)} sessions, "
                 f"{len(case.questions)} questions)"
             )
-
-        usage = adapter.usage_snapshot()
-        config = adapter.config_snapshot()
     finally:
+        # An in-flight exception (start() failure, unexpected crash,
+        # KeyboardInterrupt) marks the report partial; it propagates
+        # after the report is written.
+        in_flight = sys.exc_info()[1]
+        if in_flight is not None and abort_reason is None:
+            partial = True
+            abort_reason = f"{type(in_flight).__name__}: {in_flight}"
+
+        # Snapshot before stop() clears the formation reference.
+        try:
+            usage = adapter.usage_snapshot()
+            config = adapter.config_snapshot()
+        except Exception:
+            pass
         await adapter.stop()
 
-    metrics = aggregate_results(results, args.k)
-    report = build_report(
-        benchmark=benchmark,
-        mode=args.mode,
-        k=args.k,
-        dataset_path=str(dataset_path),
-        dataset_stats={
-            "cases": len(dataset.cases),
-            "questions": dataset.question_count,
-            "sessions": dataset.session_count,
-            "fixture": used_fixture,
-            "split": args.split,
-            "seed": args.seed,
-        },
-        config={**config, "fetch_limit": fetch_limit, "qa": args.qa},
-        metrics=metrics,
-        results=results,
-        usage=usage,
-        started_at=started_at,
-        wall_seconds=time.monotonic() - started,
-        repo_root=REPO_ROOT,
-    )
+        try:
+            metrics = aggregate_results(results, args.k)
+            report = build_report(
+                benchmark=benchmark,
+                mode=args.mode,
+                k=args.k,
+                dataset_path=str(dataset_path),
+                dataset_stats={
+                    "cases": len(dataset.cases),
+                    "questions": dataset.question_count,
+                    "sessions": dataset.session_count,
+                    "fixture": used_fixture,
+                    "split": args.split,
+                    "seed": args.seed,
+                },
+                config={**config, "fetch_limit": fetch_limit, "qa": args.qa},
+                metrics=metrics,
+                results=results,
+                usage=usage,
+                started_at=started_at,
+                wall_seconds=time.monotonic() - started,
+                partial=partial,
+                abort_reason=abort_reason,
+                case_stats={
+                    "completed": cases_completed,
+                    "failed": cases_failed,
+                    "skipped": len(dataset.cases) - cases_completed - cases_failed,
+                },
+                repo_root=REPO_ROOT,
+            )
+            output = (
+                Path(args.output)
+                if args.output
+                else default_output_path(benchmark, args.mode, args.split, used_fixture)
+            )
+            write_report(report, output)
+            print(render_summary(report))
+            print(f"Report written to {output}")
+        except Exception as report_exc:
+            # Never mask the in-flight exception with a report failure.
+            print(f"[membench] failed to write report: {report_exc}", file=sys.stderr)
 
-    output = (
-        Path(args.output)
-        if args.output
-        else default_output_path(benchmark, args.mode, args.split, used_fixture)
-    )
-    write_report(report, output)
-    print(render_summary(report))
-    print(f"Report written to {output}")
-
-    return 1 if metrics["questions_errored"] else 0
+    return 1 if (partial or metrics.get("questions_errored")) else 0
 
 
 def main(benchmark: str, default_k: int, argv: Optional[List[str]] = None) -> int:

--- a/bench/memory/runner.py
+++ b/bench/memory/runner.py
@@ -1,0 +1,283 @@
+"""Shared run loop and CLI for the Tier 1 memory benchmark runners.
+
+The dataset-specific entry points (``longmemeval_runner.py``,
+``locomo_runner.py``, ``convomem_runner.py``) only pick the loader and
+defaults; everything else — ingestion, retrieval, scoring, QA, report
+writing — lives here so the three benchmarks stay comparable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+from typing import List, Optional
+
+from .adapter import DEFAULT_FORMATION_YAML, MODES, MuxiMemoryAdapter
+from .datasets import BenchmarkDataset, load_dataset
+from .report import build_report, render_summary, write_report
+from .scoring import QuestionResult, aggregate_results
+from .split import DEFAULT_DEV_SIZE, DEFAULT_SEED, select_split
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+RESULTS_DIR = Path(__file__).resolve().parent / "results"
+
+DATA_DIR_ENV = "MUXI_BENCH_DATA_DIR"
+
+DATASET_FILENAMES = {
+    "longmemeval": "longmemeval_s_cleaned.json",
+    "locomo": "locomo10.json",
+    "convomem": "convomem.json",
+}
+
+FIXTURE_FILENAMES = {
+    "longmemeval": "longmemeval_sample.json",
+    "locomo": "locomo_sample.json",
+    "convomem": "convomem_sample.json",
+}
+
+
+def default_dataset_path(benchmark: str) -> Optional[Path]:
+    """Resolve the full dataset from ``$MUXI_BENCH_DATA_DIR`` if present."""
+    data_dir = os.environ.get(DATA_DIR_ENV)
+    if not data_dir:
+        return None
+    candidate = Path(data_dir) / DATASET_FILENAMES[benchmark]
+    return candidate if candidate.exists() else None
+
+
+def fixture_path(benchmark: str) -> Path:
+    return FIXTURES_DIR / FIXTURE_FILENAMES[benchmark]
+
+
+def build_arg_parser(benchmark: str, default_k: int) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            f"Run the {benchmark} memory benchmark against a real MUXI formation. "
+            "Defaults to the committed fixture sample; point --dataset (or "
+            f"${DATA_DIR_ENV}) at the full dataset for publishable numbers."
+        )
+    )
+    parser.add_argument(
+        "--dataset",
+        default=None,
+        help=(
+            "Path to the dataset JSON. Defaults to "
+            f"${DATA_DIR_ENV}/{DATASET_FILENAMES[benchmark]} when set, "
+            "otherwise the committed fixture sample."
+        ),
+    )
+    parser.add_argument(
+        "--fixture",
+        action="store_true",
+        help="Force the committed fixture sample even when a full dataset is available.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=MODES,
+        default="combined",
+        help="Retrieval mode: working (FAISS), persistent (SQLite), or combined (RRF).",
+    )
+    parser.add_argument("--k", type=int, default=default_k, help="Recall@K cutoff.")
+    parser.add_argument(
+        "--fetch-limit",
+        type=int,
+        default=None,
+        help="Turn-level results fetched per query (default: max(25, 5*k)).",
+    )
+    parser.add_argument(
+        "--qa",
+        action="store_true",
+        help="Also measure end-to-end QA accuracy (answer + LLM judge; costs tokens).",
+    )
+    parser.add_argument(
+        "--qa-context",
+        type=int,
+        default=10,
+        help="Retrieved excerpts injected into the QA answer prompt.",
+    )
+    parser.add_argument(
+        "--split",
+        choices=("dev", "holdout", "all"),
+        default="all",
+        help="Question split to run (seeded 50-question dev split per the PRD).",
+    )
+    parser.add_argument("--dev-size", type=int, default=DEFAULT_DEV_SIZE)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="Split shuffle seed.")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Run only the first N questions (after split selection); for smoke runs.",
+    )
+    parser.add_argument(
+        "--formation",
+        default=str(DEFAULT_FORMATION_YAML),
+        help="Benchmark formation YAML (SQLite + local embeddings by default).",
+    )
+    parser.add_argument(
+        "--run-dir",
+        default=None,
+        help="Run directory for the rendered formation + SQLite DB (default: temp dir).",
+    )
+    parser.add_argument(
+        "--secrets-dir",
+        default=None,
+        help="Directory holding .key/secrets.enc (default: <repo>/e2e/assets).",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help=(
+            "Report JSON path (default: bench/memory/results/"
+            f"{benchmark}_<mode>_<split>.json for fixture runs, timestamped otherwise)."
+        ),
+    )
+    return parser
+
+
+def _limit_dataset(dataset: BenchmarkDataset, limit: Optional[int]) -> BenchmarkDataset:
+    if limit is None:
+        return dataset
+    kept = []
+    remaining = limit
+    for case in dataset.cases:
+        if remaining <= 0:
+            break
+        questions = case.questions[:remaining]
+        remaining -= len(questions)
+        kept.append(type(case)(case_id=case.case_id, sessions=case.sessions, questions=questions))
+    return BenchmarkDataset(name=dataset.name, cases=tuple(kept))
+
+
+def resolve_dataset(benchmark: str, args: argparse.Namespace) -> tuple:
+    """Return ``(dataset, dataset_path, used_fixture)`` per CLI selection."""
+    if args.fixture or args.dataset is None:
+        path = Path(args.dataset) if args.dataset else None
+        if args.fixture or path is None:
+            full = None if args.fixture else default_dataset_path(benchmark)
+            path = full or fixture_path(benchmark)
+    else:
+        path = Path(args.dataset)
+    used_fixture = path == fixture_path(benchmark)
+    dataset = load_dataset(benchmark, path)
+    return dataset, path, used_fixture
+
+
+def default_output_path(benchmark: str, mode: str, split: str, used_fixture: bool) -> Path:
+    if used_fixture:
+        return RESULTS_DIR / f"{benchmark}_fixture_{mode}.json"
+    stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    return RESULTS_DIR / f"{benchmark}_{mode}_{split}_{stamp}.json"
+
+
+async def run_benchmark(benchmark: str, args: argparse.Namespace) -> int:
+    """Execute one benchmark run end-to-end. Returns the process exit code."""
+    dataset, dataset_path, used_fixture = resolve_dataset(benchmark, args)
+    dataset = select_split(dataset, args.split, dev_size=args.dev_size, seed=args.seed)
+    dataset = _limit_dataset(dataset, args.limit)
+    if dataset.question_count == 0:
+        print("No questions selected (check --split / --limit).", file=sys.stderr)
+        return 1
+
+    fetch_limit = args.fetch_limit or max(25, 5 * args.k)
+    adapter = MuxiMemoryAdapter(
+        mode=args.mode,
+        formation_yaml=Path(args.formation),
+        run_dir=Path(args.run_dir) if args.run_dir else None,
+        secrets_dir=Path(args.secrets_dir) if args.secrets_dir else None,
+    )
+
+    print(
+        f"[membench] {benchmark}: {dataset.question_count} questions / "
+        f"{len(dataset.cases)} cases (split={args.split}, mode={args.mode}, "
+        f"fixture={used_fixture})"
+    )
+
+    started = time.monotonic()
+    results: List[QuestionResult] = []
+    await adapter.start()
+    try:
+        for case_index, case in enumerate(dataset.cases, start=1):
+            adapter.clear_case()
+            user_id = f"bench-{benchmark}-{case.case_id}"
+            for session in case.sessions:
+                await adapter.ingest_session(user_id, session)
+
+            for question in case.questions:
+                q_started = time.monotonic()
+                result = QuestionResult(
+                    question_id=question.question_id,
+                    question_type=question.question_type,
+                    is_abstention=question.is_abstention,
+                    evidence_session_ids=list(question.evidence_session_ids),
+                    evidence_turn_ids=list(question.evidence_turn_ids),
+                )
+                try:
+                    items = await adapter.search(user_id, question.question, fetch_limit)
+                    result.retrieved_session_ids = adapter.ranked_session_ids(items)
+                    result.retrieved_turn_ids = adapter.ranked_turn_ids(items)
+                    if args.qa:
+                        predicted = await adapter.answer_question(
+                            question, items, context_limit=args.qa_context
+                        )
+                        result.qa_answer = predicted
+                        result.qa_correct = await adapter.judge_answer(question, predicted)
+                except Exception as exc:  # keep the run alive; errors are scored
+                    result.error = f"{type(exc).__name__}: {exc}"
+                result.elapsed_seconds = round(time.monotonic() - q_started, 3)
+                results.append(result)
+
+            print(
+                f"[membench] case {case_index}/{len(dataset.cases)} done "
+                f"({case.case_id}: {len(case.sessions)} sessions, "
+                f"{len(case.questions)} questions)"
+            )
+
+        usage = adapter.usage_snapshot()
+        config = adapter.config_snapshot()
+    finally:
+        await adapter.stop()
+
+    metrics = aggregate_results(results, args.k)
+    report = build_report(
+        benchmark=benchmark,
+        mode=args.mode,
+        k=args.k,
+        dataset_path=str(dataset_path),
+        dataset_stats={
+            "cases": len(dataset.cases),
+            "questions": dataset.question_count,
+            "sessions": dataset.session_count,
+            "fixture": used_fixture,
+            "split": args.split,
+            "seed": args.seed,
+        },
+        config={**config, "fetch_limit": fetch_limit, "qa": args.qa},
+        metrics=metrics,
+        results=results,
+        usage=usage,
+        wall_seconds=time.monotonic() - started,
+        repo_root=REPO_ROOT,
+    )
+
+    output = (
+        Path(args.output)
+        if args.output
+        else default_output_path(benchmark, args.mode, args.split, used_fixture)
+    )
+    write_report(report, output)
+    print(render_summary(report))
+    print(f"Report written to {output}")
+
+    return 1 if metrics["questions_errored"] else 0
+
+
+def main(benchmark: str, default_k: int, argv: Optional[List[str]] = None) -> int:
+    parser = build_arg_parser(benchmark, default_k)
+    args = parser.parse_args(argv)
+    return asyncio.run(run_benchmark(benchmark, args))

--- a/bench/memory/runner.py
+++ b/bench/memory/runner.py
@@ -221,6 +221,7 @@ async def run_benchmark(benchmark: str, args: argparse.Namespace) -> int:
     started = time.monotonic()
     results: List[QuestionResult] = []
     partial = False
+    report_failed = False
     abort_reason: Optional[str] = None
     cases_completed = 0
     cases_failed = 0
@@ -370,10 +371,13 @@ async def run_benchmark(benchmark: str, args: argparse.Namespace) -> int:
             print(render_summary(report))
             print(f"Report written to {output}")
         except Exception as report_exc:
-            # Never mask the in-flight exception with a report failure.
+            # Never mask the in-flight exception with a report failure --
+            # but a run without a report is a failed run, so record it
+            # for the exit code below.
+            report_failed = True
             print(f"[membench] failed to write report: {report_exc}", file=sys.stderr)
 
-    return 1 if (partial or metrics.get("questions_errored")) else 0
+    return 1 if (partial or report_failed or metrics.get("questions_errored")) else 0
 
 
 def main(benchmark: str, default_k: int, argv: Optional[List[str]] = None) -> int:

--- a/bench/memory/scoring.py
+++ b/bench/memory/scoring.py
@@ -1,0 +1,218 @@
+"""Retrieval and QA scoring for the memory benchmarks.
+
+Metrics
+-------
+- ``hit_at_k``       — 1 if ANY evidence id appears in the top-K
+  retrieved ids. This is the standard "Recall@K" reported by
+  LongMemEval-style leaderboards (fraction of questions whose
+  evidence is retrieved), and the headline number in reports.
+- ``coverage_at_k``  — fraction of evidence ids present in the top-K.
+  Stricter than hit@K for multi-evidence questions.
+- ``mrr``            — reciprocal rank of the first evidence id.
+
+Abstention questions (no evidence exists by design, e.g. LongMemEval
+``_abs`` ids and LoCoMo adversarial questions) are excluded from
+retrieval aggregates and counted separately; retrieval metrics are
+undefined for them.
+
+All functions are pure and deterministic: same inputs, same outputs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional, Sequence
+
+
+def ranked_unique(ids: Iterable[str]) -> List[str]:
+    """Deduplicate ``ids`` preserving first-seen (rank) order."""
+    seen = set()
+    ordered: List[str] = []
+    for item_id in ids:
+        if item_id not in seen:
+            seen.add(item_id)
+            ordered.append(item_id)
+    return ordered
+
+
+def hit_at_k(retrieved_ids: Sequence[str], evidence_ids: Sequence[str], k: int) -> bool:
+    """True if any evidence id appears in the top-``k`` retrieved ids.
+
+    ``retrieved_ids`` must already be ranked best-first; duplicates are
+    collapsed to their best rank before applying the cutoff.
+    """
+    if k <= 0:
+        raise ValueError(f"k must be positive, got {k}")
+    if not evidence_ids:
+        raise ValueError("hit_at_k is undefined without evidence ids (abstention question?)")
+    top_k = set(ranked_unique(retrieved_ids)[:k])
+    return any(evidence_id in top_k for evidence_id in evidence_ids)
+
+
+def coverage_at_k(retrieved_ids: Sequence[str], evidence_ids: Sequence[str], k: int) -> float:
+    """Fraction of evidence ids present in the top-``k`` retrieved ids."""
+    if k <= 0:
+        raise ValueError(f"k must be positive, got {k}")
+    if not evidence_ids:
+        raise ValueError("coverage_at_k is undefined without evidence ids")
+    top_k = set(ranked_unique(retrieved_ids)[:k])
+    unique_evidence = set(evidence_ids)
+    return len(unique_evidence & top_k) / len(unique_evidence)
+
+
+def mrr(retrieved_ids: Sequence[str], evidence_ids: Sequence[str]) -> float:
+    """Reciprocal rank of the first evidence id (0.0 if none retrieved)."""
+    if not evidence_ids:
+        raise ValueError("mrr is undefined without evidence ids")
+    evidence = set(evidence_ids)
+    for rank, item_id in enumerate(ranked_unique(retrieved_ids), start=1):
+        if item_id in evidence:
+            return 1.0 / rank
+    return 0.0
+
+
+def reciprocal_rank_fusion(rankings: Sequence[Sequence[str]], rrf_k: int = 60) -> List[str]:
+    """Merge ranked id lists with Reciprocal Rank Fusion.
+
+    Used for the "combined" retrieval mode: working-memory scores
+    (cosine + recency blend) and persistent-memory scores (SQLite
+    distance-derived) live on different scales, so score-based merging
+    would silently favor one backend. RRF is scale-free: each list
+    contributes ``1 / (rrf_k + rank)`` per id.
+
+    Ties are broken by first-seen order across ``rankings`` (stable,
+    deterministic).
+    """
+    if rrf_k <= 0:
+        raise ValueError(f"rrf_k must be positive, got {rrf_k}")
+    scores: Dict[str, float] = {}
+    first_seen: Dict[str, int] = {}
+    counter = 0
+    for ranking in rankings:
+        for rank, item_id in enumerate(ranked_unique(ranking), start=1):
+            scores[item_id] = scores.get(item_id, 0.0) + 1.0 / (rrf_k + rank)
+            if item_id not in first_seen:
+                first_seen[item_id] = counter
+                counter += 1
+    return sorted(scores, key=lambda item_id: (-scores[item_id], first_seen[item_id]))
+
+
+@dataclass
+class QuestionResult:
+    """Everything measured for a single benchmark question."""
+
+    question_id: str
+    question_type: str
+    is_abstention: bool
+    evidence_session_ids: List[str] = field(default_factory=list)
+    evidence_turn_ids: List[str] = field(default_factory=list)
+    retrieved_session_ids: List[str] = field(default_factory=list)
+    retrieved_turn_ids: List[str] = field(default_factory=list)
+    elapsed_seconds: float = 0.0
+    qa_answer: Optional[str] = None
+    qa_correct: Optional[bool] = None
+    error: Optional[str] = None
+
+    def session_metrics(self, k: int) -> Optional[Dict[str, float]]:
+        """Session-level retrieval metrics, or None for abstention/error."""
+        if self.is_abstention or self.error or not self.evidence_session_ids:
+            return None
+        return {
+            f"hit@{k}": float(hit_at_k(self.retrieved_session_ids, self.evidence_session_ids, k)),
+            f"coverage@{k}": coverage_at_k(
+                self.retrieved_session_ids, self.evidence_session_ids, k
+            ),
+            "mrr": mrr(self.retrieved_session_ids, self.evidence_session_ids),
+        }
+
+    def turn_metrics(self, k: int) -> Optional[Dict[str, float]]:
+        """Turn-level retrieval metrics, or None when turn evidence is absent."""
+        if self.is_abstention or self.error or not self.evidence_turn_ids:
+            return None
+        return {
+            f"hit@{k}": float(hit_at_k(self.retrieved_turn_ids, self.evidence_turn_ids, k)),
+            f"coverage@{k}": coverage_at_k(self.retrieved_turn_ids, self.evidence_turn_ids, k),
+            "mrr": mrr(self.retrieved_turn_ids, self.evidence_turn_ids),
+        }
+
+
+def _mean(values: Sequence[float]) -> Optional[float]:
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _aggregate_level(
+    results: Sequence[QuestionResult], k: int, level: str
+) -> Optional[Dict[str, object]]:
+    """Aggregate one retrieval level ("session" or "turn") across results."""
+    metric_fn = (
+        QuestionResult.session_metrics if level == "session" else QuestionResult.turn_metrics
+    )
+    scored = [(result, metric_fn(result, k)) for result in results]
+    scored = [(result, metrics) for result, metrics in scored if metrics is not None]
+    if not scored:
+        return None
+
+    def summarize(pairs) -> Dict[str, object]:
+        return {
+            "questions": len(pairs),
+            f"recall@{k}": _mean([m[f"hit@{k}"] for _, m in pairs]),
+            f"coverage@{k}": _mean([m[f"coverage@{k}"] for _, m in pairs]),
+            "mrr": _mean([m["mrr"] for _, m in pairs]),
+        }
+
+    by_type: Dict[str, List] = {}
+    for result, metrics in scored:
+        by_type.setdefault(result.question_type, []).append((result, metrics))
+
+    return {
+        "overall": summarize(scored),
+        "by_question_type": {
+            question_type: summarize(pairs) for question_type, pairs in sorted(by_type.items())
+        },
+    }
+
+
+def aggregate_results(results: Sequence[QuestionResult], k: int) -> Dict[str, object]:
+    """Aggregate per-question results into the report's ``metrics`` block.
+
+    Returns session-level and turn-level retrieval aggregates (overall
+    and per question type), QA accuracy when QA was run, and counts of
+    abstention/errored questions excluded from retrieval aggregates.
+    """
+    errors = [result for result in results if result.error]
+    abstentions = [result for result in results if result.is_abstention and not result.error]
+
+    qa_scored = [result for result in results if result.qa_correct is not None]
+    qa_block = None
+    if qa_scored:
+        by_type: Dict[str, List[QuestionResult]] = {}
+        for result in qa_scored:
+            by_type.setdefault(result.question_type, []).append(result)
+        qa_block = {
+            "overall": {
+                "questions": len(qa_scored),
+                "accuracy": _mean([float(result.qa_correct) for result in qa_scored]),
+            },
+            "by_question_type": {
+                question_type: {
+                    "questions": len(type_results),
+                    "accuracy": _mean([float(result.qa_correct) for result in type_results]),
+                }
+                for question_type, type_results in sorted(by_type.items())
+            },
+        }
+
+    return {
+        "k": k,
+        "questions_total": len(results),
+        "questions_scored": len(results) - len(abstentions) - len(errors),
+        "questions_abstention": len(abstentions),
+        "questions_errored": len(errors),
+        "retrieval": {
+            "session_level": _aggregate_level(results, k, "session"),
+            "turn_level": _aggregate_level(results, k, "turn"),
+        },
+        "qa": qa_block,
+    }

--- a/bench/memory/split.py
+++ b/bench/memory/split.py
@@ -1,0 +1,82 @@
+"""Deterministic dev/holdout split for the memory benchmarks.
+
+The PRD calls for a 50-question dev split (for tuning) and a held-out
+remainder (for published numbers) so configuration changes are never
+overfit to the full question set. The split is seeded and stable:
+questions are keyed by ``(case_id, question_id)``, sorted, then
+shuffled with ``random.Random(seed)``.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import List, Tuple
+
+from .datasets import BenchmarkCase, BenchmarkDataset
+
+DEFAULT_DEV_SIZE = 50
+DEFAULT_SEED = 42
+
+
+def split_question_keys(
+    dataset: BenchmarkDataset, dev_size: int = DEFAULT_DEV_SIZE, seed: int = DEFAULT_SEED
+) -> Tuple[List[Tuple[str, str]], List[Tuple[str, str]]]:
+    """Return ``(dev_keys, holdout_keys)`` of ``(case_id, question_id)``.
+
+    Deterministic for a given ``(dataset, dev_size, seed)``. When the
+    dataset holds fewer questions than ``dev_size``, every question
+    lands in the dev split and the holdout is empty.
+    """
+    if dev_size < 0:
+        raise ValueError(f"dev_size must be >= 0, got {dev_size}")
+    keys = sorted(
+        (case.case_id, question.question_id) for case, question in dataset.iter_questions()
+    )
+    rng = random.Random(seed)
+    rng.shuffle(keys)
+    return keys[:dev_size], keys[dev_size:]
+
+
+def _filter_dataset(dataset: BenchmarkDataset, keys: set) -> BenchmarkDataset:
+    cases: List[BenchmarkCase] = []
+    for case in dataset.cases:
+        questions = tuple(
+            question for question in case.questions if (case.case_id, question.question_id) in keys
+        )
+        if questions:
+            cases.append(
+                BenchmarkCase(case_id=case.case_id, sessions=case.sessions, questions=questions)
+            )
+    return BenchmarkDataset(name=dataset.name, cases=tuple(cases))
+
+
+def split_dataset(
+    dataset: BenchmarkDataset, dev_size: int = DEFAULT_DEV_SIZE, seed: int = DEFAULT_SEED
+) -> Tuple[BenchmarkDataset, BenchmarkDataset]:
+    """Split ``dataset`` into ``(dev, holdout)`` datasets.
+
+    Cases whose questions land entirely in the other split are dropped
+    from a split, so each split only ingests the haystacks it needs.
+    """
+    dev_keys, holdout_keys = split_question_keys(dataset, dev_size=dev_size, seed=seed)
+    return (
+        _filter_dataset(dataset, set(dev_keys)),
+        _filter_dataset(dataset, set(holdout_keys)),
+    )
+
+
+def select_split(
+    dataset: BenchmarkDataset,
+    split: str,
+    dev_size: int = DEFAULT_DEV_SIZE,
+    seed: int = DEFAULT_SEED,
+) -> BenchmarkDataset:
+    """Return the requested split: ``dev``, ``holdout``, or ``all``."""
+    if split == "all":
+        return dataset
+    dev, holdout = split_dataset(dataset, dev_size=dev_size, seed=seed)
+    if split == "dev":
+        return dev
+    if split == "holdout":
+        return holdout
+    raise ValueError(f"Unknown split: {split} (expected dev, holdout, or all)")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -348,7 +348,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.isort]
-known-first-party = ["muxi"]
+known-first-party = ["muxi", "bench"]
 combine-as-imports = true
 
 [tool.ruff.format]

--- a/tests/unit/bench_memory/conftest.py
+++ b/tests/unit/bench_memory/conftest.py
@@ -1,0 +1,13 @@
+"""Make the repository root importable so ``bench.memory.*`` resolves.
+
+The bench package lives outside ``src/`` (it is a harness, not part of
+the shipped runtime), so unit tests add the repo root to ``sys.path``
+regardless of how pytest was invoked.
+"""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/tests/unit/bench_memory/test_adapter.py
+++ b/tests/unit/bench_memory/test_adapter.py
@@ -1,0 +1,151 @@
+"""Unit tests for the adapter's pure logic (no formation boot).
+
+The formation-backed paths (start/ingest/search against real memory)
+are exercised by the harness self-run; these tests pin the mapping,
+truncation, and run-dir rendering logic that the self-run depends on.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from bench.memory.adapter import (
+    DEFAULT_FORMATION_YAML,
+    MuxiMemoryAdapter,
+    RetrievedItem,
+)
+from bench.memory.datasets import Session, Turn
+
+
+def _adapter(mode="working", **kwargs):
+    return MuxiMemoryAdapter(mode=mode, **kwargs)
+
+
+class TestConstruction:
+    def test_rejects_unknown_mode(self):
+        with pytest.raises(ValueError, match="Unknown mode"):
+            MuxiMemoryAdapter(mode="kg-routing")
+
+    def test_default_formation_yaml_exists(self):
+        assert DEFAULT_FORMATION_YAML.exists()
+
+
+class TestResultMapping:
+    def test_working_results_mapped(self):
+        raw = [
+            {
+                "text": "user: hello",
+                "score": 0.9,
+                "metadata": {
+                    "bench_turn_id": "s1:0",
+                    "bench_session_id": "s1",
+                },
+            },
+            # Item without bench ids (e.g. other namespace) is skipped.
+            {"text": "noise", "score": 0.8, "metadata": {}},
+        ]
+        items = MuxiMemoryAdapter._items_from_working(raw)
+        assert len(items) == 1
+        assert items[0].turn_id == "s1:0"
+        assert items[0].session_id == "s1"
+        assert items[0].source == "working"
+
+    def test_persistent_results_mapped(self):
+        raw = [
+            {
+                "text": "assistant: hi",
+                "score": 0.7,
+                "metadata": {"bench_turn_id": "s2:1", "bench_session_id": "s2"},
+            }
+        ]
+        items = MuxiMemoryAdapter._items_from_persistent(raw)
+        assert items[0].source == "persistent"
+        assert items[0].score == 0.7
+
+    def test_ranked_session_ids_dedupe_by_best_turn(self):
+        items = [
+            RetrievedItem("s1:0", "s1", "a", 0.9, "working"),
+            RetrievedItem("s2:0", "s2", "b", 0.8, "working"),
+            RetrievedItem("s1:1", "s1", "c", 0.7, "working"),
+        ]
+        assert MuxiMemoryAdapter.ranked_session_ids(items) == ["s1", "s2"]
+        assert MuxiMemoryAdapter.ranked_turn_ids(items) == ["s1:0", "s2:0", "s1:1"]
+
+
+class TestTurnRendering:
+    def test_date_and_role_prefix(self):
+        adapter = _adapter()
+        session = Session(
+            session_id="s1",
+            turns=(),
+            date="2023/04/02 (Sun) 09:12",
+        )
+        turn = Turn(turn_id="s1:0", role="user", content="hello world")
+        text = adapter._render_turn_text(session, turn)
+        assert text == "[2023/04/02 (Sun) 09:12] user: hello world"
+        assert adapter.truncated_turns == 0
+
+    def test_no_date(self):
+        adapter = _adapter()
+        session = Session(session_id="s1", turns=())
+        turn = Turn(turn_id="s1:0", role="Nadia", content="hi")
+        assert adapter._render_turn_text(session, turn) == "Nadia: hi"
+
+    def test_truncation_counted(self):
+        adapter = _adapter(max_embed_chars=20)
+        session = Session(session_id="s1", turns=())
+        turn = Turn(turn_id="s1:0", role="user", content="x" * 100)
+        text = adapter._render_turn_text(session, turn)
+        assert len(text) == 20
+        assert adapter.truncated_turns == 1
+
+
+class TestRunDirRendering:
+    def test_renders_run_local_sqlite_path(self, tmp_path):
+        adapter = _adapter(run_dir=tmp_path / "run", secrets_dir=tmp_path / "nosecrets")
+        rendered = adapter._prepare_run_dir()
+        assert rendered == tmp_path / "run" / "formation.yaml"
+        config = yaml.safe_load(rendered.read_text())
+        connection = config["memory"]["persistent"]["connection_string"]
+        assert connection == str(tmp_path / "run" / "membench.db")
+        # Template fields survive the rewrite.
+        assert config["id"] == "membench"
+        assert config["llm"]["models"][1]["embedding"].startswith("local/")
+
+    def test_secrets_symlinked_when_present(self, tmp_path):
+        secrets_dir = tmp_path / "assets"
+        secrets_dir.mkdir()
+        (secrets_dir / ".key").write_text("key")
+        (secrets_dir / "secrets.enc").write_text("enc")
+        adapter = _adapter(run_dir=tmp_path / "run", secrets_dir=secrets_dir)
+        adapter._prepare_run_dir()
+        assert (tmp_path / "run" / ".key").exists()
+        assert (tmp_path / "run" / "secrets.enc").exists()
+
+    def test_missing_secrets_tolerated(self, tmp_path):
+        adapter = _adapter(run_dir=tmp_path / "run", secrets_dir=tmp_path / "missing")
+        adapter._prepare_run_dir()
+        assert not (tmp_path / "run" / ".key").exists()
+
+    def test_idempotent(self, tmp_path):
+        secrets_dir = tmp_path / "assets"
+        secrets_dir.mkdir()
+        (secrets_dir / ".key").write_text("key")
+        (secrets_dir / "secrets.enc").write_text("enc")
+        adapter = _adapter(run_dir=tmp_path / "run", secrets_dir=secrets_dir)
+        adapter._prepare_run_dir()
+        adapter._prepare_run_dir()  # second call must not raise on symlinks
+
+
+class TestFormationTemplate:
+    def test_template_is_cheap_model_configuration(self):
+        config = yaml.safe_load(Path(DEFAULT_FORMATION_YAML).read_text())
+        models = {k: v for entry in config["llm"]["models"] for k, v in entry.items()}
+        assert models["text"] == "openai/gpt-4o-mini"
+        assert models["embedding"] == "local/nomic-ai/nomic-embed-text-v1.5"
+        assert config["memory"]["persistent"]["provider"] == "sqlite"
+        assert config["memory"]["buffer"]["vector_search"] is True
+        # Buffer must hold the largest LongMemEval-S haystack (~2.5k turns).
+        buffer = config["memory"]["buffer"]
+        assert buffer["size"] * buffer["multiplier"] >= 2500

--- a/tests/unit/bench_memory/test_adapter.py
+++ b/tests/unit/bench_memory/test_adapter.py
@@ -149,3 +149,95 @@ class TestFormationTemplate:
         # Buffer must hold the largest LongMemEval-S haystack (~2.5k turns).
         buffer = config["memory"]["buffer"]
         assert buffer["size"] * buffer["multiplier"] >= 2500
+
+
+class TestStopAndRunDirCleanup:
+    async def test_stop_on_never_started_adapter(self):
+        adapter = _adapter()
+        await adapter.stop()  # must not raise
+        assert adapter.formation is None
+
+    async def test_stop_is_idempotent(self, tmp_path):
+        adapter = _adapter(secrets_dir=tmp_path / "nosecrets")
+        adapter._prepare_run_dir()
+        await adapter.stop()
+        await adapter.stop()  # second call is a no-op, must not raise
+
+    async def test_temp_run_dir_removed_on_stop(self, tmp_path):
+        adapter = _adapter(secrets_dir=tmp_path / "nosecrets")
+        adapter._prepare_run_dir()  # run_dir=None -> adapter-created temp dir
+        run_dir = adapter.run_dir
+        assert run_dir.exists()
+        await adapter.stop()
+        assert not run_dir.exists()
+
+    async def test_keep_run_dir_flag_preserves_temp_dir(self, tmp_path):
+        adapter = _adapter(secrets_dir=tmp_path / "nosecrets", keep_run_dir=True)
+        adapter._prepare_run_dir()
+        run_dir = adapter.run_dir
+        await adapter.stop()
+        assert run_dir.exists()
+        # Manual cleanup since the adapter intentionally kept it.
+        import shutil
+
+        shutil.rmtree(run_dir, ignore_errors=True)
+
+    async def test_keep_run_dir_env_var_preserves_temp_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MUXI_BENCH_KEEP_RUN_DIR", "1")
+        adapter = _adapter(secrets_dir=tmp_path / "nosecrets")
+        adapter._prepare_run_dir()
+        run_dir = adapter.run_dir
+        await adapter.stop()
+        assert run_dir.exists()
+        import shutil
+
+        shutil.rmtree(run_dir, ignore_errors=True)
+
+    async def test_keep_run_dir_env_var_false_values_ignored(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MUXI_BENCH_KEEP_RUN_DIR", "0")
+        adapter = _adapter(secrets_dir=tmp_path / "nosecrets")
+        adapter._prepare_run_dir()
+        run_dir = adapter.run_dir
+        await adapter.stop()
+        assert not run_dir.exists()
+
+    async def test_user_supplied_run_dir_never_removed(self, tmp_path):
+        run_dir = tmp_path / "my-run"
+        adapter = _adapter(run_dir=run_dir, secrets_dir=tmp_path / "nosecrets")
+        adapter._prepare_run_dir()
+        await adapter.stop()
+        assert run_dir.exists()
+
+    async def test_corrupt_yaml_failure_cleans_temp_dir(self, tmp_path):
+        # Unparseable YAML fails during run-dir rendering, before the
+        # Formation exists; stop() must still remove the temp dir.
+        import yaml as yaml_module
+
+        bad_yaml = tmp_path / "broken.yaml"
+        bad_yaml.write_text("agents: [unbalanced")
+        adapter = _adapter(formation_yaml=bad_yaml, secrets_dir=tmp_path / "nosecrets")
+        with pytest.raises(yaml_module.YAMLError):
+            await adapter.start()
+        run_dir = adapter.run_dir
+        assert run_dir is not None and run_dir.exists()
+        await adapter.stop()
+        assert not run_dir.exists()
+
+    @pytest.mark.timeout(120)
+    async def test_formation_load_failure_reaches_stop_and_cleans_temp_dir(self, tmp_path):
+        # Valid YAML but an invalid formation: Formation.load() raises
+        # after the Formation object exists (the partially-started
+        # case); stop() must tear it down and remove the temp dir.
+        from muxi.runtime.datatypes.exceptions import ConfigurationValidationError
+
+        bad_yaml = tmp_path / "invalid.yaml"
+        bad_yaml.write_text('schema: "1.0.0"\nid: "broken"\nagents: []\n')  # no llm/description
+        adapter = _adapter(formation_yaml=bad_yaml, secrets_dir=tmp_path / "nosecrets")
+        with pytest.raises(ConfigurationValidationError):
+            await adapter.start()
+        run_dir = adapter.run_dir
+        assert run_dir is not None and run_dir.exists()
+        assert adapter.formation is not None  # partially started
+        await adapter.stop()
+        assert not run_dir.exists()
+        assert adapter.formation is None

--- a/tests/unit/bench_memory/test_datasets.py
+++ b/tests/unit/bench_memory/test_datasets.py
@@ -1,0 +1,251 @@
+"""Loader tests, driven by the committed fixture samples.
+
+The fixtures are schema-faithful synthetic samples of each published
+dataset; these tests pin the exact normalization the runners rely on
+(ids, evidence mapping, abstention flags).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bench.memory.datasets import (
+    load_convomem,
+    load_dataset,
+    load_locomo,
+    load_longmemeval,
+)
+
+FIXTURES = Path(__file__).resolve().parents[3] / "bench" / "memory" / "fixtures"
+
+
+@pytest.fixture(scope="module")
+def longmemeval_dataset():
+    return load_longmemeval(FIXTURES / "longmemeval_sample.json")
+
+
+@pytest.fixture(scope="module")
+def locomo_dataset():
+    return load_locomo(FIXTURES / "locomo_sample.json")
+
+
+@pytest.fixture(scope="module")
+def convomem_dataset():
+    return load_convomem(FIXTURES / "convomem_sample.json")
+
+
+class TestLongMemEvalLoader:
+    @pytest.fixture
+    def dataset(self, longmemeval_dataset):
+        return longmemeval_dataset
+
+    def test_one_case_per_instance(self, dataset):
+        assert len(dataset.cases) == 6
+        assert dataset.question_count == 6
+
+    def test_session_ids_preserved(self, dataset):
+        case = next(c for c in dataset.cases if c.case_id == "fixture_ssu_001")
+        assert [s.session_id for s in case.sessions] == [
+            "fixture_ssu_001_s1",
+            "fixture_ssu_001_s2",
+            "fixture_ssu_001_s3",
+            "fixture_ssu_001_s4",
+        ]
+
+    def test_session_dates_attached(self, dataset):
+        case = next(c for c in dataset.cases if c.case_id == "fixture_ssu_001")
+        assert case.sessions[0].date == "2023/04/02 (Sun) 09:12"
+
+    def test_evidence_session_ids(self, dataset):
+        case = next(c for c in dataset.cases if c.case_id == "fixture_ms_001")
+        question = case.questions[0]
+        assert question.evidence_session_ids == (
+            "fixture_ms_001_s1",
+            "fixture_ms_001_s3",
+        )
+
+    def test_evidence_turns_from_has_answer(self, dataset):
+        case = next(c for c in dataset.cases if c.case_id == "fixture_ms_001")
+        question = case.questions[0]
+        assert question.evidence_turn_ids == (
+            "fixture_ms_001_s1:0",
+            "fixture_ms_001_s3:0",
+        )
+
+    def test_turn_ids_are_session_scoped_indices(self, dataset):
+        case = next(c for c in dataset.cases if c.case_id == "fixture_ssu_001")
+        turns = case.sessions[1].turns
+        assert turns[0].turn_id == "fixture_ssu_001_s2:0"
+        assert turns[3].turn_id == "fixture_ssu_001_s2:3"
+
+    def test_abstention_flagged_by_id_suffix(self, dataset):
+        case = next(c for c in dataset.cases if c.case_id == "fixture_tr_001_abs")
+        assert case.questions[0].is_abstention is True
+        assert case.questions[0].evidence_session_ids == ()
+
+    def test_non_abstention_not_flagged(self, dataset):
+        case = next(c for c in dataset.cases if c.case_id == "fixture_ku_001")
+        assert case.questions[0].is_abstention is False
+
+    def test_question_type_preserved(self, dataset):
+        types = {c.questions[0].question_type for c in dataset.cases}
+        assert "knowledge-update" in types
+        assert "multi-session" in types
+
+    def test_rejects_non_list(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text('{"not": "a list"}')
+        with pytest.raises(ValueError, match="JSON list"):
+            load_longmemeval(path)
+
+    def test_rejects_mismatched_haystack(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text(
+            json.dumps(
+                [
+                    {
+                        "question_id": "x",
+                        "question": "q",
+                        "answer": "a",
+                        "haystack_sessions": [[]],
+                        "haystack_session_ids": ["s1", "s2"],
+                        "answer_session_ids": [],
+                    }
+                ]
+            )
+        )
+        with pytest.raises(ValueError, match="length mismatch"):
+            load_longmemeval(path)
+
+    def test_missing_file(self):
+        with pytest.raises(FileNotFoundError):
+            load_longmemeval(FIXTURES / "does_not_exist.json")
+
+
+class TestLoCoMoLoader:
+    @pytest.fixture
+    def dataset(self, locomo_dataset):
+        return locomo_dataset
+
+    def test_one_case_per_sample(self, dataset):
+        assert len(dataset.cases) == 1
+        assert dataset.cases[0].case_id == "fixture_1"
+
+    def test_sessions_ordered_numerically(self, dataset):
+        assert [s.session_id for s in dataset.cases[0].sessions] == [
+            "session_1",
+            "session_2",
+            "session_3",
+        ]
+
+    def test_session_dates(self, dataset):
+        assert dataset.cases[0].sessions[0].date == "1:15 pm on 8 January, 2023"
+
+    def test_turn_ids_are_dia_ids(self, dataset):
+        session_1 = dataset.cases[0].sessions[0]
+        assert session_1.turns[0].turn_id == "D1:1"
+        assert session_1.turns[3].turn_id == "D1:4"
+
+    def test_speaker_kept_as_role(self, dataset):
+        session_1 = dataset.cases[0].sessions[0]
+        assert session_1.turns[0].role == "Nadia"
+        assert session_1.turns[1].role == "Omar"
+
+    def test_evidence_turn_ids(self, dataset):
+        questions = dataset.cases[0].questions
+        cat1 = next(q for q in questions if q.question_type == "multi-hop")
+        assert cat1.evidence_turn_ids == ("D2:2", "D2:4", "D3:1")
+
+    def test_evidence_session_ids_derived_from_dia_ids(self, dataset):
+        questions = dataset.cases[0].questions
+        cat1 = next(q for q in questions if q.question_type == "multi-hop")
+        assert cat1.evidence_session_ids == ("session_2", "session_3")
+
+    def test_category_names(self, dataset):
+        types = {q.question_type for q in dataset.cases[0].questions}
+        assert {"single-hop", "multi-hop", "temporal", "adversarial"} <= types
+
+    def test_adversarial_is_abstention_with_adversarial_answer(self, dataset):
+        adversarial = next(
+            q for q in dataset.cases[0].questions if q.question_type == "adversarial"
+        )
+        assert adversarial.is_abstention is True
+        assert adversarial.answer == "Nadia never mentioned owning a car."
+
+    def test_question_ids_unique(self, dataset):
+        ids = [q.question_id for q in dataset.cases[0].questions]
+        assert len(ids) == len(set(ids))
+
+    def test_rejects_missing_conversation(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text(json.dumps([{"sample_id": "x", "qa": []}]))
+        with pytest.raises(ValueError, match="conversation"):
+            load_locomo(path)
+
+
+class TestConvoMemLoader:
+    @pytest.fixture
+    def dataset(self, convomem_dataset):
+        return convomem_dataset
+
+    def test_one_case_per_evidence_item(self, dataset):
+        assert len(dataset.cases) == 3
+
+    def test_evidence_conversation_located_by_text_match(self, dataset):
+        case = next(c for c in dataset.cases if c.case_id == "fixture_user_evidence_1")
+        question = case.questions[0]
+        assert question.evidence_session_ids == ("conv_1",)
+        assert question.evidence_turn_ids == ("conv_1:0",)
+
+    def test_assistant_evidence_matched(self, dataset):
+        case = next(c for c in dataset.cases if c.case_id == "fixture_assistant_evidence_1")
+        question = case.questions[0]
+        assert question.evidence_session_ids == ("conv_0",)
+        assert question.evidence_turn_ids == ("conv_0:1",)
+
+    def test_turns_marked_has_answer(self, dataset):
+        case = next(c for c in dataset.cases if c.case_id == "fixture_user_evidence_2")
+        evidence_turn = case.sessions[0].turns[0]
+        assert evidence_turn.has_answer is True
+        assert case.sessions[1].turns[0].has_answer is False
+
+    def test_not_abstention_when_evidence_found(self, dataset):
+        assert all(not c.questions[0].is_abstention for c in dataset.cases)
+
+    def test_accepts_category_grouped_object(self, tmp_path):
+        raw = json.loads((FIXTURES / "convomem_sample.json").read_text())
+        grouped = {"user_evidence": raw[:2], "assistant_evidence": raw[2:]}
+        path = tmp_path / "grouped.json"
+        path.write_text(json.dumps(grouped))
+        dataset = load_convomem(path)
+        assert len(dataset.cases) == 3
+
+    def test_rejects_empty(self, tmp_path):
+        path = tmp_path / "empty.json"
+        path.write_text("[]")
+        with pytest.raises(ValueError, match="no evidence items"):
+            load_convomem(path)
+
+
+class TestLoadDatasetDispatch:
+    def test_dispatch_by_name(self):
+        dataset = load_dataset("locomo", FIXTURES / "locomo_sample.json")
+        assert dataset.name == "locomo"
+
+    def test_unknown_benchmark(self):
+        with pytest.raises(ValueError, match="Unknown benchmark"):
+            load_dataset("nope", FIXTURES / "locomo_sample.json")
+
+
+class TestDatasetProperties:
+    def test_counts(self):
+        dataset = load_longmemeval(FIXTURES / "longmemeval_sample.json")
+        assert dataset.session_count == sum(len(c.sessions) for c in dataset.cases)
+        assert dataset.cases[0].turn_count == sum(len(s.turns) for s in dataset.cases[0].sessions)
+
+    def test_iter_questions_order(self):
+        dataset = load_locomo(FIXTURES / "locomo_sample.json")
+        pairs = list(dataset.iter_questions())
+        assert len(pairs) == dataset.question_count
+        assert pairs[0][0].case_id == "fixture_1"

--- a/tests/unit/bench_memory/test_report.py
+++ b/tests/unit/bench_memory/test_report.py
@@ -1,6 +1,7 @@
 """Report generation and cost-estimation tests."""
 
 import json
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -121,6 +122,17 @@ class TestBuildReport:
 
     def test_report_is_json_serializable(self):
         json.dumps(_report())
+
+    def test_started_at_uses_injected_run_start(self):
+        started = datetime(2026, 7, 7, 12, 30, 45, tzinfo=timezone.utc)
+        report = _report(started_at=started)
+        assert report["run"]["started_at"] == "2026-07-07T12:30:45Z"
+
+    def test_started_at_normalized_to_utc(self):
+        cet = timezone(timedelta(hours=2))
+        started = datetime(2026, 7, 7, 14, 30, 45, tzinfo=cet)
+        report = _report(started_at=started)
+        assert report["run"]["started_at"] == "2026-07-07T12:30:45Z"
 
 
 class TestWriteReport:

--- a/tests/unit/bench_memory/test_report.py
+++ b/tests/unit/bench_memory/test_report.py
@@ -1,0 +1,169 @@
+"""Report generation and cost-estimation tests."""
+
+import json
+
+import pytest
+
+from bench.memory.report import (
+    build_report,
+    estimate_cost_usd,
+    relativize,
+    render_summary,
+    write_report,
+)
+from bench.memory.scoring import QuestionResult, aggregate_results
+
+
+def _results():
+    return [
+        QuestionResult(
+            question_id="q2",
+            question_type="multi-session",
+            is_abstention=False,
+            evidence_session_ids=["s1"],
+            retrieved_session_ids=["s1", "s2"],
+            qa_correct=True,
+        ),
+        QuestionResult(
+            question_id="q1",
+            question_type="single-hop",
+            is_abstention=False,
+            evidence_session_ids=["s3"],
+            retrieved_session_ids=["s9"],
+            qa_correct=False,
+        ),
+    ]
+
+
+def _report(**overrides):
+    results = _results()
+    defaults = {
+        "benchmark": "longmemeval",
+        "mode": "combined",
+        "k": 5,
+        "dataset_path": "bench/memory/fixtures/longmemeval_sample.json",
+        "dataset_stats": {"cases": 2, "questions": 2, "sessions": 4, "fixture": True},
+        "config": {"text_model": "openai/gpt-4o-mini"},
+        "metrics": aggregate_results(results, 5),
+        "results": results,
+        "usage": {
+            "llm_requests": 4,
+            "tokens": {"total": 1200, "in": 1000, "out": 200},
+            "tokens_by_model": {"openai/gpt-4o-mini": [1200, 1000, 200, 0, 0, 0]},
+            "cost": estimate_cost_usd({"openai/gpt-4o-mini": [1200, 1000, 200, 0, 0, 0]}),
+        },
+        "wall_seconds": 12.345,
+    }
+    defaults.update(overrides)
+    return build_report(**defaults)
+
+
+class TestEstimateCost:
+    def test_known_model_priced(self):
+        cost = estimate_cost_usd({"openai/gpt-4o-mini": [0, 1_000_000, 1_000_000, 0, 0, 0]})
+        assert cost["estimated_usd"] == pytest.approx(0.15 + 0.60)
+        assert cost["per_model_usd"]["openai/gpt-4o-mini"] == pytest.approx(0.75)
+
+    def test_local_model_free(self):
+        cost = estimate_cost_usd({"local/nomic-ai/nomic-embed-text-v1.5": [500, 500, 0, 0, 0, 0]})
+        assert cost["estimated_usd"] == 0.0
+        assert cost["per_model_usd"]["local/nomic-ai/nomic-embed-text-v1.5"] == 0.0
+        assert cost["unpriced_models"] == []
+
+    def test_unknown_model_reported_unpriced(self):
+        cost = estimate_cost_usd({"mystery/model": [10, 10, 0, 0, 0, 0]})
+        assert cost["per_model_usd"]["mystery/model"] is None
+        assert cost["unpriced_models"] == ["mystery/model"]
+
+    def test_mixed_models(self):
+        cost = estimate_cost_usd(
+            {
+                "openai/gpt-4o-mini": [0, 2_000_000, 0, 0, 0, 0],
+                "mystery/model": [10, 10, 0, 0, 0, 0],
+            }
+        )
+        assert cost["estimated_usd"] == pytest.approx(0.30)
+        assert cost["unpriced_models"] == ["mystery/model"]
+
+    def test_empty_breakdown(self):
+        cost = estimate_cost_usd({})
+        assert cost["per_model_usd"] == {}
+        assert cost["unpriced_models"] == []
+
+
+class TestRelativize:
+    def test_inside_repo_root(self, tmp_path):
+        target = tmp_path / "bench" / "memory" / "fixtures" / "x.json"
+        assert relativize(target, tmp_path) == "bench/memory/fixtures/x.json"
+
+    def test_outside_repo_root_unchanged(self, tmp_path):
+        assert relativize("/datasets/full.json", tmp_path) == "/datasets/full.json"
+
+    def test_no_repo_root(self):
+        assert relativize("/datasets/full.json", None) == "/datasets/full.json"
+
+
+class TestBuildReport:
+    def test_results_sorted_by_question_id(self):
+        report = _report()
+        ids = [result["question_id"] for result in report["results"]]
+        assert ids == sorted(ids)
+
+    def test_core_fields_present(self):
+        report = _report()
+        assert report["benchmark"] == "longmemeval"
+        assert report["mode"] == "combined"
+        assert report["k"] == 5
+        assert report["dataset"]["questions"] == 2
+        assert report["metrics"]["questions_scored"] == 2
+        assert "started_at" in report["run"]
+        assert report["run"]["wall_seconds"] == 12.35
+
+    def test_report_is_json_serializable(self):
+        json.dumps(_report())
+
+
+class TestWriteReport:
+    def test_writes_sorted_deterministic_json(self, tmp_path):
+        report = _report()
+        path = write_report(report, tmp_path / "sub" / "report.json")
+        assert path.exists()
+        loaded = json.loads(path.read_text())
+        assert loaded["benchmark"] == "longmemeval"
+        # Deterministic apart from run metadata: writing the same report
+        # twice yields identical bytes.
+        second = tmp_path / "again.json"
+        write_report(report, second)
+        assert path.read_text() == second.read_text()
+
+
+class TestRenderSummary:
+    def test_contains_headline_numbers(self):
+        summary = render_summary(_report())
+        assert "longmemeval" in summary
+        assert "R@5=50.0%" in summary
+        assert "QA accuracy" in summary
+        assert "50.0%" in summary
+        assert "tokens_in=1000" in summary
+
+    def test_handles_missing_qa_block(self):
+        results = [
+            QuestionResult(
+                question_id="q1",
+                question_type="single-hop",
+                is_abstention=False,
+                evidence_session_ids=["s1"],
+                retrieved_session_ids=["s1"],
+            )
+        ]
+        report = _report(
+            metrics=aggregate_results(results, 5),
+            results=results,
+        )
+        summary = render_summary(report)
+        assert "QA accuracy" not in summary
+
+    def test_per_type_breakdown_rendered(self):
+        summary = render_summary(_report())
+        assert "multi-session" in summary
+        assert "single-hop" in summary

--- a/tests/unit/bench_memory/test_report.py
+++ b/tests/unit/bench_memory/test_report.py
@@ -134,6 +134,24 @@ class TestBuildReport:
         report = _report(started_at=started)
         assert report["run"]["started_at"] == "2026-07-07T12:30:45Z"
 
+    def test_complete_run_has_no_partial_or_abort_keys(self):
+        report = _report()
+        assert "partial" not in report
+        assert "abort_reason" not in report["run"]
+
+    def test_partial_run_records_flag_and_abort_reason(self):
+        report = _report(partial=True, abort_reason="RuntimeError: boom")
+        assert report["partial"] is True
+        assert report["run"]["abort_reason"] == "RuntimeError: boom"
+
+    def test_case_stats_included_when_provided(self):
+        stats = {"completed": 3, "failed": 2, "skipped": 1}
+        report = _report(case_stats=stats)
+        assert report["run"]["cases"] == stats
+
+    def test_case_stats_absent_when_not_provided(self):
+        assert "cases" not in _report()["run"]
+
 
 class TestWriteReport:
     def test_writes_sorted_deterministic_json(self, tmp_path):
@@ -179,3 +197,17 @@ class TestRenderSummary:
         summary = render_summary(_report())
         assert "multi-session" in summary
         assert "single-hop" in summary
+
+    def test_partial_run_banner_and_case_counts(self):
+        report = _report(
+            partial=True,
+            abort_reason="aborted after 3 consecutive case ingestion failures",
+            case_stats={"completed": 1, "failed": 3, "skipped": 2},
+        )
+        summary = render_summary(report)
+        assert "PARTIAL RUN" in summary
+        assert "consecutive case ingestion failures" in summary
+        assert "Cases: 1 completed, 3 failed, 2 skipped" in summary
+
+    def test_complete_run_has_no_partial_banner(self):
+        assert "PARTIAL RUN" not in render_summary(_report())

--- a/tests/unit/bench_memory/test_runner.py
+++ b/tests/unit/bench_memory/test_runner.py
@@ -186,3 +186,19 @@ class TestIngestionFailureIsolation:
         # Cleanup still ran.
         (adapter,) = _StubAdapter.instances
         assert adapter.stop_called == 1
+
+
+class TestReportWriteFailureExitCode:
+    """A run whose report cannot be written must not exit 0 (review P1)."""
+
+    async def test_report_write_failure_returns_nonzero(self, monkeypatch, tmp_path):
+        import bench.memory.runner as runner_mod
+
+        def exploding_write(report, output):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(runner_mod, "write_report", exploding_write)
+        exit_code = await run_benchmark(
+            "longmemeval", _args("--output", str(tmp_path / "report.json"))
+        )
+        assert exit_code != 0

--- a/tests/unit/bench_memory/test_runner.py
+++ b/tests/unit/bench_memory/test_runner.py
@@ -1,22 +1,34 @@
 """Runner lifecycle tests (stubbed adapter; no formation boot).
 
-Pins the guarantee that every exit path — including a failure inside
-``adapter.start()`` — reaches ``adapter.stop()``, so temp run dirs and
-partially-initialized formations never leak.
+Pins two guarantees:
+- every exit path — including a failure inside ``adapter.start()`` and
+  per-case ingestion failures — reaches ``adapter.stop()``, so temp run
+  dirs and partially-initialized formations never leak;
+- a report is written on EVERY exit path: complete runs, runs with
+  failed cases, early-stopped failure storms, and aborts all leave a
+  report with whatever finished (marked ``partial`` when cut short).
 """
+
+import json
 
 import pytest
 
 from bench.memory import runner as runner_module
-from bench.memory.runner import build_arg_parser, run_benchmark
+from bench.memory.runner import (
+    MAX_CONSECUTIVE_CASE_FAILURES,
+    build_arg_parser,
+    run_benchmark,
+)
 
 
 class _StubAdapter:
-    """Records lifecycle calls; start() raises when configured to."""
+    """Records lifecycle calls; failure points are class-configurable."""
 
     instances = []
 
     fail_on_start = False
+    fail_ingest_case_ids = frozenset()
+    fail_all_ingest = False
 
     def __init__(self, **kwargs):
         self.kwargs = kwargs
@@ -36,7 +48,9 @@ class _StubAdapter:
         pass
 
     async def ingest_session(self, user_id, session):
-        pass
+        case_id = user_id.split("-", 2)[-1]
+        if self.fail_all_ingest or case_id in self.fail_ingest_case_ids:
+            raise OSError("embedding model unavailable")
 
     async def search(self, user_id, query, fetch_limit):
         return []
@@ -60,6 +74,8 @@ class _StubAdapter:
 def _stub_adapter(monkeypatch):
     _StubAdapter.instances = []
     _StubAdapter.fail_on_start = False
+    _StubAdapter.fail_ingest_case_ids = frozenset()
+    _StubAdapter.fail_all_ingest = False
     monkeypatch.setattr(runner_module, "MuxiMemoryAdapter", _StubAdapter)
 
 
@@ -68,14 +84,25 @@ def _args(*extra):
     return parser.parse_args(["--fixture", *extra])
 
 
+def _read_report(path):
+    return json.loads(path.read_text())
+
+
 class TestRunnerLifecycle:
-    async def test_start_failure_still_calls_stop(self):
+    async def test_start_failure_calls_stop_and_writes_partial_report(self, tmp_path):
         _StubAdapter.fail_on_start = True
+        output = tmp_path / "report.json"
         with pytest.raises(RuntimeError, match="boom"):
-            await run_benchmark("longmemeval", _args())
+            await run_benchmark("longmemeval", _args("--output", str(output)))
         (adapter,) = _StubAdapter.instances
         assert adapter.start_called
         assert adapter.stop_called == 1
+        # The report still exists, marked partial with the abort reason.
+        report = _read_report(output)
+        assert report["partial"] is True
+        assert "boom: formation load failed" in report["run"]["abort_reason"]
+        assert report["run"]["cases"] == {"completed": 0, "failed": 0, "skipped": 6}
+        assert report["results"] == []
 
     async def test_successful_run_calls_stop_once(self, tmp_path):
         exit_code = await run_benchmark(
@@ -85,6 +112,14 @@ class TestRunnerLifecycle:
         assert adapter.stop_called == 1
         assert exit_code == 0
         assert (tmp_path / "report.json").exists()
+
+    async def test_happy_path_report_has_no_partial_flag(self, tmp_path):
+        output = tmp_path / "report.json"
+        await run_benchmark("longmemeval", _args("--output", str(output)))
+        report = _read_report(output)
+        assert "partial" not in report
+        assert "abort_reason" not in report["run"]
+        assert report["run"]["cases"] == {"completed": 6, "failed": 0, "skipped": 0}
 
     async def test_keep_run_dir_flag_forwarded(self, tmp_path):
         await run_benchmark(
@@ -98,3 +133,56 @@ class TestRunnerLifecycle:
         await run_benchmark("longmemeval", _args("--output", str(tmp_path / "report.json")))
         (adapter,) = _StubAdapter.instances
         assert adapter.kwargs["keep_run_dir"] is False
+
+
+class TestIngestionFailureIsolation:
+    async def test_single_case_failure_run_continues(self, tmp_path):
+        _StubAdapter.fail_ingest_case_ids = frozenset({"fixture_ms_001"})
+        output = tmp_path / "report.json"
+        exit_code = await run_benchmark("longmemeval", _args("--output", str(output)))
+        assert exit_code == 1  # errored questions surface in the exit code
+        report = _read_report(output)
+        # Run completed: not partial, all six cases attempted.
+        assert "partial" not in report
+        assert report["run"]["cases"] == {"completed": 5, "failed": 1, "skipped": 0}
+        # The failed case's question carries the ingestion error; the
+        # other five questions completed normally.
+        by_id = {result["question_id"]: result for result in report["results"]}
+        assert len(by_id) == 6
+        assert "case ingestion failed: OSError" in by_id["fixture_ms_001"]["error"]
+        clean = [r for r in report["results"] if r["error"] is None]
+        assert len(clean) == 5
+        assert report["metrics"]["questions_errored"] == 1
+        # Cleanup still happened exactly once.
+        (adapter,) = _StubAdapter.instances
+        assert adapter.stop_called == 1
+
+    async def test_consecutive_failure_counter_resets_after_success(self, tmp_path):
+        # Two isolated failures with successes between them must NOT
+        # trip the early stop (the threshold is CONSECUTIVE failures).
+        _StubAdapter.fail_ingest_case_ids = frozenset({"fixture_ssu_001", "fixture_ms_001"})
+        output = tmp_path / "report.json"
+        await run_benchmark("longmemeval", _args("--output", str(output)))
+        report = _read_report(output)
+        assert "partial" not in report
+        assert report["run"]["cases"] == {"completed": 4, "failed": 2, "skipped": 0}
+
+    async def test_failure_storm_stops_early_with_partial_report(self, tmp_path):
+        _StubAdapter.fail_all_ingest = True
+        output = tmp_path / "report.json"
+        exit_code = await run_benchmark("longmemeval", _args("--output", str(output)))
+        assert exit_code == 1
+        report = _read_report(output)
+        assert report["partial"] is True
+        assert "consecutive case ingestion failures" in report["run"]["abort_reason"]
+        assert "embedding model unavailable" in report["run"]["abort_reason"]
+        cases = report["run"]["cases"]
+        assert cases["completed"] == 0
+        assert cases["failed"] == MAX_CONSECUTIVE_CASE_FAILURES
+        assert cases["skipped"] == 6 - MAX_CONSECUTIVE_CASE_FAILURES
+        # Only the attempted cases' questions are recorded, all errored.
+        assert len(report["results"]) == MAX_CONSECUTIVE_CASE_FAILURES
+        assert all(result["error"] for result in report["results"])
+        # Cleanup still ran.
+        (adapter,) = _StubAdapter.instances
+        assert adapter.stop_called == 1

--- a/tests/unit/bench_memory/test_runner.py
+++ b/tests/unit/bench_memory/test_runner.py
@@ -1,0 +1,100 @@
+"""Runner lifecycle tests (stubbed adapter; no formation boot).
+
+Pins the guarantee that every exit path — including a failure inside
+``adapter.start()`` — reaches ``adapter.stop()``, so temp run dirs and
+partially-initialized formations never leak.
+"""
+
+import pytest
+
+from bench.memory import runner as runner_module
+from bench.memory.runner import build_arg_parser, run_benchmark
+
+
+class _StubAdapter:
+    """Records lifecycle calls; start() raises when configured to."""
+
+    instances = []
+
+    fail_on_start = False
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.start_called = False
+        self.stop_called = 0
+        type(self).instances.append(self)
+
+    async def start(self):
+        self.start_called = True
+        if self.fail_on_start:
+            raise RuntimeError("boom: formation load failed")
+
+    async def stop(self):
+        self.stop_called += 1
+
+    def clear_case(self):
+        pass
+
+    async def ingest_session(self, user_id, session):
+        pass
+
+    async def search(self, user_id, query, fetch_limit):
+        return []
+
+    @staticmethod
+    def ranked_session_ids(items):
+        return []
+
+    @staticmethod
+    def ranked_turn_ids(items):
+        return []
+
+    def usage_snapshot(self):
+        return {"llm_requests": 0, "tokens": {}, "tokens_by_model": {}, "cost": {}}
+
+    def config_snapshot(self):
+        return {"mode": self.kwargs.get("mode", "?")}
+
+
+@pytest.fixture(autouse=True)
+def _stub_adapter(monkeypatch):
+    _StubAdapter.instances = []
+    _StubAdapter.fail_on_start = False
+    monkeypatch.setattr(runner_module, "MuxiMemoryAdapter", _StubAdapter)
+
+
+def _args(*extra):
+    parser = build_arg_parser("longmemeval", default_k=5)
+    return parser.parse_args(["--fixture", *extra])
+
+
+class TestRunnerLifecycle:
+    async def test_start_failure_still_calls_stop(self):
+        _StubAdapter.fail_on_start = True
+        with pytest.raises(RuntimeError, match="boom"):
+            await run_benchmark("longmemeval", _args())
+        (adapter,) = _StubAdapter.instances
+        assert adapter.start_called
+        assert adapter.stop_called == 1
+
+    async def test_successful_run_calls_stop_once(self, tmp_path):
+        exit_code = await run_benchmark(
+            "longmemeval", _args("--output", str(tmp_path / "report.json"))
+        )
+        (adapter,) = _StubAdapter.instances
+        assert adapter.stop_called == 1
+        assert exit_code == 0
+        assert (tmp_path / "report.json").exists()
+
+    async def test_keep_run_dir_flag_forwarded(self, tmp_path):
+        await run_benchmark(
+            "longmemeval",
+            _args("--keep-run-dir", "--output", str(tmp_path / "report.json")),
+        )
+        (adapter,) = _StubAdapter.instances
+        assert adapter.kwargs["keep_run_dir"] is True
+
+    async def test_keep_run_dir_defaults_false(self, tmp_path):
+        await run_benchmark("longmemeval", _args("--output", str(tmp_path / "report.json")))
+        (adapter,) = _StubAdapter.instances
+        assert adapter.kwargs["keep_run_dir"] is False

--- a/tests/unit/bench_memory/test_scoring.py
+++ b/tests/unit/bench_memory/test_scoring.py
@@ -1,0 +1,246 @@
+"""Metric correctness tests for the memory benchmark scorer.
+
+These numbers drive published results and tuning decisions, so every
+metric is pinned with hand-computed expectations, including edge cases
+(duplicates, abstention, errors, k cutoffs, tie-breaking).
+"""
+
+import pytest
+
+from bench.memory.scoring import (
+    QuestionResult,
+    aggregate_results,
+    coverage_at_k,
+    hit_at_k,
+    mrr,
+    ranked_unique,
+    reciprocal_rank_fusion,
+)
+
+
+class TestRankedUnique:
+    def test_preserves_first_seen_order(self):
+        assert ranked_unique(["b", "a", "b", "c", "a"]) == ["b", "a", "c"]
+
+    def test_empty(self):
+        assert ranked_unique([]) == []
+
+    def test_no_duplicates_passthrough(self):
+        assert ranked_unique(["x", "y", "z"]) == ["x", "y", "z"]
+
+
+class TestHitAtK:
+    def test_hit_at_top_rank(self):
+        assert hit_at_k(["s1", "s2", "s3"], ["s1"], k=1) is True
+
+    def test_hit_exactly_at_k(self):
+        assert hit_at_k(["s1", "s2", "s3"], ["s3"], k=3) is True
+
+    def test_miss_just_below_cutoff(self):
+        assert hit_at_k(["s1", "s2", "s3"], ["s3"], k=2) is False
+
+    def test_any_evidence_suffices(self):
+        assert hit_at_k(["s1", "s2"], ["s9", "s2"], k=2) is True
+
+    def test_no_evidence_retrieved(self):
+        assert hit_at_k(["s1", "s2"], ["s9"], k=5) is False
+
+    def test_empty_retrieval_is_miss(self):
+        assert hit_at_k([], ["s1"], k=5) is False
+
+    def test_duplicates_collapse_to_best_rank(self):
+        # s2 first appears at rank 2; duplicates must not push it out.
+        assert hit_at_k(["s1", "s2", "s1", "s1"], ["s2"], k=2) is True
+
+    def test_k_zero_rejected(self):
+        with pytest.raises(ValueError):
+            hit_at_k(["s1"], ["s1"], k=0)
+
+    def test_no_evidence_ids_rejected(self):
+        with pytest.raises(ValueError):
+            hit_at_k(["s1"], [], k=5)
+
+
+class TestCoverageAtK:
+    def test_full_coverage(self):
+        assert coverage_at_k(["s1", "s2"], ["s1", "s2"], k=2) == 1.0
+
+    def test_half_coverage(self):
+        assert coverage_at_k(["s1", "s3"], ["s1", "s2"], k=2) == 0.5
+
+    def test_zero_coverage(self):
+        assert coverage_at_k(["s3", "s4"], ["s1", "s2"], k=2) == 0.0
+
+    def test_cutoff_applies_before_matching(self):
+        # s2 is retrieved but at rank 3, beyond k=2.
+        assert coverage_at_k(["s9", "s8", "s2"], ["s1", "s2"], k=2) == 0.0
+
+    def test_duplicate_evidence_ids_counted_once(self):
+        assert coverage_at_k(["s1"], ["s1", "s1"], k=1) == 1.0
+
+    def test_no_evidence_ids_rejected(self):
+        with pytest.raises(ValueError):
+            coverage_at_k(["s1"], [], k=1)
+
+
+class TestMRR:
+    def test_first_rank(self):
+        assert mrr(["s1", "s2"], ["s1"]) == 1.0
+
+    def test_third_rank(self):
+        assert mrr(["a", "b", "s1"], ["s1"]) == pytest.approx(1 / 3)
+
+    def test_first_matching_evidence_wins(self):
+        assert mrr(["a", "e2", "e1"], ["e1", "e2"]) == pytest.approx(1 / 2)
+
+    def test_not_retrieved(self):
+        assert mrr(["a", "b"], ["s1"]) == 0.0
+
+    def test_duplicates_do_not_shift_rank(self):
+        assert mrr(["a", "a", "s1"], ["s1"]) == pytest.approx(1 / 2)
+
+    def test_no_evidence_rejected(self):
+        with pytest.raises(ValueError):
+            mrr(["a"], [])
+
+
+class TestReciprocalRankFusion:
+    def test_agreement_ranks_first(self):
+        fused = reciprocal_rank_fusion([["a", "b", "c"], ["a", "c", "b"]])
+        assert fused[0] == "a"
+
+    def test_single_ranking_passthrough_order(self):
+        assert reciprocal_rank_fusion([["x", "y", "z"]]) == ["x", "y", "z"]
+
+    def test_exact_scores(self):
+        # a: 1/61 + 1/62 ; b: 1/62 + 1/61 -> tie, first-seen order wins (a).
+        fused = reciprocal_rank_fusion([["a", "b"], ["b", "a"]])
+        assert fused == ["a", "b"]
+
+    def test_id_unique_to_one_list_still_ranked(self):
+        fused = reciprocal_rank_fusion([["a", "b"], ["c"]])
+        assert set(fused) == {"a", "b", "c"}
+        # c holds rank 1 in its list (1/61), beating b's rank 2 (1/62).
+        assert fused.index("c") < fused.index("b")
+
+    def test_empty_rankings(self):
+        assert reciprocal_rank_fusion([[], []]) == []
+
+    def test_invalid_rrf_k(self):
+        with pytest.raises(ValueError):
+            reciprocal_rank_fusion([["a"]], rrf_k=0)
+
+
+def _result(
+    question_id="q1",
+    question_type="single-session-user",
+    is_abstention=False,
+    evidence_session_ids=("s1",),
+    evidence_turn_ids=(),
+    retrieved_session_ids=("s1", "s2"),
+    retrieved_turn_ids=(),
+    qa_correct=None,
+    error=None,
+):
+    return QuestionResult(
+        question_id=question_id,
+        question_type=question_type,
+        is_abstention=is_abstention,
+        evidence_session_ids=list(evidence_session_ids),
+        evidence_turn_ids=list(evidence_turn_ids),
+        retrieved_session_ids=list(retrieved_session_ids),
+        retrieved_turn_ids=list(retrieved_turn_ids),
+        qa_correct=qa_correct,
+        error=error,
+    )
+
+
+class TestQuestionResultMetrics:
+    def test_session_metrics_values(self):
+        result = _result(retrieved_session_ids=["s9", "s1"], evidence_session_ids=["s1"])
+        metrics = result.session_metrics(k=5)
+        assert metrics["hit@5"] == 1.0
+        assert metrics["coverage@5"] == 1.0
+        assert metrics["mrr"] == pytest.approx(1 / 2)
+
+    def test_abstention_returns_none(self):
+        assert _result(is_abstention=True).session_metrics(k=5) is None
+
+    def test_error_returns_none(self):
+        assert _result(error="boom").session_metrics(k=5) is None
+
+    def test_turn_metrics_absent_without_turn_evidence(self):
+        assert _result(evidence_turn_ids=()).turn_metrics(k=5) is None
+
+    def test_turn_metrics_values(self):
+        result = _result(
+            evidence_turn_ids=["t1", "t2"],
+            retrieved_turn_ids=["t2", "x", "t1"],
+        )
+        metrics = result.turn_metrics(k=2)
+        assert metrics["hit@2"] == 1.0
+        assert metrics["coverage@2"] == 0.5  # t1 is at rank 3
+        assert metrics["mrr"] == 1.0
+
+
+class TestAggregateResults:
+    def test_overall_recall_is_mean_of_hits(self):
+        results = [
+            _result(question_id="q1", retrieved_session_ids=["s1"]),  # hit
+            _result(question_id="q2", retrieved_session_ids=["s9"]),  # miss
+        ]
+        agg = aggregate_results(results, k=5)
+        overall = agg["retrieval"]["session_level"]["overall"]
+        assert overall["questions"] == 2
+        assert overall["recall@5"] == 0.5
+
+    def test_by_question_type_breakdown(self):
+        results = [
+            _result(question_id="q1", question_type="multi-session"),
+            _result(
+                question_id="q2",
+                question_type="temporal-reasoning",
+                retrieved_session_ids=["nope"],
+            ),
+        ]
+        by_type = aggregate_results(results, k=5)["retrieval"]["session_level"]["by_question_type"]
+        assert by_type["multi-session"]["recall@5"] == 1.0
+        assert by_type["temporal-reasoning"]["recall@5"] == 0.0
+
+    def test_abstention_and_errors_excluded_and_counted(self):
+        results = [
+            _result(question_id="q1"),
+            _result(question_id="q2", is_abstention=True, evidence_session_ids=()),
+            _result(question_id="q3", error="ValueError: x"),
+        ]
+        agg = aggregate_results(results, k=5)
+        assert agg["questions_total"] == 3
+        assert agg["questions_scored"] == 1
+        assert agg["questions_abstention"] == 1
+        assert agg["questions_errored"] == 1
+        assert agg["retrieval"]["session_level"]["overall"]["questions"] == 1
+
+    def test_turn_level_none_when_no_turn_evidence(self):
+        agg = aggregate_results([_result()], k=5)
+        assert agg["retrieval"]["turn_level"] is None
+
+    def test_qa_accuracy(self):
+        results = [
+            _result(question_id="q1", qa_correct=True),
+            _result(question_id="q2", qa_correct=False),
+            _result(question_id="q3", qa_correct=True),
+            _result(question_id="q4"),  # QA not run
+        ]
+        qa = aggregate_results(results, k=5)["qa"]
+        assert qa["overall"]["questions"] == 3
+        assert qa["overall"]["accuracy"] == pytest.approx(2 / 3)
+
+    def test_qa_block_absent_when_not_run(self):
+        assert aggregate_results([_result()], k=5)["qa"] is None
+
+    def test_all_abstention_gives_no_session_block(self):
+        results = [_result(is_abstention=True, evidence_session_ids=())]
+        assert aggregate_results(results, k=5)["retrieval"]["session_level"] is None
+
+    def test_k_recorded(self):
+        assert aggregate_results([_result()], k=7)["k"] == 7

--- a/tests/unit/bench_memory/test_split.py
+++ b/tests/unit/bench_memory/test_split.py
@@ -1,0 +1,92 @@
+"""Determinism and correctness tests for the dev/holdout split."""
+
+from pathlib import Path
+
+import pytest
+
+from bench.memory.datasets import load_locomo, load_longmemeval
+from bench.memory.split import select_split, split_dataset, split_question_keys
+
+FIXTURES = Path(__file__).resolve().parents[3] / "bench" / "memory" / "fixtures"
+
+
+@pytest.fixture(scope="module")
+def longmemeval():
+    return load_longmemeval(FIXTURES / "longmemeval_sample.json")
+
+
+@pytest.fixture(scope="module")
+def locomo():
+    return load_locomo(FIXTURES / "locomo_sample.json")
+
+
+class TestSplitQuestionKeys:
+    def test_deterministic_for_same_seed(self, longmemeval):
+        first = split_question_keys(longmemeval, dev_size=3, seed=42)
+        second = split_question_keys(longmemeval, dev_size=3, seed=42)
+        assert first == second
+
+    def test_different_seed_changes_assignment(self, longmemeval):
+        dev_a, _ = split_question_keys(longmemeval, dev_size=3, seed=1)
+        dev_b, _ = split_question_keys(longmemeval, dev_size=3, seed=2)
+        assert dev_a != dev_b
+
+    def test_partition_is_complete_and_disjoint(self, longmemeval):
+        dev, holdout = split_question_keys(longmemeval, dev_size=3, seed=42)
+        assert len(dev) == 3
+        assert len(dev) + len(holdout) == longmemeval.question_count
+        assert not set(dev) & set(holdout)
+
+    def test_dev_size_larger_than_dataset(self, longmemeval):
+        dev, holdout = split_question_keys(longmemeval, dev_size=100, seed=42)
+        assert len(dev) == longmemeval.question_count
+        assert holdout == []
+
+    def test_negative_dev_size_rejected(self, longmemeval):
+        with pytest.raises(ValueError):
+            split_question_keys(longmemeval, dev_size=-1)
+
+
+class TestSplitDataset:
+    def test_questions_partitioned(self, longmemeval):
+        dev, holdout = split_dataset(longmemeval, dev_size=2, seed=42)
+        assert dev.question_count == 2
+        assert holdout.question_count == longmemeval.question_count - 2
+
+    def test_cases_without_questions_dropped(self, longmemeval):
+        # LongMemEval has one question per case, so the dev split must
+        # contain exactly dev_size cases.
+        dev, _ = split_dataset(longmemeval, dev_size=2, seed=42)
+        assert len(dev.cases) == 2
+
+    def test_shared_case_kept_in_both_splits(self, locomo):
+        # LoCoMo has one case with many questions; both splits keep the
+        # case (with its full haystack) but different question subsets.
+        dev, holdout = split_dataset(locomo, dev_size=2, seed=42)
+        assert len(dev.cases) == 1
+        assert len(holdout.cases) == 1
+        assert dev.cases[0].sessions == holdout.cases[0].sessions
+        dev_ids = {q.question_id for q in dev.cases[0].questions}
+        holdout_ids = {q.question_id for q in holdout.cases[0].questions}
+        assert not dev_ids & holdout_ids
+
+    def test_sessions_preserved_in_split(self, longmemeval):
+        dev, _ = split_dataset(longmemeval, dev_size=2, seed=42)
+        original = {case.case_id: case for case in longmemeval.cases}
+        for case in dev.cases:
+            assert case.sessions == original[case.case_id].sessions
+
+
+class TestSelectSplit:
+    def test_all_returns_original(self, longmemeval):
+        assert select_split(longmemeval, "all") is longmemeval
+
+    def test_dev_and_holdout_partition(self, longmemeval):
+        dev = select_split(longmemeval, "dev", dev_size=3, seed=42)
+        holdout = select_split(longmemeval, "holdout", dev_size=3, seed=42)
+        assert dev.question_count == 3
+        assert dev.question_count + holdout.question_count == longmemeval.question_count
+
+    def test_unknown_split_rejected(self, longmemeval):
+        with pytest.raises(ValueError, match="Unknown split"):
+            select_split(longmemeval, "test")


### PR DESCRIPTION
## What

Tier 1 of the memory benchmarking PRD (`engineering/prds/memory-benchmarking.md`), whose sequencing condition ("defer until Phases 1-3 stabilize") is now met. Per the PRD, Tier 1 = compete on the standard academic benchmarks and establish directly comparable scores against Mem0 / Mastra / Zep / MemPalace:

- `bench/memory/longmemeval_runner.py` — LongMemEval (primary, K=5, target R@5 >= 94%)
- `bench/memory/locomo_runner.py` — LoCoMo (secondary, K=10, target R@10 >= 85%)
- `bench/memory/convomem_runner.py` — ConvoMem (secondary, K=5, target >= 85%)
- Train/test split utility (seeded 50-question dev split / holdout, per the PRD)
- `bench/memory/README.md` reproduction guide + committed `bench/memory/results/`

The harness lives under the repo's existing `bench/` directory (the PRD says `benchmarks/`; `bench/` is the established convention here).

Every run measures both PRD metrics: **retrieval recall** (session-level R@K comparable to published numbers, plus turn-level R@K, coverage@K, MRR) and **answer accuracy** (`--qa`: full retrieval + LLM answer, scored by an LLM judge at temperature 0).

## How it runs (no mocks)

Each run boots a real `Formation` (SQLite + sqlite-vec persistent memory, FAISS working memory) through the same public APIs production uses. Three retrieval modes per the PRD's mode table: `working`, `persistent`, and `combined` (Reciprocal Rank Fusion — the two backends score on different scales, so scale-free rank fusion is used instead of score mixing). The PRD's fourth mode (combined + KG routing) is deliberately out of Tier 1 scope: it requires per-turn KG extraction (one LLM call per ingested turn), and lands with the Tier 2 structured-recall work where the KG is the subject under test.

Isolation: per-case `user_id` scoping (memory namespaces), working memory cleared between cases, per-run temp dir for the rendered formation + database + JSONL event log. Deterministic: exact vector search, `recency_bias=0`, seeded splits, temperature-0 QA, sorted-key reports.

**Cheap-model configuration:** embeddings are `local/nomic-ai/nomic-embed-text-v1.5` (free, on-box), so retrieval-only runs make zero API calls. The text model (`openai/gpt-4o-mini`) is only invoked with `--qa`. Every report prints per-run LLM requests, token totals per model, and estimated cost.

## Dataset / fixture strategy

- **Committed fixtures** (`bench/memory/fixtures/`) are small **synthetic** samples that follow each dataset's published schema — CI and the self-run never download anything, and no third-party data is committed.
- **Full datasets** are fetched locally via `bench/memory/download_datasets.py` into `$MUXI_BENCH_DATA_DIR`. Licensing: LoCoMo and ConvoMem are CC-BY-NC-4.0 (non-commercial; must never be committed or redistributed), LongMemEval is a research release (license per upstream repo). The README states this explicitly.

## How to run the full tier

```bash
uv run python -m bench.memory.download_datasets --data-dir ~/datasets/membench
export MUXI_BENCH_DATA_DIR=~/datasets/membench

for mode in working persistent combined; do
    uv run python -m bench.memory.longmemeval_runner --split holdout --mode "$mode"
done
uv run python -m bench.memory.longmemeval_runner --split holdout --mode combined --qa
uv run python -m bench.memory.locomo_runner --mode combined --qa
uv run python -m bench.memory.convomem_runner --mode combined --qa
```

## Fixture self-run (real formation, sqlite, exit 0)

```
Memory benchmark: longmemeval  (mode=combined, k=5)
Scored: 5  abstention: 1  errors: 0
Session-level retrieval:  R@5=100.0%  coverage@5=100.0%  MRR=1.000  (n=5)
Turn-level retrieval:     R@5=100.0%  coverage@5=100.0%  MRR=0.900  (n=5)
QA accuracy (end-to-end): 100.0%  (n=6)
LLM usage: requests=12  tokens_in=3254  tokens_out=227  est_cost=$0.000624
```

LoCoMo fixture: R@10 100% (session + turn), QA 83.3% (one strict judge call: "data analyst" vs gold "senior data analyst"). ConvoMem fixture: R@5 100%, QA 100%. Retrieval-only modes (`working`, `persistent`): R@5 100%, $0. All exit 0; reports committed under `bench/memory/results/`.

## Production code changes

None to runtime logic. Two support-level changes:
- `pyproject.toml`: ruff's isort config now treats `bench` as first-party (aligns ruff with isort's auto-detection for the new package).
- The harness calls the existing `enable_conversation_logging(formation)` hook (normally invoked by the server after startup) so conversation events go to the run-local JSONL instead of stdout — existing public API, no changes to it.

## Tests

- **Unit:** 117 new tests (`tests/unit/bench_memory/`) — hand-computed expectations for every metric (hit@K cutoffs, duplicate collapse, coverage, MRR, RRF tie-breaking, abstention/error exclusion), loader normalization for all three schemas, split determinism/partition, report determinism and cost estimation, adapter mapping/truncation/run-dir rendering. Full suite: 1793 passed, 10 skipped.
- **validate_events:** 100% (no new events added).
- **Lint:** black / isort / ruff / flake8 clean on the new files.

## E2E

`cd e2e && uv run python run_random_tests.py 5` (gitignored `.key`/`secrets.enc` replicated from the main checkout first):

- Run 1: 4/5 — `19_api/test_19x1_auth_gate.py` failed with a SecretsManager `InvalidToken`: the two `formation-api-authgate-*` dirs have committed `secrets.enc` symlinks but no `.key` replica anywhere (SecretsManager auto-generates a fresh key when missing, which cannot decrypt the committed secrets). Environment replication issue, not a code issue: after symlinking `.key -> ../../../assets/.key` (same pattern as sibling `formation-api/`), the test passes with all 6 checks green.
- Run 2 (fresh random 5): **5/5 passed** (13_triggers, 21_skills, 7_orchestration x2, 8_clarification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)