### PR TITLE
feat: proactiveness phase 2 - channel templates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,6 +15,9 @@ recursive-include src/muxi/formation/prompts *.md *.txt
 # Include all MCP built-in server definitions
 recursive-include src/muxi/services/mcp/built_in *.yaml *.yml
 
+# Include bundled channel transformer templates (dormant until referenced)
+recursive-include src/muxi/runtime/formation/background/builtin *.yaml *.yml
+
 # Include all document processing assets
 recursive-include src/muxi/formation/documents *.md *.txt
 

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -140,6 +140,7 @@ runtime/
 | [prompt-management.md](prompt-management.md) | Centralized prompt loader system |
 | [id-conventions.md](id-conventions.md) | ID format conventions (prefixes, nanoid) |
 | [type-safety-guide.md](type-safety-guide.md) | TypedDict conventions |
+| [channel-templates.md](channel-templates.md) | Slack/Telegram/Discord/email channel templates and transformer/webhook composition |
 
 ## Key Concepts for Contributors
 

--- a/contributing/channel-templates.md
+++ b/contributing/channel-templates.md
@@ -1,0 +1,183 @@
+# Channel Templates
+
+How MUXI formations talk to Slack, Telegram, Discord, and email without
+platform SDKs, MCPs, or new delivery paths.
+
+A channel integration is two declarative pieces riding existing machinery:
+
+- **Inbound**: a trigger (`POST /v1/triggers/{id}`) with `parse:` extraction
+  and `channel:` tagging.
+- **Outbound**: a transformer (payload template, auth, retry) delivered by
+  the standard transformer stack.
+
+The runtime bundles dormant transformer templates for `slack`, `telegram`,
+`discord`, and `email`. They define payload formats only -- no URLs, no
+credentials -- and are inert until a trigger or `proactive.channels` entry
+references them by name. A formation-local `transformers/<name>.yaml`
+shadows a bundled template of the same name (the same rule as built-in
+skills).
+
+## Composition: transformer + webhook
+
+In trigger frontmatter, `transformer:` and `webhook:` compose:
+
+| Frontmatter | Behavior |
+|---|---|
+| `webhook:` only | Raw standard MUXI payload delivered to the URL (unchanged) |
+| `transformer:` only | Formatted payload delivered to the transformer's own `endpoint.url` (unchanged) |
+| both | Formatted payload delivered to the trigger's webhook URL |
+
+URL resolution order: trigger/channel-supplied URL first, the transformer's
+`endpoint.url` second. A transformer with no URL from either source fails at
+formation load time, not at delivery time.
+
+`proactive.channels` declarations get the same override via a `url:` key,
+which may be a literal http(s) URL or a `${{ secrets.* }}` template:
+
+```yaml
+proactive:
+  channels:
+    slack:
+      transformer: slack                        # bundled template
+      url: "${{ secrets.SLACK_BRIDGE_URL }}"    # channel supplies the URL
+```
+
+## The developer owns the bridge
+
+MUXI posts the platform-shaped payload to a URL you provide. Getting it the
+last mile (bot token auth, SMTP, etc.) is your bridge's job. Messages are
+text-only in v1.
+
+## Slack
+
+1. Create a bridge endpoint that forwards JSON to Slack `chat.postMessage`
+   with your bot token (or accept an incoming-webhook URL directly).
+2. Point your Slack app's event subscription (message events) at
+   `POST /v1/triggers/slack` on your formation.
+3. Add `triggers/slack.md`:
+
+```markdown
+---
+transformer: slack
+webhook: https://bridge.example.com/slack
+parse:
+  message: $.event.text
+  user_id: $.event.user
+  context:
+    channel: $.event.channel
+    thread_ts: $.event.thread_ts
+channel: slack
+---
+Respond to this Slack message: ${{ data.event.text }}
+```
+
+Payload delivered to your bridge (`thread_ts` is dropped when absent):
+
+```json
+{"channel": "C0ABC123", "thread_ts": "1234.5678", "text": "..."}
+```
+
+## Telegram
+
+1. Create a bot via @BotFather and set its webhook to
+   `POST /v1/triggers/telegram` (or proxy through your bridge).
+2. Your bridge forwards the payload to
+   `https://api.telegram.org/bot<token>/sendMessage`.
+3. Add `triggers/telegram.md`:
+
+```markdown
+---
+transformer: telegram
+webhook: https://bridge.example.com/telegram
+parse:
+  message: $.message.text
+  user_id: $.message.from.id
+  context:
+    chat_id: $.message.chat.id
+channel: telegram
+---
+Respond to this Telegram message: ${{ data.message.text }}
+```
+
+Payload (markdown stripped, capped at 4096 chars):
+
+```json
+{"chat_id": "123456789", "text": "..."}
+```
+
+## Discord
+
+1. Create a channel webhook (channel settings > Integrations) or run a bot
+   bridge that posts inbound messages to `POST /v1/triggers/discord`.
+2. The `webhook:` URL can be the Discord webhook URL itself -- the payload
+   is already in Discord's `content` format.
+3. Add `triggers/discord.md`:
+
+```markdown
+---
+transformer: discord
+webhook: https://discord.com/api/webhooks/<id>/<token>
+parse:
+  message: $.content
+  user_id: $.author.id
+  context:
+    channel_id: $.channel_id
+channel: discord
+---
+Respond to this Discord message: ${{ data.content }}
+```
+
+Payload (capped at Discord's 2000-char limit):
+
+```json
+{"content": "..."}
+```
+
+## Email
+
+1. Run a bridge that accepts the constructed message object and sends it
+   via SMTP/SES/Mailgun/etc.
+2. Point your inbound-email webhook (e.g. SES/Mailgun inbound parse) at
+   `POST /v1/triggers/email`.
+3. Add `triggers/email.md`:
+
+```markdown
+---
+transformer: email
+webhook: https://bridge.example.com/email
+parse:
+  message: $.body_plain
+  user_id: $.sender
+  context:
+    address: $.sender
+    subject: $.subject
+channel: email
+---
+Respond to this email: ${{ data.body_plain }}
+```
+
+Payload (`from`/`subject` are dropped when absent; the bridge applies its
+own defaults):
+
+```json
+{
+  "from": "Assistant <assistant@example.com>",
+  "to": "user@example.com",
+  "subject": "Re: ...",
+  "body": "...",
+  "headers": {"X-Muxi-Agent": "assistant", "X-Muxi-Timestamp": "..."}
+}
+```
+
+## Customizing a template
+
+Copy the bundled file into your formation and edit it -- the local file
+wins:
+
+```
+src/muxi/runtime/formation/background/builtin/transformers/slack.yaml
+  -> <formation>/transformers/slack.yaml
+```
+
+Bundled templates never define `endpoint.url`; if your copy adds one, the
+trigger's `webhook:`/channel's `url:` still takes precedence when present.

--- a/e2e/tests/23_proactive/formation-templates/formation.yaml
+++ b/e2e/tests/23_proactive/formation-templates/formation.yaml
@@ -1,0 +1,42 @@
+schema: "1.0.0"
+id: formation-templates-test
+description: Test formation for proactiveness phase 2 (channel templates, transformer/webhook composition)
+
+llm:
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+
+agents:
+  - id: assistant
+    name: Assistant
+    description: Simple assistant for channel template testing
+    system_message: |
+      You are a test assistant. Follow instructions exactly and keep
+      responses under 30 words.
+    default: true
+
+overlord:
+  workflow:
+    auto_decomposition: true
+    complexity_threshold: 9.0  # Direct responses for trivial deterministic prompts
+    plan_approval_threshold: 10
+  response:
+    streaming: false
+    widgets: false
+
+server:
+  host: 0.0.0.0
+  port: 18233
+  access_log: false
+  api_keys:
+    admin_key: "testing-api-key"
+    client_key: "testing-api-key"
+
+logging:
+  system:
+    level: "error"
+    destination: "stdout"
+  conversation:
+    enabled: false

--- a/e2e/tests/23_proactive/formation-templates/secrets.enc
+++ b/e2e/tests/23_proactive/formation-templates/secrets.enc
@@ -1,0 +1,1 @@
+../../../assets/secrets.enc

--- a/e2e/tests/23_proactive/formation-templates/transformers/custom-format.yaml
+++ b/e2e/tests/23_proactive/formation-templates/transformers/custom-format.yaml
@@ -1,0 +1,9 @@
+# E2E test transformer: payload format only (no endpoint.url). The
+# referencing trigger supplies the destination via 'webhook:' frontmatter.
+name: custom-format
+headers:
+  Content-Type: application/json
+body:
+  room: "${{ context.room }}"
+  sender: "${{ request.user_id }}"
+  reply: "${{ response.content }}"

--- a/e2e/tests/23_proactive/formation-templates/triggers/custom.md
+++ b/e2e/tests/23_proactive/formation-templates/triggers/custom.md
@@ -1,0 +1,12 @@
+---
+# Formation-local URL-less transformer + trigger-supplied webhook URL:
+# the same composition mechanism with a custom payload shape.
+transformer: custom-format
+webhook: http://127.0.0.1:18241/custom-bridge
+parse:
+  message: $.payload.text
+  user_id: $.payload.sender
+  context:
+    room: $.payload.room
+---
+Respond in one short sentence to this message: ${{ data.payload.text }}

--- a/e2e/tests/23_proactive/formation-templates/triggers/slack.md
+++ b/e2e/tests/23_proactive/formation-templates/triggers/slack.md
@@ -1,0 +1,14 @@
+---
+# Bundled channel template composition: the 'slack' transformer ships with
+# the runtime (payload format only); this trigger supplies the destination.
+transformer: slack
+webhook: http://127.0.0.1:18241/slack-bridge
+parse:
+  message: $.event.text
+  user_id: $.event.user
+  context:
+    channel: $.event.channel
+    thread_ts: $.event.thread_ts
+channel: slack
+---
+Respond in one short sentence to this Slack message: ${{ data.event.text }}

--- a/e2e/tests/23_proactive/test_23a5_channel_template_composition.py
+++ b/e2e/tests/23_proactive/test_23a5_channel_template_composition.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+Test 23A5: Channel templates + transformer/webhook composition (Phase 2)
+
+Verifies the two Phase 2 mechanisms end to end:
+
+1. Bundled dormant template activated by reference: a trigger whose
+   frontmatter declares `transformer: slack` (shipped with the runtime,
+   payload format only, no URL) plus `webhook: <dev url>` must format the
+   agent response as a Slack chat.postMessage-style payload and deliver it
+   to the trigger-supplied webhook URL.
+
+2. Composition with a formation-local URL-less transformer: the trigger's
+   webhook URL is the destination, the transformer defines the payload
+   shape. This also pins the URL resolution order (trigger URL wins when
+   the transformer defines none).
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import httpx
+from aiohttp import web
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from muxi.runtime.formation import Formation  # noqa: E402
+
+SINK_PORT = 18241
+SERVER_PORT = 18233
+
+
+class SinkServer:
+    """Local HTTP sink standing in for the developer's webhook bridge."""
+
+    def __init__(self):
+        self.requests = []
+        self.runner = None
+
+    async def _handle(self, request: web.Request) -> web.Response:
+        self.requests.append({"path": request.path, "json": await request.json()})
+        return web.json_response({"ok": True})
+
+    async def start(self):
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", self._handle)
+        self.runner = web.AppRunner(app)
+        await self.runner.setup()
+        site = web.TCPSite(self.runner, "127.0.0.1", SINK_PORT)
+        await site.start()
+
+    async def stop(self):
+        if self.runner:
+            await self.runner.cleanup()
+
+    def requests_for(self, path):
+        return [r for r in self.requests if r["path"] == path]
+
+
+async def wait_for(predicate, timeout=45):
+    for _ in range(timeout):
+        if predicate():
+            return True
+        await asyncio.sleep(1)
+    return predicate()
+
+
+async def main():
+    print("MUXI Runtime - Test 23A5: Channel Template Composition")
+    print("=" * 60)
+
+    formation_path = Path(__file__).parent / "formation-templates"
+    sink = SinkServer()
+
+    try:
+        # Start the local bridge sink first so delivery cannot race it
+        await sink.start()
+        print(f"Bridge sink listening on 127.0.0.1:{SINK_PORT}")
+
+        formation = Formation()
+        await formation.load(str(formation_path))
+        await formation.start_server(block=False)
+        await asyncio.sleep(2)
+
+        base_url = f"http://localhost:{SERVER_PORT}/v1"
+        headers = {"X-Muxi-Client-Key": "testing-api-key", "X-Muxi-User-Id": "webhook-caller"}
+        print(f"Formation loaded: {formation.formation_id}")
+
+        slack_question = "What is the capital of France? Answer with the city name."
+        custom_question = "What is two plus two? Answer with the number."
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            # --- Part 1: bundled 'slack' template + trigger webhook ---------
+            print("\nPOST /triggers/slack (bundled template + webhook composition)...")
+            response = await client.post(
+                f"{base_url}/triggers/slack",
+                headers=headers,
+                json={
+                    "data": {
+                        "event": {
+                            "text": slack_question,
+                            "user": "U-E2E-23A5",
+                            "channel": "C-E2E-23A5",
+                        }
+                    },
+                    "use_async": True,
+                },
+            )
+            assert response.status_code == 200, f"Unexpected status: {response.text}"
+            print("Async ack received")
+
+            # --- Part 2: formation-local URL-less transformer + webhook -----
+            print("POST /triggers/custom (URL-less transformer + webhook composition)...")
+            response = await client.post(
+                f"{base_url}/triggers/custom",
+                headers=headers,
+                json={
+                    "data": {
+                        "payload": {
+                            "text": custom_question,
+                            "sender": "sender-1",
+                            "room": "room-42",
+                        }
+                    },
+                    "use_async": True,
+                },
+            )
+            assert response.status_code == 200, f"Unexpected status: {response.text}"
+            print("Async ack received")
+
+        print("\nWaiting for composed deliveries to the bridge sink...")
+        assert await wait_for(
+            lambda: sink.requests_for("/slack-bridge") and sink.requests_for("/custom-bridge")
+        ), f"Deliveries missing; sink saw: {[r['path'] for r in sink.requests]}"
+
+        # Bundled slack template: chat.postMessage-style payload delivered to
+        # the TRIGGER-supplied URL (the template itself has none)
+        slack_payload = sink.requests_for("/slack-bridge")[0]["json"]
+        print(f"Slack bridge received: {slack_payload}")
+        assert slack_payload.get("channel") == "C-E2E-23A5", f"Bad channel: {slack_payload}"
+        slack_text = slack_payload.get("text", "")
+        assert slack_text and "paris" in slack_text.lower(), f"Bad text: {slack_payload}"
+        assert "thread_ts" not in slack_payload, "Absent thread_ts must be dropped, not null"
+        assert set(slack_payload.keys()) <= {"channel", "thread_ts", "text"}, (
+            f"Unexpected keys in Slack payload: {sorted(slack_payload)}"
+        )
+        print("Bundled slack template rendered a chat.postMessage-style payload")
+
+        # Formation-local URL-less transformer: custom shape, trigger URL
+        custom_payload = sink.requests_for("/custom-bridge")[0]["json"]
+        print(f"Custom bridge received: {custom_payload}")
+        assert custom_payload.get("room") == "room-42", f"Context lost: {custom_payload}"
+        assert custom_payload.get("sender") == "sender-1", f"Parsed user lost: {custom_payload}"
+        custom_reply = custom_payload.get("reply", "")
+        assert custom_reply and (
+            "4" in custom_reply or "four" in custom_reply.lower()
+        ), f"Bad reply: {custom_payload}"
+        print("URL-less transformer delivered to the trigger-supplied webhook URL")
+
+        print("\n" + "=" * 40)
+        print("\n### Test Result:")
+        print("  🎉 SUCCESS: Channel template composition works end-to-end")
+        print("  ✓ Bundled slack template activated by reference and delivered")
+        print("  ✓ Transformer+webhook composition routed to the trigger URL")
+        print("  ✓ Platform payload shapes rendered from the parse context")
+        print("\n" + "=" * 40)
+        print("\n### Chat transcript:")
+        print(f"\nUser: {slack_question}")
+        print(f"System: {slack_text}")
+        print(f"\nUser: {custom_question}")
+        print(f"System: {custom_reply}")
+
+        print("\nTest 23A5 PASSED")
+        return True
+
+    except Exception as e:
+        print(f"\nTest failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+    finally:
+        if "formation" in locals():
+            formation.stop()
+        await sink.stop()
+        await asyncio.sleep(1)
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    import os
+
+    os._exit(0 if success else 1)

--- a/mental-model.md
+++ b/mental-model.md
@@ -2952,8 +2952,68 @@ management, client-key auth).
 
 **e2e:** area `e2e/tests/23_proactive/` (routing precedence, last-channel
 tracking via trigger, heartbeat active-hours gating, slash commands +
-soul). Heartbeat tests call `heartbeat.run_once(fixed_datetime)` for
-deterministic timing instead of waiting on scheduler cycles.
+soul, channel template composition). Heartbeat tests call
+`heartbeat.run_once(fixed_datetime)` for deterministic timing instead of
+waiting on scheduler cycles.
+
+### Channel Templates (2026-07-08, Phase 2)
+
+**Location:** `formation/background/transformers.py`,
+`formation/background/builtin/transformers/`
+
+Phase 2 of the proactiveness PRD (REVISED): channels ship as dormant
+trigger + transformer template pairs, NOT MCPs. Everything rides the
+existing transformer delivery stack; no platform SDKs, no new delivery
+paths, text-only in v1.
+
+**Transformer/webhook composition.** `transformer:` and `webhook:` in
+trigger frontmatter compose instead of excluding each other: the
+transformer defines the payload format/auth/retry, the trigger's webhook
+URL is the delivery destination. Alone, each keeps its original
+semantics (webhook = raw standard payload; transformer = its own
+`endpoint.url`). `endpoint.url` is now OPTIONAL in transformer YAML
+(`TransformerConfig.url: Optional[str]`; `endpoint:` may be omitted
+entirely). URL resolution order (`resolve_transformer_url`):
+trigger/channel-supplied URL first, transformer's `endpoint.url` second,
+load-time `ValueError` when neither exists. `deliver_via_transformer`
+takes `url_override`; override URLs participate in secret scanning
+(`collect_secret_names(config, *extra)`) so a secret-backed bridge URL
+(`${{ secrets.SLACK_BRIDGE_URL }}`) resolves like any transformer value.
+`proactive.channels` declarations get the same override via a `url:` key
+(literal http(s) or `${{ ... }}` template).
+
+**Fail-fast validation.** FormationValidator gained
+`_validate_trigger_transformer_urls` (trigger names a transformer but
+neither it nor the trigger supplies a URL -> load error; malformed
+frontmatter and missing transformer files keep their request-time 400
+semantics) and `_validate_proactive_channel_transformers` (mirrors the
+NotificationRouter's startup fail-fast: missing transformer or
+unresolvable URL -> validation error). The NotificationRouter also
+resolves URLs eagerly in `__init__`. Request-time failure isolation is
+unchanged (render/delivery errors fall back to the async webhook with
+`transformer_error` metadata).
+
+**Bundled dormant templates.** `background/builtin/transformers/` ships
+`slack.yaml`, `telegram.yaml`, `discord.yaml`, `email.yaml` -- payload
+formats only, NO urls, NO auth; inert until referenced by name (mirrors
+the `skills/builtin/` convention; packaged via setup.py package_data
+`**/*.yaml` + MANIFEST.in). `load_transformer` resolves formation-local
+`transformers/<name>.yaml` first, then the builtin dir, so a
+formation-local file shadows a bundled template of the same name (same
+shadowing rule as built-in skills). Payload shapes: Slack
+chat.postMessage-style (`channel`/`thread_ts`/`text`; absent thread_ts
+is dropped), Telegram sendMessage (`chat_id`/`text`, markdown stripped,
+4096 cap), Discord webhook (`content`, 2000 cap), email constructed
+message object (`from`/`to`/`subject`/`body`/`headers`, dev's webhook
+bridges to SMTP/SES/etc.). The developer owns the bridge: MUXI posts the
+platform-shaped payload to the dev-supplied URL, credentials/last-mile
+delivery are the bridge's job.
+
+**Docs:** `contributing/channel-templates.md` (per-platform setup guides
++ example trigger files). **e2e:**
+`23_proactive/test_23a5_channel_template_composition.py` (bundled slack
+template activated by reference + URL-less local transformer, both
+delivering composed payloads to a trigger-supplied mock bridge).
 
 ---
 

