### PR TITLE
fix: migrate scope columns across all embedding-dimension tables

### DIFF
--- a/src/muxi/runtime/formation/initialization.py
+++ b/src/muxi/runtime/formation/initialization.py
@@ -11,6 +11,7 @@ The initialization order is critical:
 """
 
 import io
+import re
 import wave
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -1291,6 +1292,47 @@ def _migrate_add_scope_columns(db_manager, table_name: str) -> None:
         pass  # Table may not exist yet on first run; create_tables handles it
 
 
+def _migrate_scope_columns_all_dims(db_manager, active_table: str) -> None:
+    """Apply the scope-column migration to every per-dimension memories table.
+
+    Memories tables are per-embedding-dimension (``memories_384``,
+    ``memories_768``, ``memories_1536``, ...) and the dimension known at
+    startup is only a provisional hint -- the real one is probed lazily on
+    first embed. A database that has seen more than one embedding model
+    also carries tables for inactive dimensions. Migrating only the active
+    table left the others without ``scope_type``/``scope_id``, breaking
+    scope-filtered queries against them, so enumerate every existing
+    ``memories_{dim}`` table and migrate each (idempotent per table).
+    """
+    from sqlalchemy import text
+
+    tables = {active_table}
+    try:
+        with db_manager.engine.connect() as conn:
+            if db_manager.database_type == "postgresql":
+                result = conn.execute(
+                    text(
+                        "SELECT table_name FROM information_schema.tables "
+                        "WHERE table_schema = current_schema() "
+                        "AND table_name LIKE 'memories%'"
+                    )
+                )
+            else:
+                result = conn.execute(
+                    text(
+                        "SELECT name FROM sqlite_master "
+                        "WHERE type = 'table' AND name LIKE 'memories%'"
+                    )
+                )
+            # Strict pattern match so companion tables (e.g. SQLite FTS
+            # mirrors) are never altered.
+            tables.update(name for (name,) in result if re.fullmatch(r"memories_\d+", name))
+    except Exception:
+        pass  # Enumeration is best-effort; still migrate the active table
+    for table_name in sorted(tables):
+        _migrate_add_scope_columns(db_manager, table_name)
+
+
 def _create_all_database_tables(db_manager, embedding_dimension: int = 1536) -> None:
     """
     Create all database tables for the MUXI runtime.
@@ -1362,8 +1404,12 @@ def _create_all_database_tables(db_manager, embedding_dimension: int = 1536) -> 
         for projection_table in ("kg_entities", "kg_relationships", "captains_log", "lessons"):
             _migrate_add_derived_from_event_ids_column(db_manager, projection_table)
         # Migrate: ensure the memory-namespaces scope columns exist on
-        # memories tables created before the scope substrate shipped
-        _migrate_add_scope_columns(db_manager, memories_table)
+        # memories tables created before the scope substrate shipped.
+        # Covers ALL memories_{dim} tables, not just the active dimension's:
+        # the startup dimension is a provisional hint (the real one is
+        # probed lazily) and old databases may carry tables from previous
+        # embedding models.
+        _migrate_scope_columns_all_dims(db_manager, memories_table)
         ensure_memory_table_indexes(db_manager, embedding_dimension)
         table_names = [
             "users",

--- a/tests/unit/test_memory_scope_substrate.py
+++ b/tests/unit/test_memory_scope_substrate.py
@@ -280,3 +280,50 @@ def test_migrate_add_scope_columns_is_additive_and_idempotent(tmp_path):
 
     # Missing table: swallowed (create_tables owns first-run creation).
     _migrate_add_scope_columns(db_manager, "memories_9999")
+
+
+def test_migrate_scope_columns_covers_all_dimension_tables(tmp_path):
+    """A database carrying memories tables from other embedding dimensions
+    (e.g. after switching embedding models) gets scope columns on ALL of
+    them, not just the active dimension's -- and companion tables that
+    merely share the prefix are left alone."""
+    from sqlalchemy import create_engine, text
+
+    from muxi.runtime.formation.initialization import _migrate_scope_columns_all_dims
+
+    db_file = tmp_path / "runtime.db"
+    engine = create_engine(f"sqlite:///{db_file}")
+    old_schema = (
+        "id TEXT PRIMARY KEY, user_id INTEGER NOT NULL, "
+        "collection TEXT NOT NULL, text TEXT NOT NULL, "
+        "embedding BLOB NOT NULL, metadata TEXT"
+    )
+    with engine.connect() as conn:
+        # Two old-schema dimension tables (embedding model was switched)
+        # plus a companion table that matches the prefix but not the
+        # memories_{dim} pattern.
+        conn.execute(text(f"CREATE TABLE memories_384 ({old_schema})"))
+        conn.execute(text(f"CREATE TABLE memories_768 ({old_schema})"))
+        conn.execute(text("CREATE TABLE memories_384_fts (id TEXT PRIMARY KEY)"))
+        conn.commit()
+
+    class _FakeDBManager:
+        database_type = "sqlite"
+
+        def __init__(self, engine):
+            self.engine = engine
+
+    db_manager = _FakeDBManager(engine)
+    # Active table is a third dimension that doesn't exist yet -- its
+    # migration is swallowed (create_tables owns first-run creation).
+    _migrate_scope_columns_all_dims(db_manager, "memories_1536")
+
+    with engine.connect() as conn:
+        for table in ("memories_384", "memories_768"):
+            columns = [row[1] for row in conn.execute(text(f"PRAGMA table_info({table})"))]
+            assert "scope_type" in columns, table
+            assert "scope_id" in columns, table
+        # The companion table was not altered.
+        fts_columns = [row[1] for row in conn.execute(text("PRAGMA table_info(memories_384_fts)"))]
+        assert "scope_type" not in fts_columns
+        assert "scope_id" not in fts_columns

--- a/tests/unit/test_memory_scope_substrate.py
+++ b/tests/unit/test_memory_scope_substrate.py
@@ -230,6 +230,15 @@ async def test_legacy_db_migrates_additively_and_search_is_unchanged(db_path):
         assert {r["text"] for r in results} == set(seeded) | {"dogs bark"}
 
 
+class _FakeDBManager:
+    """Minimal stand-in for DatabaseManager as read by the scope migrations."""
+
+    database_type = "sqlite"
+
+    def __init__(self, engine):
+        self.engine = engine
+
+
 def test_migrate_add_scope_columns_is_additive_and_idempotent(tmp_path):
     """The runtime migration used by _create_all_database_tables adds the
     columns to an old-schema table and is a no-op when re-run."""
@@ -255,12 +264,6 @@ def test_migrate_add_scope_columns_is_additive_and_idempotent(tmp_path):
             )
         )
         conn.commit()
