### PR TITLE
fix: MCP tool generation broken by FastAPI lazy router inclusion

### DIFF
--- a/src/muxi/runtime/formation/server/server.py
+++ b/src/muxi/runtime/formation/server/server.py
@@ -119,6 +119,11 @@ class FormationServer:
         self._active_connections_lock = threading.Lock()
         self._shutdown_timeout = 30.0
 
+        # Client route paths (with explicit operation_id) exposed as MCP
+        # tools; populated by _register_client_routes, consumed by
+        # _mount_mcp_server
+        self._mcp_tool_paths: set = set()
+
         # Server metrics
         self._start_time = time.time()
         self._request_count = 0
@@ -546,17 +551,15 @@ class FormationServer:
             # Client routes have explicit operation_id; admin/health routes don't.
             # Build include patterns dynamically so new client endpoints are
             # picked up automatically without maintaining a hardcoded allowlist.
+            # Paths come from _register_client_routes rather than app.routes:
+            # FastAPI 0.137+ includes routers lazily, so app.routes holds
+            # _IncludedRouter placeholders without operation_id or path.
             client_patterns = set()
-            for route in app.routes:
-                op_id = getattr(route, "operation_id", None)
-                if not op_id:
-                    continue
-                path = getattr(route, "path", "")
-                if path:
-                    escaped = re.escape(path)
-                    # Convert \{param\} back to .* for path parameters
-                    pattern = re.sub(r"\\{[^}]+\\}", ".*", escaped)
-                    client_patterns.add(f".*{pattern}$")
+            for path in self._mcp_tool_paths:
+                escaped = re.escape(path)
+                # Convert \{param\} back to .* for path parameters
+                pattern = re.sub(r"\\{[^}]+\\}", ".*", escaped)
+                client_patterns.add(f".*{pattern}$")
 
             route_maps = [RouteMap(pattern=p, mcp_type=MCPType.TOOL) for p in client_patterns]
             route_maps.append(RouteMap(pattern=r".*", mcp_type=MCPType.EXCLUDE))
@@ -729,6 +732,14 @@ class FormationServer:
 
         for router in dual_auth_routers:
             app.include_router(router, prefix="/v1", dependencies=[Depends(dual_auth)])
+
+        # Record routes with explicit operation_id for MCP tool exposure.
+        # Collected from the source routers because app.routes no longer
+        # flattens included routers (FastAPI 0.137+ lazy inclusion).
+        for router in (*user_gated_routers, *client_only_routers, *dual_auth_routers):
+            for route in router.routes:
+                if getattr(route, "operation_id", None) and getattr(route, "path", ""):
+                    self._mcp_tool_paths.add(f"/v1{route.path}")
 
     async def start(self, block: bool = True, install_signal_handlers: bool = True) -> None:
         """


### PR DESCRIPTION
## Problem

All `20_mcp_server` e2e tests fail on develop — the MCP server mounts fine but exposes **zero tools**, so clients get `Unknown tool: 'list_sessions'` (test 20e1) and `Expected >= 20 tools, got 0` (test 20b1).

## Root cause

FastAPI 0.137+ includes routers **lazily**: `app.include_router(...)` now stores `_IncludedRouter` placeholders in `app.routes` instead of flattened `APIRoute` objects. `_mount_mcp_server` built its include patterns by scanning `app.routes` for routes with an explicit `operation_id`; that scan now finds nothing, so the only remaining route map is the catch-all `EXCLUDE`, which drops every candidate tool from the generated MCP server.

## Fix

Collect the client tool paths in `_register_client_routes` from the source `APIRouter` objects — those still hold real `APIRoute`s with `operation_id` and `path` — and have `_mount_mcp_server` build its route-map patterns from that set. Same semantics as before (only client routes with explicit `operation_id` are exposed; admin/health stay hidden), no hardcoded allowlist, and no dependence on FastAPI's private route internals.

## Verification

- All 6 `e2e/tests/20_mcp_server` tests pass (44 tools registered, clean names, no admin/health routes exposed, REST/MCP parity holds)
- `cd e2e && uv run python run_random_tests.py 5`: 5/5 passed (19_api, 2_memory, 3_multimodal ×2, 4_mcp)
- MCP unit tests (`tests/unit/test_mcp_tool_filter.py`, `test_mcp_protocol_features.py`, `test_mcp_http_request_lifecycle.py`): 40 passed
- ruff / black / isort clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)