--- a/src/muxi/runtime/formation/background/__init__.py
+++ b/src/muxi/runtime/formation/background/__init__.py
@@ -8,15 +8,18 @@ long-running agentic tasks gracefully.
 from .request_tracker import RequestState, RequestStatus, RequestTracker
 from .time_estimator import TimeEstimator
 from .transformers import (
+    BUILTIN_TRANSFORMERS_DIR,
     TransformerConfig,
     deliver_via_transformer,
     extract_parse_values,
     load_transformer,
     parse_trigger_frontmatter,
+    resolve_transformer_url,
 )
 from .webhook_manager import WebhookManager, sign_webhook
 
 __all__ = [
+    "BUILTIN_TRANSFORMERS_DIR",
     "RequestTracker",
     "RequestState",
     "RequestStatus",
@@ -27,5 +30,6 @@ __all__ = [
     "extract_parse_values",
     "load_transformer",
     "parse_trigger_frontmatter",
+    "resolve_transformer_url",
     "sign_webhook",
 ]

--- a/src/muxi/runtime/formation/background/builtin/transformers/discord.yaml
+++ b/src/muxi/runtime/formation/background/builtin/transformers/discord.yaml
@@ -1,0 +1,18 @@
+# Bundled channel template: Discord (dormant until referenced).
+#
+# Payload format only (Discord webhook 'content' JSON) with NO destination
+# URL: the referencing trigger ('webhook:' frontmatter) or proactive channel
+# ('url:' key) supplies where to deliver -- typically the channel's Discord
+# webhook URL or the developer's bridge in front of it.
+#
+# Discord renders markdown natively, so content passes through unchanged,
+# capped at Discord's 2000-character message limit.
+#
+# Shadow this template by placing transformers/discord.yaml in the formation.
+name: discord
+headers:
+  Content-Type: application/json
+body:
+  content: "${{ response.content }}"
+content_transform:
+  max_length: 2000

--- a/src/muxi/runtime/formation/background/builtin/transformers/email.yaml
+++ b/src/muxi/runtime/formation/background/builtin/transformers/email.yaml
@@ -1,0 +1,25 @@
+# Bundled channel template: Email (dormant until referenced).
+#
+# Payload format only (constructed message object) with NO destination URL:
+# the referencing trigger ('webhook:' frontmatter) or proactive channel
+# ('url:' key) supplies the developer's webhook, which bridges the message
+# to SMTP/SES/Mailgun/etc. MUXI provides the mechanism only.
+#
+# Addressing context (from trigger 'parse:' extraction or user channel state):
+#   context.address  recipient email address
+#   context.from     optional sender identity (dropped when absent)
+#   context.subject  optional subject line (dropped when absent; the bridge
+#                    should apply its own default)
+#
+# Shadow this template by placing transformers/email.yaml in the formation.
+name: email
+headers:
+  Content-Type: application/json
+body:
+  from: "${{ context.from }}"
+  to: "${{ context.address }}"
+  subject: "${{ context.subject }}"
+  body: "${{ response.content }}"
+  headers:
+    X-Muxi-Agent: "${{ agent.name }}"
+    X-Muxi-Timestamp: "${{ timestamp }}"

--- a/src/muxi/runtime/formation/background/builtin/transformers/slack.yaml
+++ b/src/muxi/runtime/formation/background/builtin/transformers/slack.yaml
@@ -1,0 +1,20 @@
+# Bundled channel template: Slack (dormant until referenced).
+#
+# Payload format only (chat.postMessage-style JSON) with NO destination URL:
+# the referencing trigger ('webhook:' frontmatter) or proactive channel
+# ('url:' key) supplies where to deliver -- typically the developer's bridge
+# that forwards to Slack (bot process, incoming-webhook proxy, etc.).
+#
+# Addressing context (from trigger 'parse:' extraction or user channel state):
+#   context.channel    Slack channel or DM id (e.g. C0ABC123, D0XYZ789)
+#   context.thread_ts  optional thread timestamp (dropped from the payload
+#                      when absent, so top-level messages stay top-level)
+#
+# Shadow this template by placing transformers/slack.yaml in the formation.
+name: slack
+headers:
+  Content-Type: application/json
+body:
+  channel: "${{ context.channel }}"
+  thread_ts: "${{ context.thread_ts }}"
+  text: "${{ response.content }}"

--- a/src/muxi/runtime/formation/background/builtin/transformers/telegram.yaml
+++ b/src/muxi/runtime/formation/background/builtin/transformers/telegram.yaml
@@ -1,0 +1,23 @@
+# Bundled channel template: Telegram (dormant until referenced).
+#
+# Payload format only (Bot API sendMessage JSON) with NO destination URL:
+# the referencing trigger ('webhook:' frontmatter) or proactive channel
+# ('url:' key) supplies where to deliver -- typically the developer's bridge
+# that forwards to https://api.telegram.org/bot<token>/sendMessage.
+#
+# Addressing context (from trigger 'parse:' extraction or user channel state):
+#   context.chat_id  Telegram chat id captured from the inbound message
+#
+# Markdown is stripped (Telegram's default parse mode renders plain text)
+# and messages are capped at Telegram's 4096-character limit.
+#
+# Shadow this template by placing transformers/telegram.yaml in the formation.
+name: telegram
+headers:
+  Content-Type: application/json
+body:
+  chat_id: "${{ context.chat_id }}"
+  text: "${{ response.content }}"
+content_transform:
+  format: text
+  max_length: 4096

--- a/src/muxi/runtime/formation/background/transformers.py
+++ b/src/muxi/runtime/formation/background/transformers.py
@@ -28,6 +28,25 @@ Transformer YAML (``transformers/slack.yaml``):
       channel: "${{ context.channel }}"
       text: "${{ response.content }}"
 
+``endpoint.url`` is optional: a transformer may define only the payload
+format and let the referencing trigger (``webhook:`` frontmatter) or
+proactive channel (``url:`` key) supply the destination. When both exist,
+the trigger/channel-supplied URL wins. A transformer with no URL anywhere
+is a load-time error (see ``resolve_transformer_url``).
+
+``transformer:`` and ``webhook:`` in trigger frontmatter therefore compose:
+the transformer defines the payload format/auth/retry, the trigger's webhook
+URL is the delivery destination. ``webhook:`` alone still delivers the raw
+standard payload; ``transformer:`` alone delivers to the transformer's own
+``endpoint.url``.
+
+Bundled dormant templates: the runtime ships payload-format-only templates
+(slack, telegram, discord, email) under ``builtin/transformers/`` next to
+this module. ``load_transformer`` resolves formation-local files first, so
+a formation ``transformers/<name>.yaml`` shadows a bundled template of the
+same name (the same rule as built-in skills). Formations that never
+reference a bundled name are completely unaffected.
+
 Template values use the runtime-wide ``${{ ... }}`` syntax (the same syntax
 used by trigger templates and formation secrets interpolation). Available
 variables: ``response.content``, ``response.files``, ``response.metadata.*``,
@@ -66,6 +85,11 @@ _ALLOWED_AUTH_TYPES = {"bearer", "basic", "header"}
 _ALLOWED_FORMATS = {"text", "markdown", "html"}
 
 _ALLOWED_FRONTMATTER_KEYS = {"name", "type", "webhook", "transformer", "parse", "model", "channel"}
+
+# Bundled dormant channel templates shipped with the runtime (payload formats
+# only, no URLs). Formation-local transformers/<name>.yaml shadows a bundled
+# template of the same name.
+BUILTIN_TRANSFORMERS_DIR = Path(__file__).parent / "builtin" / "transformers"
 _ALLOWED_PARSE_KEYS = {"message", "user_id", "context", "files"}
 
 
@@ -90,7 +114,7 @@ def parse_trigger_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
 
     Raises:
         ValueError: If the frontmatter block is malformed (invalid YAML,
-            non-mapping, unknown keys, or mutually exclusive routing fields)
+            non-mapping, unknown keys, or invalid routing fields)
     """
     if not content.startswith("---"):
         return {}, content
@@ -118,10 +142,12 @@ def parse_trigger_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
             f"Allowed keys: {sorted(_ALLOWED_FRONTMATTER_KEYS)}"
         )
 
+    # 'webhook' and 'transformer' compose when both are present: the
+    # transformer defines the payload format/auth/retry and the webhook URL
+    # is the delivery destination. Alone, each keeps its original semantics
+    # (webhook = raw standard payload, transformer = its own endpoint.url).
     webhook = meta.get("webhook")
     transformer = meta.get("transformer")
-    if webhook is not None and transformer is not None:
-        raise ValueError("'webhook' and 'transformer' are mutually exclusive")
     if webhook is not None:
         if not isinstance(webhook, str) or not webhook.strip():
             raise ValueError("'webhook' must be a non-empty URL string")
@@ -334,10 +360,15 @@ class ContentTransform:
 
 @dataclass
 class TransformerConfig:
-    """Parsed and validated transformer definition."""
+    """Parsed and validated transformer definition.
+
+    ``url`` is None for payload-format-only transformers (e.g. the bundled
+    channel templates): the referencing trigger/channel must then supply the
+    destination URL (see ``resolve_transformer_url``).
+    """
 
     name: str
-    url: str
+    url: Optional[str] = None
     method: str = "POST"
     version: Optional[str] = None
     auth: Optional[TransformerAuth] = None
@@ -361,17 +392,22 @@ class TransformerConfig:
                 "hyphens, and underscores"
             )
 
+        # 'endpoint' (and 'endpoint.url') is optional: payload-format-only
+        # transformers rely on the referencing trigger/channel for the URL.
         endpoint = raw.get("endpoint")
-        if not isinstance(endpoint, dict):
-            raise ValueError("'endpoint' is required and must be a mapping")
-        url = endpoint.get("url")
-        if not isinstance(url, str) or not url.strip():
-            raise ValueError("'endpoint.url' is required and must be a non-empty string")
-        method = endpoint.get("method", "POST")
-        if not isinstance(method, str) or method.upper() not in _ALLOWED_METHODS:
-            raise ValueError(
-                f"'endpoint.method' must be one of {sorted(_ALLOWED_METHODS)}, got {method!r}"
-            )
+        url = None
+        method = "POST"
+        if endpoint is not None:
+            if not isinstance(endpoint, dict):
+                raise ValueError("'endpoint' must be a mapping")
+            url = endpoint.get("url")
+            if url is not None and (not isinstance(url, str) or not url.strip()):
+                raise ValueError("'endpoint.url' must be a non-empty string when present")
+            method = endpoint.get("method", "POST")
+            if not isinstance(method, str) or method.upper() not in _ALLOWED_METHODS:
+                raise ValueError(
+                    f"'endpoint.method' must be one of {sorted(_ALLOWED_METHODS)}, got {method!r}"
+                )
 
         version = raw.get("version")
         if version is not None and not isinstance(version, str):
@@ -410,18 +446,25 @@ class TransformerConfig:
 
 def load_transformer(formation_dir: Path, name: str) -> TransformerConfig:
     """