-
-    class _FakeDBManager:
-        database_type = "sqlite"
-
-        def __init__(self, engine):
-            self.engine = engine
 
     db_manager = _FakeDBManager(engine)
     _migrate_add_scope_columns(db_manager, "memories_384")
@@ -306,12 +309,6 @@ def test_migrate_scope_columns_covers_all_dimension_tables(tmp_path):
         conn.execute(text(f"CREATE TABLE memories_768 ({old_schema})"))
         conn.execute(text("CREATE TABLE memories_384_fts (id TEXT PRIMARY KEY)"))
         conn.commit()
-
-    class _FakeDBManager:
-        database_type = "sqlite"
-
-        def __init__(self, engine):
-            self.engine = engine
 
     db_manager = _FakeDBManager(engine)
     # Active table is a third dimension that doesn't exist yet -- its


### PR DESCRIPTION
## Problem

The memory-namespaces scope-column migration (`_migrate_add_scope_columns`) only ran against the memories table for the dimension known at startup. That dimension is a provisional hint (`getattr(ltm, "dimension", 1536)`) — the real dimension is probed lazily on first embed and can differ. Memories tables are per-embedding-dimension (`memories_384`, `memories_768`, `memories_1536`, ...), so:

- a database that has seen multiple embedding models carries tables for inactive dimensions that never got `scope_type`/`scope_id`, and
- worse, the table the runtime actually queries (the lazily-probed dimension) can be one of the unmigrated ones when it differs from the startup hint.

Scope-filtered queries against such tables then fail (`column scope_type does not exist`). Two independent runs hit this as a `test_2p1` e2e failure on local Postgres, where the startup hint (1536) differs from the probed default dimension (768).

## Fix

New `_migrate_scope_columns_all_dims` helper in `src/muxi/runtime/formation/initialization.py`: enumerates every existing `memories_{dim}` table (`information_schema.tables` on Postgres, `sqlite_master` on SQLite, strict `memories_\d+` pattern so companion tables like SQLite FTS mirrors are never altered) and applies the existing idempotent per-table migration to each. Enumeration is best-effort and falls back to the active table; migrations still never break startup.

## Testing

- New unit test: two old-schema dimension tables both gain scope columns; a prefix-sharing companion table is left untouched; a missing active table is swallowed.
- `uv run python -m pytest tests/unit/ -q`: 2039 passed, 10 skipped.
- black 100 / isort (black profile) / ruff clean on changed files.
- e2e `test_2p1_local_384_embeddings` passes against local Postgres.
- e2e `run_random_tests.py 5`: memory/mcp/artifacts/skills areas pass; the two observed failures are unrelated (`test_18c_pii_redaction_observability` fails identically on develop without this change, `test_routing_confirmed` is LLM-flaky and passes on rerun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)