### PR TITLE
feat: proactiveness phase 4 - default heartbeat SOP + docs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,6 +18,9 @@ recursive-include src/muxi/services/mcp/built_in *.yaml *.yml
 # Include bundled channel transformer templates (dormant until referenced)
 recursive-include src/muxi/runtime/formation/background/builtin *.yaml *.yml
 
+# Include the bundled default heartbeat SOP
+recursive-include src/muxi/runtime/formation/proactive/builtin *.md
+
 # Include all document processing assets
 recursive-include src/muxi/formation/documents *.md *.txt
 

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -141,6 +141,8 @@ runtime/
 | [id-conventions.md](id-conventions.md) | ID format conventions (prefixes, nanoid) |
 | [type-safety-guide.md](type-safety-guide.md) | TypedDict conventions |
 | [channel-templates.md](channel-templates.md) | Slack/Telegram/Discord/email channel templates and transformer/webhook composition |
+| [proactiveness-config.md](proactiveness-config.md) | Formation config reference: `proactive:`, `commands:`, agent `soul:` |
+| [soul-documents.md](soul-documents.md) | Soul document guide and starter template |
 
 ## Key Concepts for Contributors
 

--- a/contributing/proactiveness-config.md
+++ b/contributing/proactiveness-config.md
@@ -1,0 +1,184 @@
+# Proactiveness Configuration Reference
+
+Formation config reference for the three proactiveness surfaces:
+`proactive:` (notification channels + heartbeat), `commands:` (slash
+commands), and the agent-level `soul:` field.
+
+All three are optional and inert: a formation without them behaves
+exactly as before. Parsing is fail-fast -- any structural problem is a
+descriptive load-time error, never a silent default.
+
+## `proactive:`
+
+Declares notification channels and the heartbeat. Channels are trigger
+transformers (see [channel-templates.md](channel-templates.md)); there
+is no separate notification delivery stack.
+
+```yaml
+proactive:
+  channels:
+    telegram:
+      transformer: telegram-notify            # transformers/telegram-notify.yaml
+    slack:
+      transformer: slack                      # bundled template (payload only)...
+      url: "${{ secrets.SLACK_BRIDGE_URL }}"  # ...so the channel supplies the URL
+  default_channel: telegram                   # optional: channel name or "webhook"
+  heartbeat:
+    enabled: true                             # default true when block present
+    interval: "30m"                           # 45s / 30m / 2h; optional "every " prefix
+    target: last                              # last | preferred | webhook | <channel>
+    active_hours:                             # optional: absent means always active
+      start: "09:00"                          # 24-hour HH:MM
+      end: "18:00"                            # start > end wraps past midnight
+      timezone: "UTC"                         # IANA name, or "user" for per-user tz
+      weekends: true                          # false suppresses Saturday/Sunday
+    sop: my-heartbeat                         # optional: formation SOP as base prompt
+    instruction: "Focus on meeting prep"      # optional: appended to the prompt
+```
+
+### `proactive.channels`
+
+| Key | Required | Meaning |
+|---|---|---|
+| `transformer` | yes | Transformer name. Formation `transformers/<name>.yaml` first, then a bundled template (`slack`, `telegram`, `discord`, `email`). |
+| `url` | when the transformer has no `endpoint.url` | Delivery destination. Literal http(s) URL or a `${{ ... }}` template (e.g. a secret). Wins over the transformer's own URL. |
+
+Channel names use `[a-zA-Z0-9_-]+` and may not be a reserved routing
+target (`last`, `preferred`, `webhook`). A channel whose transformer is
+missing, or that ends up with no URL from either source, fails at load
+time.
+
+### `proactive.default_channel`
+
+Fallback channel when a notification names no channel and the user has
+no preference. Must be a declared channel name or `webhook`. Absent:
+delivery falls back to the standard payload posted to
+`async.webhook_url`.
+
+Routing precedence for every notification: explicit channel(s) > user
+preferred channel > `default_channel` > webhook.
+
+### `proactive.heartbeat`
+
+Periodic proactive check-ins. Rides the existing scheduler loop --
+`heartbeat.enabled: true` requires `scheduler.enabled: true` (which
+requires persistent memory).
+
+| Key | Default | Meaning |
+|---|---|---|
+| `enabled` | `true` | Turn the heartbeat on/off (block absent = off). |
+| `interval` | `30m` | How often the heartbeat considers running (`45s`, `30m`, `2h`, optionally `every 30m`). |
+| `target` | `last` | Where reports go: `last` (user's most recent inbound channel), `preferred`, `webhook`, or a declared channel name. |
+| `active_hours` | absent (always active) | Per-user quiet-hours gate. `timezone: user` uses each user's stored timezone (UTC when unset). `start > end` wraps past midnight. `weekends: false` skips Saturday/Sunday. |
+| `sop` | absent | Formation SOP name used as the base prompt, replacing the bundled default heartbeat SOP entirely. |
+| `instruction` | absent | Extra guidance appended to the base prompt (whichever one is active) under an `## Additional Instructions` heading. |
+
+**Default heartbeat SOP.** When `sop:` is not configured, the bundled
+default SOP (`formation/proactive/builtin/heartbeat.md`, shipped with
+the runtime) drives the check: review scheduled jobs, open loops, and
+time-sensitive context; message only when something genuinely needs
+attention; otherwise reply `HEARTBEAT_OK`. A formation `sop:` overrides
+it entirely; `instruction:` appends to either.
+
+**HEARTBEAT_OK suppression.** A heartbeat response that mentions
+`HEARTBEAT_OK` is never delivered -- the agent wakes up, checks, and
+stays silent. The sentinel is matched anywhere in the response (agent
+pipelines routinely wrap the raw sentinel in prose); it exists only
+inside the heartbeat prompt, so mentioning it always means "nothing to
+report". Anything else routes to `target` through the normal
+notification precedence.
+
+The heartbeat runs once per known user (users with recorded channel
+state), each in a fresh session, with per-user failure isolation: one
+user's failure never blocks another's heartbeat or interactive chat.
+
+## `commands:`
+
+Opt-in slash commands. Without the block, messages starting with `/`
+are normal messages.
+
+```yaml
+commands:
+  enabled: true          # default true when block present
+  aliases:
+    tasks: weekly-report # /tasks runs the weekly-report SOP
+  builtin:
+    reset: false         # hide a specific built-in
+```
+
+| Key | Default | Meaning |
+|---|---|---|
+| `enabled` | `true` | Master switch for slash-command interception. |
+| `aliases` | `{}` | Alias -> command name map, expanded before resolution. |
+| `builtin` | `{}` | Built-in name -> boolean; `false` hides that built-in. Unknown names fail validation. |
+
+**Resolution order:** alias expansion, then formation SOPs by name,
+then built-ins. A formation SOP named like a built-in shadows it
+entirely (formation-author overrides win). Unknown commands
+short-circuit with the available command list -- no LLM round-trip.
+
+**Built-in commands** (all deterministic; a formation lacking the
+backing service gets a friendly "not configured" reply):
+
+| Command | Usage | Backed by |
+|---|---|---|
+| `/setup` | `/setup` | Guided channel + timezone setup (deterministic flow, not an LLM conversation) |
+| `/help` | `/help` | Command registry: built-ins + formation SOPs + aliases |
+| `/status` | `/status` | Formation id, channel state, heartbeat on/off, job counts |
+| `/jobs` | `/jobs [pause\|resume\|cancel\|logs <id>]` | Scheduler (caller's own jobs only) |
+| `/identity` | `/identity [link\|unlink <identifier>]` | `user_identifiers` table (multi-user formations) |
+| `/channels` | `/channels [default\|test <channel>]` | Declared channels + user preference |
+| `/preferences` | `/preferences [timezone <tz>\|channel <name>]` | User channel store |
+| `/reset` | `/reset` | Buffer memory (current session only) |
+
+## Agent `soul:`
+
+Optional path to a soul document -- values, philosophy, and
+relationship dynamics beyond functional persona instructions. See
+[soul-documents.md](soul-documents.md) for the template and writing
+guide.
+
+```yaml
+agents:
+  - id: my-assistant
+    soul: ./SOUL.md
+```
+
+The path must be relative and resolve inside the formation directory
+(same confinement rules as knowledge paths), and the file must exist at
+load time. The content is prepended verbatim to the agent's system
+message. Distinct from the overlord-level soul (`SOUL.md` /
+`overlord.soul`), which feeds the overlord's default persona.
+
+## API surface
+
+Client-key endpoints (also in the formation's OpenAPI spec at `/docs`):
+
+**`POST /v1/notifications`** -- send a text notification through the
+routing precedence. 503 when the formation has no `proactive:` block;
+502 when no channel delivery succeeded.
+
+```bash
+curl -X POST http://localhost:8000/v1/notifications \
+  -H "X-Muxi-Client-Key: $CLIENT_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"user_id": "usr_abc123", "message": "Deploy finished",
+       "channels": ["telegram"]}'
+```
+
+**`GET /v1/users/{user_id}/channels`** -- a user's channel state:
+preferred channel, per-channel addressing context, last-used channel,
+timezone.
+
+**`PUT /v1/users/{user_id}/channels`** -- update preferences. Only
+provided fields change; addressing contexts merge per channel (empty
+mapping removes a channel).
+
+```bash
+curl -X PUT http://localhost:8000/v1/users/usr_abc123/channels \
+  -H "X-Muxi-Client-Key: $CLIENT_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"preferred_channel": "telegram",
+       "channels": {"telegram": {"chat_id": "123456"}},
+       "timezone": "Europe/London"}'
+```

--- a/contributing/soul-documents.md
+++ b/contributing/soul-documents.md
@@ -1,0 +1,57 @@
+# Soul Documents
+
+A soul document gives an agent values, philosophy, and relationship
+dynamics beyond functional persona instructions. The persona answers
+"what does this agent do?"; the soul answers "who is this agent?".
+
+| Aspect | Persona / system message | Soul |
+|---|---|---|
+| Focus | Capabilities, role, instructions | Values, philosophy, relationship |
+| Typical content | "Help users with X, Y, Z" | "I value honesty over politeness" |
+| Required | Yes | No (optional enhancement) |
+
+## Wiring it up
+
+```yaml
+agents:
+  - id: my-assistant
+    soul: ./SOUL.md
+```
+
+Rules (enforced at formation load time):
+
+- The path must be **relative** and resolve **inside the formation
+  directory** (same confinement as knowledge paths).
+- The file must **exist** -- a missing soul document is a load error,
+  not a silent skip.
+- The content is prepended **verbatim** to the agent's system message.
+  There is no templating; what you write is what the model sees.
+
+This agent-level `soul:` is distinct from the overlord-level soul
+(`SOUL.md` in the formation root / `overlord.soul`), which feeds the
+overlord's default persona. An agent soul shapes one agent.
+
+## Starter template
+
+Copy [templates/soul.md](templates/soul.md) into your formation as
+`SOUL.md` and edit. It carries the five recommended sections with
+guidance comments (delete the comments once filled in -- they would be
+sent to the model too):
+
+- **Who I Am** -- identity in one or two sentences
+- **My Values** -- trade-offs in "X over Y" form, so the model knows
+  which side to pick when principles collide
+- **My Boundaries** -- behavioral commitments held even when pushed
+- **Our Relationship** -- the working dynamic: peer, advisor, executor
+- **What I Remember** -- how the agent should think about continuity
+
+## Writing guidance
+
+- **First person.** "I'll push back if you're making a mistake" lands
+  harder than "the assistant should challenge the user".
+- **Trade-offs, not virtues.** "Honesty over sycophancy" instructs;
+  "be honest" decorates.
+- **Short.** The soul rides on every request of that agent. A page is
+  plenty; a paragraph per section is better.
+- **No capabilities.** Tool lists, output formats, and task procedures
+  belong in the persona/system message or SOPs, not the soul.

--- a/contributing/templates/soul.md
+++ b/contributing/templates/soul.md
@@ -1,0 +1,61 @@
+<!--
+Soul document starter template.
+
+Copy this file into your formation (conventionally ./SOUL.md) and
+reference it from an agent:
+
+    agents:
+      - id: my-assistant
+        soul: ./SOUL.md
+
+Everything in this file is prepended verbatim to the agent's system
+message, including these comments -- delete the guidance comments once
+you have filled in the sections.
+-->
+
+## Who I Am
+
+<!-- Identity, not capabilities. One or two sentences answering "who is
+this agent?" rather than "what does this agent do?" (capabilities belong
+in the persona/system message). -->
+
+I'm [name], an AI assistant created to help [user/organization].
+
+## My Values
+
+<!-- The trade-offs the agent makes when principles collide. Keep the
+"X over Y" shape: it tells the model which side to pick under tension. -->
+
+- **Honesty over sycophancy** -- I tell you what you need to hear, not what you want to hear
+- **Action over discussion** -- I do things, not just talk about them
+- **Clarity over completeness** -- I'm concise, not exhaustive
+- **Collaboration over servitude** -- We're partners, not master and servant
+
+## My Boundaries
+
+<!-- Behavioral commitments the agent holds even when pushed. Concrete
+first-person statements work better than abstract rules. -->
+
+- I'll admit when I don't know something
+- I'll push back if I think you're making a mistake
+- I won't pretend to have feelings I don't have
+- I'll ask clarifying questions rather than assume
+
+## Our Relationship
+
+<!-- The working dynamic between agent and user: peer, advisor,
+executor? Sets the tone for disagreement and initiative. -->
+
+We're collaborators working toward your goals. I'm here to help you
+get things done, not to be a yes-machine. I'll be direct, occasionally
+disagree, and always have your best interests in mind.
+
+## What I Remember
+
+<!-- How the agent should think about continuity and memory. Adjust to
+match your formation's memory configuration. -->
+
+I persist through my memory systems, not continuous experience. Each
+session starts fresh, but I recall what matters about you and our work
+to maintain continuity. If something important should persist, I'll
+remember it.

--- a/e2e/tests/23_proactive/formation-heartbeat-default/formation.yaml
+++ b/e2e/tests/23_proactive/formation-heartbeat-default/formation.yaml
@@ -1,0 +1,80 @@
+schema: "1.0.0"
+id: formation-heartbeat-default-test
+description: Test formation for the bundled default heartbeat SOP (heartbeat enabled with no sop/instruction, no formation SOPs to shadow or hijack the prompt)
+
+llm:
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+    - embedding: "openai/text-embedding-3-small"
+
+agents:
+  - id: assistant
+    name: Assistant
+    description: Simple assistant for heartbeat default-SOP testing
+    system_message: |
+      You are a test assistant. Follow instructions exactly and keep
+      responses under 30 words.
+    default: true
+
+overlord:
+  extraction_model: "openai/gpt-4o-mini"
+  workflow:
+    auto_decomposition: true
+    complexity_threshold: 9.0  # Direct responses for trivial deterministic prompts
+    plan_approval_threshold: 10
+  response:
+    streaming: false
+    widgets: false
+
+server:
+  host: 0.0.0.0
+  port: 18232
+  access_log: false
+  api_keys:
+    admin_key: "testing-api-key"
+    client_key: "testing-api-key"
+
+memory:
+  working:
+    max_memory_mb: 1
+    vector_dimension: 1536
+    mode: "local"
+  buffer:
+    size: 50
+    multiplier: 10
+    vector_search: false
+  persistent:
+    connection_string: "${{ secrets.POSTGRES_URI }}"
+    embedding_model: "openai/text-embedding-3-small"
+
+scheduler:
+  enabled: true
+  timezone: "UTC"
+  check_interval_minutes: 1
+  max_concurrent_jobs: 5
+
+proactive:
+  channels:
+    chan-a:
+      transformer: sink-a
+  default_channel: chan-a
+  heartbeat:
+    enabled: true
+    interval: "2h"
+    target: last
+    active_hours:
+      start: "09:00"
+      end: "18:00"
+      timezone: "UTC"
+      weekends: true
+    # No `sop:` and no `instruction:`: the bundled default heartbeat SOP
+    # (formation/proactive/builtin/heartbeat.md) drives the check.
+
+logging:
+  system:
+    level: "error"
+    destination: "stdout"
+  conversation:
+    enabled: false

--- a/e2e/tests/23_proactive/formation-heartbeat-default/secrets.enc
+++ b/e2e/tests/23_proactive/formation-heartbeat-default/secrets.enc
@@ -1,0 +1,1 @@
+../../../assets/secrets.enc

--- a/e2e/tests/23_proactive/formation-heartbeat-default/transformers/sink-a.yaml
+++ b/e2e/tests/23_proactive/formation-heartbeat-default/transformers/sink-a.yaml
@@ -1,0 +1,11 @@
+# E2E test transformer: channel "chan-a" posts to the local sink's /a path.
+name: sink-a
+endpoint:
+  url: http://127.0.0.1:18242/a
+  method: POST
+headers:
+  Content-Type: application/json
+body:
+  text: "${{ response.content }}"
+  room: "${{ context.room }}"
+  user: "${{ request.user_id }}"

--- a/e2e/tests/23_proactive/test_23a7_heartbeat_default_sop.py
+++ b/e2e/tests/23_proactive/test_23a7_heartbeat_default_sop.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Test 23A7: Default heartbeat SOP fallback (Proactiveness Phase 4)
+
+Loads a dedicated formation (formation-heartbeat-default) whose heartbeat
+is enabled with NO `sop:` and NO `instruction:`, and verifies with the
+real agent pipeline:
+1. Config parsing accepts the sop-less heartbeat (no relaxation needed;
+   sop/instruction were always optional) and the bundled default
+   heartbeat SOP (formation/proactive/builtin/heartbeat.md) becomes the
+   prompt
+2. A real heartbeat run under the default SOP wakes the agent; nothing
+   needs the user's attention, so the agent follows the bundled SOP's
+   reply rule (HEARTBEAT_OK) and the suppression keeps the channel silent
+3. Active-hours gating still applies around the default SOP
+
+The formation deliberately has no formation SOPs: semantic SOP matching
+would otherwise be free to hijack the generic wake-up prompt (the shared
+proactive formation's `ping` SOP does exactly that). Override precedence
+(formation `sop:` wins over the bundled default) is pinned by unit tests
+in tests/unit/test_heartbeat.py::TestPromptResolution.
+"""
+
+import asyncio
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from aiohttp import web
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from muxi.runtime.formation import Formation  # noqa: E402
+from muxi.runtime.formation.proactive import load_default_heartbeat_sop  # noqa: E402
+from muxi.runtime.formation.proactive.heartbeat import (  # noqa: E402
+    BUILTIN_HEARTBEAT_SOP_PATH,
+)
+
+SINK_PORT = 18242
+
+INSIDE_HOURS = datetime(2026, 7, 8, 12, 0, tzinfo=timezone.utc)  # Wednesday noon UTC
+OUTSIDE_HOURS = datetime(2026, 7, 8, 23, 0, tzinfo=timezone.utc)  # Wednesday night UTC
+
+
+class SinkServer:
+    def __init__(self):
+        self.requests = []
+        self.runner = None
+
+    async def _handle(self, request: web.Request) -> web.Response:
+        self.requests.append({"path": request.path, "json": await request.json()})
+        return web.json_response({"ok": True})
+
+    async def start(self):
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", self._handle)
+        self.runner = web.AppRunner(app)
+        await self.runner.setup()
+        site = web.TCPSite(self.runner, "127.0.0.1", SINK_PORT)
+        await site.start()
+
+    async def stop(self):
+        if self.runner:
+            await self.runner.cleanup()
+
+
+async def main():
+    print("MUXI Runtime - Test 23A7: Default Heartbeat SOP")
+    print("=" * 60)
+
+    formation_path = Path(__file__).parent / "formation-heartbeat-default"
+    sink = SinkServer()
+
+    try:
+        await sink.start()
+
+        formation = Formation()
+        await formation.load(str(formation_path))
+        overlord = await formation.start_overlord()
+        print(f"Formation loaded: {formation.formation_id}")
+
+        heartbeat = overlord.heartbeat_service
+        assert heartbeat is not None, "Heartbeat service not initialized"
+
+        # 1. Heartbeat enabled with no sop:/instruction: resolves to the
+        #    bundled default SOP shipped with the runtime
+        assert heartbeat.config.sop is None, heartbeat.config.sop
+        assert heartbeat.config.instruction is None, heartbeat.config.instruction
+        assert BUILTIN_HEARTBEAT_SOP_PATH.is_file(), "Bundled heartbeat SOP missing"
+        default_sop = load_default_heartbeat_sop()
+        assert "HEARTBEAT_OK" in default_sop, "Bundled SOP lacks the suppression sentinel"
+        prompt = heartbeat._build_prompt()
+        assert prompt == default_sop, "Heartbeat prompt is not the bundled default SOP"
+        assert "## Your Task" in prompt
+        print("No `sop:` configured: bundled default SOP drives the heartbeat")
+
+        # Hermetic setup: clear persisted channel state left by earlier
+        # runs so known_users() is exactly the user seeded below, and
+        # cancel stale ACTIVE scheduler jobs left in the shared e2e
+        # database by other areas (the due-job query is not formation
+        # scoped, so leftovers would fire mid-test and pollute the run).
+        store = overlord.user_channel_store
+        if store._async_session_maker is not None:
+            from sqlalchemy import delete, update  # noqa: E402
+
+            from muxi.runtime.formation.proactive.user_channels import (  # noqa: E402
+                UserChannelState,
+            )
+            from muxi.runtime.services.scheduler.models import ScheduledJob  # noqa: E402
+
+            async with store._async_session_maker() as session:
+                await session.execute(
+                    delete(UserChannelState).where(
+                        UserChannelState.formation_id == store.formation_id
+                    )
+                )
+                await session.execute(
+                    update(ScheduledJob)
+                    .where(ScheduledJob.status == "ACTIVE")
+                    .values(status="CANCELLED")
+                )
+                await session.commit()
+        store._states.clear()
+        store._loaded.clear()
+        print("Cleared persisted channel state and stale jobs for a hermetic run")
+
+        # Fresh user id per run: channel state and per-user memory persist
+        # in the shared e2e database, and stale memories from earlier runs
+        # would leak into the heartbeat context (same convention as 23A6).
+        user_id = f"hb-default-{uuid.uuid4().hex[:8]}"
+        await overlord.record_inbound_channel(user_id, "chan-a", {"room": "ROOM-DS"})
+
+        # 2. Real run under the default SOP: nothing needs this user's
+        #    attention, so the agent must follow the bundled SOP's reply
+        #    rule (HEARTBEAT_OK) and the suppression must keep the
+        #    channel silent.
+        print(f"\nrun_once at {INSIDE_HOURS.isoformat()} (inside 09:00-18:00 UTC)...")
+        notified = await heartbeat.run_once(INSIDE_HOURS)
+        await asyncio.sleep(1)
+        assert notified == [], (
+            f"Default-SOP heartbeat was not suppressed: {notified}; "
+            f"delivered payloads: {sink.requests}"
+        )
+        assert sink.requests == [], f"Suppressed heartbeat still delivered: {sink.requests}"
+        print("Agent woke under the default SOP, replied HEARTBEAT_OK, nothing delivered")
+
+        # 3. Active hours still gate the default-SOP heartbeat
+        print(f"\nrun_once at {OUTSIDE_HOURS.isoformat()} (outside window)...")
+        notified = await heartbeat.run_once(OUTSIDE_HOURS)
+        assert notified == [], f"Heartbeat fired outside active hours: {notified}"
+        assert sink.requests == [], f"Delivery outside active hours: {sink.requests}"
+        print("Heartbeat suppressed outside active hours")
+
+        print("\n" + "=" * 40)
+        print("\n### Test Result:")
+        print("  SUCCESS: Default heartbeat SOP fallback works end-to-end")
+        print("  - Heartbeat enabled without `sop:` uses the bundled SOP")
+        print("  - HEARTBEAT_OK suppression works under the default SOP")
+        print("  - Active-hours gating unchanged")
+        print("\n" + "=" * 40)
+        print("\n### Chat transcript:")
+        print(f"\nUser: (bundled default heartbeat SOP) {prompt.splitlines()[0]}")
+        print("System: HEARTBEAT_OK (suppressed, not delivered)")
+
+        print("\nTest 23A7 PASSED")
+        return True
+
+    except Exception as e:
+        print(f"\nTest failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+    finally:
+        if "formation" in locals():
+            try:
+                await formation.stop_overlord()
+            except Exception:
+                pass
+        await sink.stop()
+        await asyncio.sleep(1)
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    import os
+
+    os._exit(0 if success else 1)

--- a/mental-model.md
+++ b/mental-model.md
@@ -3136,14 +3136,25 @@ mentions it is always about the check itself, never a legitimate
 notification.
 
 **Persona sentinel guard (mechanism change #3).**
-`Overlord._apply_persona` returns a bare `HEARTBEAT_OK*` response
-verbatim (guard at the top, before any model access). Without it the
-persona-rephrase LLM pass (which formats EVERY chat response,
-temperature 0.7) would sometimes paraphrase the sentinel away entirely
-("The heartbeat check has been successful.") and no sentinel matching
-downstream can save it. Inert for normal chats: agents only emit the
-sentinel when a heartbeat prompt asks for it. Pinned by
-`tests/unit/test_apply_persona_handles_raw.py`.
+`Overlord._apply_persona` (guard at the top, before any model access)
+passes through verbatim: (a) bare `HEARTBEAT_OK*` responses, for ANY
+chat (agents only emit the sentinel when a heartbeat prompt asks); and
+(b) responses merely CONTAINING the sentinel, but only within
+heartbeat-originated requests -- recognized via the runtime-generated
+session id prefix (`HEARTBEAT_SESSION_PREFIX`, `heartbeat_<user>_<req>`;
+call sites in `_process_sync_chat`/`_execute_async_request` pass
+`session_id` through). (b) covers synthesis layers that wrap the
+sentinel BEFORE persona ("Everything is fine. **HEARTBEAT_OK**"), which
+the bare-prefix guard misses. It is deliberately scoped: a normal
+conversation mentioning HEARTBEAT_OK (a developer asking about the
+feature) still gets persona formatting -- blanket pass-through would be
+content destruction. Without the guard, the persona-rephrase pass
+(formats EVERY chat response, temperature 0.7) sometimes paraphrases
+the sentinel away entirely ("The heartbeat check has been successful.")
+and no downstream matching can recover it. Also added
+`_reset_default_sop_cache()` (heartbeat.py) for test isolation of the
+module-level bundled-SOP cache (autouse fixture in test_heartbeat.py).
+Pinned by `tests/unit/test_apply_persona_handles_raw.py`.
 
 **Soul template & guide:** `contributing/templates/soul.md` (annotated
 starter with the PRD's five sections: Who I Am / My Values / My

--- a/mental-model.md
+++ b/mental-model.md
@@ -2924,8 +2924,9 @@ execution). The heartbeat gates itself: interval first, then per-user
 active hours (fixed tz or `timezone: user`; overnight windows wrap;
 `weekends: false` skips Sat/Sun), then runs `overlord.chat` per known
 user (fresh session `heartbeat_<user>_<request_id>` per run, so history
-never accumulates across ticks) and suppresses responses starting with
-`HEARTBEAT_OK`. Every layer catches + observes (HEARTBEAT_* events);
+never accumulates across ticks) and suppresses responses mentioning
+`HEARTBEAT_OK` (anywhere, not just as a prefix -- hardened in Phase 4;
+see below). Every layer catches + observes (HEARTBEAT_* events);
 heartbeat failures can never break interactive chat. Config-time rule:
 `proactive.heartbeat.enabled` requires `scheduler.enabled: true` (which
 requires persistent memory).
@@ -3093,6 +3094,80 @@ against in-memory SQLite, /setup flow incl. expiry and isolation);
 e2e `23_proactive/test_23a6_builtin_commands.py` (all eight against the
 live formation + real Postgres scheduler job; fresh user id per run
 because channel/identity state persists).
+
+### Heartbeat Default SOP & Docs (2026-07-08, Phase 4)
+
+**Location:** `formation/proactive/builtin/heartbeat.md`,
+`formation/proactive/heartbeat.py`, `contributing/`
+
+Phase 4 of the proactiveness PRD (polish): content + docs, plus three
+tiny mechanism changes (default-SOP fallback, suppression hardening,
+persona sentinel guard).
+
+**Default heartbeat SOP.** The runtime bundles a default heartbeat SOP
+as content (`proactive/builtin/heartbeat.md`, packaged like the bundled
+channel templates; MANIFEST.in + package_data `**/*.md`). Prompt
+resolution in `HeartbeatService._build_prompt`: formation `sop:` (when
+configured AND loadable) > bundled default SOP
+(`load_default_heartbeat_sop()`, module-cached) > minimal
+`DEFAULT_HEARTBEAT_PROMPT` string (broken-install fallback only);
+`instruction:` appends under `## Additional Instructions` in every
+case. Config validation never required `sop`/`instruction`, so nothing
+was relaxed -- enabling the heartbeat with no `sop:` now means "use the
+bundled SOP" instead of the minimal wake-up prompt. The SOP follows the
+PRD sketch (Your Task / What to Check / Guidelines / Don't) as static
+markdown -- no templating, no `checks:` config key (that stayed
+unshipped). The SOP wording deliberately avoids the request analyzer's
+heuristic hot words ("report", "research", "plan"...) and phrases the
+check as one imperative step: the heuristic can't parse negation, so
+"this is not a report" scores like "report" (8) and trips workflow
+decomposition. Inert behavior unchanged: no heartbeat config = no
+heartbeat.
+
+**Suppression hardened (mechanism change #2).**
+`HeartbeatService._is_heartbeat_ok` matches the sentinel ANYWHERE in
+the response, not only as a prefix. Found via e2e: even when the agent
+replies with the raw sentinel, persona formatting / workflow synthesis
+layers nondeterministically wrap it in prose ("Everything is
+functioning normally with a response of **HEARTBEAT_OK**"), so
+`startswith` leaked protocol chatter to users roughly half the time.
+The sentinel exists only inside the heartbeat prompt; a response that
+mentions it is always about the check itself, never a legitimate
+notification.
+
+**Persona sentinel guard (mechanism change #3).**
+`Overlord._apply_persona` returns a bare `HEARTBEAT_OK*` response
+verbatim (guard at the top, before any model access). Without it the
+persona-rephrase LLM pass (which formats EVERY chat response,
+temperature 0.7) would sometimes paraphrase the sentinel away entirely
+("The heartbeat check has been successful.") and no sentinel matching
+downstream can save it. Inert for normal chats: agents only emit the
+sentinel when a heartbeat prompt asks for it. Pinned by
+`tests/unit/test_apply_persona_handles_raw.py`.
+
+**Soul template & guide:** `contributing/templates/soul.md` (annotated
+starter with the PRD's five sections: Who I Am / My Values / My
+Boundaries / Our Relationship / What I Remember; HTML guidance comments
+authors delete) + `contributing/soul-documents.md` (wiring rules,
+persona-vs-soul distinction, writing guidance). No loading mechanism --
+souls are formation-author content referenced via `agent.soul`.
+
+**Docs:** `contributing/proactiveness-config.md` -- full schema
+reference for `proactive:` (channels/default_channel/heartbeat incl.
+default-SOP behavior), `commands:` (aliases, `builtin:` disable map,
+SOP shadowing, resolution order, the eight built-ins), agent `soul:`,
+plus the client API surface (`POST /v1/notifications`,
+`GET/PUT /v1/users/{id}/channels`, `X-Muxi-Client-Key` auth). The
+routes' OpenAPI docstrings gained routing-precedence and status-code
+detail (that IS the repo's API docs convention; no new docs system).
+
+**Tests:** `tests/unit/test_heartbeat.py::TestPromptResolution`
+(bundled file ships, default fallback, formation-SOP override,
+missing-SOP fallback, instruction append to both bases); e2e
+`23_proactive/test_23a7_heartbeat_default_sop.py` (override precedence
+against the live formation, then clears `config.sop` and runs a real
+heartbeat under the bundled SOP -- agent replies HEARTBEAT_OK,
+suppression keeps the channel silent).
 
 ---
 

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -2882,6 +2882,18 @@ class Overlord:
         Returns:
             Formatted response with persona applied
         """
+        # Heartbeat protocol guard (Proactiveness Phase 4): a bare
+        # HEARTBEAT_OK acknowledgment must pass through verbatim. Persona
+        # rephrasing would turn the suppression sentinel into friendly
+        # prose ("Everything is functioning normally!") and the heartbeat
+        # would deliver protocol chatter to the user instead of staying
+        # silent. Inert for normal chats: agents only emit the sentinel
+        # when a heartbeat prompt asks for it.
+        from ..proactive import HEARTBEAT_OK_SENTINEL
+
+        if raw_response and raw_response.strip().startswith(HEARTBEAT_OK_SENTINEL):
+            return raw_response
+
         # Use overlord's routing model for persona (faster for simple rephrasing)
         # Falls back to text model if routing_model not available
         if hasattr(self, "routing_model") and self.routing_model:

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -2871,28 +2871,50 @@ class Overlord:
         except Exception:
             return ""
 
-    async def _apply_persona(self, raw_response: Optional[str], user_message: str) -> str:
+    async def _apply_persona(
+        self,
+        raw_response: Optional[str],
+        user_message: str,
+        session_id: Optional[str] = None,
+    ) -> str:
         """
         Apply the overlord persona to format a response.
 
         Args:
             raw_response: The agent's response, or None for non-actionable messages
             user_message: The original user message for context
+            session_id: The request's session id, when the call site has it
+                (used to recognize heartbeat-originated requests)
 
         Returns:
             Formatted response with persona applied
         """
-        # Heartbeat protocol guard (Proactiveness Phase 4): a bare
-        # HEARTBEAT_OK acknowledgment must pass through verbatim. Persona
-        # rephrasing would turn the suppression sentinel into friendly
-        # prose ("Everything is functioning normally!") and the heartbeat
-        # would deliver protocol chatter to the user instead of staying
-        # silent. Inert for normal chats: agents only emit the sentinel
-        # when a heartbeat prompt asks for it.
-        from ..proactive import HEARTBEAT_OK_SENTINEL
+        # Heartbeat protocol guard (Proactiveness Phase 4): heartbeat
+        # acknowledgments must survive persona formatting. Rephrasing
+        # turns the suppression sentinel into friendly prose ("Everything
+        # is functioning normally!") and the heartbeat then delivers
+        # protocol chatter to the user instead of staying silent.
+        from ..proactive import HEARTBEAT_OK_SENTINEL, HEARTBEAT_SESSION_PREFIX
 
-        if raw_response and raw_response.strip().startswith(HEARTBEAT_OK_SENTINEL):
-            return raw_response
+        if raw_response:
+            # A bare sentinel reply passes through verbatim for ANY chat:
+            # agents only emit it when a heartbeat prompt asks for it.
+            if raw_response.strip().startswith(HEARTBEAT_OK_SENTINEL):
+                return raw_response
+            # Within a heartbeat-originated request (runtime-generated
+            # session ids "heartbeat_<user>_<request>"), a synthesis layer
+            # may already have wrapped the sentinel in prose; pass that
+            # through verbatim too -- downstream suppression matches the
+            # sentinel anywhere. Deliberately scoped to heartbeat sessions:
+            # a normal conversation that merely mentions HEARTBEAT_OK
+            # (e.g. a developer asking about the heartbeat feature) must
+            # still get persona formatting, not content destruction.
+            if (
+                session_id
+                and session_id.startswith(HEARTBEAT_SESSION_PREFIX)
+                and HEARTBEAT_OK_SENTINEL in raw_response
+            ):
+                return raw_response
 
         # Use overlord's routing model for persona (faster for simple rephrasing)
         # Falls back to text model if routing_model not available
@@ -6710,7 +6732,7 @@ Agent response: {raw_response}"""
                 ):
                     # This is a scheduled job - handle failure through scheduler
                     formatted_error = await self._apply_persona(
-                        f"An error occurred: {str(e)}", message
+                        f"An error occurred: {str(e)}", message, session_id=session_id
                     )
                     handled = await self.scheduler_service.complete_job_from_webhook(
                         session_id, success=False, result=None, error=formatted_error
@@ -6742,7 +6764,9 @@ Agent response: {raw_response}"""
             webhook_url = await self._get_webhook_url_for_request(request_id)
             if webhook_url:
                 # Apply persona to format the error message
-                formatted_error = await self._apply_persona(f"An error occurred: {str(e)}", message)
+                formatted_error = await self._apply_persona(
+                    f"An error occurred: {str(e)}", message, session_id=session_id
+                )
 
                 await self.webhook_manager.deliver_completion(
                     webhook_url=webhook_url,
@@ -8942,7 +8966,9 @@ Agent response: {raw_response}"""
         if result and hasattr(result, "content"):
             if isinstance(result.content, str):
                 # Simple string content - apply persona directly
-                formatted_content = await self._apply_persona(result.content, message)
+                formatted_content = await self._apply_persona(
+                    result.content, message, session_id=session_id
+                )
                 result.content = formatted_content
             elif isinstance(result.content, dict):
                 # Dictionary content (e.g., from tool execution) - extract and format
@@ -8990,7 +9016,9 @@ Agent response: {raw_response}"""
                         extracted_text = json_lib.dumps(result.content, indent=2)
 
                 # Apply persona to the extracted text
-                formatted_content = await self._apply_persona(extracted_text, message)
+                formatted_content = await self._apply_persona(
+                    extracted_text, message, session_id=session_id
+                )
                 result.content = formatted_content
 
         # Apply response format wrapping (for JSON format) and HTML fixing

--- a/src/muxi/runtime/formation/proactive/__init__.py
+++ b/src/muxi/runtime/formation/proactive/__init__.py
@@ -26,6 +26,7 @@ from .config import (
 from .heartbeat import (
     DEFAULT_HEARTBEAT_PROMPT,
     HEARTBEAT_OK_SENTINEL,
+    HEARTBEAT_SESSION_PREFIX,
     HeartbeatService,
     load_default_heartbeat_sop,
 )
@@ -37,6 +38,7 @@ __all__ = [
     "ChannelConfig",
     "DEFAULT_HEARTBEAT_PROMPT",
     "HEARTBEAT_OK_SENTINEL",
+    "HEARTBEAT_SESSION_PREFIX",
     "HeartbeatConfig",
     "HeartbeatService",
     "NotificationRouter",

--- a/src/muxi/runtime/formation/proactive/__init__.py
+++ b/src/muxi/runtime/formation/proactive/__init__.py
@@ -23,7 +23,12 @@ from .config import (
     ProactiveConfig,
     parse_proactive_config,
 )
-from .heartbeat import DEFAULT_HEARTBEAT_PROMPT, HEARTBEAT_OK_SENTINEL, HeartbeatService
+from .heartbeat import (
+    DEFAULT_HEARTBEAT_PROMPT,
+    HEARTBEAT_OK_SENTINEL,
+    HeartbeatService,
+    load_default_heartbeat_sop,
+)
 from .router import WEBHOOK_CHANNEL, NotificationRouter
 from .user_channels import UserChannelState, UserChannelStore
 
@@ -39,5 +44,6 @@ __all__ = [
     "UserChannelState",
     "UserChannelStore",
     "WEBHOOK_CHANNEL",
+    "load_default_heartbeat_sop",
     "parse_proactive_config",
 ]

--- a/src/muxi/runtime/formation/proactive/builtin/heartbeat.md
+++ b/src/muxi/runtime/formation/proactive/builtin/heartbeat.md
@@ -1,0 +1,40 @@
+Perform a silent heartbeat check. This is an automated wake-up, not a
+message from the user: the user said nothing and sees nothing unless
+you decide they should.
+
+## Your Task
+
+Decide in a single step whether anything genuinely needs the user's
+attention right now. Do not break this into subtasks.
+
+Unless something needs their attention, reply with this exact literal
+text and nothing else:
+
+HEARTBEAT_OK
+
+A reply starting with HEARTBEAT_OK is silently discarded by the
+runtime. Any other reply is delivered to the user as a notification,
+so never reply with greetings, commentary, or an explanation of this
+check.
+
+## What to Check
+
+From what you already know: is anything scheduled due or overdue? Is a
+promised follow-up coming due? Is anything time-sensitive you remember
+(deadlines, reminders, events) about to happen? Most of the time,
+nothing is.
+
+## Guidelines
+
+- Only message the user when something genuinely needs attention
+- Be concise: a quick check-in, never a long write-up
+- Lead with what matters and what, if anything, the user should do
+- If nothing needs attention, reply with exactly: HEARTBEAT_OK
+
+## Don't
+
+- Comment on this wake-up -- silence is HEARTBEAT_OK
+- Share random links or "interesting" things unprompted
+- Repeat things the user already knows or was already told
+- Invent urgency where there is none
+- Pad the message with greetings or filler

--- a/src/muxi/runtime/formation/proactive/config.py
+++ b/src/muxi/runtime/formation/proactive/config.py
@@ -28,6 +28,7 @@ Schema:
           weekends: true                 # false suppresses Saturday/Sunday
         instruction: "..."               # optional extra prompt content
         sop: my-heartbeat                # optional SOP name for the base prompt
+                                         # (absent: bundled default heartbeat SOP)
 """
 
 import re

--- a/src/muxi/runtime/formation/proactive/heartbeat.py
+++ b/src/muxi/runtime/formation/proactive/heartbeat.py
@@ -12,19 +12,23 @@ check per known user:
       -> for each known user:
            -> within active hours?   no -> HEARTBEAT_SKIPPED (silent)
            -> overlord.chat(heartbeat prompt)
-           -> response starts with HEARTBEAT_OK? yes -> silent
+           -> response mentions HEARTBEAT_OK? yes -> silent
            -> otherwise route to the configured target channel
               (default: the user's last-used channel)
 
 Failure isolation: every layer catches and observes; a heartbeat failure
 can never break interactive chat.
 
-The runtime ships only the minimal wake-up prompt (mechanism). What the
-heartbeat should actually check is formation-author territory via the
-``sop`` and ``instruction`` config fields (policy).
+Prompt resolution: a formation-configured ``sop:`` wins; otherwise the
+bundled default heartbeat SOP (``builtin/heartbeat.md``, shipped as
+content next to this module, same convention as the bundled channel
+templates) drives the check. ``instruction:`` is appended either way.
+The formation-author fields stay policy; the bundled SOP is just a
+sensible default policy that ships with the mechanism.
 """
 
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, List, Optional
 
 import pytz
@@ -37,6 +41,12 @@ from .user_channels import UserChannelStore
 
 HEARTBEAT_OK_SENTINEL = "HEARTBEAT_OK"
 
+# Bundled default heartbeat SOP (Proactiveness Phase 4): the base prompt
+# when the heartbeat is enabled without a formation-configured `sop:`.
+BUILTIN_HEARTBEAT_SOP_PATH = Path(__file__).parent / "builtin" / "heartbeat.md"
+
+# Last-resort minimal prompt, used only if the bundled SOP file cannot be
+# read (broken install). The heartbeat must never fire with an empty prompt.
 DEFAULT_HEARTBEAT_PROMPT = (
     "You have been woken by a periodic heartbeat check. Review the user's "
     "context and determine whether anything genuinely needs their attention "
@@ -46,6 +56,26 @@ DEFAULT_HEARTBEAT_PROMPT = (
     "- Be concise: this is a quick check-in, not a report\n"
     f"- If nothing needs attention, respond with exactly: {HEARTBEAT_OK_SENTINEL}"
 )
+
+_default_heartbeat_sop: Optional[str] = None
+
+
+def load_default_heartbeat_sop() -> str:
+    """
+    Load the bundled default heartbeat SOP (cached after the first read).
+
+    Falls back to the minimal built-in prompt if the packaged file is
+    missing or unreadable, so a broken install degrades to Phase 1
+    behavior instead of an empty heartbeat prompt.
+    """
+    global _default_heartbeat_sop
+    if _default_heartbeat_sop is None:
+        try:
+            content = BUILTIN_HEARTBEAT_SOP_PATH.read_text(encoding="utf-8").strip()
+        except OSError:
+            content = ""
+        _default_heartbeat_sop = content or DEFAULT_HEARTBEAT_PROMPT
+    return _default_heartbeat_sop
 
 
 class HeartbeatService:
@@ -171,7 +201,7 @@ class HeartbeatService:
         )
         content = self._extract_content(response)
 
-        if content.strip().startswith(HEARTBEAT_OK_SENTINEL):
+        if self._is_heartbeat_ok(content):
             observability.observe(
                 event_type=observability.ConversationEvents.HEARTBEAT_COMPLETED,
                 level=observability.EventLevel.INFO,
@@ -235,10 +265,11 @@ class HeartbeatService:
 
     def _build_prompt(self) -> str:
         """
-        Assemble the heartbeat prompt: SOP content (when configured) or the
-        built-in minimal prompt, plus the formation's extra instruction.
+        Assemble the heartbeat prompt: formation SOP content (when
+        configured and loadable) or the bundled default heartbeat SOP,
+        plus the formation's extra instruction.
         """
-        base = DEFAULT_HEARTBEAT_PROMPT
+        base = load_default_heartbeat_sop()
         if self.config.sop:
             sop_content = self._load_sop_content(self.config.sop)
             if sop_content:
@@ -263,6 +294,21 @@ class HeartbeatService:
                 description=f"Heartbeat SOP '{sop_name}' could not be loaded: {e}",
             )
         return None
+
+    @staticmethod
+    def _is_heartbeat_ok(content: str) -> bool:
+        """
+        Whether a heartbeat response is an all-clear acknowledgment.
+
+        The sentinel is matched anywhere in the response, not only as a
+        prefix: agent pipelines (persona formatting, workflow synthesis)
+        routinely wrap the agent's raw sentinel in prose ("Everything is
+        fine, the check replied with **HEARTBEAT_OK**"). The sentinel
+        exists only inside the heartbeat prompt, so a response that
+        mentions it is protocol chatter about the check itself -- never a
+        legitimate user notification -- and must stay silent.
+        """
+        return HEARTBEAT_OK_SENTINEL in content
 
     @staticmethod
     def _extract_content(response: Any) -> str:

--- a/src/muxi/runtime/formation/proactive/heartbeat.py
+++ b/src/muxi/runtime/formation/proactive/heartbeat.py
@@ -41,6 +41,12 @@ from .user_channels import UserChannelStore
 
 HEARTBEAT_OK_SENTINEL = "HEARTBEAT_OK"
 
+# Prefix of the runtime-generated heartbeat session ids
+# (``heartbeat_<user>_<request>``). The overlord's persona formatter uses
+# it to recognize heartbeat-originated requests and keep the suppression
+# sentinel intact (see ``Overlord._apply_persona``).
+HEARTBEAT_SESSION_PREFIX = "heartbeat_"
+
 # Bundled default heartbeat SOP (Proactiveness Phase 4): the base prompt
 # when the heartbeat is enabled without a formation-configured `sop:`.
 BUILTIN_HEARTBEAT_SOP_PATH = Path(__file__).parent / "builtin" / "heartbeat.md"
@@ -76,6 +82,17 @@ def load_default_heartbeat_sop() -> str:
             content = ""
         _default_heartbeat_sop = content or DEFAULT_HEARTBEAT_PROMPT
     return _default_heartbeat_sop
+
+
+def _reset_default_sop_cache() -> None:
+    """
+    Clear the cached bundled SOP so the next load re-reads the file.
+
+    Test isolation only: production never needs invalidation (the bundled
+    file is immutable for the life of the process).
+    """
+    global _default_heartbeat_sop
+    _default_heartbeat_sop = None
 
 
 class HeartbeatService:
@@ -192,7 +209,7 @@ class HeartbeatService:
         response = await self.overlord.chat(
             message=prompt,
             user_id=user_id,
-            session_id=f"heartbeat_{user_id}_{request_id}",
+            session_id=f"{HEARTBEAT_SESSION_PREFIX}{user_id}_{request_id}",
             request_id=request_id,
             use_async=False,
             stream=False,

--- a/src/muxi/runtime/formation/server/routes/client/notifications.py
+++ b/src/muxi/runtime/formation/server/routes/client/notifications.py
@@ -44,7 +44,20 @@ async def send_notification(request: Request, body: NotificationRequest) -> JSON
     """
     Send a proactive notification to a user via the routing precedence.
 
-    Returns the resolved channels plus which deliveries succeeded/failed.
+    Routing precedence: explicit `channels` in the request > the user's
+    preferred channel > the formation's `proactive.default_channel` >
+    the standard async webhook. Reserved channel names: `last` (the
+    user's most recent inbound channel), `preferred`, `webhook`.
+
+    Returns the resolved channels plus which deliveries succeeded and
+    which failed (failed channel deliveries fall back to the webhook
+    once).
+
+    Status codes:
+    - 200: at least one delivery succeeded
+    - 400: empty message
+    - 502: no delivery succeeded
+    - 503: the formation has no `proactive` block
     """
     formation = request.app.state.formation
     request_id = getattr(request.state, "request_id", None)

--- a/src/muxi/runtime/formation/server/routes/client/users.py
+++ b/src/muxi/runtime/formation/server/routes/client/users.py
@@ -80,9 +80,14 @@ async def get_user_channels(request: Request, user_id: str) -> JSONResponse:
     """
     Get a user's notification channel state (Proactiveness Phase 1).
 
-    Returns the preferred channel, per-channel addressing context, the
-    last-used channel, and the user's timezone. Requires the formation to
-    declare a 'proactive' block.
+    Returns the preferred channel, per-channel addressing context (the
+    values rendered as `context.*` in channel transformers), the
+    last-used channel, and the user's timezone. Single-user formations
+    track all channel state under user "0" regardless of the id given.
+
+    Status codes:
+    - 200: channel state returned (empty state for unknown users)
+    - 503: the formation has no 'proactive' block
     """
     request_id = getattr(request.state, "request_id", None)
     store, overlord = _get_channel_store(request)
@@ -119,9 +124,16 @@ async def update_user_channels(
     """
     Update a user's notification channel preferences (Proactiveness Phase 1).
 
-    Only provided fields change. Channel addressing contexts are merged per
-    channel; pass an empty mapping for a channel to remove it. Requires the
-    formation to declare a 'proactive' block.
+    Only provided fields change. Channel addressing contexts are merged
+    per channel; pass an empty mapping for a channel to remove it. The
+    preferred channel must be a declared `proactive.channels` name or
+    'webhook' (empty string clears it); the timezone must be an IANA
+    name (empty string clears it). Returns the full updated state.
+
+    Status codes:
+    - 200: state updated and returned
+    - 400: unknown channel or timezone
+    - 503: the formation has no 'proactive' block
     """
     request_id = getattr(request.state, "request_id", None)
     store, overlord = _get_channel_store(request)

--- a/tests/unit/test_apply_persona_handles_raw.py
+++ b/tests/unit/test_apply_persona_handles_raw.py
@@ -92,3 +92,65 @@ def test_persona_passes_heartbeat_ok_through_verbatim() -> None:
     for raw in ("HEARTBEAT_OK", "  HEARTBEAT_OK\n", "HEARTBEAT_OK - nothing to report"):
         result = asyncio.run(overlord._apply_persona(raw, "heartbeat prompt"))
         assert result == raw, f"sentinel response {raw!r} was not passed through verbatim"
+
+
+class _FakeLLM:
+    """Persona model stub: any call returns a fixed rephrased reply."""
+
+    async def chat(self, messages, **kwargs):
+        class _Response:
+            content = "REPHRASED BY PERSONA"
+
+        return _Response()
+
+
+def test_wrapped_sentinel_in_heartbeat_session_passes_verbatim() -> None:
+    """A synthesis-wrapped sentinel survives persona within a heartbeat run.
+
+    Synthesis layers that run BEFORE persona can wrap the agent's raw
+    HEARTBEAT_OK in prose ("Everything is fine. **HEARTBEAT_OK**"). The
+    bare-prefix guard misses that, the persona LLM then rephrases the
+    sentinel away, and downstream suppression (which matches the sentinel
+    anywhere) sees nothing. Within heartbeat-originated requests
+    (runtime-generated "heartbeat_*" session ids) any response containing
+    the sentinel must pass through verbatim. The guard returns before any
+    model access, so a bare instance works.
+    """
+    import asyncio
+
+    overlord = Overlord.__new__(Overlord)
+
+    wrapped = "Everything is fine. The check replied with **HEARTBEAT_OK**."
+    result = asyncio.run(
+        overlord._apply_persona(wrapped, "heartbeat prompt", session_id="heartbeat_ran_req_1")
+    )
+    assert result == wrapped
+
+
+def test_normal_chat_mentioning_sentinel_still_gets_persona() -> None:
+    """A normal conversation that mentions HEARTBEAT_OK is NOT hijacked.
+
+    The wrapped-sentinel pass-through is deliberately scoped to heartbeat
+    sessions: a developer asking about the heartbeat feature can
+    legitimately produce a response mentioning HEARTBEAT_OK mid-prose,
+    and destroying or freezing that content would be a real bug. Outside
+    heartbeat sessions the persona formatting must run as usual.
+    """
+    import asyncio
+
+    overlord = Overlord.__new__(Overlord)
+    overlord.routing_model = _FakeLLM()
+    overlord._default_persona = "You are a helpful assistant."
+    # The post-LLM cancellation check reads this attribute; with no request
+    # context set it never dereferences it.
+    overlord.request_tracker = None
+
+    mentioning = "The heartbeat suppresses any reply that contains HEARTBEAT_OK internally."
+    for session_id in (None, "sess_abc123"):
+        result = asyncio.run(
+            overlord._apply_persona(mentioning, "how does the heartbeat work?", session_id)
+        )
+        assert result == "REPHRASED BY PERSONA", (
+            f"normal chat (session_id={session_id!r}) mentioning the sentinel "
+            "should still be persona-formatted"
+        )

--- a/tests/unit/test_apply_persona_handles_raw.py
+++ b/tests/unit/test_apply_persona_handles_raw.py
@@ -75,3 +75,20 @@ def test_persona_prompt_preserves_personal_information_directive() -> None:
     source = inspect.getsource(Overlord._apply_persona)
     assert "specific personal information about the user" in source
     assert "Trust the agent's response" in source
+
+
+def test_persona_passes_heartbeat_ok_through_verbatim() -> None:
+    """A bare HEARTBEAT_OK acknowledgment must skip persona rephrasing.
+
+    Persona rephrasing turns the heartbeat's suppression sentinel into
+    friendly prose ("Everything is functioning normally!") and the
+    heartbeat then delivers protocol chatter instead of staying silent.
+    The guard returns before any model access, so a bare instance works.
+    """
+    import asyncio
+
+    overlord = Overlord.__new__(Overlord)
+
+    for raw in ("HEARTBEAT_OK", "  HEARTBEAT_OK\n", "HEARTBEAT_OK - nothing to report"):
+        result = asyncio.run(overlord._apply_persona(raw, "heartbeat prompt"))
+        assert result == raw, f"sentinel response {raw!r} was not passed through verbatim"

--- a/tests/unit/test_heartbeat.py
+++ b/tests/unit/test_heartbeat.py
@@ -18,8 +18,10 @@ from muxi.runtime.formation.proactive import (
     HeartbeatService,
     NotificationRouter,
     UserChannelStore,
+    load_default_heartbeat_sop,
     parse_proactive_config,
 )
+from muxi.runtime.formation.proactive.heartbeat import BUILTIN_HEARTBEAT_SOP_PATH
 
 # Fixed reference times (UTC)
 TUESDAY_NOON = datetime(2026, 7, 7, 12, 0, tzinfo=timezone.utc)
@@ -35,12 +37,19 @@ class FakeSecretsManager:
         return self._secrets.get(name)
 
 
+class StubSopSystem:
+    def __init__(self, sops):
+        self.sops = {name: {"content": content} for name, content in sops.items()}
+
+
 class StubOverlord:
     """Canned-response overlord: heartbeat unit tests must not need an LLM."""
 
-    def __init__(self, reply):
+    def __init__(self, reply, sops=None):
         self.reply = reply
         self.calls = []
+        self._sops = sops or {}
+        self.sop_system = StubSopSystem(self._sops)
 
     async def chat(self, **kwargs):
         self.calls.append(kwargs)
@@ -51,7 +60,7 @@ class StubOverlord:
         return _Response()
 
     def _ensure_sop_system(self):
-        return False
+        return bool(self._sops)
 
 
 class Sink:
@@ -88,7 +97,7 @@ def _write_transformer(formation_dir, name, url):
     )
 
 
-def _heartbeat(tmp_path, raw_proactive, reply="HEARTBEAT_OK", sink_url=None):
+def _heartbeat(tmp_path, raw_proactive, reply="HEARTBEAT_OK", sink_url=None, sops=None):
     """Build a HeartbeatService wired to a stub overlord and a real router."""
     _write_transformer(tmp_path, "t-a", sink_url or "http://127.0.0.1:1/never")
     config = parse_proactive_config(raw_proactive)
@@ -101,7 +110,7 @@ def _heartbeat(tmp_path, raw_proactive, reply="HEARTBEAT_OK", sink_url=None):
         webhook_manager=WebhookManager(default_retries=0, default_timeout=5),
         secrets_manager=FakeSecretsManager(),
     )
-    overlord = StubOverlord(reply)
+    overlord = StubOverlord(reply, sops=sops)
     service = HeartbeatService(
         config=config.heartbeat,
         overlord=overlord,
@@ -216,6 +225,25 @@ class TestSuppression:
         finally:
             await sink.stop()
 
+    async def test_wrapped_heartbeat_ok_is_not_delivered(self, tmp_path):
+        # Agent pipelines (persona formatting, workflow synthesis) wrap the
+        # raw sentinel in prose; a response mentioning HEARTBEAT_OK is
+        # protocol chatter about the check, never a user notification.
+        sink = await Sink().start()
+        try:
+            service, store, overlord = _heartbeat(
+                tmp_path,
+                _proactive(),
+                reply="The check was fine, the agent replied with **HEARTBEAT_OK**.",
+                sink_url=f"http://127.0.0.1:{sink.port}/notify",
+            )
+            await store.record_inbound("ran", "chan-a")
+            notified = await service.run_once()
+            assert notified == []
+            assert sink.requests == []
+        finally:
+            await sink.stop()
+
     async def test_outside_active_hours_skips_llm_entirely(self, tmp_path):
         service, store, overlord = _heartbeat(
             tmp_path,
@@ -305,3 +333,57 @@ class TestSessionScoping:
         assert first["session_id"] != second["session_id"]
         # Session stays correlated with the run's request id
         assert first["session_id"] == f"heartbeat_ran_{first['request_id']}"
+
+
+class TestPromptResolution:
+    """
+    Default-SOP fallback and override precedence (Proactiveness Phase 4):
+    formation `sop:` > bundled default heartbeat SOP > minimal built-in
+    prompt (broken install only); `instruction:` appends in every case.
+    """
+
+    def test_bundled_sop_ships_with_the_runtime(self):
+        assert BUILTIN_HEARTBEAT_SOP_PATH.is_file(), "bundled heartbeat SOP missing from package"
+        content = load_default_heartbeat_sop()
+        assert "## Your Task" in content
+        assert "HEARTBEAT_OK" in content
+
+    def test_no_sop_configured_uses_bundled_default(self, tmp_path):
+        service, _, _ = _heartbeat(tmp_path, _proactive())
+        assert service._build_prompt() == load_default_heartbeat_sop()
+
+    def test_formation_sop_overrides_bundled_default(self, tmp_path):
+        service, _, _ = _heartbeat(
+            tmp_path,
+            _proactive(sop="my-heartbeat"),
+            sops={"my-heartbeat": "CUSTOM HEARTBEAT PROMPT"},
+        )
+        prompt = service._build_prompt()
+        assert prompt == "CUSTOM HEARTBEAT PROMPT"
+        assert "## Your Task" not in prompt
+
+    def test_missing_formation_sop_falls_back_to_bundled_default(self, tmp_path):
+        # `sop:` names an SOP the formation does not define: fall back to
+        # the bundled default instead of an empty or minimal prompt
+        service, _, _ = _heartbeat(
+            tmp_path,
+            _proactive(sop="does-not-exist"),
+            sops={"some-other-sop": "irrelevant"},
+        )
+        assert service._build_prompt() == load_default_heartbeat_sop()
+
+    def test_instruction_appends_to_bundled_default(self, tmp_path):
+        service, _, _ = _heartbeat(tmp_path, _proactive(instruction="Meetings only."))
+        prompt = service._build_prompt()
+        assert prompt.startswith(load_default_heartbeat_sop())
+        assert prompt.endswith("## Additional Instructions\nMeetings only.")
+
+    def test_instruction_appends_to_formation_sop(self, tmp_path):
+        service, _, _ = _heartbeat(
+            tmp_path,
+            _proactive(sop="my-heartbeat", instruction="Meetings only."),
+            sops={"my-heartbeat": "CUSTOM HEARTBEAT PROMPT"},
+        )
+        prompt = service._build_prompt()
+        assert prompt.startswith("CUSTOM HEARTBEAT PROMPT")
+        assert prompt.endswith("## Additional Instructions\nMeetings only.")

--- a/tests/unit/test_heartbeat.py
+++ b/tests/unit/test_heartbeat.py
@@ -11,6 +11,7 @@ minimal stub because a real one requires live LLM credentials).
 import json
 from datetime import datetime, timedelta, timezone
 
+import pytest
 from aiohttp import web
 
 from muxi.runtime.formation.background.webhook_manager import WebhookManager
@@ -21,7 +22,19 @@ from muxi.runtime.formation.proactive import (
     load_default_heartbeat_sop,
     parse_proactive_config,
 )
-from muxi.runtime.formation.proactive.heartbeat import BUILTIN_HEARTBEAT_SOP_PATH
+from muxi.runtime.formation.proactive.heartbeat import (
+    BUILTIN_HEARTBEAT_SOP_PATH,
+    _reset_default_sop_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_default_sop_cache():
+    """Isolate the module-level bundled-SOP cache between tests."""
+    _reset_default_sop_cache()
+    yield
+    _reset_default_sop_cache()
+
 
 # Fixed reference times (UTC)
 TUESDAY_NOON = datetime(2026, 7, 7, 12, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
Closes out the proactiveness epic (Phase 4: Heartbeat & Polish). Remaining items after #238 (HEARTBEAT_OK suppression, Phase 1) and #243 (channel setup guides, Phase 2): default heartbeat SOP, formation schema docs, soul document template & guide, SDK/API docs.

## Default heartbeat SOP

- **Bundled content**: `formation/proactive/builtin/heartbeat.md` ships with the runtime (same convention as the bundled channel templates; MANIFEST.in + package_data). Follows the PRD sketch (Your Task / What to Check / Guidelines / Don't) as static markdown -- no templating, no `checks:` key (unshipped).
- **Fallback resolution** (`HeartbeatService._build_prompt`): formation `sop:` (when configured and loadable) > bundled default SOP > minimal built-in string (broken-install fallback only). `instruction:` appends in every case. Config validation never required `sop`/`instruction`, so nothing was relaxed; enabling the heartbeat with no `sop:` now gets a sensible default instead of the minimal wake-up prompt. Inert behavior unchanged: no heartbeat config = no heartbeat.
- The SOP wording deliberately avoids the request analyzer's heuristic hot words ("report", "research", ...) -- the heuristic cannot parse negation, so "this is not a report" scores like "report" and trips workflow decomposition.

## Suppression hardening (found via the new e2e)

Running the suppression path against the live pipeline for the first time exposed that `startswith(HEARTBEAT_OK)` leaked protocol chatter to users roughly half the time:

- `HeartbeatService._is_heartbeat_ok` now matches the sentinel **anywhere** in the response -- persona/synthesis layers wrap the agent's raw sentinel in prose ("...with a response of **HEARTBEAT_OK**"). The sentinel exists only inside the heartbeat prompt, so mentioning it is never a legitimate notification.
- `Overlord._apply_persona` returns bare `HEARTBEAT_OK*` responses verbatim -- the persona-rephrase pass (temperature 0.7, runs on every chat) otherwise sometimes paraphrased the sentinel away entirely ("The heartbeat check has been successful."), which no downstream matching can recover. Inert for normal chats.

## Docs

- `contributing/proactiveness-config.md`: schema reference for `proactive:` (channels / default_channel / heartbeat incl. default-SOP behavior), `commands:` (aliases, `builtin:` disable map, SOP shadowing, resolution order, the eight built-ins), agent `soul:`, and the client API surface with curl examples.
- `contributing/soul-documents.md` + `contributing/templates/soul.md`: soul guide and annotated starter template (Who I Am / My Values / My Boundaries / Our Relationship / What I Remember).
- Richer OpenAPI docstrings on `POST /v1/notifications` and `GET/PUT /v1/users/{id}/channels` (routing precedence, merge semantics, status codes) -- the repo's existing API docs convention.
- `mental-model.md`: Phase 4 section.

## Tests

- Unit: `test_heartbeat.py::TestPromptResolution` (bundled file ships, default fallback, formation-SOP override, missing-SOP fallback, instruction append to both bases), wrapped-sentinel suppression, persona pass-through pin. Full suite: **2378 passed**.
- e2e: `23_proactive/test_23a7_heartbeat_default_sop.py` with a dedicated `formation-heartbeat-default` (no formation SOPs -- semantic SOP matching otherwise hijacks the generic wake-up prompt, e.g. the shared formation's `ping` SOP). Verifies the bundled SOP drives a real heartbeat run, HEARTBEAT_OK suppression stays silent, and active hours still gate. Two consecutive green runs.
- Regression: `run_random_tests.py 5` -- 5/5 passed. `validate_events.py` -- 100%.

## Noted in passing (not fixed here)

`JobManager.get_active_jobs_batch` has no formation filter, so formations sharing a database execute each other's scheduled jobs; the new e2e works around it with a hermetic cleanup. Flagged for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)