### PR TITLE
fix: use relative secrets.enc symlink in formation-artifact-memory fixture

### DIFF
--- a/e2e/tests/5_artifacts/formations/formation-artifact-memory/secrets.enc
+++ b/e2e/tests/5_artifacts/formations/formation-artifact-memory/secrets.enc
@@ -1,1 +1,1 @@
-/Users/ran/Projects/muxi/code/runtime/e2e/assets/secrets.enc
+../../../../assets/secrets.enc


### PR DESCRIPTION
## Summary
The `secrets.enc` symlink in `e2e/tests/5_artifacts/formations/formation-artifact-memory/` pointed to an absolute local path (`/Users/ran/...`), which breaks the fixture on any other checkout. This replaces it with a relative target (`../../../../assets/secrets.enc`), matching the convention used by the other e2e formation fixtures (e.g. `e2e/tests/12_scheduling/formation-scheduling/secrets.enc`).

Note: the gitignored `.key` symlink for this fixture still needs to be created per-checkout (`ln -s ../../../../assets/.key .key`), same as other fixtures.

## Test plan
- `cd e2e/tests/5_artifacts && uv run python test_5_15_artifact_memory.py` → SUCCESS (all 7 assertions pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)