-    Load and validate a transformer definition from the formation directory.
+    Load and validate a transformer definition.
+
+    Formation-local files are resolved first; when absent, the bundled
+    dormant templates shipped with the runtime are consulted, so a
+    formation ``transformers/<name>.yaml`` shadows a bundled template of
+    the same name (the same shadowing rule as built-in skills). Bundled
+    templates are inert until referenced by name.
 
     Args:
         formation_dir: Formation root directory
-        name: Transformer name (resolves ``transformers/<name>.yaml``)
+        name: Transformer name (resolves ``transformers/<name>.yaml``,
+            then ``builtin/transformers/<name>.yaml``)
 
     Returns:
         Validated TransformerConfig
 
     Raises:
-        ValueError: If the name is invalid, the file is missing, or the
-            config fails validation
+        ValueError: If the name is invalid, no file exists in either
+            location, or the config fails validation
     """
     if not _NAME_PATTERN.match(name):
         raise ValueError(
@@ -430,22 +473,60 @@ def load_transformer(formation_dir: Path, name: str) -> TransformerConfig:
         )
 
     transformers_dir = Path(formation_dir) / "transformers"
-    for suffix in (".yaml", ".yml"):
-        candidate = transformers_dir / f"{name}{suffix}"
-        if candidate.exists():
-            try:
-                raw = yaml.safe_load(candidate.read_text(encoding="utf-8"))
-            except yaml.YAMLError as e:
-                raise ValueError(f"transformer '{name}' contains invalid YAML: {e}")
-            config = TransformerConfig.from_dict(raw)
-            if config.name != name:
-                raise ValueError(
-                    f"transformer file '{candidate.name}' declares name "
-                    f"{config.name!r}; it must match the filename"
-                )
-            return config
+    for directory in (transformers_dir, BUILTIN_TRANSFORMERS_DIR):
+        for suffix in (".yaml", ".yml"):
+            candidate = directory / f"{name}{suffix}"
+            if candidate.exists():
+                try:
+                    raw = yaml.safe_load(candidate.read_text(encoding="utf-8"))
+                except yaml.YAMLError as e:
+                    raise ValueError(f"transformer '{name}' contains invalid YAML: {e}")
+                config = TransformerConfig.from_dict(raw)
+                if config.name != name:
+                    raise ValueError(
+                        f"transformer file '{candidate.name}' declares name "
+                        f"{config.name!r}; it must match the filename"
+                    )
+                return config
 
-    raise ValueError(f"transformer '{name}' not found in {transformers_dir}")
+    raise ValueError(
+        f"transformer '{name}' not found in {transformers_dir} "
+        "(and no bundled template has that name)"
+    )
+
+
+def resolve_transformer_url(
+    transformer: TransformerConfig, override_url: Optional[str] = None
+) -> str:
+    """
+    Resolve the delivery destination for a transformer.
+
+    Resolution order: the trigger/channel-supplied URL first, then the
+    transformer's own ``endpoint.url``. A transformer with no URL from
+    either source is a configuration error (callers surface this at
+    formation load time so a URL-less template referenced without a
+    destination fails fast, not at delivery time).
+
+    Args:
+        transformer: The loaded transformer config
+        override_url: URL supplied by the referencing trigger (``webhook:``
+            frontmatter) or proactive channel (``url:`` key), if any
+
+    Returns:
+        The URL to deliver to (may still contain ``${{ ... }}`` placeholders)
+
+    Raises:
+        ValueError: If neither the caller nor the transformer supplies a URL
+    """
+    url = override_url or transformer.url
+    if not url:
+        raise ValueError(
+            f"transformer '{transformer.name}' defines no 'endpoint.url' and the "
+            "referencing trigger/channel supplies no destination URL; add "
+            "'endpoint.url' to the transformer, a 'webhook:' to the trigger "
+            "frontmatter, or a 'url:' to the proactive channel declaration"
+        )
+    return url
 
 
 # ---------------------------------------------------------------------------
@@ -523,8 +604,14 @@ def render_template_value(value: Any, variables: Dict[str, Any]) -> Any:
     return value
 
 
-def collect_secret_names(config: TransformerConfig) -> Set[str]:
-    """Collect all ``${{ secrets.* }}`` names referenced by a transformer."""
+def collect_secret_names(config: TransformerConfig, *extra_values: Any) -> Set[str]:
+    """
+    Collect all ``${{ secrets.* }}`` names referenced by a transformer.
+
+    ``extra_values`` allows callers to include additional template strings
+    in the scan (e.g. a trigger/channel-supplied destination URL, which may
+    itself reference a secret such as a Slack incoming-webhook URL).
+    """
     secret_names: Set[str] = set()
 
     def _scan(value: Any) -> None:
@@ -548,6 +635,8 @@ def collect_secret_names(config: TransformerConfig) -> Set[str]:
         _scan(config.auth.username)
         _scan(config.auth.password)
         _scan(config.auth.header_value)
+    for extra in extra_values:
+        _scan(extra)
     return secret_names
 
 
@@ -716,9 +805,14 @@ async def deliver_via_transformer(
     request_id: str,
     formation_id: Optional[str] = None,
     fallback_webhook_url: Optional[str] = None,
+    url_override: Optional[str] = None,
 ) -> bool:
     """
     Format an agent response with a transformer and deliver it.
