### PR TITLE
fix: scope scheduler due-job queries to formation

### DIFF
--- a/e2e/tests/23_proactive/test_23a7_heartbeat_default_sop.py
+++ b/e2e/tests/23_proactive/test_23a7_heartbeat_default_sop.py
@@ -96,18 +96,16 @@ async def main():
         print("No `sop:` configured: bundled default SOP drives the heartbeat")
 
         # Hermetic setup: clear persisted channel state left by earlier
-        # runs so known_users() is exactly the user seeded below, and
-        # cancel stale ACTIVE scheduler jobs left in the shared e2e
-        # database by other areas (the due-job query is not formation
-        # scoped, so leftovers would fire mid-test and pollute the run).
+        # runs so known_users() is exactly the user seeded below. Scheduler
+        # jobs left by other areas in the shared e2e database no longer
+        # need cleanup here: the due-job queries are formation scoped.
         store = overlord.user_channel_store
         if store._async_session_maker is not None:
-            from sqlalchemy import delete, update  # noqa: E402
+            from sqlalchemy import delete  # noqa: E402
 
             from muxi.runtime.formation.proactive.user_channels import (  # noqa: E402
                 UserChannelState,
             )
-            from muxi.runtime.services.scheduler.models import ScheduledJob  # noqa: E402
 
             async with store._async_session_maker() as session:
                 await session.execute(
@@ -115,15 +113,10 @@ async def main():
                         UserChannelState.formation_id == store.formation_id
                     )
                 )
-                await session.execute(
-                    update(ScheduledJob)
-                    .where(ScheduledJob.status == "ACTIVE")
-                    .values(status="CANCELLED")
-                )
                 await session.commit()
         store._states.clear()
         store._loaded.clear()
-        print("Cleared persisted channel state and stale jobs for a hermetic run")
+        print("Cleared persisted channel state for a hermetic run")
 
         # Fresh user id per run: channel state and per-user memory persist
         # in the shared e2e database, and stale memories from earlier runs

--- a/src/muxi/runtime/services/scheduler/manager.py
+++ b/src/muxi/runtime/services/scheduler/manager.py
@@ -1010,7 +1010,11 @@ class JobManager:
             with self.db_manager.get_session() as session:
                 count = (
                     session.query(func.count(ScheduledJob.id))
-                    .filter(ScheduledJob.status == "ACTIVE")
+                    .join(User, ScheduledJob.user_id == User.id)
+                    .filter(
+                        ScheduledJob.status == "ACTIVE",
+                        User.formation_id == self.formation_id,
+                    )
                     .scalar()
                 )
                 return count or 0
