### PR TITLE
fix: implement should_emit on e2e CapturingLogger fakes so observe() emits again

### DIFF
--- a/e2e/tests/18_observability/test_18c_pii_redaction_observability.py
+++ b/e2e/tests/18_observability/test_18c_pii_redaction_observability.py
@@ -50,6 +50,10 @@ class CapturingLogger:
         self._events = []
         self._lock = threading.Lock()
 
+    def should_emit(self, event_type, level):
+        """Pre-check observe() calls before redaction/emission; capture everything."""
+        return True
+
     def emit_event(
         self,
         event_type=None,

--- a/e2e/tests/18_observability/test_18d_pii_redaction_chat.py
+++ b/e2e/tests/18_observability/test_18d_pii_redaction_chat.py
@@ -39,6 +39,10 @@ class CapturingLogger:
         self._events = []
         self._lock = threading.Lock()
 
+    def should_emit(self, event_type, level):
+        """Pre-check observe() calls before redaction/emission; capture everything."""
+        return True
+
     def emit_event(
         self,
         event_type=None,


### PR DESCRIPTION
## Problem

`e2e/tests/18_observability/test_18c_pii_redaction_observability.py` fails on develop with:

```
AssertionError: no events were captured from the observe() pipeline
```

## Root cause (test bug, not a runtime bug)

PR #196 (`6650f581`, perf: drop filtered observability events before redaction) added a pre-check in `observe()`:

```python
if not configured_logger.should_emit(event_type, level):
    return
```

The `CapturingLogger` fakes in tests 18c and 18d were written against the pre-#196 contract (from PR #186) and only implement `emit_event()`. The missing `should_emit()` raises `AttributeError` inside `observe()`, which is swallowed by its blanket `except Exception: pass`, so the pipeline silently emits nothing and the tests capture zero events.

The runtime itself is unaffected: the real `EventLogger` implements `should_emit()` (`src/muxi/runtime/services/observability/logger.py:139`), and redaction behavior is unchanged.

## Fix

Add `should_emit()` returning `True` to both tests' `CapturingLogger` fakes, bringing them in line with the current EventLogger duck-type contract. Test 18d had the same latent bug and is fixed in the same way.

## Verification

- `test_18c_pii_redaction_observability.py`: SUCCESS (1 event captured per case; secret/card/email/SSN redacted; entity layer on/off both verified)
- `test_18d_pii_redaction_chat.py`: SUCCESS (44 events captured during a real chat turn; no raw secret/email/name leaks)
- `test_init_formatting_success.py`: 4/4 pass; `test_init_formatting_failures.py`: 3/3 pass
- `uv run python -m pytest tests/unit/ -q`: 2083 passed, 10 skipped
- black / isort (profile=black) / ruff (line-length 120) clean on changed files
- `e2e/run_random_tests.py 5`: 5/5 pass (1_foundation, 2_memory, 3_multimodal x2, 7_orchestration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)