### PR TITLE
feat: bundled compute skill

### DIFF
--- a/e2e/tests/21_skills/test_21c4_compute_skill.py
+++ b/e2e/tests/21_skills/test_21c4_compute_skill.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Test 21c4: Compute skill (code as a reasoning primitive) via RCE.
+
+Verifies that the bundled compute skill loads as a built-in, that its
+executor runs agent-written Python through the RCE sandbox, that failures
+(runtime errors, import policy violations) surface to the agent, and that
+an agent can activate the skill through overlord.chat() and return a
+computed value without narrating code.
+
+Requires: Skills RCE server running on localhost:7891.
+"""
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Skip if RCE server is not running
+try:
+    import httpx
+
+    resp = httpx.get("http://localhost:7891/health", timeout=2)
+    if resp.status_code != 200:
+        print("SKIP: RCE server not healthy on localhost:7891")
+        sys.exit(0)
+except Exception:
+    print("SKIP: RCE server not running on localhost:7891")
+    sys.exit(0)
+
+from common import BaseE2ETest, TestOutputFormatter, TestTimeouts  # noqa: E402
+
+STDEV_CODE = (
+    "import statistics\n"
+    "values = [12, 7, 3, 21, 9]\n"
+    "print(round(statistics.stdev(values), 2))\n"
+)
+
+
+class TestComputeSkill(BaseE2ETest):
+    def __init__(self):
+        super().__init__(
+            test_name="test_21c4_compute_skill",
+            test_description="Verify bundled compute skill executes agent code via RCE",
+            test_area="21_skills",
+        )
+
+    async def test_compute_skill(self):
+        formatter = TestOutputFormatter()
+        start_time = time.time()
+        checks = []
+        transcript = []
+
+        formatter.print_test_header(
+            test_name=self.test_name,
+            description=self.test_description,
+        )
+
+        try:
+            # 1. Load formation with RCE config (compute is a built-in, no declaration needed)
+            print("\n1. Loading formation with RCE config...")
+            formation_path = Path(__file__).parent / "formations" / "formation-skills-rce"
+            await self.setup_formation(formation_path=formation_path)
+            overlord = self.overlord
+            skill_manager = self.formation._skill_manager
+            rce_client = getattr(self.formation, "_rce_client", None)
+
+            assert rce_client is not None, "RCE client not initialized"
+            assert "compute" in skill_manager.skills, "compute built-in not loaded"
+            assert "compute" in skill_manager._builtin_skills, "compute not marked builtin"
+            print(f"   RCE connected: v{rce_client.status.version}")
+            checks.append("Formation loaded; compute built-in present")
+
+            # 2. Verify compute is executable via run_skill with input_files support
+            print("\n2. Checking run_skill tool exposes compute...")
+            run_tool = skill_manager.build_run_skill_tool("general-agent")
+            assert run_tool is not None, "run_skill tool not built"
+            props = run_tool["function"]["parameters"]["properties"]
+            enum = props["skill_name"]["enum"]
+            assert "compute" in enum, f"compute not in run_skill enum: {enum}"
+            assert "input_files" in props, "input_files missing from run_skill schema"
+            checks.append("compute in run_skill enum with input_files support")
+
+            # 3. Direct execution: compute a standard deviation through RCE
+            print("\n3. Direct compute execution (stdev)...")
+            agent = overlord.agents.get("general-agent")
+            assert agent is not None, "general-agent not found"
+
+            result = await agent.invoke_tool(
+                tool_name="run_skill",
+                parameters={
+                    "skill_name": "compute",
+                    "command": "python3 scripts/run_python.py main.py",
+                    "input_files": {"main.py": STDEV_CODE},
+                },
+            )
+            print(f"   Result: {result}")
+            assert result.get("status") == "success", f"Expected success, got: {result}"
+            assert (
+                result.get("stdout", "").strip() == "6.77"
+            ), f"Unexpected stdout: {result.get('stdout')!r}"
+            checks.append("Direct compute execution returned 6.77")
+
+            # 4. Runtime error is surfaced (agent can see the traceback and refine)
+            print("\n4. Broken code surfaces a runtime error...")
+            result = await agent.invoke_tool(
+                tool_name="run_skill",
+                parameters={
+                    "skill_name": "compute",
+                    "command": "python3 scripts/run_python.py main.py",
+                    "input_files": {"main.py": "print(1 / 0)\n"},
+                },
+            )
+            print(f"   Status: {result.get('status')}, stderr: {result.get('stderr', '')[:120]}")
+            assert result.get("status") != "success", f"Expected failure, got: {result}"
+            assert "ZeroDivisionError" in result.get(
+                "stderr", ""
+            ), f"Traceback not surfaced: {result.get('stderr')!r}"
+            checks.append("Runtime error surfaced with traceback")
+
+            # 5. Import policy violation is surfaced distinctly
+            print("\n5. Disallowed import is rejected...")
+            result = await agent.invoke_tool(
+                tool_name="run_skill",
+                parameters={
+                    "skill_name": "compute",
+                    "command": "python3 scripts/run_python.py main.py",
+                    "input_files": {"main.py": "import socket\nprint('x')\n"},
+                },
+            )
+            assert result.get("status") != "success", f"Expected failure, got: {result}"
+            assert "ImportPolicyViolation" in result.get(
+                "stderr", ""
+            ), f"Policy violation not surfaced: {result.get('stderr')!r}"
+            checks.append("Import policy violation surfaced distinctly")
+
+            # 6. LLM-driven path: agent activates compute and answers with the value
+            print("\n6. Compute via overlord.chat()...")
+            compute_calls = []
+            original_run_skill = rce_client.run_skill
+
+            async def counting_run_skill(skill_id, command, **kwargs):
+                exec_result = await original_run_skill(skill_id, command, **kwargs)
+                compute_calls.append((skill_id, exec_result.status, exec_result.stdout.strip()))
+                return exec_result
+
+            rce_client.run_skill = counting_run_skill
+
+            timeout = TestTimeouts.get_timeout("simple_chat") + 60
+            response = await asyncio.wait_for(
+                overlord.chat(
+                    "Use the compute skill for this: what is the sample standard "
+                    "deviation of these values: 12, 7, 3, 21, 9? "
+                    "Report the value rounded to two decimals.",
+                    user_id="test_user",
+                ),
+                timeout=timeout,
+            )
+            rce_client.run_skill = original_run_skill
+            response_text = response.content if hasattr(response, "content") else str(response)
+            print(f"   Response: {response_text[:200]}...")
+            transcript.append(("Stdev via compute skill", response_text[:200]))
+
+            print(f"   Compute calls during chat: {compute_calls}")
+            successful = [
+                c for c in compute_calls if c[0] == "compute" and c[1] == "success" and c[2]
+            ]
+            assert successful, (
+                f"compute skill produced no successful output via RCE during chat "
+                f"(calls: {compute_calls})"
+            )
+            checks.append("Agent executed compute skill through RCE during chat")
+
+            if "6.77" in response_text or "6.8" in response_text:
+                checks.append("Response contains the computed value")
+            else:
+                checks.append(
+                    f"WARNING: computed value not found in response: {response_text[:100]}"
+                )
+
+            if "```" not in response_text and "run_python" not in response_text:
+                checks.append("Response does not narrate code")
+            else:
+                checks.append("WARNING: response narrates code or sandbox details")
+
+            # 7. Cleanup
+            print("\n7. Cleaning up...")
+            try:
+                await rce_client.delete_skill("compute")
+            except Exception:
+                pass
+            await rce_client.close()
+            await self.cleanup_formation()
+            checks.append("Clean shutdown")
+
+            duration = time.time() - start_time
+            formatter.print_test_result(
+                test_name=self.test_name,
+                success=True,
+                checks=checks,
+                transcript=transcript,
+                duration=duration,
+            )
+            return True
+
+        except Exception as e:
+            duration = time.time() - start_time
+            formatter.print_test_result(
+                test_name=self.test_name,
+                success=False,
+                checks=checks + [f"FAILED: {e}"],
+                transcript=transcript,
+                duration=duration,
+            )
+            try:
+                rce_client = getattr(self.formation, "_rce_client", None)
+                if rce_client:
+                    await rce_client.close()
+                await self.cleanup_formation()
+            except Exception:
+                pass
+            return False
+
+
+if __name__ == "__main__":
+    test = TestComputeSkill()
+    result = asyncio.run(test.test_compute_skill())
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0 if result else 1)

--- a/src/muxi/runtime/datatypes/observability.py
+++ b/src/muxi/runtime/datatypes/observability.py
@@ -922,6 +922,18 @@ class ConversationEvents(Enum):
     # When agent creates execution plan
 
     # ===================================================================
+    # COMPUTE SKILL (code as a reasoning primitive)
+    # ===================================================================
+    COMPUTATION_REQUESTED = "computation.requested"
+    # When an agent invokes the compute skill executor (run_python)
+
+    COMPUTATION_COMPLETED = "computation.completed"
+    # When a compute skill execution returns successfully (exit_code == 0)
+
+    COMPUTATION_FAILED = "computation.failed"
+    # When a compute skill execution fails (runtime error, timeout, or policy violation)
+
+    # ===================================================================
     # PROMPT FORMATION & ENHANCEMENT
     # ===================================================================
     PROMPT_FORMATION_ENHANCEMENT_STARTED = "prompt.formation.enhancement.started"

--- a/src/muxi/runtime/formation/agents/agent.py
+++ b/src/muxi/runtime/formation/agents/agent.py
@@ -5975,8 +5975,17 @@ class Agent:
                     planning_prompt += (
                         "\nSkills with scripts can be executed using the run_skill tool. "
                         "Use activate_skill first to load instructions, then run_skill "
-                        "to execute the script (e.g., command: 'python3 scripts/run.py').\n"
+                        "to execute the script. The command parameter must invoke one of "
+                        "the skill's scripts; raw code in command WILL BE REJECTED. "
+                        "Deliver code or data files via the input_files parameter.\n"
                     )
+                    if "compute" in available_skill_names:
+                        planning_prompt += (
+                            "Example run_skill parameters for the compute skill: "
+                            '{"skill_name": "compute", "command": '
+                            '"python3 scripts/run_python.py main.py", "input_files": '
+                            '{"main.py": "<complete python source>"}}\n'
+                        )
                 planning_prompt += "\n"
 
         from ..prompts.loader import PromptLoader

--- a/src/muxi/runtime/formation/agents/skill_dispatch.py
+++ b/src/muxi/runtime/formation/agents/skill_dispatch.py
@@ -88,6 +88,7 @@ async def run_skill_command(
     rce: Any,
     skill_name: str,
     command: str,
+    input_files: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
     """Execute a skill command via RCE without streaming/observability coupling.
 