+
+    ``url_override`` is the trigger/channel-supplied destination URL; it
+    takes precedence over the transformer's own ``endpoint.url`` (the
+    transformer+webhook composition mechanism).
 
     On rendering or delivery failure, the standard MUXI payload is delivered
     to ``fallback_webhook_url`` (the formation's default async webhook) with
@@ -727,11 +821,13 @@ async def deliver_via_transformer(
     Returns:
         True if the transformer endpoint accepted the delivery
     """
-    endpoint_url = transformer.url
+    endpoint_url = url_override or transformer.url
     attempts = 0
     last_error: Optional[str] = None
     try:
-        secrets = await resolve_secrets(collect_secret_names(transformer), secrets_manager)
+        secrets = await resolve_secrets(
+            collect_secret_names(transformer, url_override), secrets_manager
+        )
         content = apply_content_transform(response_content, transformer.content_transform)
         variables = build_transformer_variables(
             response_content=content,
@@ -745,9 +841,11 @@ async def deliver_via_transformer(
             secrets=secrets,
         )
 
-        rendered_url = render_template_string(transformer.url, variables)
+        # Trigger/channel-supplied URL first, transformer endpoint.url second
+        effective_url = resolve_transformer_url(transformer, url_override)
+        rendered_url = render_template_string(effective_url, variables)
         if not isinstance(rendered_url, str) or not rendered_url.strip():
-            raise ValueError("'endpoint.url' rendered to an empty value")
+            raise ValueError("delivery URL rendered to an empty value")
         endpoint_url = rendered_url
 
         headers = {

--- a/src/muxi/runtime/formation/background/transformers.py
+++ b/src/muxi/runtime/formation/background/transformers.py
@@ -821,7 +821,8 @@ async def deliver_via_transformer(
     Returns:
         True if the transformer endpoint accepted the delivery
     """
-    endpoint_url = url_override or transformer.url
+    # Pre-render fallback value for failure paths; may be None until resolved
+    endpoint_url: Optional[str] = url_override or transformer.url
     attempts = 0
     last_error: Optional[str] = None
     try:

--- a/src/muxi/runtime/formation/config/validation.py
+++ b/src/muxi/runtime/formation/config/validation.py
@@ -279,6 +279,12 @@ class FormationValidator:
             self._validate_triggers_model_references(dir_path / "triggers")
             self._validate_skills_model_references(dir_path / "skills")
 
+            # Validate transformer URL resolution (fail fast at load time):
+            # a URL-less transformer (e.g. a bundled channel template) must
+            # get its destination from the referencing trigger/channel.
+            self._validate_trigger_transformer_urls(dir_path / "triggers", dir_path)
+            self._validate_proactive_channel_transformers(dir_path, config)
+
         except Exception as e:
             self.result.add_error(f"Error validating modular formation: {str(e)}")
 
@@ -1453,6 +1459,77 @@ class FormationValidator:
                 self._validate_model_reference(
                     metadata["model"], f"Trigger '{md_file.name}' frontmatter"
                 )
+
+    def _validate_trigger_transformer_urls(self, triggers_dir: Path, formation_dir: Path) -> None:
+        """
+        Validate transformer URL resolution for triggers (fail fast at load).
+
+        A trigger that names a transformer must yield a delivery URL: the
+        trigger's 'webhook:' frontmatter first, the transformer's own
+        'endpoint.url' second. Malformed frontmatter and missing transformer
+        files keep their existing request-time (HTTP 400) semantics and are
+        skipped here; only the URL-resolution rule is enforced at load time.
+        """
+        from ..background.transformers import (
+            load_transformer,
+            parse_trigger_frontmatter,
+            resolve_transformer_url,
+        )
+
+        if not triggers_dir.is_dir():
+            return
+
+        for md_file in sorted(triggers_dir.glob("*.md")):
+            try:
+                content = md_file.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            try:
+                meta, _body = parse_trigger_frontmatter(content)
+            except ValueError:
+                # Rejected at request time with a 400 (existing behavior)
+                continue
+            transformer_name = meta.get("transformer")
+            if not transformer_name:
+                continue
+            try:
+                transformer = load_transformer(formation_dir, transformer_name)
+            except ValueError:
+                # Missing/invalid transformer files keep request-time semantics
+                continue
+            try:
+                resolve_transformer_url(transformer, meta.get("webhook"))
+            except ValueError as e:
+                self.result.add_error(f"Trigger '{md_file.name}': {e}")
+
+    def _validate_proactive_channel_transformers(
+        self, formation_dir: Path, config: Dict[str, Any]
+    ) -> None:
+        """
+        Validate proactive channel transformers and URL resolution at load.
+
+        Mirrors the NotificationRouter's startup fail-fast (missing/invalid
+        transformer, or no delivery URL from either the channel 'url:' or the
+        transformer's 'endpoint.url') so misconfigurations surface as
+        validation errors instead of startup exceptions.
+        """
+        from ..background.transformers import load_transformer, resolve_transformer_url
+        from ..proactive import parse_proactive_config
+
+        try:
+            parsed = parse_proactive_config(config.get("proactive"))
+        except ValueError:
+            # Structural problems are reported by _validate_proactive_config
+            return
+        if not parsed or not parsed.channels:
+            return
+
+        for name, channel in parsed.channels.items():
+            try:
+                transformer = load_transformer(formation_dir, channel.transformer)
+                resolve_transformer_url(transformer, channel.url)
+            except ValueError as e:
+                self.result.add_error(f"'proactive.channels.{name}': {e}")
 
     def _validate_skills_model_references(self, skills_dir: Path) -> None:
         """Validate model references in SKILL.md frontmatter."""

--- a/src/muxi/runtime/formation/proactive/config.py
+++ b/src/muxi/runtime/formation/proactive/config.py
@@ -14,7 +14,8 @@ Schema:
         telegram:
           transformer: telegram-notify   # transformers/telegram-notify.yaml
         slack:
-          transformer: slack-notify
+          transformer: slack            # bundled template (payload only)...
+          url: "${{ secrets.SLACK_BRIDGE_URL }}"  # ...so the channel supplies the URL
       default_channel: telegram          # optional: channel name or "webhook"
       heartbeat:                         # optional
         enabled: true                    # default true when block present
@@ -51,7 +52,11 @@ PREFERRED_TARGET = "preferred"
 RESERVED_TARGETS = {WEBHOOK_TARGET, LAST_TARGET, PREFERRED_TARGET}
 
 _ALLOWED_PROACTIVE_KEYS = {"channels", "default_channel", "heartbeat"}
-_ALLOWED_CHANNEL_KEYS = {"transformer"}
+_ALLOWED_CHANNEL_KEYS = {"transformer", "url"}
+
+# ${{ ... }} placeholder marker: channel URLs may be templates (e.g. a
+# secret-backed Slack incoming-webhook URL) instead of literal http(s) URLs.
+_PLACEHOLDER_MARKER = "${{"
 _ALLOWED_HEARTBEAT_KEYS = {"enabled", "interval", "target", "active_hours", "instruction", "sop"}
 _ALLOWED_ACTIVE_HOURS_KEYS = {"start", "end", "timezone", "weekends"}
 
@@ -60,10 +65,17 @@ DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 30 * 60  # "30m"
 
 @dataclass
 class ChannelConfig:
-    """A notification channel backed by a trigger transformer."""
+    """A notification channel backed by a trigger transformer.
+
+    ``url`` optionally supplies/overrides the delivery destination: it wins
+    over the transformer's own ``endpoint.url``, and is required (at load
+    time) when the transformer defines none (e.g. the bundled payload-only
+    channel templates).
+    """
 
     name: str
     transformer: str
+    url: Optional[str] = None
 
 
 @dataclass
@@ -275,7 +287,17 @@ def parse_proactive_config(raw: Any) -> Optional[ProactiveConfig]:
                 f"'proactive.channels.{name}.transformer' is required and must be a "
                 "transformer name containing only letters, numbers, hyphens, and underscores"
             )
-        channels[name] = ChannelConfig(name=name, transformer=transformer)
+        url = channel_raw.get("url")
+        if url is not None:
+            if not isinstance(url, str) or not url.strip():
+                raise ValueError(f"'proactive.channels.{name}.url' must be a non-empty string")
+            url = url.strip()
+            if _PLACEHOLDER_MARKER not in url and not url.startswith(("http://", "https://")):
+                raise ValueError(
+                    f"'proactive.channels.{name}.url' must be an http(s) URL or a "
+                    "template containing ${{ ... }} placeholders"
+                )
+        channels[name] = ChannelConfig(name=name, transformer=transformer, url=url)
 
     default_channel = raw.get("default_channel")
     if default_channel is not None:

--- a/src/muxi/runtime/formation/proactive/router.py
+++ b/src/muxi/runtime/formation/proactive/router.py
@@ -33,6 +33,7 @@ from ..background.transformers import (
     TransformerConfig,
     deliver_via_transformer,
     load_transformer,
+    resolve_transformer_url,
 )
 from .config import LAST_TARGET, PREFERRED_TARGET, WEBHOOK_TARGET, ProactiveConfig
 from .user_channels import UserChannelStore
@@ -74,7 +75,8 @@ class NotificationRouter:
 
         Raises:
             ValueError: If any declared channel references a missing or
-                invalid transformer (fail fast at formation startup)
+                invalid transformer, or the channel/transformer pair yields
+                no delivery URL (fail fast at formation startup)
         """
         self.config = config
         self.formation_id = formation_id
@@ -87,7 +89,13 @@ class NotificationRouter:
         self._transformers: Dict[str, TransformerConfig] = {}
         for name, channel in config.channels.items():
             # Raises ValueError on missing/invalid transformer definitions
-            self._transformers[name] = load_transformer(Path(formation_dir), channel.transformer)
+            transformer = load_transformer(Path(formation_dir), channel.transformer)
+            # URL resolution order: channel 'url:' first, transformer's own
+            # endpoint.url second; no URL from either source is a startup
+            # error (a payload-only template referenced without a destination
+            # must fail here, not at delivery time).
+            resolve_transformer_url(transformer, channel.url)
+            self._transformers[name] = transformer
 
     async def resolve_channels(
         self, user_id: str, channels: Optional[List[str]] = None
@@ -288,6 +296,7 @@ class NotificationRouter:
             webhook_manager=self.webhook_manager,
             secrets_manager=self.secrets_manager,
             transformer=transformer,
+            url_override=self.config.channels[channel].url,
             response_content=message,
             request_user_id=user_id,
             context=context,

--- a/src/muxi/runtime/formation/server/routes/client/triggers.py
+++ b/src/muxi/runtime/formation/server/routes/client/triggers.py
@@ -23,6 +23,7 @@ from ....background.transformers import (
     extract_parse_values,
     load_transformer,
     parse_trigger_frontmatter,
+    resolve_transformer_url,
 )
 from ...responses import (
     APIResponse,
@@ -318,17 +319,24 @@ async def execute_trigger(
             detail=f"Invalid frontmatter in trigger '{trigger_name}': {str(e)}",
         )
 
-    # Fail fast on malformed/missing transformer config before any LLM work
+    # Fail fast on malformed/missing transformer config before any LLM work.
+    # 'transformer' + 'webhook' compose: the transformer defines the payload
+    # format/auth/retry, the trigger's webhook URL is the delivery destination
+    # (it wins over the transformer's own endpoint.url).
+    webhook_override: Optional[str] = trigger_meta.get("webhook")
     transformer_config: Optional[TransformerConfig] = None
     if trigger_meta.get("transformer"):
         try:
             transformer_config = load_transformer(formation_dir, trigger_meta["transformer"])
+            # URL-less transformer with no trigger-supplied destination:
+            # formation validation already rejects this at load time, but
+            # guard here too so directly-loaded formations fail before LLM work
+            resolve_transformer_url(transformer_config, webhook_override)
         except ValueError as e:
             raise HTTPException(
                 status_code=400,
                 detail=f"Invalid transformer for trigger '{trigger_name}': {str(e)}",
             )
-    webhook_override: Optional[str] = trigger_meta.get("webhook")
     # Trigger-level model override (hierarchical model selection). Applies to
     # the chat turn unless an SOP/step/skill level specifies its own model.
     trigger_model: Optional[str] = trigger_meta.get("model")
@@ -395,6 +403,7 @@ async def execute_trigger(
                 webhook_manager=overlord.webhook_manager,
                 secrets_manager=formation.secrets_manager,
                 transformer=transformer_config,
+                url_override=webhook_override,
                 response_content=response_content,
                 response=response,
                 request_message=parsed_request.get("message"),
@@ -521,6 +530,8 @@ async def execute_trigger(
             # Use overlord's chat method (non-streaming for triggers)
             # Bypass workflow approval for triggers (automated execution)
             # Explicitly disable streaming to get actual content, not a generator
+            # When a transformer is present the webhook URL is its delivery
+            # destination (composition), not a raw standard-payload webhook.
             response = await overlord.chat(
                 rendered_message,
                 user_id=chat_user_id,
@@ -528,7 +539,7 @@ async def execute_trigger(
                 request_id=request_id,
                 bypass_workflow_approval=True,
                 stream=False,
-                webhook_url=webhook_override,
+                webhook_url=webhook_override if transformer_config is None else None,
                 model_override=trigger_model,
                 source_channel=source_channel,
                 source_context=parsed_request.get("context"),

--- a/tests/unit/test_channel_templates.py
+++ b/tests/unit/test_channel_templates.py
@@ -1,0 +1,149 @@
+"""
+Unit tests for the bundled channel transformer templates (Phase 2).
+
+Pins that each bundled template (slack, telegram, discord, email) renders a
+valid platform payload from a sample substitution context, ships with no
+destination URL (dormant/payload-only), and stays inert for formations that
+never reference it.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from muxi.runtime.formation.background.transformers import (
+    BUILTIN_TRANSFORMERS_DIR,
+    apply_content_transform,
+    build_transformer_variables,
+    load_transformer,
+    render_template_value,
+)
+
+# A formation directory with no transformers/ of its own: every load below
+# exercises the builtin fallback exactly as a real formation would.
+EMPTY_FORMATION = Path("/nonexistent-formation-dir")
+
+
+def _render(name, *, response_content, context):
+    """Load a bundled template and render its body like delivery does."""
+    config = load_transformer(EMPTY_FORMATION, name)
+    content = apply_content_transform(response_content, config.content_transform)
+    variables = build_transformer_variables(
+        response_content=content,
+        request_user_id="user-1",
+        context=context,
+        agent_name="assistant",
+    )
+    return config, render_template_value(config.body, variables)
+
+
+class TestDormancy:
+    @pytest.mark.parametrize("name", ["slack", "telegram", "discord", "email"])
+    def test_no_destination_url_and_no_auth(self, name):
+        # Payload formats only: no URLs, no baked-in credentials.
+        config = load_transformer(EMPTY_FORMATION, name)
+        assert config.url is None
+        assert config.auth is None
+
+    def test_unreferenced_names_behave_as_before(self):
+        # Inert-when-unreferenced: a formation that does not name a bundled
+        # template gets identical behavior to today, including identical
+        # errors for unknown transformer names.
+        with pytest.raises(ValueError, match="not found"):
+            load_transformer(EMPTY_FORMATION, "whatsapp")
+
+
+class TestSlackTemplate:
+    def test_renders_chat_post_message_payload(self):
+        _config, body = _render(
+            "slack",
+            response_content="**Deploy done**",
+            context={"channel": "C0ABC123", "thread_ts": "1234.5678"},
+        )
+        assert body == {
+            "channel": "C0ABC123",
+            "thread_ts": "1234.5678",
+            "text": "**Deploy done**",
+        }
+
+    def test_absent_thread_ts_is_dropped(self):
+        _config, body = _render(
+            "slack",
+            response_content="hi",
+            context={"channel": "D0XYZ789", "thread_ts": None},
+        )
+        assert "thread_ts" not in body
+        assert body["channel"] == "D0XYZ789"
+
+
+class TestTelegramTemplate:
+    def test_renders_send_message_payload(self):
+        _config, body = _render(
+            "telegram",
+            response_content="Reminder: standup in 15 minutes",
+            context={"chat_id": "123456789"},
+        )
+        assert body == {"chat_id": "123456789", "text": "Reminder: standup in 15 minutes"}
+
+    def test_markdown_stripped_and_length_capped(self):
+        config = load_transformer(EMPTY_FORMATION, "telegram")
+        assert config.content_transform.format == "text"
+        assert config.content_transform.max_length == 4096
+        stripped = apply_content_transform("**bold** and `code`", config.content_transform)
+        assert stripped == "bold and code"
+        capped = apply_content_transform("a" * 5000, config.content_transform)
+        assert len(capped) == 4096
+
+
+class TestDiscordTemplate:
+    def test_renders_webhook_content_payload(self):
+        _config, body = _render(
+            "discord",
+            response_content="Build passed",
+            context={},
+        )
+        assert body == {"content": "Build passed"}
+
+    def test_discord_message_limit_enforced(self):
+        config = load_transformer(EMPTY_FORMATION, "discord")
+        capped = apply_content_transform("x" * 3000, config.content_transform)
+        assert len(capped) == 2000
+
+
+class TestEmailTemplate:
+    def test_renders_constructed_message_object(self):
+        _config, body = _render(
+            "email",
+            response_content="Weekly report attached below.",
+            context={
+                "address": "ran@example.com",
+                "from": "Assistant <assistant@example.com>",
+                "subject": "Weekly report",
+            },
+        )
+        assert body["from"] == "Assistant <assistant@example.com>"
+        assert body["to"] == "ran@example.com"
+        assert body["subject"] == "Weekly report"
+        assert body["body"] == "Weekly report attached below."
+        assert body["headers"]["X-Muxi-Agent"] == "assistant"
+        assert body["headers"]["X-Muxi-Timestamp"]  # ISO string, non-empty
+
+    def test_optional_fields_dropped_when_absent(self):
+        _config, body = _render(
+            "email",
+            response_content="hello",
+            context={"address": "ran@example.com"},
+        )
+        assert body["to"] == "ran@example.com"
+        assert "from" not in body
+        assert "subject" not in body
+
+
+class TestBundledDirIsPackaged:
+    def test_templates_live_inside_the_runtime_package(self):
+        # The bundled dir must be under the installed package so wheels and
+        # SIF images ship it (package_data includes **/*.yaml).
+        package_root = BUILTIN_TRANSFORMERS_DIR
+        assert package_root.name == "transformers"
+        assert package_root.parent.name == "builtin"
+        assert package_root.parent.parent.name == "background"

--- a/tests/unit/test_notification_router.py
+++ b/tests/unit/test_notification_router.py
@@ -191,10 +191,45 @@ class TestRoutingPrecedence:
         assert await router.resolve_channels("ran") == ["webhook"]
 
 
+def _write_url_less_transformer(formation_dir, name):
+    transformers_dir = formation_dir / "transformers"
+    transformers_dir.mkdir(exist_ok=True)
+    (transformers_dir / f"{name}.yaml").write_text(
+        f"name: {name}\n"
+        f"body:\n"
+        f'  text: "${{{{ response.content }}}}"\n'
+        f'  room: "${{{{ context.room }}}}"\n'
+        f'  user: "${{{{ request.user_id }}}}"\n'
+    )
+
+
 class TestConstruction:
     def test_missing_transformer_fails_fast(self, tmp_path):
         with pytest.raises(ValueError, match="not found"):
             _router(tmp_path, {"channels": {"chan-a": {"transformer": "missing"}}})
+
+    def test_url_less_transformer_without_channel_url_fails_fast(self, tmp_path):
+        # URL resolution is a startup error, not a delivery-time surprise
+        _write_url_less_transformer(tmp_path, "shape-only")
+        with pytest.raises(ValueError, match="no 'endpoint.url'"):
+            _router(tmp_path, {"channels": {"chan-a": {"transformer": "shape-only"}}})
+
+    def test_channel_url_satisfies_url_less_transformer(self, tmp_path):
+        _write_url_less_transformer(tmp_path, "shape-only")
+        router, _ = _router(
+            tmp_path,
+            {"channels": {"chan-a": {"transformer": "shape-only", "url": "https://bridge.test/a"}}},
+        )
+        assert router.config.channels["chan-a"].url == "https://bridge.test/a"
+
+    def test_bundled_template_with_channel_url_constructs(self, tmp_path):
+        # A bundled dormant template (no formation-local file at all)
+        # activates by reference when the channel supplies the URL.
+        router, _ = _router(
+            tmp_path,
+            {"channels": {"slack": {"transformer": "slack", "url": "https://bridge.test/s"}}},
+        )
+        assert router.config.channels["slack"].transformer == "slack"
 
 
 class TestDelivery:
@@ -216,6 +251,61 @@ class TestDelivery:
             assert payload["text"] == "hello there"
             assert payload["room"] == "R42"
             assert payload["user"] == "ran"
+        finally:
+            await sink.stop()
+
+    async def test_channel_url_override_wins_over_transformer_url(self, tmp_path):
+        own = await Sink().start()
+        override = await Sink().start()
+        try:
+            _write_transformer(tmp_path, "t-a", f"http://127.0.0.1:{own.port}/own")
+            router, store = _router(
+                tmp_path,
+                {
+                    "channels": {
+                        "chan-a": {
+                            "transformer": "t-a",
+                            "url": f"http://127.0.0.1:{override.port}/override",
+                        }
+                    }
+                },
+            )
+            await store.set_preferences("ran", preferred_channel="chan-a")
+
+            result = await router.notify(user_id="ran", message="ping")
+
+            assert result["delivered"] == ["chan-a"]
+            assert own.requests == []
+            assert len(override.requests) == 1
+            assert override.requests[0]["path"] == "/override"
+        finally:
+            await own.stop()
+            await override.stop()
+
+    async def test_url_less_transformer_delivers_to_channel_url(self, tmp_path):
+        sink = await Sink().start()
+        try:
+            _write_url_less_transformer(tmp_path, "shape-only")
+            router, store = _router(
+                tmp_path,
+                {
+                    "channels": {
+                        "chan-a": {
+                            "transformer": "shape-only",
+                            "url": f"http://127.0.0.1:{sink.port}/bridge",
+                        }
+                    }
+                },
+            )
+            await store.set_preferences(
+                "ran", preferred_channel="chan-a", channels={"chan-a": {"room": "R7"}}
+            )
+
+            result = await router.notify(user_id="ran", message="composed")
+
+            assert result["delivered"] == ["chan-a"]
+            payload = json.loads(sink.requests[0]["body"])
+            assert payload == {"text": "composed", "room": "R7", "user": "ran"}
         finally:
             await sink.stop()
 

--- a/tests/unit/test_proactive_config.py
+++ b/tests/unit/test_proactive_config.py
@@ -52,6 +52,36 @@ class TestChannels:
         with pytest.raises(ValueError, match="unknown 'proactive.channels.telegram' key"):
             parse_proactive_config({"channels": {"telegram": {"transformer": "t", "token": "x"}}})
 
+    def test_channel_url_override_parsed(self):
+        config = parse_proactive_config(
+            {"channels": {"slack": {"transformer": "slack", "url": "https://bridge.test/slack"}}}
+        )
+        assert config.channels["slack"].url == "https://bridge.test/slack"
+
+    def test_channel_url_defaults_to_none(self):
+        config = parse_proactive_config({"channels": {"telegram": {"transformer": "t"}}})
+        assert config.channels["telegram"].url is None
+
+    def test_channel_url_may_be_secret_template(self):
+        config = parse_proactive_config(
+            {
+                "channels": {
+                    "slack": {"transformer": "slack", "url": "${{ secrets.SLACK_BRIDGE_URL }}"}
+                }
+            }
+        )
+        assert config.channels["slack"].url == "${{ secrets.SLACK_BRIDGE_URL }}"
+
+    def test_channel_url_must_be_http_or_template(self):
+        with pytest.raises(ValueError, match="http"):
+            parse_proactive_config(
+                {"channels": {"slack": {"transformer": "slack", "url": "ftp://x.test"}}}
+            )
+
+    def test_empty_channel_url_rejected(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            parse_proactive_config({"channels": {"slack": {"transformer": "slack", "url": "  "}}})
+
 
 class TestDefaultChannel:
     def test_default_channel_must_be_declared(self):

--- a/tests/unit/test_proactive_validation.py
+++ b/tests/unit/test_proactive_validation.py
@@ -101,6 +101,130 @@ class TestCommandsBlock:
         assert _errors_mentioning(validator, "aliases")
 
 
+def _write_transformer(formation_dir, name, url=None):
+    transformers_dir = formation_dir / "transformers"
+    transformers_dir.mkdir(exist_ok=True)
+    endpoint = f"endpoint:\n  url: {url}\n" if url else ""
+    (transformers_dir / f"{name}.yaml").write_text(
+        f"name: {name}\n{endpoint}" 'body:\n  text: "${{ response.content }}"\n'
+    )
+
+
+def _write_trigger(formation_dir, name, frontmatter):
+    triggers_dir = formation_dir / "triggers"
+    triggers_dir.mkdir(exist_ok=True)
+    (triggers_dir / f"{name}.md").write_text(f"---\n{frontmatter}---\nBody: ${{{{ data.x }}}}\n")
+
+
+class TestTriggerTransformerUrlValidation:
+    """Load-time URL resolution for the transformer+webhook composition."""
+
+    def test_url_less_transformer_without_webhook_rejected(self, tmp_path):
+        _write_transformer(tmp_path, "shape-only")
+        _write_trigger(tmp_path, "notify", "transformer: shape-only\n")
+        validator = FormationValidator()
+        validator._validate_trigger_transformer_urls(tmp_path / "triggers", tmp_path)
+        assert _errors_mentioning(validator, "no 'endpoint.url'")
+
+    def test_composition_with_webhook_is_clean(self, tmp_path):
+        _write_transformer(tmp_path, "shape-only")
+        _write_trigger(
+            tmp_path, "notify", "transformer: shape-only\nwebhook: https://bridge.test/n\n"
+        )
+        validator = FormationValidator()
+        validator._validate_trigger_transformer_urls(tmp_path / "triggers", tmp_path)
+        assert validator.result.errors == []
+
+    def test_transformer_with_own_url_is_clean(self, tmp_path):
+        _write_transformer(tmp_path, "with-url", url="https://own.test/n")
+        _write_trigger(tmp_path, "notify", "transformer: with-url\n")
+        validator = FormationValidator()
+        validator._validate_trigger_transformer_urls(tmp_path / "triggers", tmp_path)
+        assert validator.result.errors == []
+
+    def test_bundled_template_without_webhook_rejected(self, tmp_path):
+        # Referencing a bundled dormant template (no URL by design) without
+        # supplying a destination fails at load time
+        _write_trigger(tmp_path, "slack-out", "transformer: slack\n")
+        validator = FormationValidator()
+        validator._validate_trigger_transformer_urls(tmp_path / "triggers", tmp_path)
+        assert _errors_mentioning(validator, "no 'endpoint.url'")
+
+    def test_bundled_template_with_webhook_is_clean(self, tmp_path):
+        _write_trigger(
+            tmp_path, "slack-out", "transformer: slack\nwebhook: https://bridge.test/slack\n"
+        )
+        validator = FormationValidator()
+        validator._validate_trigger_transformer_urls(tmp_path / "triggers", tmp_path)
+        assert validator.result.errors == []
+
+    def test_triggers_without_transformers_are_ignored(self, tmp_path):
+        _write_trigger(tmp_path, "plain", "webhook: https://x.test/h\n")
+        (tmp_path / "triggers" / "no-frontmatter.md").write_text("Plain: ${{ data.x }}\n")
+        validator = FormationValidator()
+        validator._validate_trigger_transformer_urls(tmp_path / "triggers", tmp_path)
+        assert validator.result.errors == []
+
+    def test_missing_transformer_file_keeps_request_time_semantics(self, tmp_path):
+        # Missing transformer files stay a request-time 400 (unchanged), so
+        # the load-time URL check skips them instead of erroring
+        _write_trigger(tmp_path, "notify", "transformer: does-not-exist\n")
+        validator = FormationValidator()
+        validator._validate_trigger_transformer_urls(tmp_path / "triggers", tmp_path)
+        assert validator.result.errors == []
+
+
+class TestProactiveChannelUrlValidation:
+    """Load-time URL resolution for proactive channel declarations."""
+
+    def test_url_less_transformer_without_channel_url_rejected(self, tmp_path):
+        _write_transformer(tmp_path, "shape-only")
+        validator = FormationValidator()
+        validator._validate_proactive_channel_transformers(
+            tmp_path, {"proactive": {"channels": {"chan-a": {"transformer": "shape-only"}}}}
+        )
+        assert _errors_mentioning(validator, "proactive.channels.chan-a")
+
+    def test_channel_url_satisfies_url_less_transformer(self, tmp_path):
+        _write_transformer(tmp_path, "shape-only")
+        validator = FormationValidator()
+        validator._validate_proactive_channel_transformers(
+            tmp_path,
+            {
+                "proactive": {
+                    "channels": {
+                        "chan-a": {"transformer": "shape-only", "url": "https://bridge.test/a"}
+                    }
+                }
+            },
+        )
+        assert validator.result.errors == []
+
+    def test_bundled_template_channel_with_url_is_clean(self, tmp_path):
+        validator = FormationValidator()
+        validator._validate_proactive_channel_transformers(
+            tmp_path,
+            {
+                "proactive": {
+                    "channels": {"slack": {"transformer": "slack", "url": "https://b.test/s"}}
+                }
+            },
+        )
+        assert validator.result.errors == []
+
+    def test_missing_transformer_rejected(self, tmp_path):
+        validator = FormationValidator()
+        validator._validate_proactive_channel_transformers(
+            tmp_path, {"proactive": {"channels": {"chan-a": {"transformer": "missing"}}}}
+        )
+        assert _errors_mentioning(validator, "not found")
+
+    def test_absent_proactive_block_is_inert(self, tmp_path):
+        validator = FormationValidator()
+        validator._validate_proactive_channel_transformers(tmp_path, {})
+        assert validator.result.errors == []
+
+
 class TestAgentSoulField:
     def test_valid_soul_path_accepted(self):
         validator = FormationValidator()

--- a/tests/unit/test_trigger_transformers.py
+++ b/tests/unit/test_trigger_transformers.py
@@ -13,6 +13,7 @@ import pytest
 from aiohttp import web
 
 from muxi.runtime.formation.background.transformers import (
+    BUILTIN_TRANSFORMERS_DIR,
     ContentTransform,
     TransformerConfig,
     apply_content_transform,
@@ -27,6 +28,7 @@ from muxi.runtime.formation.background.transformers import (
     render_template_string,
     render_template_value,
     resolve_secrets,
+    resolve_transformer_url,
 )
 from muxi.runtime.formation.background.webhook_manager import WebhookManager
 
@@ -82,10 +84,24 @@ class TestParseTriggerFrontmatter:
         assert meta["webhook"] == "https://example.com/hook"
         assert body == "body"
 
-    def test_webhook_and_transformer_are_mutually_exclusive(self):
+    def test_webhook_and_transformer_compose(self):
+        # Phase 2 composition: transformer defines the payload format, the
+        # trigger's webhook URL is the delivery destination.
         content = "---\nwebhook: https://x.test/h\ntransformer: slack\n---\nbody"
-        with pytest.raises(ValueError, match="mutually exclusive"):
-            parse_trigger_frontmatter(content)
+        meta, body = parse_trigger_frontmatter(content)
+        assert meta["webhook"] == "https://x.test/h"
+        assert meta["transformer"] == "slack"
+        assert body == "body"
+
+    def test_webhook_only_semantics_unchanged(self):
+        meta, _body = parse_trigger_frontmatter("---\nwebhook: https://x.test/h\n---\nbody")
+        assert meta["webhook"] == "https://x.test/h"
+        assert "transformer" not in meta
+
+    def test_transformer_only_semantics_unchanged(self):
+        meta, _body = parse_trigger_frontmatter("---\ntransformer: slack\n---\nbody")
+        assert meta["transformer"] == "slack"
+        assert "webhook" not in meta
 
     def test_malformed_yaml_fails_fast(self):
         content = "---\ntransformer: [unclosed\n---\nbody"
@@ -192,9 +208,21 @@ class TestTransformerConfigValidation:
         with pytest.raises(ValueError, match="'name'"):
             TransformerConfig.from_dict({"endpoint": {"url": "https://x.test"}})
 
-    def test_missing_endpoint_rejected(self):
+    def test_missing_endpoint_yields_url_less_transformer(self):
+        # Payload-format-only transformers (bundled channel templates) have
+        # no endpoint at all: the referencing trigger/channel supplies the URL.
+        config = TransformerConfig.from_dict({"name": "t", "body": {"text": "x"}})
+        assert config.url is None
+        assert config.method == "POST"
+
+    def test_endpoint_without_url_is_valid(self):
+        config = TransformerConfig.from_dict({"name": "t", "endpoint": {"method": "PUT"}})
+        assert config.url is None
+        assert config.method == "PUT"
+
+    def test_non_mapping_endpoint_rejected(self):
         with pytest.raises(ValueError, match="'endpoint'"):
-            TransformerConfig.from_dict({"name": "t"})
+            TransformerConfig.from_dict({"name": "t", "endpoint": "https://x.test"})
 
     def test_empty_url_rejected(self):
         with pytest.raises(ValueError, match="'endpoint.url'"):
@@ -305,6 +333,64 @@ class TestLoadTransformer:
         (transformers_dir / "bad.yaml").write_text("name: [unclosed\n")
         with pytest.raises(ValueError, match="invalid YAML"):
             load_transformer(tmp_path, "bad")
+
+
+class TestBundledTemplates:
+    """Bundled dormant channel templates (Phase 2)."""
+
+    BUNDLED = ["slack", "telegram", "discord", "email"]
+
+    def test_bundled_templates_exist(self):
+        assert BUILTIN_TRANSFORMERS_DIR.is_dir()
+        names = sorted(p.stem for p in BUILTIN_TRANSFORMERS_DIR.glob("*.yaml"))
+        assert names == sorted(self.BUNDLED)
+
+    @pytest.mark.parametrize("name", BUNDLED)
+    def test_bundled_template_loads_without_url(self, tmp_path, name):
+        # Loads via the builtin fallback from a formation with no transformers
+        # directory at all; payload format only, no destination URL.
+        config = load_transformer(tmp_path, name)
+        assert config.name == name
+        assert config.url is None
+        assert config.method == "POST"
+        assert config.body, f"bundled template '{name}' must define a body"
+
+    def test_formation_local_file_shadows_bundled_template(self, tmp_path):
+        transformers_dir = tmp_path / "transformers"
+        transformers_dir.mkdir()
+        (transformers_dir / "slack.yaml").write_text(
+            "name: slack\nendpoint:\n  url: https://my-bridge.test/slack\n"
+            'body:\n  text: "${{ response.content }}"\n'
+        )
+        config = load_transformer(tmp_path, "slack")
+        assert config.url == "https://my-bridge.test/slack"
+
+    def test_unknown_name_still_fails_fast(self, tmp_path):
+        # Inert-when-unreferenced pin: names matching neither a formation
+        # file nor a bundled template error exactly as before.
+        with pytest.raises(ValueError, match="not found"):
+            load_transformer(tmp_path, "matrix")
+
+
+class TestResolveTransformerUrl:
+    def test_override_wins_over_transformer_url(self):
+        transformer = TransformerConfig.from_dict(
+            {"name": "t", "endpoint": {"url": "https://own.test"}}
+        )
+        assert resolve_transformer_url(transformer, "https://override.test") == (
+            "https://override.test"
+        )
+
+    def test_transformer_url_used_without_override(self):
+        transformer = TransformerConfig.from_dict(
+            {"name": "t", "endpoint": {"url": "https://own.test"}}
+        )
+        assert resolve_transformer_url(transformer, None) == "https://own.test"
+
+    def test_no_url_anywhere_fails_fast(self):
+        transformer = TransformerConfig.from_dict({"name": "t"})
+        with pytest.raises(ValueError, match="no 'endpoint.url'"):
+            resolve_transformer_url(transformer, None)
 
 
 # ---------------------------------------------------------------------------
@@ -655,6 +741,115 @@ class TestTransformerDelivery:
             await manager.close()
             await sink.stop()
             await fallback.stop()
+
+    async def test_url_override_wins_over_transformer_endpoint(self):
+        own = await Sink().start()
+        override = await Sink().start()
+        manager = WebhookManager(default_retries=0, default_timeout=5)
+        try:
+            transformer = _make_transformer(
+                f"http://127.0.0.1:{own.port}/own",
+                body={"text": "${{ response.content }}"},
+            )
+            success = await deliver_via_transformer(
+                webhook_manager=manager,
+                secrets_manager=None,
+                transformer=transformer,
+                url_override=f"http://127.0.0.1:{override.port}/override",
+                response_content="hi",
+                request_id="req_test_override_1",
+            )
+            assert success is True
+            assert own.requests == [], "transformer endpoint must not be contacted"
+            assert len(override.requests) == 1
+            assert override.requests[0]["path"] == "/override"
+        finally:
+            await manager.close()
+            await own.stop()
+            await override.stop()
+
+    async def test_url_less_transformer_delivers_to_override(self):
+        # The transformer+webhook composition: payload format from the
+        # transformer, destination from the trigger/channel.
+        sink = await Sink().start()
+        manager = WebhookManager(default_retries=0, default_timeout=5)
+        try:
+            transformer = TransformerConfig.from_dict(
+                {
+                    "name": "slack-shape",
+                    "headers": {"Content-Type": "application/json"},
+                    "body": {
+                        "channel": "${{ context.channel }}",
+                        "text": "${{ response.content }}",
+                    },
+                }
+            )
+            success = await deliver_via_transformer(
+                webhook_manager=manager,
+                secrets_manager=None,
+                transformer=transformer,
+                url_override=f"http://127.0.0.1:{sink.port}/bridge",
+                response_content="composed",
+                context={"channel": "C1"},
+                request_id="req_test_override_2",
+            )
+            assert success is True
+            import json
+
+            payload = json.loads(sink.requests[0]["body"])
+            assert payload == {"channel": "C1", "text": "composed"}
+        finally:
+            await manager.close()
+            await sink.stop()
+
+    async def test_url_less_transformer_without_override_falls_back(self):
+        fallback = await Sink().start()
+        manager = WebhookManager(default_retries=0, default_timeout=5)
+        try:
+            transformer = TransformerConfig.from_dict(
+                {"name": "no-url", "body": {"text": "${{ response.content }}"}}
+            )
+            success = await deliver_via_transformer(
+                webhook_manager=manager,
+                secrets_manager=None,
+                transformer=transformer,
+                response_content="orphan",
+                request_id="req_test_override_3",
+                fallback_webhook_url=f"http://127.0.0.1:{fallback.port}/default",
+            )
+            assert success is False
+            import json
+
+            payload = json.loads(fallback.requests[0]["body"])
+            assert "no 'endpoint.url'" in payload["transformer_error"]["last_error"]
+        finally:
+            await manager.close()
+            await fallback.stop()
+
+    async def test_secret_backed_override_url_resolves(self):
+        # A channel 'url:' may be a secret-backed template (e.g. a Slack
+        # incoming-webhook URL); the override participates in secret scanning.
+        sink = await Sink().start()
+        manager = WebhookManager(default_retries=0, default_timeout=5)
+        try:
+            transformer = TransformerConfig.from_dict(
+                {"name": "shape", "body": {"text": "${{ response.content }}"}}
+            )
+            success = await deliver_via_transformer(
+                webhook_manager=manager,
+                secrets_manager=FakeSecretsManager(
+                    {"BRIDGE_URL": f"http://127.0.0.1:{sink.port}/secret-bridge"}
+                ),
+                transformer=transformer,
+                url_override="${{ secrets.BRIDGE_URL }}",
+                response_content="hi",
+                request_id="req_test_override_4",
+            )
+            assert success is True
+            assert sink.requests[0]["path"] == "/secret-bridge"
+        finally:
+            await manager.close()
+            await sink.stop()
 
     async def test_header_auth_and_custom_method(self):
         sink = await Sink().start()


### PR DESCRIPTION
## Summary

Phase 2 of the proactiveness PRD (REVISED 2026-07-08): channels ship as dormant trigger + transformer template pairs, not MCPs. This PR adds one composition mechanism and bundled content -- everything rides the existing transformer delivery stack (no platform SDKs, no MCPs, no new delivery paths, text-only per the PRD).

Phase 1 (runtime #238) made both directions declarative; this builds directly on it and on the transformer machinery from #228.

## Composition semantics

`transformer:` and `webhook:` in trigger frontmatter now **compose** instead of excluding each other:

| Frontmatter | Behavior |
|---|---|
| `webhook:` only | Raw standard MUXI payload to the URL (**unchanged**) |
| `transformer:` only | Formatted payload to the transformer's own `endpoint.url` (**unchanged**) |
| both | Formatted payload (transformer defines format/auth/retry) delivered to the trigger's webhook URL |

- `endpoint.url` is now **optional** in transformer YAML (`endpoint:` may be omitted entirely for payload-format-only templates).
- URL resolution order (`resolve_transformer_url`): trigger/channel-supplied URL first, transformer `endpoint.url` second, **fail-fast at load time** when neither exists (`FormationValidator._validate_trigger_transformer_urls` / `_validate_proactive_channel_transformers`, mirrored by an eager check in `NotificationRouter.__init__` and a request-time guard in the triggers route).
- `proactive.channels` declarations get the same override via a `url:` key -- literal http(s) or a `${{ secrets.* }}` template. Override URLs participate in transformer secret scanning, so secret-backed bridge URLs (e.g. Slack incoming-webhook URLs) resolve like any transformer value.
- Request-time failure isolation is unchanged: render/delivery errors still fall back to the async webhook with `transformer_error` metadata.
- Malformed frontmatter and missing transformer files keep their existing request-time (HTTP 400) semantics; only the new URL-resolution rule is enforced at load time.

## Bundled dormant templates

`src/muxi/runtime/formation/background/builtin/transformers/{slack,telegram,discord,email}.yaml` -- payload formats only, no URLs, no credentials; **inert until referenced by name** (pinned by tests: unreferenced names error exactly as before).

**Location rationale:** mirrors the builtin-skills convention (`formation/skills/builtin/` next to the skill machinery) -- a `builtin/transformers/` dir next to `background/transformers.py`. Shipped via existing `package_data` (`**/*.yaml`) plus a MANIFEST.in line matching the MCP `built_in` precedent. Formation-local `transformers/<name>.yaml` shadows a bundled template of the same name (same shadowing rule as builtin skills; `load_transformer` checks the formation dir first).

Payload shapes (real inbound-webhook formats, dev owns the bridge):
- **slack**: chat.postMessage-style `{channel, thread_ts, text}` (absent `thread_ts` dropped)
- **telegram**: sendMessage `{chat_id, text}`, markdown stripped, 4096-char cap
- **discord**: webhook `{content}`, 2000-char cap
- **email**: constructed message object `{from, to, subject, body, headers}` -- the dev's webhook bridges to SMTP/SES/etc.

Per-platform setup guides + example trigger files: `contributing/channel-templates.md` (indexed in `contributing/README.md`; this repo has no separate examples dir, so examples are inline per the flat contributing-docs convention). `mental-model.md` gained a "Channel Templates (Phase 2)" section.

## Deviations / notes

- Trigger `webhook:` keeps its literal-http(s) validation (unchanged from #228); the secret-template form is supported on the channel `url:` key where the destination is more likely to be sensitive.
- Missing transformer files referenced by triggers remain request-time 400s (not load errors) to avoid breaking formations with dormant/unused triggers; only the new no-URL composition rule fails at load time.
- Pre-existing lint debt in untouched files (e.g. `tests/unit/test_mcp_default_parameters.py`) was left alone.

## Test evidence

- **Unit**: full suite `uv run python -m pytest tests/unit/ -q` -> **2308 passed, 10 skipped**. New/extended coverage: composition parsing (webhook+transformer compose; webhook-only/transformer-only pinned unchanged), URL resolution order (override > transformer URL > load error), bundled template loading + formation shadowing + inert-when-unreferenced pins, per-platform payload rendering from sample contexts (`tests/unit/test_channel_templates.py`), channel `url:` parsing/validation, router startup fail-fast + delivery override, and validator load-time checks.
- **e2e (new)**: `23_proactive/test_23a5_channel_template_composition.py` -- a trigger pairing the **bundled slack template** with a trigger-supplied webhook delivers a chat.postMessage-shaped payload to a mock bridge, and a **URL-less formation-local transformer** + webhook composition delivers its custom shape. PASSED.
- **e2e (regression of touched paths)**: `13_triggers/test_13c1_trigger_transformer.py` (transformer-only + no-frontmatter passthrough) PASSED; `23_proactive/test_23a1_notification_routing.py` PASSED.
- **Random-5 regression**: `cd e2e && uv run python run_random_tests.py 5` -> **5/5 PASS** (19_api/19d1, 20_mcp_server/20a1, 23_proactive/23a1, 5_artifacts/5_13, 8_clarification/8a2).
- **Gates**: `scripts/validate_events.py` -> 1332/1332 (100%); black/isort/ruff clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