@@ -1043,7 +1047,10 @@ class JobManager:
                 jobs = (
                     session.query(ScheduledJob)
                     .join(User, ScheduledJob.user_id == User.id)
-                    .filter(ScheduledJob.status == "ACTIVE")
+                    .filter(
+                        ScheduledJob.status == "ACTIVE",
+                        User.formation_id == self.formation_id,
+                    )
                     .order_by(ScheduledJob.created_at)
                     .offset(offset)
                     .limit(limit)

--- a/tests/unit/test_scheduler_formation_isolation.py
+++ b/tests/unit/test_scheduler_formation_isolation.py
@@ -1,0 +1,67 @@
+"""
+Formation isolation for scheduler batch queries.
+
+Multiple formations can share a single database, so every query that feeds the
+due-job worker must be scoped to the manager's formation_id.  Without that
+scope, a formation executes jobs created by other formations (observed in e2e
+where formations sharing one Postgres ran each other's stale recurring jobs).
+"""
+
+import pytest
+
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.long_term import User, UserIdentifier
+from muxi.runtime.services.scheduler.manager import JobManager
+from muxi.runtime.services.scheduler.models import ScheduledJob, ScheduledJobAudit
+
+SCHEDULER_TABLES = [
+    User.__table__,
+    UserIdentifier.__table__,
+    ScheduledJob.__table__,
+    ScheduledJobAudit.__table__,
+]
+
+
+@pytest.fixture
+def db_manager(tmp_path):
+    manager = DatabaseManager(f"sqlite:///{tmp_path}/scheduler.db")
+    manager.create_tables(Base.metadata, tables=SCHEDULER_TABLES)
+    yield manager
+    manager.engine.dispose()
+
+
+async def _create_recurring_job(job_manager: JobManager, user_id: str, title: str) -> str:
+    return await job_manager.create_job(
+        user_id=user_id,
+        title=title,
+        original_prompt="tell me a dad joke every minute",
+        execution_prompt="tell me a dad joke",
+        cron_expression="* * * * *",
+        is_recurring=True,
+    )
+
+
+async def test_get_active_jobs_batch_excludes_other_formations(db_manager):
+    manager_a = JobManager(db_manager, formation_id="formation-a")
+    manager_b = JobManager(db_manager, formation_id="formation-b")
+
+    job_a = await _create_recurring_job(manager_a, "user-a", "Formation A job")
+    job_b = await _create_recurring_job(manager_b, "user-b", "Formation B job")
+
+    batch_a = await manager_a.get_active_jobs_batch(offset=0, limit=100)
+    batch_b = await manager_b.get_active_jobs_batch(offset=0, limit=100)
+
+    assert [job["id"] for job in batch_a] == [job_a]
+    assert [job["id"] for job in batch_b] == [job_b]
+
+
+async def test_get_active_jobs_count_excludes_other_formations(db_manager):
+    manager_a = JobManager(db_manager, formation_id="formation-a")
+    manager_b = JobManager(db_manager, formation_id="formation-b")
+
+    await _create_recurring_job(manager_a, "user-a", "Formation A job one")
+    await _create_recurring_job(manager_a, "user-a", "Formation A job two")
+    await _create_recurring_job(manager_b, "user-b", "Formation B job")
+
+    assert await manager_a.get_active_jobs_count() == 2
+    assert await manager_b.get_active_jobs_count() == 1


### PR DESCRIPTION
## Problem

When several formations share one Postgres database, the scheduler executes jobs belonging to OTHER formations. `JobManager.get_active_jobs_batch` (and its pagination companion `get_active_jobs_count`) filtered only on `ScheduledJob.status == "ACTIVE"` with no formation scope, so `SchedulerService`'s due-job worker picked up every ACTIVE job in the database regardless of which formation created it.

Observed in practice: e2e formations sharing the e2e Postgres each executed stale "tell me a dad joke every minute" jobs created by other test areas, which forced a hermetic-cleanup workaround in test 23A7 that cancelled ALL active jobs at setup.

## Fix

- Add `User.formation_id == self.formation_id` to `get_active_jobs_batch` and `get_active_jobs_count` in `src/muxi/runtime/services/scheduler/manager.py`, matching every other query in the file. Both had to change together — the batch processor uses the count to paginate the batches.
- Audited the remaining `ScheduledJob` queries: `cleanup_old_jobs_batch`, `get_active_jobs`, `count_active_jobs_sync`, `get_all_jobs`, `pause_job`, `resume_job`, and `complete_onetime_job` are already formation-scoped. The job-id-only lookups (`get_job`, `mark_job_execution_*`, `get_consecutive_failures`, `update_job_metadata`, `delete_job`) operate on unguessable nanoid job IDs obtained from already-scoped queries.
- New unit tests (`tests/unit/test_scheduler_formation_isolation.py`) create jobs under two formations sharing one database and prove each manager's batch/count only sees its own. Verified they fail against the unfixed code.
- Simplified the 23A7 e2e hermetic setup: removed the cancel-all-ACTIVE-jobs workaround (which also had the side effect of cancelling other areas' jobs mid-run); the channel-state cleanup stays.

## Testing

- `uv run python -m pytest tests/unit/ -q` — 2382 passed, 10 skipped
- black 100 / isort / ruff clean on changed files
- 23A7 e2e not re-run here (needs the e2e Postgres + LLM keys); worth including in the next regression run

🤖 Generated with [Claude Code](https://claude.com/claude-code)