@@ -102,7 +103,13 @@ async def run_skill_command(
     await rce.ensure_cached(skill_name, metadata.base_dir, content_hash)
 
     skill_env = await skill_manager.resolve_skill_env(skill_name)
-    result = await rce.run_skill(skill_name, command, timeout=60, env=skill_env or None)
+    result = await rce.run_skill(
+        skill_name,
+        command,
+        input_files=input_files or None,
+        timeout=60,
+        env=skill_env or None,
+    )
 
     response: Dict[str, Any] = {
         "status": result.status,
@@ -126,6 +133,95 @@ async def run_skill_command(
     return response
 
 
+def _coerce_input_files(raw: Any) -> Optional[Dict[str, str]]:
+    """Normalise the run_skill input_files parameter to a str->str map."""
+    if not isinstance(raw, dict) or not raw:
+        return None
+    return {
+        str(name): content if isinstance(content, str) else str(content)
+        for name, content in raw.items()
+    }
+
+
+_COMPUTE_SKILL_NAME = "compute"
+_COMPUTE_EVENT_OUTPUT_LIMIT = 16384
+_COMPUTE_EXECUTOR = "scripts/run_python.py"
+
+
+def _normalize_compute_parameters(
+    command: str,
+    input_files: Optional[Dict[str, str]],
+) -> tuple:
+    """Recover malformed compute invocations instead of failing them opaquely.
+
+    LLM planners sometimes put raw Python in ``command`` (the only sanctioned
+    compute command is the bundled executor). Move such code into input_files
+    and invoke the executor; likewise, point an argument-less executor command
+    at the first provided Python input file.
+    """
+    stripped = command.strip()
+    if _COMPUTE_EXECUTOR in stripped:
+        if stripped.endswith(_COMPUTE_EXECUTOR) and input_files:
+            main = next((n for n in input_files if n.endswith(".py")), None)
+            if main:
+                return f"{stripped} {main}", input_files
+        return command, input_files
+    if input_files:
+        main = next((n for n in input_files if n.endswith(".py")), None)
+        if main:
+            return f"python3 {_COMPUTE_EXECUTOR} {main}", input_files
+        return command, input_files
+    return f"python3 {_COMPUTE_EXECUTOR} main.py", {"main.py": command}
+
+
+def _compute_failure_kind(response: Dict[str, Any]) -> str:
+    """Classify a failed compute execution for COMPUTATION_FAILED events."""
+    if response.get("status") == "timeout":
+        return "timeout"
+    stderr = response.get("stderr", "") or ""
+    if "ImportPolicyViolation:" in stderr:
+        return "import_violation"
+    if "PathValidationError:" in stderr:
+        return "path_violation"
+    return "runtime_error"
+
+
+def _observe_compute_result(
+    agent_id: str,
+    response: Dict[str, Any],
+    input_files: Optional[Dict[str, str]],
+) -> None:
+    """Emit COMPUTATION_COMPLETED/COMPUTATION_FAILED for a compute skill run."""
+    code = "\n".join((input_files or {}).values())
+    if response.get("status") == "success":
+        observability.observe(
+            event_type=observability.ConversationEvents.COMPUTATION_COMPLETED,
+            level=observability.EventLevel.INFO,
+            data={
+                "agent_id": agent_id,
+                "code": code,
+                "stdout": (response.get("stdout", "") or "")[:_COMPUTE_EVENT_OUTPUT_LIMIT],
+                "execution_time_ms": response.get("duration_ms"),
+                "artifact_count": len(response.get("artifacts", [])),
+            },
+            description=f"Computation completed for agent '{agent_id}'",
+        )
+    else:
+        failure_kind = _compute_failure_kind(response)
+        observability.observe(
+            event_type=observability.ConversationEvents.COMPUTATION_FAILED,
+            level=observability.EventLevel.WARNING,
+            data={
+                "agent_id": agent_id,
+                "code": code,
+                "stderr": (response.get("stderr", "") or "")[:_COMPUTE_EVENT_OUTPUT_LIMIT],
+                "failure_kind": failure_kind,
+                "exit_code": response.get("exit_code"),
+            },
+            description=f"Computation failed for agent '{agent_id}' ({failure_kind})",
+        )
+
+
 async def handle_run_skill(
     agent_id: str,
     parameters: Dict[str, Any],
@@ -134,8 +230,12 @@ async def handle_run_skill(
     """Handle the run_skill tool call via RCE."""
     skill_name = parameters.get("skill_name", "")
     command = parameters.get("command", "")
+    input_files = _coerce_input_files(parameters.get("input_files"))
     manager = overlord.skill_manager
     rce = overlord.rce_client
+    is_compute = skill_name == _COMPUTE_SKILL_NAME
+    if is_compute:
+        command, input_files = _normalize_compute_parameters(command, input_files)
 
     try:
         streaming.stream(
@@ -148,7 +248,24 @@ async def handle_run_skill(
             skip_rephrase=True,
         )
 
-        response = await run_skill_command(manager, rce, skill_name, command)
+        if is_compute:
+            observability.observe(
+                event_type=observability.ConversationEvents.COMPUTATION_REQUESTED,
+                level=observability.EventLevel.INFO,
+                data={
+                    "agent_id": agent_id,
+                    "file_names": sorted(input_files) if input_files else [],
+                    "code_size_bytes": sum(len(c.encode()) for c in (input_files or {}).values()),
+                },
+                description=f"Computation requested by agent '{agent_id}'",
+            )
+
+        response = await run_skill_command(
+            manager, rce, skill_name, command, input_files=input_files
+        )
+
+        if is_compute:
+            _observe_compute_result(agent_id, response, input_files)
 
         observability.observe(
             event_type=observability.ConversationEvents.AGENT_MESSAGE_PROCESSING,
@@ -168,6 +285,18 @@ async def handle_run_skill(
         return response
 
     except Exception as e:
+        if is_compute:
+            observability.observe(
+                event_type=observability.ConversationEvents.COMPUTATION_FAILED,
+                level=observability.EventLevel.WARNING,
+                data={
+                    "agent_id": agent_id,
+                    "code": "\n".join((input_files or {}).values()),
+                    "stderr": str(e),
+                    "failure_kind": "service_error",
+                },
+                description=f"Computation failed for agent '{agent_id}' (service_error)",
+            )
         observability.observe(
             event_type=observability.ErrorEvents.SERVICE_UNAVAILABLE,
             level=observability.EventLevel.ERROR,

--- a/src/muxi/runtime/formation/agents/skill_dispatch.py
+++ b/src/muxi/runtime/formation/agents/skill_dispatch.py
@@ -181,6 +181,8 @@ def _compute_failure_kind(response: Dict[str, Any]) -> str:
     stderr = response.get("stderr", "") or ""
     if "ImportPolicyViolation:" in stderr:
         return "import_violation"
+    if "SyntaxValidationError:" in stderr:
+        return "syntax_error"
     if "PathValidationError:" in stderr:
         return "path_violation"
     return "runtime_error"

--- a/src/muxi/runtime/formation/skills/builtin/compute/SKILL.md
+++ b/src/muxi/runtime/formation/skills/builtin/compute/SKILL.md
@@ -54,8 +54,10 @@ The result contains `status`, `exit_code`, `stdout`, `stderr`, and
 On failure (`status` is not `success`), inspect `stderr`:
 
 - A Python traceback means your code ran and raised. Fix the code and retry.
-- `ImportPolicyViolation:` means you used a disallowed import. Rewrite with
-  allowed imports only.
+- `SyntaxValidationError:` means the file failed to parse. Fix the syntax
+  and retry; the imports are not the problem.
+- `ImportPolicyViolation:` means you used a disallowed import or builtin.
+  Rewrite with allowed imports only.
 - `PathValidationError:` means the file path was rejected. Use a plain
   relative filename such as `main.py`.
 

--- a/src/muxi/runtime/formation/skills/builtin/compute/SKILL.md
+++ b/src/muxi/runtime/formation/skills/builtin/compute/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: compute
+description: "Use Python execution to compute precise answers when in-context reasoning is unreliable (arithmetic, date math, regex, parsing, data manipulation). Returns a value, not an artifact."
+license: Apache-2.0
+compatibility: ">=1.0"
+allowed-tools: run_skill
+---
+
+# Compute
+
+Use Python execution as a reasoning step. Write a small self-contained program,
+run it in the sandbox, and read the printed answer back into your reasoning.
+The user gets an answer, never code.
+
+## When to activate
+
+- Precise multi-step arithmetic (totals, percentages, compound interest)
+- Date and time arithmetic (durations, business days, time zones)
+- Regex and structured-text parsing
+- Aggregations over more than a handful of rows
+- Numerical work (statistics, percentiles, standard deviation)
+- Format conversions (encoding, hashing, base conversions)
+
+Do NOT use this skill:
+
+- When a dedicated tool or MCP already answers the question
+- For natural-language reasoning, judgment, or writing
+- To produce user-facing files (use the `generate_file` tool instead)
+
+## Contract
+
+Write ONE self-contained Python file that:
+
+1. Imports only from the allowed list below.
+2. Prints the answer to stdout. Scalar result: print the value directly.
+   Structured result: print a single JSON object via `json.dumps`.
+   (A trailing bare expression is echoed automatically, REPL-style, but
+   prefer an explicit print.)
+3. Contains no explanatory comments or prose. The file is code, not narration.
+4. Writes no files unless a side-effect artifact is intended (any file created
+   in the working directory is auto-registered as an artifact).
+
+## Invocation
+
+Call the `run_skill` tool:
+
+- `skill_name`: `compute`
+- `command`: `python3 scripts/run_python.py main.py`
+- `input_files`: `{"main.py": "<your Python source>"}`
+
+The result contains `status`, `exit_code`, `stdout`, `stderr`, and
+`duration_ms`. Read the answer from `stdout`.
+
+On failure (`status` is not `success`), inspect `stderr`:
+
+- A Python traceback means your code ran and raised. Fix the code and retry.
+- `ImportPolicyViolation:` means you used a disallowed import. Rewrite with
+  allowed imports only.
+- `PathValidationError:` means the file path was rejected. Use a plain
+  relative filename such as `main.py`.
+
+Retry at most twice with a fixed or different approach. If it still fails,
+report the failure plainly; do not loop.
+
+If stdout looks truncated, rewrite the script to print a compact summary or
+write the bulk output to a file (it becomes an artifact) and print only the
+key result.
+
+## Allowed imports
+
+Most common: `json`, `math`, `datetime`, `re`, `statistics`, `csv`,
+`pandas`, `numpy`.
+
+Also allowed: `scipy`, `statsmodels`, `dateutil`, `decimal`, `fractions`,
+`random`, `cmath`, `time`, `calendar`, `zoneinfo`, `collections`,
+`itertools`, `functools`, `operator`, `string`, `textwrap`, `unicodedata`,
+`io`, `base64`, `hashlib`, `binascii`, `struct`, `uuid`, `heapq`, `bisect`,
+`array`.
+
+No networking, no filesystem access outside the working directory, no
+subprocesses. Execution is sandboxed with a hard timeout.
+
+## Examples
+
+Worked examples ship with this skill under `references/`:
+
+- `references/arithmetic.md` - compound interest to the cent
+- `references/date-math.md` - timezone-aware date arithmetic
+- `references/regex-parsing.md` - extracting values from raw text
+- `references/data-aggregation.md` - grouped statistics over rows
+
+## Response style
+
+Never show the code, the file path, or sandbox details in your response
+unless the user explicitly asks for them. Report the computed answer as a
+plain statement, e.g. "The standard deviation is 6.24."

--- a/src/muxi/runtime/formation/skills/builtin/compute/references/arithmetic.md
+++ b/src/muxi/runtime/formation/skills/builtin/compute/references/arithmetic.md
@@ -1,0 +1,34 @@
+# Example: Precise Arithmetic
+
+**Question:** "If I invest $12,500 at 4.35% compounded monthly, what is it worth after 7 years?"
+
+**File to write (`main.py`):**
+
+```python
+principal = 12500.0
+rate = 0.0435
+n = 12
+years = 7
+
+amount = principal * (1 + rate / n) ** (n * years)
+print(f"{amount:.2f}")
+```
+
+**Invocation:**
+
+```
+run_skill(
+    skill_name="compute",
+    command="python3 scripts/run_python.py main.py",
+    input_files={"main.py": "<the code above>"},
+)
+```
+
+**Expected stdout:**
+
+```
+16940.01
+```
+
+**Using the result:** Report the value in the answer: "After 7 years the
+investment would be worth $16,940.01." Do not show the code.

--- a/src/muxi/runtime/formation/skills/builtin/compute/references/data-aggregation.md
+++ b/src/muxi/runtime/formation/skills/builtin/compute/references/data-aggregation.md
@@ -1,0 +1,32 @@
+# Example: Data Aggregation
+
+**Question:** "Given these sales rows, what is the average order value per region?" (rows supplied in the conversation)
+
+**File to write (`main.py`):**
+
+```python
+import json
+import pandas as pd
+
+rows = [
+    {"region": "north", "amount": 120.50},
+    {"region": "south", "amount": 89.99},
+    {"region": "north", "amount": 240.00},
+    {"region": "east", "amount": 55.25},
+    {"region": "south", "amount": 310.10},
+]
+
+df = pd.DataFrame(rows)
+avg = df.groupby("region")["amount"].mean().round(2)
+print(json.dumps(avg.to_dict()))
+```
+
+**Expected stdout:**
+
+```
+{"east": 55.25, "north": 180.25, "south": 200.04}
+```
+
+**Using the result:** "Average order value: North $180.25, South $200.04,
+East $55.25." For plain statistics without grouping, the `statistics`
+module is enough - reach for pandas only when rows and grouping are involved.

--- a/src/muxi/runtime/formation/skills/builtin/compute/references/date-math.md
+++ b/src/muxi/runtime/formation/skills/builtin/compute/references/date-math.md
@@ -1,0 +1,30 @@
+# Example: Date Math
+
+**Question:** "A meeting starts 2026-03-27 09:30 in New York. What time is that in Tokyo, and how many days away is it from 2026-01-15?"
+
+**File to write (`main.py`):**
+
+```python
+import json
+from datetime import datetime, date
+from zoneinfo import ZoneInfo
+
+start_ny = datetime(2026, 3, 27, 9, 30, tzinfo=ZoneInfo("America/New_York"))
+start_tokyo = start_ny.astimezone(ZoneInfo("Asia/Tokyo"))
+days_away = (start_ny.date() - date(2026, 1, 15)).days
+
+print(json.dumps({
+    "tokyo_time": start_tokyo.isoformat(),
+    "days_from_jan_15": days_away,
+}))
+```
+
+**Expected stdout:**
+
+```
+{"tokyo_time": "2026-03-27T22:30:00+09:00", "days_from_jan_15": 71}
+```
+
+**Using the result:** "In Tokyo the meeting starts at 22:30 on March 27,
+which is 71 days after January 15." Structured results print one JSON
+object so each field can be read unambiguously.

--- a/src/muxi/runtime/formation/skills/builtin/compute/references/regex-parsing.md
+++ b/src/muxi/runtime/formation/skills/builtin/compute/references/regex-parsing.md
@@ -1,0 +1,39 @@
+# Example: Regex Parsing
+
+**Question:** "How many unique error codes appear in this log excerpt, and which is most frequent?" (log text supplied in the conversation)
+
+**File to write (`main.py`):**
+
+```python
+import json
+import re
+from collections import Counter
+
+log = """\
+2026-05-01 12:00:01 ERR-4102 timeout on upstream
+2026-05-01 12:00:04 ERR-2201 invalid payload
+2026-05-01 12:00:09 ERR-4102 timeout on upstream
+2026-05-01 12:01:13 ERR-7300 quota exceeded
+2026-05-01 12:02:44 ERR-4102 timeout on upstream
+"""
+
+codes = re.findall(r"ERR-\d{4}", log)
+counts = Counter(codes)
+top_code, top_count = counts.most_common(1)[0]
+
+print(json.dumps({
+    "unique_codes": len(counts),
+    "most_frequent": top_code,
+    "occurrences": top_count,
+}))
+```
+
+**Expected stdout:**
+
+```
+{"unique_codes": 3, "most_frequent": "ERR-4102", "occurrences": 3}
+```
+
+**Using the result:** "There are 3 unique error codes; ERR-4102 is the most
+frequent with 3 occurrences." Embed the data to parse directly in the file
+as a literal - the script has no access to the conversation.

--- a/src/muxi/runtime/formation/skills/builtin/compute/scripts/run_python.py
+++ b/src/muxi/runtime/formation/skills/builtin/compute/scripts/run_python.py
@@ -13,6 +13,7 @@ Usage:
 Exit code mirrors the executed file's exit code. Errors detected before
 execution are reported on stderr with a machine-readable prefix:
     PathValidationError: ...
+    SyntaxValidationError: ...
     ImportPolicyViolation: ...
 """
 
@@ -141,29 +142,51 @@ def transform_trailing_expression(tree: ast.Module) -> str:
     return ast.unparse(tree)
 
 
+def _attribute_root_name(node: ast.AST) -> str:
+    """Walk an attribute chain (e.g. eval.__call__.__call__) to its root Name id."""
+    while isinstance(node, ast.Attribute):
+        node = node.value
+    return node.id if isinstance(node, ast.Name) else ""
+
+
 def validate_code(code: str) -> tuple:
-    """AST-validate imports and dangerous builtins. Returns (ok, error, tree)."""
+    """AST-validate syntax, imports, and dangerous builtins.
+
+    Returns (ok, prefixed error message, tree). Error messages carry a
+    machine-readable prefix so the agent can tell syntax problems apart
+    from policy violations.
+    """
     try:
         tree = ast.parse(code)
     except SyntaxError as e:
-        return False, f"Syntax error: {e}", None
+        return False, f"SyntaxValidationError: {e}", None
 
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
                 mod = alias.name.split(".")[0]
                 if mod not in ALLOWED_IMPORTS:
-                    return False, f"import not allowed: {alias.name}", None
+                    return False, f"ImportPolicyViolation: import not allowed: {alias.name}", None
         elif isinstance(node, ast.ImportFrom):
             if node.module:
                 mod = node.module.split(".")[0]
                 if mod not in ALLOWED_IMPORTS:
-                    return False, f"import not allowed: {node.module}", None
+                    return False, f"ImportPolicyViolation: import not allowed: {node.module}", None
         elif isinstance(node, ast.Call):
             if isinstance(node.func, ast.Name) and node.func.id in DANGEROUS_FUNCS:
-                return False, f"function not allowed: {node.func.id}", None
-            elif isinstance(node.func, ast.Attribute) and node.func.attr in DANGEROUS_FUNCS:
-                return False, f"attribute not allowed: {node.func.attr}", None
+                return False, f"ImportPolicyViolation: function not allowed: {node.func.id}", None
+            elif isinstance(node.func, ast.Attribute):
+                if node.func.attr in DANGEROUS_FUNCS:
+                    return (
+                        False,
+                        f"ImportPolicyViolation: attribute not allowed: {node.func.attr}",
+                        None,
+                    )
+                # Catch dangerous builtins invoked through attribute chains,
+                # e.g. eval.__call__(...) or exec.__call__.__call__(...)
+                root = _attribute_root_name(node.func)
+                if root in DANGEROUS_FUNCS:
+                    return False, f"ImportPolicyViolation: function not allowed: {root}", None
 
     return True, None, tree
 
@@ -185,7 +208,7 @@ def main():
 
     valid, error, tree = validate_code(code)
     if not valid:
-        print(f"ImportPolicyViolation: {error}", file=sys.stderr)
+        print(error, file=sys.stderr)
         sys.exit(2)
 
     # REPL semantics: a trailing bare expression is echoed to stdout

--- a/src/muxi/runtime/formation/skills/builtin/compute/scripts/run_python.py
+++ b/src/muxi/runtime/formation/skills/builtin/compute/scripts/run_python.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+Compute skill executor for RCE execution.
+
+Runs a self-contained Python file written by the agent (delivered as an
+input file into the sandbox working directory), after validating the path
+and the import policy. Sandboxing, ulimits, and subprocess isolation are
+provided by the Skill RCE service; this script does not duplicate them.
+
+Usage:
+    python3 scripts/run_python.py main.py
+
+Exit code mirrors the executed file's exit code. Errors detected before
+execution are reported on stderr with a machine-readable prefix:
+    PathValidationError: ...
+    ImportPolicyViolation: ...
+"""
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+ALLOWED_IMPORTS = {
+    # Most common (inlined in SKILL.md)
+    "json",
+    "math",
+    "datetime",
+    "re",
+    "statistics",
+    "csv",
+    "pandas",
+    "numpy",
+    # Scientific / data
+    "scipy",
+    "statsmodels",
+    "dateutil",
+    # Numbers, time, text
+    "decimal",
+    "fractions",
+    "random",
+    "cmath",
+    "time",
+    "calendar",
+    "zoneinfo",
+    "collections",
+    "itertools",
+    "functools",
+    "operator",
+    "string",
+    "textwrap",
+    "unicodedata",
+    # Encoding / hashing / binary
+    "io",
+    "base64",
+    "hashlib",
+    "binascii",
+    "struct",
+    "uuid",
+    # Data structures
+    "heapq",
+    "bisect",
+    "array",
+}
+
+DANGEROUS_FUNCS = {
+    "exec",
+    "eval",
+    "compile",
+    "__import__",
+    "getattr",
+    "setattr",
+    "delattr",
+    "hasattr",
+    "vars",
+    "dir",
+    "globals",
+    "locals",
+}
+
+EXECUTION_TIMEOUT = 60
+
+
+def validate_path(raw_path: str) -> tuple:
+    """Validate that the target file is a plain file inside the working directory.
+
+    Rejects absolute paths, path traversal components, and symlinks.
+    Returns (path or None, error message or None).
+    """
+    candidate = Path(raw_path)
+
+    if candidate.is_absolute():
+        return None, f"absolute paths are not allowed: {raw_path}"
+    if ".." in candidate.parts:
+        return None, f"path traversal is not allowed: {raw_path}"
+
+    workdir = Path.cwd().resolve()
+    full = workdir / candidate
+
+    # Reject symlinks at the target or any intermediate component
+    probe = full
+    while probe != workdir and probe != probe.parent:
+        if probe.is_symlink():
+            return None, f"symlinks are not allowed: {raw_path}"
+        probe = probe.parent
+
+    if not full.is_file():
+        return None, f"file not found: {raw_path}"
+
+    resolved = full.resolve()
+    if not resolved.is_relative_to(workdir):
+        return None, f"path escapes the working directory: {raw_path}"
+
+    return full, None
+
+
+def transform_trailing_expression(tree: ast.Module) -> str:
+    """Give the file REPL semantics: echo the value of a trailing bare expression.
+
+    Returns transformed source, or an empty string when no transform applies
+    (no trailing expression, a docstring, or an explicit print call).
+    """
+    last = tree.body[-1] if tree.body else None
+    if not isinstance(last, ast.Expr):
+        return ""
+    value = last.value
+    if isinstance(value, ast.Constant) and isinstance(value.value, str):
+        return ""
+    if (
+        isinstance(value, ast.Call)
+        and isinstance(value.func, ast.Name)
+        and value.func.id == "print"
+    ):
+        return ""
+
+    assign = ast.parse("_muxi_result = None").body[0]
+    assign.value = value
+    guard = ast.parse("if _muxi_result is not None:\n    print(_muxi_result)").body[0]
+    tree.body[-1:] = [assign, guard]
+    ast.fix_missing_locations(tree)
+    return ast.unparse(tree)
+
+
+def validate_code(code: str) -> tuple:
+    """AST-validate imports and dangerous builtins. Returns (ok, error, tree)."""
+    try:
+        tree = ast.parse(code)
+    except SyntaxError as e:
+        return False, f"Syntax error: {e}", None
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                mod = alias.name.split(".")[0]
+                if mod not in ALLOWED_IMPORTS:
+                    return False, f"import not allowed: {alias.name}", None
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                mod = node.module.split(".")[0]
+                if mod not in ALLOWED_IMPORTS:
+                    return False, f"import not allowed: {node.module}", None
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name) and node.func.id in DANGEROUS_FUNCS:
+                return False, f"function not allowed: {node.func.id}", None
+            elif isinstance(node.func, ast.Attribute) and node.func.attr in DANGEROUS_FUNCS:
+                return False, f"attribute not allowed: {node.func.attr}", None
+
+    return True, None, tree
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("PathValidationError: usage: run_python.py <file>", file=sys.stderr)
+        sys.exit(2)
+
+    path, error = validate_path(sys.argv[1])
+    if error:
+        print(f"PathValidationError: {error}", file=sys.stderr)
+        sys.exit(2)
+
+    code = path.read_text(encoding="utf-8")
+    if not code.strip():
+        print("PathValidationError: file is empty", file=sys.stderr)
+        sys.exit(2)
+
+    valid, error, tree = validate_code(code)
+    if not valid:
+        print(f"ImportPolicyViolation: {error}", file=sys.stderr)
+        sys.exit(2)
+
+    # REPL semantics: a trailing bare expression is echoed to stdout
+    transformed = transform_trailing_expression(tree)
+    exec_path = path
+    temp_path = None
+    if transformed:
+        temp_path = Path("_muxi_exec.py")
+        temp_path.write_text(transformed, encoding="utf-8")
+        exec_path = temp_path
+
+    try:
+        result = subprocess.run(
+            [sys.executable, str(exec_path)],
+            capture_output=True,
+            text=True,
+            timeout=EXECUTION_TIMEOUT,
+            cwd=str(Path.cwd()),
+        )
+    except subprocess.TimeoutExpired:
+        print(f"Error: execution timed out ({EXECUTION_TIMEOUT}s)", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+
+    if result.stdout:
+        sys.stdout.write(result.stdout)
+    if result.stderr:
+        sys.stderr.write(result.stderr)
+    sys.exit(result.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/muxi/runtime/formation/skills/skill_manager.py
+++ b/src/muxi/runtime/formation/skills/skill_manager.py
@@ -267,7 +267,20 @@ class SkillManager:
                             "type": "string",
                             "description": (
                                 "Shell command to run (e.g., 'python3 scripts/run.py input.csv'). "
-                                "Paths are relative to the skill root directory."
+                                "Paths are relative to the skill root directory. Must be an "
+                                "executable command, NEVER raw code; deliver code or data via "
+                                "input_files instead."
+                            ),
+                        },
+                        "input_files": {
+                            "type": "object",
+                            "additionalProperties": {"type": "string"},
+                            "description": (
+                                "Optional map of relative filename to text content. Files are "
+                                "written into the working directory before the command runs. "
+                                "Use this to deliver code or data the command operates on "
+                                "(e.g., command 'python3 scripts/run_python.py main.py' with "
+                                "input_files {'main.py': '<python source>'})."
                             ),
                         },
                     },

--- a/tests/unit/skills/test_compute_executor.py
+++ b/tests/unit/skills/test_compute_executor.py
@@ -1,0 +1,178 @@
+"""Unit tests for the compute skill executor (scripts/run_python.py).
+
+The executor is a standalone script shipped inside the bundled compute skill.
+These tests run it exactly the way the RCE sandbox does: as a subprocess with
+the working directory set to a scratch dir containing the agent's input file.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+EXECUTOR = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "muxi"
+    / "runtime"
+    / "formation"
+    / "skills"
+    / "builtin"
+    / "compute"
+    / "scripts"
+    / "run_python.py"
+)
+
+
+def run_executor(workdir: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(EXECUTOR), *args],
+        capture_output=True,
+        text=True,
+        timeout=90,
+        cwd=str(workdir),
+    )
+
+
+@pytest.fixture
+def workdir(tmp_path):
+    return tmp_path
+
+
+class TestComputeExecutorSuccess:
+    def test_scalar_result(self, workdir):
+        (workdir / "main.py").write_text("print(2**16 + 1)\n")
+        result = run_executor(workdir, "main.py")
+        assert result.returncode == 0
+        assert result.stdout.strip() == "65537"
+
+    def test_json_result(self, workdir):
+        (workdir / "main.py").write_text(
+            "import json\n"
+            "import statistics\n"
+            "values = [12, 7, 3, 21, 9]\n"
+            "print(json.dumps({'stdev': round(statistics.stdev(values), 2)}))\n"
+        )
+        result = run_executor(workdir, "main.py")
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == {"stdev": 6.77}
+
+    def test_allowed_stdlib_imports(self, workdir):
+        (workdir / "main.py").write_text(
+            "import math, datetime, re, csv, decimal, hashlib\n" "print(math.factorial(10))\n"
+        )
+        result = run_executor(workdir, "main.py")
+        assert result.returncode == 0
+        assert result.stdout.strip() == "3628800"
+
+    def test_trailing_expression_echoed_repl_style(self, workdir):
+        (workdir / "main.py").write_text("import statistics\nstatistics.stdev([12, 7, 3, 21, 9])\n")
+        result = run_executor(workdir, "main.py")
+        assert result.returncode == 0
+        assert result.stdout.strip().startswith("6.76")
+        # The transformed helper file is cleaned up, not left as an artifact
+        assert not (workdir / "_muxi_exec.py").exists()
+
+    def test_trailing_none_expression_not_echoed(self, workdir):
+        (workdir / "main.py").write_text("x = [1, 2]\nx.sort()\n")
+        result = run_executor(workdir, "main.py")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_trailing_print_not_double_echoed(self, workdir):
+        (workdir / "main.py").write_text("print(7)\n")
+        result = run_executor(workdir, "main.py")
+        assert result.returncode == 0
+        assert result.stdout.strip() == "7"
+
+
+class TestComputeExecutorRuntimeErrors:
+    def test_runtime_error_surfaces_traceback(self, workdir):
+        (workdir / "main.py").write_text("print(1 / 0)\n")
+        result = run_executor(workdir, "main.py")
+        assert result.returncode != 0
+        assert "ZeroDivisionError" in result.stderr
+        assert "ImportPolicyViolation" not in result.stderr
+        assert "PathValidationError" not in result.stderr
+
+    def test_empty_file_rejected(self, workdir):
+        (workdir / "main.py").write_text("   \n")
+        result = run_executor(workdir, "main.py")
+        assert result.returncode == 2
+        assert "PathValidationError" in result.stderr
+
+
+class TestComputeExecutorImportPolicy:
+    def test_disallowed_import_rejected(self, workdir):
+        (workdir / "main.py").write_text("import socket\nprint('x')\n")
+        result = run_executor(workdir, "main.py")
+        assert result.returncode == 2
+        assert "ImportPolicyViolation" in result.stderr
+        assert "socket" in result.stderr
+
+    def test_disallowed_import_from_rejected(self, workdir):
+        (workdir / "main.py").write_text("from os import getcwd\nprint(getcwd())\n")
+        result = run_executor(workdir, "main.py")
+        assert result.returncode == 2
+        assert "ImportPolicyViolation" in result.stderr
+
+    def test_dangerous_builtin_rejected(self, workdir):
+        (workdir / "main.py").write_text("eval('1+1')\n")
+        result = run_executor(workdir, "main.py")
+        assert result.returncode == 2
+        assert "ImportPolicyViolation" in result.stderr
+        assert "eval" in result.stderr
+
+    def test_syntax_error_rejected(self, workdir):
+        (workdir / "main.py").write_text("def broken(:\n")
+        result = run_executor(workdir, "main.py")
+        assert result.returncode == 2
+        assert "ImportPolicyViolation" in result.stderr
+        assert "Syntax error" in result.stderr
+
+
+class TestComputeExecutorPathValidation:
+    def test_path_traversal_rejected(self, workdir):
+        outside = workdir.parent / "evil.py"
+        outside.write_text("print('escaped')\n")
+        result = run_executor(workdir, "../evil.py")
+        assert result.returncode == 2
+        assert "PathValidationError" in result.stderr
+        assert "escaped" not in result.stdout
+
+    def test_absolute_path_rejected(self, workdir):
+        target = workdir / "main.py"
+        target.write_text("print('abs')\n")
+        result = run_executor(workdir, str(target))
+        assert result.returncode == 2
+        assert "PathValidationError" in result.stderr
+
+    def test_symlink_rejected(self, workdir):
+        outside = workdir.parent / "target.py"
+        outside.write_text("print('via symlink')\n")
+        (workdir / "link.py").symlink_to(outside)
+        result = run_executor(workdir, "link.py")
+        assert result.returncode == 2
+        assert "PathValidationError" in result.stderr
+        assert "via symlink" not in result.stdout
+
+    def test_symlinked_directory_rejected(self, workdir):
+        outside_dir = workdir.parent / "outside"
+        outside_dir.mkdir()
+        (outside_dir / "main.py").write_text("print('via dir symlink')\n")
+        (workdir / "sub").symlink_to(outside_dir)
+        result = run_executor(workdir, "sub/main.py")
+        assert result.returncode == 2
+        assert "PathValidationError" in result.stderr
+
+    def test_missing_file_rejected(self, workdir):
+        result = run_executor(workdir, "missing.py")
+        assert result.returncode == 2
+        assert "PathValidationError" in result.stderr
+
+    def test_no_argument_rejected(self, workdir):
+        result = run_executor(workdir)
+        assert result.returncode == 2
+        assert "PathValidationError" in result.stderr

--- a/tests/unit/skills/test_compute_executor.py
+++ b/tests/unit/skills/test_compute_executor.py
@@ -125,12 +125,26 @@ class TestComputeExecutorImportPolicy:
         assert "ImportPolicyViolation" in result.stderr
         assert "eval" in result.stderr
 
-    def test_syntax_error_rejected(self, workdir):
-        (workdir / "main.py").write_text("def broken(:\n")
+    def test_dangerous_builtin_via_dunder_call_rejected(self, workdir):
+        (workdir / "main.py").write_text("eval.__call__('1+1')\n")
         result = run_executor(workdir, "main.py")
         assert result.returncode == 2
         assert "ImportPolicyViolation" in result.stderr
-        assert "Syntax error" in result.stderr
+        assert "eval" in result.stderr
+
+    def test_dangerous_builtin_via_nested_attribute_chain_rejected(self, workdir):
+        (workdir / "main.py").write_text("exec.__call__.__call__('x = 1')\n")
+        result = run_executor(workdir, "main.py")
+        assert result.returncode == 2
+        assert "ImportPolicyViolation" in result.stderr
+        assert "exec" in result.stderr
+
+    def test_syntax_error_rejected_with_distinct_prefix(self, workdir):
+        (workdir / "main.py").write_text("def broken(:\n")
+        result = run_executor(workdir, "main.py")
+        assert result.returncode == 2
+        assert "SyntaxValidationError" in result.stderr
+        assert "ImportPolicyViolation" not in result.stderr
 
 
 class TestComputeExecutorPathValidation:

--- a/tests/unit/skills/test_skill_dispatch.py
+++ b/tests/unit/skills/test_skill_dispatch.py
@@ -250,6 +250,7 @@ async def test_compute_skill_emits_requested_and_completed_events():
         ("error", "Traceback (most recent call last):\nZeroDivisionError", "runtime_error"),
         ("timeout", "Execution exceeded timeout", "timeout"),
         ("error", "ImportPolicyViolation: import not allowed: socket", "import_violation"),
+        ("error", "SyntaxValidationError: invalid syntax (main.py, line 1)", "syntax_error"),
         ("error", "PathValidationError: path traversal is not allowed", "path_violation"),
     ],
 )

--- a/tests/unit/skills/test_skill_dispatch.py
+++ b/tests/unit/skills/test_skill_dispatch.py
@@ -3,7 +3,10 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from muxi.runtime.formation.agents.skill_dispatch import handle_run_skill
+from muxi.runtime.formation.agents.skill_dispatch import (
+    _normalize_compute_parameters,
+    handle_run_skill,
+)
 from muxi.runtime.formation.skills.skill_manager import SkillManager
 
 
@@ -101,3 +104,278 @@ async def test_handle_run_skill_leaves_plain_stdout_unstructured(executable_skil
     assert result["status"] == "success"
     assert result["output"] == "worksheet names: Summary, Data"
     assert "structuredContent" not in result
+
+
+@pytest.mark.asyncio
+async def test_handle_run_skill_passes_input_files_to_rce(executable_skills_dir):
+    manager = SkillManager(executable_skills_dir)
+    manager.load_public_skills(["drive-helper"])
+
+    rce_result = SimpleNamespace(
+        status="success",
+        exit_code=0,
+        stdout="42",
+        stderr="",
+        duration_ms=5,
+        artifacts=[],
+    )
+    run_skill_mock = AsyncMock(return_value=rce_result)
+    overlord = SimpleNamespace(
+        skill_manager=manager,
+        rce_client=SimpleNamespace(
+            ensure_cached=AsyncMock(),
+            run_skill=run_skill_mock,
+        ),
+    )
+
+    with (
+        patch("muxi.runtime.formation.agents.skill_dispatch.streaming.stream"),
+        patch("muxi.runtime.formation.agents.skill_dispatch.observability.observe"),
+    ):
+        result = await handle_run_skill(
+            "agent-a",
+            {
+                "skill_name": "drive-helper",
+                "command": "python3 scripts/run.py main.py",
+                "input_files": {"main.py": "print(42)"},
+            },
+            overlord,
+        )
+
+    assert result["status"] == "success"
+    call_kwargs = run_skill_mock.call_args.kwargs
+    assert call_kwargs["input_files"] == {"main.py": "print(42)"}
+
+
+@pytest.mark.asyncio
+async def test_handle_run_skill_ignores_invalid_input_files(executable_skills_dir):
+    manager = SkillManager(executable_skills_dir)
+    manager.load_public_skills(["drive-helper"])
+
+    rce_result = SimpleNamespace(
+        status="success",
+        exit_code=0,
+        stdout="ok",
+        stderr="",
+        duration_ms=5,
+        artifacts=[],
+    )
+    run_skill_mock = AsyncMock(return_value=rce_result)
+    overlord = SimpleNamespace(
+        skill_manager=manager,
+        rce_client=SimpleNamespace(
+            ensure_cached=AsyncMock(),
+            run_skill=run_skill_mock,
+        ),
+    )
+
+    with (
+        patch("muxi.runtime.formation.agents.skill_dispatch.streaming.stream"),
+        patch("muxi.runtime.formation.agents.skill_dispatch.observability.observe"),
+    ):
+        result = await handle_run_skill(
+            "agent-a",
+            {
+                "skill_name": "drive-helper",
+                "command": "python3 scripts/run.py",
+                "input_files": "not-a-dict",
+            },
+            overlord,
+        )
+
+    assert result["status"] == "success"
+    assert run_skill_mock.call_args.kwargs["input_files"] is None
+
+
+def _compute_overlord(rce_result):
+    manager = SkillManager()
+    manager.load_builtin_skills()
+    return SimpleNamespace(
+        skill_manager=manager,
+        rce_client=SimpleNamespace(
+            ensure_cached=AsyncMock(),
+            run_skill=AsyncMock(return_value=rce_result),
+        ),
+    )
+
+
+def _observed_event_names(observe_mock):
+    names = []
+    for call in observe_mock.call_args_list:
+        event = call.kwargs.get("event_type") or (call.args[0] if call.args else None)
+        names.append(getattr(event, "name", str(event)))
+    return names
+
+
+@pytest.mark.asyncio
+async def test_compute_skill_emits_requested_and_completed_events():
+    rce_result = SimpleNamespace(
+        status="success",
+        exit_code=0,
+        stdout="6.77",
+        stderr="",
+        duration_ms=31,
+        artifacts=[],
+    )
+    overlord = _compute_overlord(rce_result)
+
+    with (
+        patch("muxi.runtime.formation.agents.skill_dispatch.streaming.stream"),
+        patch("muxi.runtime.formation.agents.skill_dispatch.observability.observe") as observe,
+    ):
+        result = await handle_run_skill(
+            "agent-a",
+            {
+                "skill_name": "compute",
+                "command": "python3 scripts/run_python.py main.py",
+                "input_files": {"main.py": "import statistics\nprint(6.77)"},
+            },
+            overlord,
+        )
+
+    assert result["status"] == "success"
+    names = _observed_event_names(observe)
+    assert "COMPUTATION_REQUESTED" in names
+    assert "COMPUTATION_COMPLETED" in names
+    assert "COMPUTATION_FAILED" not in names
+    completed = observe.call_args_list[names.index("COMPUTATION_COMPLETED")]
+    assert completed.kwargs["data"]["code"] == "import statistics\nprint(6.77)"
+    assert completed.kwargs["data"]["stdout"] == "6.77"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status,stderr,expected_kind",
+    [
+        ("error", "Traceback (most recent call last):\nZeroDivisionError", "runtime_error"),
+        ("timeout", "Execution exceeded timeout", "timeout"),
+        ("error", "ImportPolicyViolation: import not allowed: socket", "import_violation"),
+        ("error", "PathValidationError: path traversal is not allowed", "path_violation"),
+    ],
+)
+async def test_compute_skill_emits_failed_event_with_failure_kind(status, stderr, expected_kind):
+    rce_result = SimpleNamespace(
+        status=status,
+        exit_code=1,
+        stdout="",
+        stderr=stderr,
+        duration_ms=8,
+        artifacts=[],
+    )
+    overlord = _compute_overlord(rce_result)
+
+    with (
+        patch("muxi.runtime.formation.agents.skill_dispatch.streaming.stream"),
+        patch("muxi.runtime.formation.agents.skill_dispatch.observability.observe") as observe,
+    ):
+        await handle_run_skill(
+            "agent-a",
+            {
+                "skill_name": "compute",
+                "command": "python3 scripts/run_python.py main.py",
+                "input_files": {"main.py": "print(1/0)"},
+            },
+            overlord,
+        )
+
+    names = _observed_event_names(observe)
+    assert "COMPUTATION_FAILED" in names
+    failed = observe.call_args_list[names.index("COMPUTATION_FAILED")]
+    assert failed.kwargs["data"]["failure_kind"] == expected_kind
+    assert failed.kwargs["data"]["code"] == "print(1/0)"
+
+
+@pytest.mark.asyncio
+async def test_non_compute_skill_emits_no_computation_events(executable_skills_dir):
+    manager = SkillManager(executable_skills_dir)
+    manager.load_public_skills(["drive-helper"])
+
+    rce_result = SimpleNamespace(
+        status="success",
+        exit_code=0,
+        stdout="ok",
+        stderr="",
+        duration_ms=5,
+        artifacts=[],
+    )
+    overlord = SimpleNamespace(
+        skill_manager=manager,
+        rce_client=SimpleNamespace(
+            ensure_cached=AsyncMock(),
+            run_skill=AsyncMock(return_value=rce_result),
+        ),
+    )
+
+    with (
+        patch("muxi.runtime.formation.agents.skill_dispatch.streaming.stream"),
+        patch("muxi.runtime.formation.agents.skill_dispatch.observability.observe") as observe,
+    ):
+        await handle_run_skill(
+            "agent-a",
+            {"skill_name": "drive-helper", "command": "python3 scripts/run.py"},
+            overlord,
+        )
+
+    names = _observed_event_names(observe)
+    assert not any(n.startswith("COMPUTATION_") for n in names)
+
+
+class TestNormalizeComputeParameters:
+    def test_well_formed_invocation_passes_through(self):
+        command, files = _normalize_compute_parameters(
+            "python3 scripts/run_python.py main.py", {"main.py": "print(1)"}
+        )
+        assert command == "python3 scripts/run_python.py main.py"
+        assert files == {"main.py": "print(1)"}
+
+    def test_raw_code_in_command_moved_to_input_files(self):
+        command, files = _normalize_compute_parameters(
+            "import numpy as np; print(np.std([1, 2, 3], ddof=1))", None
+        )
+        assert command == "python3 scripts/run_python.py main.py"
+        assert files == {"main.py": "import numpy as np; print(np.std([1, 2, 3], ddof=1))"}
+
+    def test_wrong_command_with_input_files_points_at_executor(self):
+        command, files = _normalize_compute_parameters("python3 calc.py", {"calc.py": "print(2)"})
+        assert command == "python3 scripts/run_python.py calc.py"
+        assert files == {"calc.py": "print(2)"}
+
+    def test_argless_executor_command_gains_input_file(self):
+        command, files = _normalize_compute_parameters(
+            "python3 scripts/run_python.py", {"main.py": "print(3)"}
+        )
+        assert command == "python3 scripts/run_python.py main.py"
+        assert files == {"main.py": "print(3)"}
+
+    @pytest.mark.asyncio
+    async def test_handle_run_skill_recovers_raw_code_command(self):
+        rce_result = SimpleNamespace(
+            status="success",
+            exit_code=0,
+            stdout="1.0",
+            stderr="",
+            duration_ms=9,
+            artifacts=[],
+        )
+        overlord = _compute_overlord(rce_result)
+        run_skill_mock = overlord.rce_client.run_skill
+
+        with (
+            patch("muxi.runtime.formation.agents.skill_dispatch.streaming.stream"),
+            patch("muxi.runtime.formation.agents.skill_dispatch.observability.observe"),
+        ):
+            result = await handle_run_skill(
+                "agent-a",
+                {
+                    "skill_name": "compute",
+                    "command": "import statistics; print(statistics.stdev([1, 2, 3]))",
+                },
+                overlord,
+            )
+
+        assert result["status"] == "success"
+        call = run_skill_mock.call_args
+        assert call.args[1] == "python3 scripts/run_python.py main.py"
+        assert call.kwargs["input_files"] == {
+            "main.py": "import statistics; print(statistics.stdev([1, 2, 3]))"
+        }

--- a/tests/unit/skills/test_skills.py
+++ b/tests/unit/skills/test_skills.py
@@ -400,6 +400,88 @@ class TestBuiltinSkills:
         manager.load_builtin_skills()
         assert manager.has_scripts("generative-ui") is False
 
+    def test_compute_builtin_loaded(self):
+        manager = SkillManager()
+        loaded = manager.load_builtin_skills()
+        assert "compute" in loaded
+        assert "compute" in manager.skills
+        assert "compute" in manager.public_skills
+        assert "compute" in manager._builtin_skills
+
+    def test_compute_builtin_metadata(self):
+        manager = SkillManager()
+        manager.load_builtin_skills()
+        skill = manager.skills["compute"]
+        assert skill.name == "compute"
+        assert "python" in skill.description.lower()
+        assert "value, not an artifact" in skill.description.lower()
+        assert skill.allowed_tools == ["run_skill"]
+        assert skill.base_dir.is_dir()
+
+    def test_compute_builtin_activation(self):
+        manager = SkillManager()
+        manager.load_builtin_skills()
+        content = manager.activate("compute", "session-1")
+        assert "skill_content" in content
+        assert "run_skill" in content
+        assert "scripts/run_python.py" in content
+        assert "input_files" in content
+        # Common allowed imports are inlined for fast lookup
+        for module in ("json", "math", "datetime", "statistics", "pandas", "numpy"):
+            assert module in content
+
+    def test_compute_builtin_has_scripts(self):
+        manager = SkillManager()
+        manager.load_builtin_skills()
+        assert manager.has_scripts("compute") is True
+
+    def test_compute_builtin_reference_examples(self):
+        manager = SkillManager()
+        manager.load_builtin_skills()
+        resources = manager._get_resources("compute")
+        assert "scripts/run_python.py" in resources
+        for example in (
+            "references/arithmetic.md",
+            "references/date-math.md",
+            "references/regex-parsing.md",
+            "references/data-aggregation.md",
+        ):
+            assert example in resources
+
+    def test_compute_builtin_in_run_skill_tool(self):
+        manager = SkillManager()
+        manager.load_builtin_skills()
+        tool = manager.build_run_skill_tool("agent-1")
+        assert tool is not None
+        enum = tool["function"]["parameters"]["properties"]["skill_name"]["enum"]
+        assert "compute" in enum
+        assert "file-generation" not in enum  # still excluded (uses generate_file)
+
+    def test_compute_builtin_disable(self):
+        manager = SkillManager()
+        loaded = manager.load_builtin_skills(disabled=["compute"])
+        assert "compute" not in loaded
+        assert "compute" not in manager.skills
+        catalog = manager.build_catalog_xml("agent-1")
+        assert "compute" not in (catalog or "")
+
+    def test_compute_builtin_catalog(self):
+        manager = SkillManager()
+        manager.load_builtin_skills()
+        catalog = manager.build_catalog_xml("agent-1")
+        assert catalog is not None
+        assert "compute" in catalog
+
+    def test_run_skill_tool_exposes_input_files(self):
+        manager = SkillManager()
+        manager.load_builtin_skills()
+        tool = manager.build_run_skill_tool("agent-1")
+        props = tool["function"]["parameters"]["properties"]
+        assert "input_files" in props
+        assert props["input_files"]["type"] == "object"
+        # input_files is optional: required stays skill_name + command
+        assert tool["function"]["parameters"]["required"] == ["skill_name", "command"]
+
     def test_manager_no_skills_dir(self):
         manager = SkillManager()
         assert manager.skills_dir is None


### PR DESCRIPTION
## Summary

Implements the [compute skill PRD](../engineering/prds/compute-skill.md): a built-in `compute` skill that gives agents Python execution as a reasoning step when in-context reasoning is unreliable (precise arithmetic, date math, regex, parsing, aggregations). The agent writes a self-contained Python file, the bundled executor runs it inside the existing Skill RCE sandbox, and the printed answer flows back into the agent's context. No inner LLM loop, no orchestration logic, agent-owns-the-loop.

## What ships

**Bundled skill** (`src/muxi/runtime/formation/skills/builtin/compute/`, same layout as `file-generation`):
- `SKILL.md` — when to activate, anti-patterns, the write-file/print-answer contract, invocation via `run_skill` + `input_files`, inlined common allowed imports (json, math, datetime, re, statistics, csv, pandas, numpy), never-narrate-code response style
- `scripts/run_python.py` — the executor: path validation (rejects absolute paths, `..` traversal, symlinks at any component), AST import/builtin policy (same pattern as `file-generation`'s `generate.py`, computation-focused list without networking), REPL-style echo of a trailing bare expression, machine-readable error prefixes (`PathValidationError:`, `ImportPolicyViolation:`) so agents can distinguish "your code raised" from "the sandbox refused"
- `references/` — four worked examples (arithmetic, date-math, regex-parsing, data-aggregation) with verified expected outputs

**Observability**: three new `ConversationEvents` (`computation.requested` / `completed` / `failed`) emitted from the existing `run_skill` handler, carrying full code, truncated stdout/stderr (16KB), execution time, and `failure_kind` (`runtime_error` | `timeout` | `import_violation` | `path_violation` | `service_error`). `validate_events.py` at 100%.

## Minimal wiring (and why)

The PRD targets zero new runtime code paths. Three small deviations were needed, all inside existing skill code paths:

1. **`input_files` pass-through on `run_skill`.** The RCE server executes commands with `strings.Fields` (no shell), so agent-written code cannot be delivered inline in `command`. The RCE client and server already support `input_files`; this exposes it on the `run_skill` tool schema and threads it through `run_skill_command`. Generic (benefits every scripted skill), optional, backward compatible.
2. **Compute parameter recovery in `handle_run_skill`.** Planner LLMs (observed with gpt-4o-mini) put raw Python in `command` despite instructions. For the compute skill only, such invocations are normalized: raw code moves to `input_files{main.py}` and the sanctioned executor command is used. Without this the call fails opaquely (`import` resolves to ImageMagick in the sandbox) and the agent falls back to hallucinated arithmetic — the exact failure mode the PRD exists to fix.
3. **Planning prompt note.** The generic run_skill note now says raw code in `command` will be rejected and shows an `input_files` example (compute example only when compute is in the agent's catalog).

## Inert when unused

- Not activated: costs only its ~30-token catalog entry, like every built-in
- `skills.disable_builtin: [compute]` removes it from catalog, tools, and planning prompt (existing mechanism, covered by tests)
- No RCE configured: degrades exactly like any scripted skill — `run_skill` is not registered
- Formation-level `skills/compute/` overrides the bundled version via the existing load order

## Testing

- **Unit** (`uv run python -m pytest tests/unit/ -q`): 2126 passed, 10 skipped. New: 20 executor tests (success/JSON/REPL echo, traceback surfacing, import policy, path traversal/symlink/absolute rejection), 9 built-in loading/catalog/activation tests, 8 dispatch tests (input_files threading, COMPUTATION_* emission, failure-kind classification, compute recovery, non-compute skills unaffected)
- **E2E** (`e2e/tests/21_skills/test_21c4_compute_skill.py`, live RCE + OpenAI): direct execution returns 6.77 for a stdev task; broken code surfaces `ZeroDivisionError`; `import socket` surfaces `ImportPolicyViolation`; LLM-driven chat activates the skill, executes through RCE, answers "approximately **6.77**" without narrating code. All checks pass.
- **Regression** (`run_random_tests.py 5`): 4/5 pass. The one failure (`test_20e1_rest_parity`, "Unknown tool: 'list_sessions'") reproduces identically on clean develop — pre-existing, unrelated.
- **Lint**: black/isort/ruff clean on all touched files; `validate_events.py` 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)