### PR TITLE
feat: unify MCP tools vocabulary on allow/deny + attachment tool overrides

### DIFF
--- a/e2e/tests/19_api/formation-api-tools-vocab-conflict/formation.yaml
+++ b/e2e/tests/19_api/formation-api-tools-vocab-conflict/formation.yaml
@@ -1,0 +1,39 @@
+schema: "1.0.0"
+id: api-test-tools-vocab-conflict
+description: "Invalid formation: a tools block declaring both 'allow' and its alias 'whitelist'"
+
+llm:
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+
+runtime:
+  built_in_mcps: false
+
+memory:
+  buffer:
+    size: 100
+    vector_search: false
+
+mcp:
+  servers:
+    - id: records-mcp
+      description: "Records tools (never registered -- load must fail)"
+      type: command
+      command: python
+      args: ["tests/19_api/formation-api-tools-vocab/records_server.py"]
+      tools:
+        allow: ["get_*"]
+        whitelist: ["list_*"]  # canonical + alias in one block: load-time error
+
+agents:
+  - id: assistant
+    name: "Conflict Test Assistant"
+    description: "Never starts"
+    system_message: "You are a helpful assistant."
+
+logging:
+  system:
+    level: "error"
+    destination: "stdout"

--- a/e2e/tests/19_api/formation-api-tools-vocab-conflict/secrets.enc
+++ b/e2e/tests/19_api/formation-api-tools-vocab-conflict/secrets.enc
@@ -1,0 +1,1 @@
+../formation-api/secrets.enc

--- a/e2e/tests/19_api/formation-api-tools-vocab/formation.yaml
+++ b/e2e/tests/19_api/formation-api-tools-vocab/formation.yaml
@@ -1,0 +1,58 @@
+schema: "1.0.0"
+id: api-test-tools-vocab
+description: "Formation exercising the allow/deny tools vocabulary across the override cascade"
+
+llm:
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+    - embedding: "openai/text-embedding-3-small"
+
+runtime:
+  built_in_mcps: false
+
+memory:
+  buffer:
+    size: 100
+    vector_search: false
+
+mcp:
+  servers:
+    - id: records-mcp
+      description: "Records tools (stub catalog for filter tests)"
+      type: command
+      command: python
+      args: ["tests/19_api/formation-api-tools-vocab/records_server.py"]
+      timeout_seconds: 60
+      # Canonical allow/deny, both together (relaxed mutex): allow keeps the
+      # non-destructive verbs plus delete_records, deny then subtracts it --
+      # deny wins on overlap. drop_database never enters the catalog.
+      tools:
+        allow: ["get_*", "list_*", "search_records", "create_record", "delete_records"]
+        deny: ["delete_records"]
+
+agents:
+  - id: assistant
+    name: "Tools Vocabulary Test Assistant"
+    description: "A helpful assistant for testing tool filter vocabulary"
+    system_message: "You are a helpful assistant. Be concise and direct."
+    mcp_servers:
+      # Reference-with-override form: attaches the formation-declared server
+      # and narrows it further with the alias spelling (blacklist == deny).
+      - id: records-mcp
+        tools:
+          blacklist: ["create_record"]
+
+server:
+  enabled: true
+  port: 8271
+  auth: required  # groups/ requires the auth gate (2026-07-07 ruling)
+  api_keys:
+    admin_key: test-admin-key-123
+    client_key: test-client-key-456
+
+logging:
+  system:
+    level: "error"
+    destination: "stdout"

--- a/e2e/tests/19_api/formation-api-tools-vocab/groups/analyst.yaml
+++ b/e2e/tests/19_api/formation-api-tools-vocab/groups/analyst.yaml
@@ -1,0 +1,11 @@
+name: "Records Analyst"
+description: "Analysts get the read path plus record creation"
+agents:
+  - assistant:
+      records-mcp:
+        tools:
+          # Group allow expands against the post-registry catalog: it
+          # supersedes the attachment override (create_record comes back)
+          # but cannot resurrect registry-pruned tools (drop_database and
+          # delete_records stay out).
+          allow: ["get_records", "create_record", "drop_database", "delete_records"]

--- a/e2e/tests/19_api/formation-api-tools-vocab/records_server.py
+++ b/e2e/tests/19_api/formation-api-tools-vocab/records_server.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Stdio MCP stub with a semantic-tool catalog for tool-filter e2e tests.
+
+Six tools spanning read / write / destructive verbs so the registry-level
+allow+deny block, the agent-attachment override, and the group-level
+cascade each have something distinct to act on. Responses are canned --
+the tests only assert on tool *visibility*, not behaviour.
+"""
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("records")
+
+
+@mcp.tool()
+def get_records(record_id: str = "all") -> str:
+    """Get one record (or all records) from the records store."""
+    return f"records for {record_id}: [alpha, beta]"
+
+
+@mcp.tool()
+def list_records() -> str:
+    """List record identifiers in the records store."""
+    return "record ids: [1, 2, 3]"
+
+
+@mcp.tool()
+def search_records(query: str) -> str:
+    """Search records matching a query string."""
+    return f"no records match {query!r}"
+
+
+@mcp.tool()
+def create_record(payload: str) -> str:
+    """Create a new record from a payload string."""
+    return f"created record from {payload!r}"
+
+
+@mcp.tool()
+def delete_records(record_id: str) -> str:
+    """Delete a record by id (destructive)."""
+    return f"deleted record {record_id}"
+
+
+@mcp.tool()
+def drop_database() -> str:
+    """Drop the entire records database (destructive)."""
+    return "database dropped"
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/e2e/tests/19_api/formation-api-tools-vocab/secrets.enc
+++ b/e2e/tests/19_api/formation-api-tools-vocab/secrets.enc
@@ -1,0 +1,1 @@
+../formation-api/secrets.enc

--- a/e2e/tests/19_api/test_19x4_tools_vocabulary.py
+++ b/e2e/tests/19_api/test_19x4_tools_vocabulary.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Test 19x4: allow/deny tools vocabulary across the override cascade.
+
+Covers the registry/agent-level unification with the group-level GBAC
+semantics (tools vocabulary unification):
+
+- formation ``mcp.servers[].tools`` accepts canonical ``allow`` + ``deny``
+  together (relaxed mutex): the registered catalog is allow minus deny,
+  with deny winning on overlap
+- an agent attaches a formation-declared server with the new
+  ``{id, tools}`` reference form; the override (alias spelling
+  ``blacklist``) chains after the registry bound and narrows the agent's
+  tool registry without touching the shared catalog
+- a group per-agent ``allow`` supersedes the attachment override
+  (``create_record`` comes back) but cannot resurrect registry-pruned
+  tools (``drop_database`` / ``delete_records`` stay out) -- both via the
+  resolver and via the enforcement helper the chat path uses
+- a ``tools`` block declaring a canonical key and its alias fails
+  formation load fail-fast
+
+The MCP stub (``records_server.py``) runs over stdio with a six-tool
+catalog; the formation launches it with a path relative to the e2e
+directory, so the test pins its working directory there first.
+"""
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+
+E2E_DIR = Path(__file__).parent.parent.parent
+os.chdir(E2E_DIR)  # the formation launches the MCP stub via an e2e-relative path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from common import BaseE2ETest, TestOutputFormatter  # noqa: E402
+
+from muxi.runtime.services.gbac import enforcement as gbac_enforcement  # noqa: E402
+from muxi.runtime.services.memory.long_term import UserGroup  # noqa: E402
+
+ANALYST_USER = "alice@example.com"
+FORMATION_ID = "api-test-tools-vocab"
+
+# What each cascade level should leave visible (see formation.yaml/groups/)
+REGISTRY_CATALOG = {"get_records", "list_records", "search_records", "create_record"}
+ATTACHMENT_VIEW = {"get_records", "list_records", "search_records"}
+GROUP_EFFECTIVE = {"get_records", "create_record"}
+
+
+class TestToolsVocabulary(BaseE2ETest):
+    def __init__(self):
+        super().__init__(
+            test_name="test_19x4_tools_vocabulary",
+            test_description="Test allow/deny tools vocabulary across the override cascade",
+            test_area="19_api",
+        )
+
+    async def _seed_membership(self, user_id: str, group_id: str):
+        from sqlalchemy import delete
+
+        async with self.formation._db_manager.get_async_session() as session:
+            # Idempotent across runs: the formation SQLite DB persists
+            await session.execute(
+                delete(UserGroup).where(
+                    UserGroup.user_id == user_id,
+                    UserGroup.formation_id == FORMATION_ID,
+                )
+            )
+            await UserGroup.create(
+                session,
+                user_id=user_id,
+                group_id=group_id,
+                formation_id=FORMATION_ID,
+            )
+            await session.commit()
+        self.formation.permission_resolver.invalidate_memberships(user_id)
+
+    async def test_19x4_tools_vocabulary(self):
+        formatter, start_time = TestOutputFormatter(), time.time()
+        formatter.print_test_header(
+            test_name="test_19x4_tools_vocabulary",
+            description="Test allow/deny tools vocabulary across the override cascade",
+        )
+        checks = []
+        try:
+            print("\n1. Starting formation with allow+deny registry filter and")
+            print("   an {id, tools} agent attachment override...")
+            await self.setup_formation(
+                formation_path=Path(__file__).parent / "formation-api-tools-vocab"
+            )
+            await asyncio.sleep(2)
+            mcp_service = self.overlord.mcp_service
+            print("✅ Formation loaded, MCP stub registered")
+            checks.append("formation with allow/deny vocabulary loads")
+
+            print("\n2. Registry level: allow+deny together prune the shared catalog...")
+            shared = mcp_service.agent_tool_registry["_shared"]["records-mcp"]
+            assert set(shared) == REGISTRY_CATALOG, f"shared catalog: {sorted(shared)}"
+            print(f"✅ Shared catalog: {sorted(shared)}")
+            print("   (delete_records denied despite matching allow; drop_database never allowed)")
+            checks.append("registry allow+deny prunes catalog (deny wins on overlap)")
+
+            print("\n3. Attachment level: {id, tools} reference narrows the agent view...")
+            agent_view = mcp_service.get_tool_registry("assistant")["records-mcp"]
+            assert set(agent_view) == ATTACHMENT_VIEW, f"agent view: {sorted(agent_view)}"
+            print(f"✅ Agent view: {sorted(agent_view)} (blacklist alias removed create_record)")
+            checks.append("{id, tools} attachment override narrows agent registry")
+
+            print("\n4. Seeding analyst membership and resolving the cascade...")
+            await self._seed_membership(ANALYST_USER, "analyst")
+            resolver = self.formation.permission_resolver
+            assert resolver is not None, "permission_resolver not constructed"
+            perms = await resolver.resolve(ANALYST_USER)
+            effective = perms.effective_tools(
+                "assistant",
+                "records-mcp",
+                inherited_tools=sorted(agent_view),
+                catalog=sorted(shared),
+            )
+            assert effective == GROUP_EFFECTIVE, f"effective: {sorted(effective)}"
+            print(f"✅ Group allow supersedes the attachment ({sorted(effective)})")
+            print("   create_record restored; drop_database/delete_records stay registry-pruned")
+            checks.append("group allow supersedes attachment, not the registry bound")
+
+            print("\n5. Enforcement helper (chat path) applies the same cascade...")
+            token = gbac_enforcement.set_current_permissions(perms)
+            try:
+                narrowed = gbac_enforcement.effective_tool_registry(
+                    "assistant",
+                    {"records-mcp": dict(agent_view)},
+                    catalogs={"records-mcp": dict(shared)},
+                )
+            finally:
+                gbac_enforcement.reset_current_permissions(token)
+            assert set(narrowed.get("records-mcp", {})) == GROUP_EFFECTIVE, narrowed
+            print("✅ effective_tool_registry matches the resolver cascade")
+            checks.append("enforcement helper feeds the cascade the same way")
+
+            await self.cleanup_formation()
+            self.formation = None
+            self.overlord = None
+            await asyncio.sleep(2)
+
+            print("\n6. Alias conflict (allow + whitelist) fails formation load...")
+            from muxi.runtime.datatypes.exceptions import ConfigurationValidationError
+            from muxi.runtime.formation import Formation
+
+            failed = False
+            try:
+                bad = Formation()
+                await bad.load(str(Path(__file__).parent / "formation-api-tools-vocab-conflict"))
+            except ConfigurationValidationError as e:
+                failed = True
+                message = str(e)
+                assert "alias" in message, message
+                assert "allow" in message and "whitelist" in message, message
+                print("✅ Load failed with a clear alias-conflict error")
+                checks.append("canonical+alias conflict fails formation load")
+            assert failed, "alias-conflict formation loaded but should have failed"
+
+            formatter.print_test_result(
+                test_name="test_19x4_tools_vocabulary",
+                success=True,
+                checks=checks,
+                transcript=[],
+                duration=time.time() - start_time,
+            )
+            print("\nSUCCESS")
+        except Exception as e:
+            formatter.print_test_result(
+                test_name="test_19x4_tools_vocabulary",
+                success=False,
+                checks=[f"Failed: {e}"],
+                transcript=[],
+                duration=time.time() - start_time,
+            )
+            import traceback
+
+            traceback.print_exc()
+            raise
+        finally:
+            if self.formation:
+                await self.cleanup_formation()
+
+
+async def main():
+    await TestToolsVocabulary().test_19x4_tools_vocabulary()
+
+
+if __name__ == "__main__":
+    os._exit(asyncio.run(main()) or 0)

--- a/src/muxi/runtime/formation/agents/agent.py
+++ b/src/muxi/runtime/formation/agents/agent.py
@@ -1564,11 +1564,17 @@ class Agent:
                 from ...services.gbac import enforcement as gbac_enforcement
 
                 agent_registries = getattr(mcp_service, "agent_tool_registry", None) or {}
+                # An empty _shared catalog means everything was filtered out
+                # on purpose; only fall back when the key is absent entirely.
+                _shared = agent_registries.get("_shared")
                 available_tools = gbac_enforcement.effective_tool_registry(
                     self.agent_id,
                     available_tools,
-                    catalogs=agent_registries.get("_shared")
-                    or getattr(mcp_service, "tool_registry", None),
+                    catalogs=(
+                        _shared
+                        if _shared is not None
+                        else getattr(mcp_service, "tool_registry", None)
+                    ),
                 )
 
                 # Tool isolation now working with shared + agent-specific tools

--- a/src/muxi/runtime/formation/agents/agent.py
+++ b/src/muxi/runtime/formation/agents/agent.py
@@ -1548,18 +1548,27 @@ class Agent:
                 # GBAC Phase 3: narrow the per-turn tool surface to the
                 # requesting user's effective set (group tool-override
                 # cascade). ``available_tools`` is the inherited view
-                # (post-registry, post-attachment); ``mcp_service.
-                # tool_registry`` is the post-registry catalog that group
-                # allow-overrides expand against. No-op when the formation
-                # has no groups/ directory. The filtered dict feeds both
-                # the planning prompt and the LLM tool schema, so a denied
-                # tool is never visible nor callable in this turn.
+                # (post-registry, post-attachment); the ``_shared`` registry
+                # is the post-registry catalog that group allow-overrides
+                # expand against — a group may supersede an attachment
+                # override, but never resurrect registry-pruned tools.
+                # (``mcp_service.tool_registry`` is last-write-wins across
+                # per-agent re-registrations, so an attachment override
+                # would narrow it; servers registered only per-agent are
+                # absent from ``_shared`` and fall back to the inherited
+                # view inside ``effective_tool_registry``.) No-op when the
+                # formation has no groups/ directory. The filtered dict
+                # feeds both the planning prompt and the LLM tool schema,
+                # so a denied tool is never visible nor callable in this
+                # turn.
                 from ...services.gbac import enforcement as gbac_enforcement
 
+                agent_registries = getattr(mcp_service, "agent_tool_registry", None) or {}
                 available_tools = gbac_enforcement.effective_tool_registry(
                     self.agent_id,
                     available_tools,
-                    catalogs=getattr(mcp_service, "tool_registry", None),
+                    catalogs=agent_registries.get("_shared")
+                    or getattr(mcp_service, "tool_registry", None),
                 )
 
                 # Tool isolation now working with shared + agent-specific tools

--- a/src/muxi/runtime/formation/config/formation_loader.py
+++ b/src/muxi/runtime/formation/config/formation_loader.py
@@ -53,6 +53,22 @@ from typing import Any, Dict, List, Optional
 from .loader import ConfigLoader
 
 
+def _mcp_reference_id(item: Any) -> Optional[str]:
+    """Return the referenced server id for a ``{id, tools}`` attachment entry.
+
+    An agent ``mcp_servers`` dict entry whose keys are a subset of
+    ``{id, tools}`` is a reference to a declared server (with an optional
+    agent-level tools override), not an inline definition — inline
+    definitions carry at least ``description`` and ``type``. Returns None
+    for anything else.
+    """
+    if isinstance(item, dict) and set(item) <= {"id", "tools"}:
+        ref = item.get("id")
+        if isinstance(ref, str) and ref.strip():
+            return ref
+    return None
+
+
 class FormationLoader:
     """
     Unified loader for both flattened and modular formation configurations.
@@ -544,13 +560,15 @@ class FormationLoader:
             if isinstance(server, dict) and "id" in server:
                 formation_mcps[server["id"]] = server
 
-        # Collect all agent string refs that are NOT in formation-level MCPs
+        # Collect all agent references (string or {id, tools} form) that are
+        # NOT in formation-level MCPs
         needs_directory_lookup = False
         for agent in config["agents"]:
             if not isinstance(agent, dict):
                 continue
             for item in agent.get("mcp_servers") or []:
-                if isinstance(item, str) and item not in formation_mcps:
+                ref = item if isinstance(item, str) else _mcp_reference_id(item)
+                if isinstance(ref, str) and ref not in formation_mcps:
                     needs_directory_lookup = True
                     break
             if needs_directory_lookup:
@@ -575,25 +593,45 @@ class FormationLoader:
 
             resolved = []
             for item in agent_mcps:
+                ref_id: Optional[str] = None
+                tools_override = None
                 if isinstance(item, str):
-                    if item in formation_mcps:
-                        resolved.append(formation_mcps[item].copy())
-                    elif item in directory_mcps:
-                        mcp_config = directory_mcps[item].copy()
+                    ref_id = item
+                elif isinstance(item, dict) and set(item) <= {"id", "tools"}:
+                    # Reference-with-override form: {id: <declared server>,
+                    # tools: {...}} — resolves like a string reference, then
+                    # carries the tools block as an agent-level override
+                    # chained after the referenced server's own filter.
+                    ref_id = item.get("id")
+                    if not isinstance(ref_id, str) or not ref_id.strip():
+                        agent_id = agent.get("id", "unknown")
+                        raise ValueError(
+                            f"Agent '{agent_id}' mcp_servers: reference entry must "
+                            f"include a non-empty string 'id', got {item!r}"
+                        )
+                    tools_override = item.get("tools")
+
+                if ref_id is not None:
+                    if ref_id in formation_mcps:
+                        mcp_config = formation_mcps[ref_id].copy()
+                    elif ref_id in directory_mcps:
+                        mcp_config = directory_mcps[ref_id].copy()
                         mcp_config.pop("_source_file", None)
                         mcp_config.pop("_raw_secrets", None)
                         mcp_config.pop("_raw_placeholders", None)
-                        resolved.append(mcp_config)
                     else:
                         agent_id = agent.get("id", "unknown")
                         available = sorted(
                             set(list(formation_mcps.keys()) + list(directory_mcps.keys()))
                         )
                         raise ValueError(
-                            f"Agent '{agent_id}' references MCP server '{item}' "
+                            f"Agent '{agent_id}' references MCP server '{ref_id}' "
                             f"but it was not found in formation mcp.servers or "
                             f"mcp/ directory. Available: {available}"
                         )
+                    if tools_override is not None:
+                        mcp_config["_tools_override"] = tools_override
+                    resolved.append(mcp_config)
                 elif isinstance(item, dict):
                     resolved.append(item)
                 else:

--- a/src/muxi/runtime/formation/config/validation.py
+++ b/src/muxi/runtime/formation/config/validation.py
@@ -694,19 +694,26 @@ class FormationValidator:
         if "auth" in server_config:
             self._validate_mcp_auth_config(server_config["auth"], server_id or index)
 
-        # Validate optional tools.{whitelist|blacklist} filter block
+        # Validate optional tools.{allow|deny} filter block
         if "tools" in server_config:
-            self._validate_mcp_tools_block(server_config["tools"], server_id or index)
+            self._validate_mcp_tools_block(
+                server_config["tools"], f"MCP server {server_id or index}"
+            )
 
-    def _validate_mcp_tools_block(
-        self, tools_block: Any, server_identifier: Union[str, int]
-    ) -> None:
+    def _validate_mcp_tools_block(self, tools_block: Any, subject: str) -> None:
         """Validate the optional ``tools`` filter block on an MCP server.
 
         Schema:
-        ``tools.whitelist`` and ``tools.blacklist`` are mutually exclusive
-        lists of fnmatch-style string patterns. Either both absent
-        (no filter, back-compat) or exactly one present.
+        ``tools.allow`` and ``tools.deny`` are fnmatch-style string
+        patterns (a single string or a list). ``whitelist`` / ``blacklist``
+        are accepted as aliases of ``allow`` / ``deny``. At least one of
+        the two roles must be present; both together are valid and apply
+        allow first, then subtract deny — the same semantics as the
+        group-level GBAC ``tools`` blocks. Declaring a canonical key and
+        its alias in the same block is an error.
+
+        ``subject`` prefixes every message, e.g. ``"MCP server github"``
+        or ``"Agent researcher MCP server github"``.
 
         Errors raised here block formation startup. Empty-list and
         zero-match cases are *runtime* concerns surfaced via
@@ -716,34 +723,54 @@ class FormationValidator:
         """
         if not isinstance(tools_block, dict):
             self.result.add_error(
-                f"MCP server {server_identifier} 'tools' must be a mapping with "
-                "'whitelist' or 'blacklist' (not both)"
+                f"{subject} 'tools' must be a mapping with 'allow' and/or 'deny' "
+                "('whitelist'/'blacklist' are accepted aliases)"
             )
             return
 
-        whitelist_present = "whitelist" in tools_block
-        blacklist_present = "blacklist" in tools_block
-
-        if whitelist_present and blacklist_present:
+        known_keys = {"allow", "deny", "whitelist", "blacklist"}
+        unknown_keys = sorted(str(k) for k in tools_block if k not in known_keys)
+        if unknown_keys:
             self.result.add_error(
-                f"MCP server {server_identifier} 'tools' must declare either "
-                "'whitelist' or 'blacklist', not both"
+                f"{subject} 'tools' has unknown key(s) {unknown_keys}; only "
+                "'allow' and 'deny' ('whitelist'/'blacklist' aliases) are supported"
             )
             return
 
-        if not whitelist_present and not blacklist_present:
+        alias_conflict = False
+        for canonical, alias in (("allow", "whitelist"), ("deny", "blacklist")):
+            if canonical in tools_block and alias in tools_block:
+                self.result.add_error(
+                    f"{subject} 'tools' declares both '{canonical}' and its alias "
+                    f"'{alias}' — use one spelling per rule"
+                )
+                alias_conflict = True
+        if alias_conflict:
+            return
+
+        allow_key = next((k for k in ("allow", "whitelist") if k in tools_block), None)
+        deny_key = next((k for k in ("deny", "blacklist") if k in tools_block), None)
+
+        if allow_key is None and deny_key is None:
             self.result.add_error(
-                f"MCP server {server_identifier} 'tools' block must contain "
-                "'whitelist' or 'blacklist' (got neither)"
+                f"{subject} 'tools' block must contain 'allow' and/or 'deny' " "(got neither)"
             )
             return
 
-        mode = "whitelist" if whitelist_present else "blacklist"
-        patterns = tools_block[mode]
+        for key in (allow_key, deny_key):
+            if key is not None:
+                self._validate_tools_pattern_list(tools_block[key], subject, key)
+
+    def _validate_tools_pattern_list(self, patterns: Any, subject: str, key: str) -> None:
+        """Validate one ``allow``/``deny`` (or alias) pattern declaration."""
+        if isinstance(patterns, str):
+            if not patterns.strip():
+                self.result.add_error(f"{subject} 'tools.{key}' must be a non-empty pattern")
+            return
 
         if not isinstance(patterns, list):
             self.result.add_error(
-                f"MCP server {server_identifier} 'tools.{mode}' must be a list "
+                f"{subject} 'tools.{key}' must be a string pattern or a list "
                 "of fnmatch-style string patterns"
             )
             return
@@ -753,8 +780,8 @@ class FormationValidator:
             # warning since the operator clearly intended *something* by
             # adding the empty key.
             self.result.add_warning(
-                f"MCP server {server_identifier} 'tools.{mode}' is an empty "
-                "list — no filter will be applied (remove the block to silence "
+                f"{subject} 'tools.{key}' is an empty "
+                "list — no filter will be applied (remove the key to silence "
                 "this warning)"
             )
             return
@@ -762,13 +789,12 @@ class FormationValidator:
         for i, pattern in enumerate(patterns):
             if not isinstance(pattern, str):
                 self.result.add_error(
-                    f"MCP server {server_identifier} 'tools.{mode}[{i}]' must be a "
+                    f"{subject} 'tools.{key}[{i}]' must be a "
                     f"string, got {type(pattern).__name__}"
                 )
             elif not pattern.strip():
                 self.result.add_error(
-                    f"MCP server {server_identifier} 'tools.{mode}[{i}]' must be "
-                    "a non-empty pattern"
+                    f"{subject} 'tools.{key}[{i}]' must be " "a non-empty pattern"
                 )
 
     def _validate_mcp_metadata_fields(
@@ -1140,6 +1166,29 @@ class FormationValidator:
                 )
                 continue
 
+            if set(server_config) <= {"id", "tools"}:
+                # Reference-with-override form: {id: <declared server>, tools: {...}}.
+                # The id resolves against formation mcp.servers / mcp/ directory
+                # files in the loader, same as a plain string reference.
+                ref_id = server_config.get("id")
+                if not isinstance(ref_id, str) or not ref_id.strip():
+                    self.result.add_error(
+                        f"Agent {agent_identifier} MCP server {i} reference must "
+                        "include a non-empty string 'id'"
+                    )
+                    continue
+                if ref_id in server_ids:
+                    self.result.add_error(
+                        f"Agent {agent_identifier} has duplicate MCP server id: {ref_id}"
+                    )
+                server_ids.add(ref_id)
+                if "tools" in server_config:
+                    self._validate_mcp_tools_block(
+                        server_config["tools"],
+                        f"Agent {agent_identifier} MCP server {ref_id}",
+                    )
+                continue
+
             # Check required fields for agent-level MCP servers
             required_fields = ["id", "description", "type"]
             for field in required_fields:
@@ -1251,6 +1300,13 @@ class FormationValidator:
         if "auth" in server_config:
             self._validate_mcp_auth_config(
                 server_config["auth"], f"Agent {agent_identifier} MCP server {server_identifier}"
+            )
+
+        # Validate optional tools.{allow|deny} filter block on inline definitions
+        if "tools" in server_config:
+            self._validate_mcp_tools_block(
+                server_config["tools"],
+                f"Agent {agent_identifier} MCP server {server_identifier}",
             )
 
     def _validate_agents_directory(self, agents_dir: Path) -> None:

--- a/src/muxi/runtime/formation/formation.py
+++ b/src/muxi/runtime/formation/formation.py
@@ -2584,9 +2584,10 @@ class Formation:
                 if "parameters" in server_config and isinstance(server_config["parameters"], dict):
                     registration_params["parameters"] = server_config["parameters"]
 
-                # Translate optional tools.{whitelist|blacklist} from the MCP
-                # `.afs` file into a ToolFilterSpec applied at registration
-                # time. Mutex / type validation already ran in
+                # Translate optional tools.{allow|deny} (whitelist/blacklist
+                # accepted as aliases) from the MCP `.afs` file into a
+                # ToolFilterSpec applied at registration time. Alias / type
+                # validation already ran in
                 # ConfigValidator._validate_mcp_tools_block; we trust the
                 # block here. Inactive spec → passthrough (back-compat).
                 tools_block = server_config.get("tools")

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -2368,19 +2368,29 @@ class Overlord:
                 if "parameters" in server_config and isinstance(server_config["parameters"], dict):
                     registration_params["parameters"] = server_config["parameters"]
 
-                # Translate optional tools.{whitelist|blacklist} into a
+                # Translate optional tools.{allow|deny} into a
                 # ToolFilterSpec — same semantics as the formation-level
                 # registration path in formation.py. Without this, a
                 # per-agent re-registration would silently restore the
                 # full upstream catalog and bloat the planning prompt
                 # back to its unfiltered size.
-                tools_block = server_config.get("tools")
-                if isinstance(tools_block, dict):
-                    from ...services.mcp.tool_filter import ToolFilterSpec
+                #
+                # A ``{id, tools}`` attachment reference carries its
+                # override under ``_tools_override`` (set by the loader);
+                # it chains AFTER the referenced server's own ``tools``
+                # block, so the attachment selects from the already-pruned
+                # catalog and cannot resurrect registry-excluded tools.
+                from ...services.mcp.tool_filter import ToolFilterSpec
 
-                    spec = ToolFilterSpec.from_config(tools_block)
-                    if spec.is_active:
-                        registration_params["tool_filter"] = spec
+                tools_block = server_config.get("tools")
+                override_block = server_config.get("_tools_override")
+                spec = ToolFilterSpec.from_config(
+                    tools_block if isinstance(tools_block, dict) else None
+                )
+                if isinstance(override_block, dict):
+                    spec = ToolFilterSpec.from_config(override_block, base=spec)
+                if spec.is_active:
+                    registration_params["tool_filter"] = spec
 
                 # Register the MCP server with process-level timeout
                 # This may raise MCPConnectionError if connection fails

--- a/src/muxi/runtime/services/mcp/service.py
+++ b/src/muxi/runtime/services/mcp/service.py
@@ -441,7 +441,7 @@ class MCPService:
             original_credentials: Original credentials with user placeholders (if any)
             agent_id: Optional agent ID for agent-specific MCP servers
             parameters: Optional default parameters injected into every tool call
-            tool_filter: Optional whitelist/blacklist filter applied to the
+            tool_filter: Optional allow/deny filter applied to the
                 upstream tool catalog at registration time. When the filter
                 yields zero tools, the server is **not** registered (no
                 ``server_configs`` entry, no agent-visible tool registry
@@ -581,7 +581,7 @@ class MCPService:
           operators can audit exactly which upstream tools each glob
           expanded to. This is the **only** signal that protects against
           silent scope expansion when an upstream adds a new tool that
-          newly matches a whitelist.
+          newly matches an allow rule.
         * ``mcp.tool_filter.unknown_tool`` (warning, **once per unknown
           pattern**) — surfaces typos with ``difflib`` "did you mean?"
           suggestions for literal patterns. Glob patterns that match
@@ -1166,7 +1166,7 @@ class MCPService:
                 try:
                     upstream_tools = await handler.list_tools(server_name)
 
-                    # Apply optional whitelist/blacklist filter declared in the
+                    # Apply optional allow/deny filter declared in the
                     # MCP `.afs` ``tools`` block. Inactive spec → passthrough.
                     tools, filter_report = apply_filter(
                         upstream_tools, tool_filter or ToolFilterSpec()
@@ -1187,7 +1187,7 @@ class MCPService:
                         # Audit-trail events (applied + unknown-pattern
                         # suggestions) still fire so operators can diagnose
                         # WHY the filter ended up empty (typo? overly tight
-                        # whitelist?). The "[ INFO ] tool filter resolved..."
+                        # allow list?). The "[ INFO ] tool filter resolved..."
                         # init-line print is suppressed inside the helper
                         # when registered_tool_count == 0 so stdout doesn't
                         # show INFO immediately followed by WARN for the

--- a/src/muxi/runtime/services/mcp/tool_filter.py
+++ b/src/muxi/runtime/services/mcp/tool_filter.py
@@ -284,8 +284,8 @@ def apply_filter(
 
         kept = [
             t
-            for t in kept
-            if (allowed is None or _tool_name(t) in allowed) and _tool_name(t) not in denied
+            for t, name in zip(kept, names)
+            if (allowed is None or name in allowed) and name not in denied
         ]
 
     all_patterns: List[str] = []

--- a/src/muxi/runtime/services/mcp/tool_filter.py
+++ b/src/muxi/runtime/services/mcp/tool_filter.py
@@ -1,14 +1,15 @@
 # =============================================================================
 # FRONTMATTER
 # =============================================================================
-# Title:        MCP Tool Filter - Whitelist/Blacklist registration-time filter
+# Title:        MCP Tool Filter - Allow/Deny registration-time filter
 # Description:  Pure filter applied between upstream tools/list response and
 #               agent-visible tool registry insertion at MCP service
 #               registration time.
 # Role:         Lets a formation scope an upstream MCP catalog to a subset
 #               (e.g. read-only tools, no destructive ops, single product
-#               surface of a multi-product MCP) via two new optional keys
-#               in MCP `.afs` files: ``tools.whitelist`` / ``tools.blacklist``.
+#               surface of a multi-product MCP) via the optional ``tools``
+#               block in MCP `.afs` files: ``tools.allow`` / ``tools.deny``
+#               (``whitelist`` / ``blacklist`` accepted as aliases).
 # Usage:        Constructed from the ``tools`` block of an MCP `.afs`
 #               config dict by ``ToolFilterSpec.from_config()``. Called by
 #               ``MCPService._connect_single_transport`` between
@@ -24,14 +25,21 @@
 #   ``[abc]``   one character from a set (rarely useful; supported)
 #   ``[!abc]``  one character NOT in set (rarely useful; supported)
 #
+# Filter semantics mirror the group-level GBAC ``ToolRules`` (deny after
+# allow): ``allow`` alone keeps only matching tools, ``deny`` alone keeps
+# everything except matching tools, both together apply allow first and
+# then subtract deny. A spec may also chain onto a ``base`` spec — the
+# base is applied first, so an agent-attachment override can never
+# resurrect tools pruned by the formation-level catalog bound.
+#
 # The module is **pure**: it does not log, does not call observe(), does not
 # raise on configuration mistakes that callers may want to surface
 # differently (empty set, unknown patterns). The caller decides what to
 # do with each FilterReport finding.
 #
-# Validation that *must* fail-fast (whitelist+blacklist mutex, non-string
-# entries) lives in ``formation/config/validation.py`` so the formation
-# loader aborts before the runtime ever sees a malformed block.
+# Validation that *must* fail-fast (alias conflicts, non-string entries,
+# unknown keys) lives in ``formation/config/validation.py`` so the
+# formation loader aborts before the runtime ever sees a malformed block.
 # =============================================================================
 
 from __future__ import annotations
@@ -45,61 +53,111 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 _MAX_SUGGESTIONS = 3
 
 
+def _normalise_patterns(value: Any) -> Optional[Tuple[str, ...]]:
+    """Normalise a pattern declaration into a non-empty tuple, or None.
+
+    Accepts a single string (the group-level ``deny: "*"`` shorthand) or
+    a list of strings. Non-string and blank entries are dropped — those
+    are load-time validation errors caught upstream; here we tolerate
+    them so unit tests can exercise the filter in isolation.
+    """
+    if isinstance(value, str):
+        return (value,) if value.strip() else None
+    if isinstance(value, list):
+        patterns = tuple(p for p in value if isinstance(p, str) and p.strip())
+        return patterns or None
+    return None
+
+
 @dataclass(frozen=True)
 class ToolFilterSpec:
     """Resolved filter declared in an MCP `.afs` ``tools`` block.
 
-    Exactly one of ``whitelist`` / ``blacklist`` is non-None when the
-    filter is active. Both being None (or the spec being absent
-    entirely) means "no filter" — the caller should pass the upstream
-    catalog through unchanged.
+    ``allow`` / ``deny`` are each either None (key not declared) or a
+    non-empty tuple of fnmatch patterns. Both may be set together —
+    semantics follow the group-level GBAC ``ToolRules``: allow first,
+    then subtract deny. Both being None (and no active ``base``) means
+    "no filter" — the caller should pass the upstream catalog through
+    unchanged.
+
+    ``base`` optionally chains another spec that is applied *before*
+    this one. The agent-attachment override cascade uses this: the
+    formation-level catalog bound is the base, so the override selects
+    from the already-pruned catalog and can never resurrect tools the
+    registry level removed.
 
     Construction goes through :meth:`from_config` so the dict shape from
     the loader can be validated and normalised in one place.
     """
 
-    mode: Optional[str] = None  # "whitelist" | "blacklist" | None
-    patterns: Tuple[str, ...] = ()
+    allow: Optional[Tuple[str, ...]] = None
+    deny: Optional[Tuple[str, ...]] = None
+    base: Optional["ToolFilterSpec"] = None
 
     @property
     def is_active(self) -> bool:
-        """True iff this spec actually filters anything."""
-        return self.mode is not None and len(self.patterns) > 0
+        """True iff this spec (or its base chain) actually filters anything."""
+        if self.allow is not None or self.deny is not None:
+            return True
+        return self.base is not None and self.base.is_active
+
+    @property
+    def mode(self) -> Optional[str]:
+        """Human-readable label for this spec's own rules (ignores base)."""
+        if self.allow is not None and self.deny is not None:
+            return "allow+deny"
+        if self.allow is not None:
+            return "allow"
+        if self.deny is not None:
+            return "deny"
+        return None
+
+    def stages(self) -> List["ToolFilterSpec"]:
+        """Flatten the base chain into application order (base first)."""
+        chain: List["ToolFilterSpec"] = []
+        if self.base is not None:
+            chain.extend(self.base.stages())
+        if self.allow is not None or self.deny is not None:
+            chain.append(self)
+        return chain
 
     @classmethod
-    def from_config(cls, tools_block: Optional[Dict[str, Any]]) -> "ToolFilterSpec":
+    def from_config(
+        cls,
+        tools_block: Optional[Dict[str, Any]],
+        base: Optional["ToolFilterSpec"] = None,
+    ) -> "ToolFilterSpec":
         """Build a spec from a parsed MCP-config ``tools`` block.
 
         ``tools_block`` is whatever lives under the ``tools`` key in the
-        MCP `.afs` file (or ``None`` if absent). Mutex and type errors
-        are not raised here — the formation loader's validation layer
-        is the canonical fail-fast site for those. This method tolerates
+        MCP `.afs` file (or ``None`` if absent). Canonical keys are
+        ``allow`` / ``deny``; ``whitelist`` / ``blacklist`` are accepted
+        as aliases (canonical spelling wins if both appear — a conflict
+        the formation loader's validation layer rejects fail-fast).
+        Type errors are not raised here either — this method tolerates
         them so unit tests can exercise the filter in isolation, and
         defaults to "no filter" on anything malformed.
+
+        ``base`` optionally chains a spec applied before this one; an
+        inactive base is dropped.
         """
+        base = base if base is not None and base.is_active else None
+
         if not tools_block or not isinstance(tools_block, dict):
-            return cls()
+            return cls(base=base)
 
-        whitelist = tools_block.get("whitelist")
-        blacklist = tools_block.get("blacklist")
+        allow_raw = tools_block.get("allow")
+        if allow_raw is None:
+            allow_raw = tools_block.get("whitelist")
+        deny_raw = tools_block.get("deny")
+        if deny_raw is None:
+            deny_raw = tools_block.get("blacklist")
 
-        # Mutex is a load-time error caught upstream; if we somehow get
-        # both at runtime, prefer "no filter" rather than make a silent
-        # choice between them.
-        if whitelist is not None and blacklist is not None:
-            return cls()
-
-        if isinstance(whitelist, list) and len(whitelist) > 0:
-            patterns = tuple(p for p in whitelist if isinstance(p, str))
-            if patterns:
-                return cls(mode="whitelist", patterns=patterns)
-
-        if isinstance(blacklist, list) and len(blacklist) > 0:
-            patterns = tuple(p for p in blacklist if isinstance(p, str))
-            if patterns:
-                return cls(mode="blacklist", patterns=patterns)
-
-        return cls()
+        return cls(
+            allow=_normalise_patterns(allow_raw),
+            deny=_normalise_patterns(deny_raw),
+            base=base,
+        )
 
 
 @dataclass
@@ -108,12 +166,15 @@ class FilterReport:
 
     Carries everything observability + init-time logging need:
 
-    * ``mode`` / ``patterns`` — what the spec asked for.
+    * ``mode`` / ``patterns`` — what the spec asked for. ``mode`` is
+      ``"allow"``, ``"deny"`` or ``"allow+deny"`` for a single-stage
+      spec; chained stages join with `` > `` in application order.
     * ``upstream_tool_count`` / ``registered_tool_count`` — sizes
       before / after.
-    * ``pattern_resolutions`` — for each pattern, the list of upstream
-      tool names it matched (in their original upstream order). Empty
-      list means the pattern matched nothing.
+    * ``pattern_resolutions`` — for each pattern, the list of tool
+      names it matched (in their original upstream order) within the
+      universe its stage saw. Empty list means the pattern matched
+      nothing.
     * ``unknown_patterns`` — patterns that produced zero matches, with
       ``difflib`` suggestions. Empty list when every pattern matched
       at least one tool.
@@ -163,17 +224,23 @@ def apply_filter(
 
     Behaviour:
 
-    * Inactive spec (no whitelist or blacklist declared) → ``upstream_tools``
-      passes through unchanged, ``report`` is ``None`` (the caller skips
-      the "filter applied" observability event entirely).
-    * Whitelist mode → keep tools whose ``name`` matches **at least one**
+    * Inactive spec (no allow or deny declared anywhere in the chain) →
+      ``upstream_tools`` passes through unchanged, ``report`` is ``None``
+      (the caller skips the "filter applied" observability event
+      entirely).
+    * ``allow`` → keep tools whose ``name`` matches **at least one**
       pattern.
-    * Blacklist mode → keep tools whose ``name`` matches **none** of the
-      patterns.
+    * ``deny`` → drop tools whose ``name`` matches **any** pattern.
+    * Both in one stage → allow first, then subtract deny (deny wins on
+      overlap). Deny patterns resolve against the stage's *input*
+      universe, not the post-allow set, so a deny that overlaps the
+      allowed set is never misreported as unknown.
+    * Chained stages (``spec.base``) apply base-first; each stage's
+      patterns resolve against the previous stage's output.
 
-    Tool order is preserved relative to the upstream sequence in both
-    modes — handy for deterministic test assertions and for the planning
-    prompt (which renders tools in registration order).
+    Tool order is preserved relative to the upstream sequence — handy
+    for deterministic test assertions and for the planning prompt
+    (which renders tools in registration order).
 
     The returned :class:`FilterReport` always carries one entry per
     pattern in :attr:`FilterReport.pattern_resolutions`. Patterns that
@@ -183,40 +250,52 @@ def apply_filter(
     if not spec.is_active:
         return list(upstream_tools), None
 
-    upstream_names = [n for n in (_tool_name(t) for t in upstream_tools) if n is not None]
+    # Nameless / malformed tools (``_tool_name(t) is None``) are dropped
+    # whenever a filter is active, in allow and deny directions alike.
+    # Since the filter cannot reason about a tool with no usable name,
+    # the conservative decision is the same in either direction: drop it.
+    kept = [t for t in upstream_tools if _tool_name(t) is not None]
 
-    # Per-pattern resolution table — name order preserved.
     resolutions: List[Tuple[str, List[str]]] = []
-    matched_set: set[str] = set()
-    for pattern in spec.patterns:
-        matches = [n for n in upstream_names if fnmatchcase(n, pattern)]
-        resolutions.append((pattern, matches))
-        matched_set.update(matches)
+    unknown: List[Tuple[str, List[str]]] = []
+    stages = spec.stages()
 
-    # Nameless / malformed tools (``_tool_name(t) is None``) are dropped in
-    # **both** modes. Without the explicit ``is not None`` guard, blacklist
-    # mode would silently let nameless tools through (``None not in
-    # matched_set`` is always True) — an asymmetry with whitelist mode
-    # where ``None in matched_set`` is always False. Since the filter
-    # cannot reason about a tool with no usable name, the conservative
-    # decision is the same in either direction: drop it.
-    if spec.mode == "whitelist":
-        kept = [t for t in upstream_tools if (n := _tool_name(t)) is not None and n in matched_set]
-    elif spec.mode == "blacklist":
+    for stage in stages:
+        names = [_tool_name(t) for t in kept]
+
+        allowed: Optional[set] = None
+        if stage.allow is not None:
+            allowed = set()
+            for pattern in stage.allow:
+                matches = [n for n in names if fnmatchcase(n, pattern)]
+                resolutions.append((pattern, matches))
+                if not matches:
+                    unknown.append((pattern, _suggestions_for(pattern, names)))
+                allowed.update(matches)
+
+        denied: set = set()
+        if stage.deny is not None:
+            for pattern in stage.deny:
+                matches = [n for n in names if fnmatchcase(n, pattern)]
+                resolutions.append((pattern, matches))
+                if not matches:
+                    unknown.append((pattern, _suggestions_for(pattern, names)))
+                denied.update(matches)
+
         kept = [
-            t for t in upstream_tools if (n := _tool_name(t)) is not None and n not in matched_set
+            t
+            for t in kept
+            if (allowed is None or _tool_name(t) in allowed) and _tool_name(t) not in denied
         ]
-    else:
-        # is_active implies mode is set; this branch is defensive only.
-        return list(upstream_tools), None
 
-    unknown: List[Tuple[str, List[str]]] = [
-        (p, _suggestions_for(p, upstream_names)) for p, matches in resolutions if not matches
-    ]
+    all_patterns: List[str] = []
+    for stage in stages:
+        all_patterns.extend(stage.allow or ())
+        all_patterns.extend(stage.deny or ())
 
     report = FilterReport(
-        mode=spec.mode,
-        patterns=spec.patterns,
+        mode=" > ".join(stage.mode or "" for stage in stages),
+        patterns=tuple(all_patterns),
         upstream_tool_count=len(upstream_tools),
         registered_tool_count=len(kept),
         pattern_resolutions=resolutions,

--- a/tests/unit/test_mcp_tool_filter.py
+++ b/tests/unit/test_mcp_tool_filter.py
@@ -1,4 +1,4 @@
-"""Unit tests for MCP tool filtering (whitelist / blacklist).
+"""Unit tests for MCP tool filtering (allow / deny, whitelist / blacklist aliases).
 
 Three layers of coverage:
 
@@ -70,8 +70,9 @@ def _make_validator() -> Any:
         def __init__(self) -> None:
             self.result = ValidationResult()
 
-        # Bind the unbound method straight onto the harness.
+        # Bind the unbound methods straight onto the harness.
         _validate_mcp_tools_block = FormationValidator._validate_mcp_tools_block
+        _validate_tools_pattern_list = FormationValidator._validate_tools_pattern_list
 
     return _V()
 
@@ -99,7 +100,7 @@ def test_whitelist_literal_only(github_like_catalog: List[Dict[str, Any]]) -> No
     kept, report = apply_filter(github_like_catalog, spec)
     assert [t["name"] for t in kept] == ["get_branch", "create_issue"]  # upstream order preserved
     assert report is not None
-    assert report.mode == "whitelist"
+    assert report.mode == "allow"
     assert report.registered_tool_count == 2
     assert report.upstream_tool_count == len(github_like_catalog)
 
@@ -112,7 +113,7 @@ def test_blacklist_literal_only(github_like_catalog: List[Dict[str, Any]]) -> No
     assert "delete_repo" not in names
     assert "delete_branch" in names  # still here; only delete_repo was named
     assert len(names) == len(github_like_catalog) - 1
-    assert report is not None and report.mode == "blacklist"
+    assert report is not None and report.mode == "deny"
 
 
 def test_whitelist_glob_star(github_like_catalog: List[Dict[str, Any]]) -> None:
@@ -280,15 +281,16 @@ def test_spec_from_empty_dict_returns_inactive() -> None:
     assert spec.is_active is False
 
 
-def test_spec_from_both_keys_present_falls_back_to_inactive() -> None:
-    """Both keys → no filter at runtime (the loader rejects this earlier).
+def test_spec_from_both_keys_is_active_allow_then_deny() -> None:
+    """Both keys together are valid: allow applies first, deny subtracts.
 
-    The runtime tolerates this so a malformed config doesn't crash
-    registration; the formation loader's
-    ``_validate_mcp_tools_block`` is the canonical fail-fast site.
+    This is the relaxed mutex — a superset of the old one-of-them rule,
+    matching the group-level GBAC ``ToolRules`` semantics.
     """
     spec = ToolFilterSpec.from_config({"whitelist": ["a"], "blacklist": ["b"]})
-    assert spec.is_active is False
+    assert spec.is_active is True
+    assert spec.allow == ("a",)
+    assert spec.deny == ("b",)
 
 
 def test_spec_from_empty_list_returns_inactive() -> None:
@@ -303,7 +305,7 @@ def test_spec_strips_non_string_entries() -> None:
     """
     spec = ToolFilterSpec.from_config({"whitelist": ["valid", 42, None, "also_valid"]})
     assert spec.is_active is True
-    assert spec.patterns == ("valid", "also_valid")
+    assert spec.allow == ("valid", "also_valid")
 
 
 # ---------------------------------------------------------------------------
@@ -311,15 +313,37 @@ def test_spec_strips_non_string_entries() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_validation_rejects_whitelist_and_blacklist_both_set() -> None:
-    """Mutex rule fires at load time with a clear, actionable message."""
+def test_validation_accepts_whitelist_and_blacklist_together() -> None:
+    """Relaxed mutex: both rules in one block are valid (deny after allow)."""
     v = _make_validator()
     v._validate_mcp_tools_block({"whitelist": ["list_*"], "blacklist": ["delete_*"]}, "demo-mcp")
+    assert v.result.errors == []
+    assert v.result.warnings == []
+
+
+def test_validation_rejects_canonical_key_plus_its_alias() -> None:
+    """``allow`` + ``whitelist`` (or ``deny`` + ``blacklist``) is ambiguous."""
+    v = _make_validator()
+    v._validate_mcp_tools_block({"allow": ["a"], "whitelist": ["b"]}, "demo-mcp")
     assert v.result.errors
     msg = v.result.errors[-1]
     assert "demo-mcp" in msg
-    assert "whitelist" in msg and "blacklist" in msg
-    assert "not both" in msg
+    assert "allow" in msg and "whitelist" in msg
+
+    v = _make_validator()
+    v._validate_mcp_tools_block({"deny": ["a"], "blacklist": ["b"]}, "demo-mcp")
+    assert v.result.errors
+    msg = v.result.errors[-1]
+    assert "deny" in msg and "blacklist" in msg
+
+
+def test_validation_rejects_unknown_tools_key() -> None:
+    """Typos like ``alow`` fail fast instead of silently not filtering."""
+    v = _make_validator()
+    v._validate_mcp_tools_block({"alow": ["list_*"]}, "demo-mcp")
+    assert v.result.errors
+    msg = v.result.errors[-1]
+    assert "alow" in msg and "unknown key" in msg
 
 
 def test_validation_rejects_neither_whitelist_nor_blacklist() -> None:
@@ -332,15 +356,26 @@ def test_validation_rejects_neither_whitelist_nor_blacklist() -> None:
     v._validate_mcp_tools_block({}, "demo-mcp")
     assert v.result.errors
     msg = v.result.errors[-1]
-    assert "whitelist" in msg and "blacklist" in msg
+    assert "'allow'" in msg and "'deny'" in msg
 
 
-def test_validation_rejects_non_list_patterns() -> None:
-    """``whitelist`` / ``blacklist`` must be a list."""
+def test_validation_accepts_single_string_pattern_shorthand() -> None:
+    """A bare string is accepted (matches group-level ``deny: "*"`` idiom)."""
     v = _make_validator()
     v._validate_mcp_tools_block({"whitelist": "list_*"}, "demo-mcp")
+    assert v.result.errors == []
+
+    v = _make_validator()
+    v._validate_mcp_tools_block({"deny": "*"}, "demo-mcp")
+    assert v.result.errors == []
+
+
+def test_validation_rejects_non_string_non_list_patterns() -> None:
+    """A mapping (or other type) where patterns belong is a load-time error."""
+    v = _make_validator()
+    v._validate_mcp_tools_block({"whitelist": {"x": 1}}, "demo-mcp")
     assert v.result.errors
-    assert "must be a list" in v.result.errors[-1]
+    assert "string pattern or a list" in v.result.errors[-1]
 
 
 def test_validation_rejects_non_string_pattern_entry() -> None:

--- a/tests/unit/test_mcp_tools_allow_deny.py
+++ b/tests/unit/test_mcp_tools_allow_deny.py
@@ -1,0 +1,399 @@
+"""Unit tests for the allow/deny tools vocabulary and attachment overrides.
+
+Covers the registry/agent-level unification with the group-level GBAC
+semantics (see prds/completed/group-based-access-control.md):
+
+* ``allow`` / ``deny`` are canonical; ``whitelist`` / ``blacklist`` are
+  accepted aliases with identical behaviour.
+* Both rules may appear in one block — allow applies first, deny
+  subtracts (deny wins on overlap), matching group-level ``ToolRules``.
+* Agent ``mcp_servers`` attachments may reference a declared server as
+  ``{id, tools}`` — the override chains AFTER the referenced server's
+  own ``tools`` block, so level 2 of the override cascade can narrow
+  but never resurrect registry-pruned tools.
+"""
+
+from typing import Any, Dict, List
+
+import pytest
+
+from muxi.runtime.formation.config.formation_loader import FormationLoader
+from muxi.runtime.formation.config.validation import FormationValidator
+from muxi.runtime.services.mcp.tool_filter import ToolFilterSpec, apply_filter
+
+
+def _catalog(*names: str) -> List[Dict[str, Any]]:
+    return [{"name": n, "description": f"{n} description", "inputSchema": {}} for n in names]
+
+
+GITHUB = _catalog(
+    "list_issues",
+    "list_branches",
+    "create_issue",
+    "delete_repo",
+    "delete_branch",
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Alias equivalence
+# ---------------------------------------------------------------------------
+
+
+def test_allow_is_equivalent_to_whitelist() -> None:
+    via_alias, _ = apply_filter(GITHUB, ToolFilterSpec.from_config({"whitelist": ["list_*"]}))
+    via_canonical, _ = apply_filter(GITHUB, ToolFilterSpec.from_config({"allow": ["list_*"]}))
+    assert via_alias == via_canonical
+    assert [t["name"] for t in via_canonical] == ["list_issues", "list_branches"]
+
+
+def test_deny_is_equivalent_to_blacklist() -> None:
+    via_alias, _ = apply_filter(GITHUB, ToolFilterSpec.from_config({"blacklist": ["delete_*"]}))
+    via_canonical, _ = apply_filter(GITHUB, ToolFilterSpec.from_config({"deny": ["delete_*"]}))
+    assert via_alias == via_canonical
+    assert [t["name"] for t in via_canonical] == ["list_issues", "list_branches", "create_issue"]
+
+
+def test_canonical_key_wins_over_alias_at_runtime() -> None:
+    """Validation rejects the conflict fail-fast; the runtime spec is tolerant
+    and prefers the canonical spelling rather than guessing a merge."""
+    spec = ToolFilterSpec.from_config({"allow": ["list_*"], "whitelist": ["delete_*"]})
+    assert spec.allow == ("list_*",)
+
+
+def test_report_mode_uses_canonical_vocabulary() -> None:
+    _, report = apply_filter(GITHUB, ToolFilterSpec.from_config({"whitelist": ["list_*"]}))
+    assert report is not None and report.mode == "allow"
+    _, report = apply_filter(GITHUB, ToolFilterSpec.from_config({"blacklist": ["delete_*"]}))
+    assert report is not None and report.mode == "deny"
+
+
+# ---------------------------------------------------------------------------
+# 2. Relaxed mutex: allow + deny in one block (deny after allow)
+# ---------------------------------------------------------------------------
+
+
+def test_allow_and_deny_together_subtract_after_allow() -> None:
+    spec = ToolFilterSpec.from_config({"allow": ["list_*", "delete_*"], "deny": ["delete_repo"]})
+    kept, report = apply_filter(GITHUB, spec)
+    assert [t["name"] for t in kept] == ["list_issues", "list_branches", "delete_branch"]
+    assert report is not None and report.mode == "allow+deny"
+
+
+def test_deny_wins_on_full_overlap() -> None:
+    """A tool matched by both rules is denied — same as group-level rules."""
+    spec = ToolFilterSpec.from_config({"allow": ["delete_*"], "deny": ["delete_*"]})
+    kept, report = apply_filter(GITHUB, spec)
+    assert kept == []
+    assert report is not None and report.registered_tool_count == 0
+
+
+def test_alias_spellings_participate_in_relaxed_mutex() -> None:
+    """whitelist+blacklist in one block now means allow+deny, not an error."""
+    spec = ToolFilterSpec.from_config({"whitelist": ["list_*"], "blacklist": ["*_branches"]})
+    kept, _ = apply_filter(GITHUB, spec)
+    assert [t["name"] for t in kept] == ["list_issues"]
+
+
+def test_deny_star_string_shorthand_hides_everything() -> None:
+    """``deny: "*"`` — the group-level hide-server idiom works here too."""
+    spec = ToolFilterSpec.from_config({"deny": "*"})
+    kept, report = apply_filter(GITHUB, spec)
+    assert kept == []
+    assert report is not None and report.registered_tool_count == 0
+
+
+def test_deny_pattern_resolves_against_stage_input_not_post_allow() -> None:
+    """A deny overlapping the allowed set must not be reported unknown."""
+    spec = ToolFilterSpec.from_config({"allow": ["list_*"], "deny": ["create_issue"]})
+    kept, report = apply_filter(GITHUB, spec)
+    assert [t["name"] for t in kept] == ["list_issues", "list_branches"]
+    assert report is not None
+    assert report.unknown_patterns == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Chained specs (attachment override after catalog bound)
+# ---------------------------------------------------------------------------
+
+
+def test_chained_override_narrows_base() -> None:
+    base = ToolFilterSpec.from_config({"allow": ["list_*", "create_*"]})
+    spec = ToolFilterSpec.from_config({"allow": ["list_issues"]}, base=base)
+    kept, report = apply_filter(GITHUB, spec)
+    assert [t["name"] for t in kept] == ["list_issues"]
+    assert report is not None and report.mode == "allow > allow"
+
+
+def test_chained_override_cannot_resurrect_base_pruned_tools() -> None:
+    """Level 2 selects from the post-level-1 catalog — never widens it."""
+    base = ToolFilterSpec.from_config({"deny": ["delete_*"]})
+    spec = ToolFilterSpec.from_config({"allow": ["delete_repo", "list_*"]}, base=base)
+    kept, _ = apply_filter(GITHUB, spec)
+    # delete_repo was pruned by the base (registry) filter; the override's
+    # allow cannot bring it back.
+    assert [t["name"] for t in kept] == ["list_issues", "list_branches"]
+
+
+def test_chained_deny_subtracts_from_base_result() -> None:
+    base = ToolFilterSpec.from_config({"allow": ["list_*", "create_*"]})
+    spec = ToolFilterSpec.from_config({"deny": ["list_branches"]}, base=base)
+    kept, _ = apply_filter(GITHUB, spec)
+    assert [t["name"] for t in kept] == ["list_issues", "create_issue"]
+
+
+def test_inactive_base_is_dropped_from_chain() -> None:
+    spec = ToolFilterSpec.from_config({"allow": ["list_*"]}, base=ToolFilterSpec())
+    assert spec.base is None
+    assert len(spec.stages()) == 1
+
+
+def test_inactive_override_with_active_base_still_filters() -> None:
+    """A bare ``{id}`` reference keeps the referenced server's own filter."""
+    base = ToolFilterSpec.from_config({"allow": ["list_*"]})
+    spec = ToolFilterSpec.from_config(None, base=base)
+    assert spec.is_active is True
+    kept, _ = apply_filter(GITHUB, spec)
+    assert [t["name"] for t in kept] == ["list_issues", "list_branches"]
+
+
+# ---------------------------------------------------------------------------
+# 4. Validation: agent-level blocks and the {id, tools} reference form
+# ---------------------------------------------------------------------------
+
+
+def test_agent_inline_tools_block_is_validated() -> None:
+    v = FormationValidator()
+    v._validate_agent_mcp_servers(
+        [
+            {
+                "id": "private-tool",
+                "description": "Private",
+                "type": "http",
+                "endpoint": "https://private.example.com/mcp",
+                "tools": {"allow": ["a"], "whitelist": ["b"]},  # alias conflict
+            }
+        ],
+        "my-agent",
+    )
+    assert any("alias" in e for e in v.result.errors)
+    assert any("my-agent" in e for e in v.result.errors)
+
+
+def test_agent_reference_with_tools_override_is_valid() -> None:
+    v = FormationValidator()
+    v._validate_agent_mcp_servers(
+        [{"id": "github-mcp", "tools": {"allow": ["list_*"], "deny": ["delete_*"]}}],
+        "my-agent",
+    )
+    assert v.result.errors == []
+
+
+def test_agent_reference_with_alias_forms_is_valid() -> None:
+    v = FormationValidator()
+    v._validate_agent_mcp_servers(
+        [{"id": "github-mcp", "tools": {"whitelist": ["list_*"]}}],
+        "my-agent",
+    )
+    assert v.result.errors == []
+
+
+def test_agent_reference_requires_string_id() -> None:
+    v = FormationValidator()
+    v._validate_agent_mcp_servers([{"tools": {"allow": ["list_*"]}}], "my-agent")
+    assert any("non-empty string 'id'" in e for e in v.result.errors)
+
+
+def test_agent_reference_bad_tools_block_fails_fast() -> None:
+    v = FormationValidator()
+    v._validate_agent_mcp_servers(
+        [{"id": "github-mcp", "tools": {"alow": ["list_*"]}}],  # typo'd key
+        "my-agent",
+    )
+    assert any("unknown key" in e for e in v.result.errors)
+
+
+def test_agent_reference_duplicate_id_rejected() -> None:
+    v = FormationValidator()
+    v._validate_agent_mcp_servers(
+        ["placeholder-unused", {"id": "github-mcp"}, {"id": "github-mcp"}],
+        "my-agent",
+    )
+    assert any("duplicate MCP server id" in e for e in v.result.errors)
+
+
+def test_formation_level_allow_deny_and_aliases_are_valid() -> None:
+    v = FormationValidator()
+    for block in (
+        {"allow": ["list_*"]},
+        {"deny": ["delete_*"]},
+        {"allow": ["list_*"], "deny": ["list_branches"]},
+        {"whitelist": ["list_*"]},
+        {"blacklist": ["delete_*"]},
+        {"whitelist": ["list_*"], "blacklist": ["delete_*"]},
+        {"deny": "*"},
+    ):
+        v._validate_mcp_tools_block(block, "demo-mcp")
+    assert v.result.errors == []
+
+
+# ---------------------------------------------------------------------------
+# 5. Loader: {id, tools} attachment references
+# ---------------------------------------------------------------------------
+
+
+FORMATION_WITH_REFERENCE = """
+schema: "1.0.0"
+id: test
+description: test
+agents:
+  - id: my-agent
+    name: My Agent
+    description: Test agent
+    system_message: "Hello"
+    mcp_servers:
+      - id: github-mcp
+        tools:
+          allow: [list_*]
+          deny: [list_branches]
+mcp:
+  servers:
+    - id: github-mcp
+      description: GitHub tools
+      type: command
+      command: npx
+      tools:
+        deny: [delete_*]
+llm:
+  models:
+    - text: "openai/gpt-4o-mini"
+"""
+
+
+def _write(path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+@pytest.fixture
+def loader():
+    return FormationLoader()
+
+
+@pytest.mark.asyncio
+async def test_reference_with_tools_resolves_and_carries_override(loader, tmp_path) -> None:
+    _write(tmp_path / "formation.yaml", FORMATION_WITH_REFERENCE)
+    config, _, _ = await loader.load(str(tmp_path))
+    servers = config["agents"][0]["mcp_servers"]
+    assert len(servers) == 1
+    resolved = servers[0]
+    # Full formation-level definition, including its own tools block...
+    assert resolved["id"] == "github-mcp"
+    assert resolved["type"] == "command"
+    assert resolved["tools"] == {"deny": ["delete_*"]}
+    # ...plus the attachment override, kept separate so the registration
+    # path chains it after the catalog bound.
+    assert resolved["_tools_override"] == {"allow": ["list_*"], "deny": ["list_branches"]}
+    # The formation-level registry entry is untouched.
+    assert "_tools_override" not in config["mcp"]["servers"][0]
+
+
+@pytest.mark.asyncio
+async def test_reference_without_tools_behaves_like_string_ref(loader, tmp_path) -> None:
+    _write(
+        tmp_path / "formation.yaml",
+        FORMATION_WITH_REFERENCE.replace(
+            """      - id: github-mcp
+        tools:
+          allow: [list_*]
+          deny: [list_branches]""",
+            "      - id: github-mcp",
+        ),
+    )
+    config, _, _ = await loader.load(str(tmp_path))
+    resolved = config["agents"][0]["mcp_servers"][0]
+    assert resolved["id"] == "github-mcp"
+    assert "_tools_override" not in resolved
+
+
+@pytest.mark.asyncio
+async def test_reference_to_directory_private_mcp_carries_override(loader, tmp_path) -> None:
+    _write(
+        tmp_path / "formation.yaml",
+        """
+schema: "1.0.0"
+id: test
+description: test
+agents:
+  - id: my-agent
+    name: My Agent
+    description: Test agent
+    system_message: "Hello"
+    mcp_servers:
+      - id: private-mcp
+        tools:
+          deny: [drop_*]
+llm:
+  models:
+    - text: "openai/gpt-4o-mini"
+""",
+    )
+    _write(
+        tmp_path / "mcp" / "private-mcp.yaml",
+        """
+id: private-mcp
+description: Private tools
+type: command
+command: npx
+""",
+    )
+    config, _, _ = await loader.load(str(tmp_path))
+    resolved = config["agents"][0]["mcp_servers"][0]
+    assert resolved["id"] == "private-mcp"
+    assert resolved["_tools_override"] == {"deny": ["drop_*"]}
+
+
+@pytest.mark.asyncio
+async def test_reference_with_unknown_id_raises(loader, tmp_path) -> None:
+    _write(
+        tmp_path / "formation.yaml",
+        FORMATION_WITH_REFERENCE.replace(
+            "- id: github-mcp\n        tools:", "- id: nope\n        tools:"
+        ),
+    )
+    with pytest.raises(ValueError, match="nope.*not found"):
+        await loader.load(str(tmp_path))
+
+
+@pytest.mark.asyncio
+async def test_reference_with_blank_id_raises(loader, tmp_path) -> None:
+    _write(
+        tmp_path / "formation.yaml",
+        FORMATION_WITH_REFERENCE.replace(
+            "- id: github-mcp\n        tools:", '- id: ""\n        tools:'
+        ),
+    )
+    with pytest.raises(ValueError, match="non-empty string 'id'"):
+        await loader.load(str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# 6. Registration-path chaining (overlord semantics, exercised directly)
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_reference_chains_override_after_catalog_bound() -> None:
+    """End-to-end over the resolved dict shape the overlord consumes."""
+    server_config = {
+        "id": "github-mcp",
+        "type": "command",
+        "command": "npx",
+        "tools": {"deny": ["delete_*"]},
+        "_tools_override": {"allow": ["list_*", "delete_repo"]},
+    }
+    base = ToolFilterSpec.from_config(server_config.get("tools"))
+    spec = ToolFilterSpec.from_config(server_config.get("_tools_override"), base=base)
+    kept, report = apply_filter(GITHUB, spec)
+    # delete_repo stays pruned by the catalog bound despite the override allow.
+    assert [t["name"] for t in kept] == ["list_issues", "list_branches"]
+    assert report is not None and report.mode == "deny > allow"


### PR DESCRIPTION
## Summary

Closes the two gaps versus the GBAC design (`engineering/prds/completed/group-based-access-control.md`; `prds/afs-spec-gaps.md` section 2, 2026-07-08 revision — the "tools vocabulary unification" follow-up).

### 1. allow/deny canonical at registry and agent level (backward compatible)

Formation `mcp.servers[].tools` and agent-level `tools:` blocks now accept canonical `allow`/`deny` keys, with `whitelist`/`blacklist` kept as accepted aliases. The strict one-of-them mutex is relaxed to both-permitted with deny-after-allow semantics, matching the group-level GBAC `ToolRules` (`allow` alone = exactly this set, `deny` alone = catalog minus these, both = allow-then-subtract, deny wins on overlap). A single string pattern is accepted alongside lists (the group-level `deny: "*"` idiom). This is a strict superset of the previous behavior — existing configs load unchanged.

Fail-fast load-time validation (`ConfigurationValidationError`):
- canonical key + its alias in one block (`allow` + `whitelist`, `deny` + `blacklist`)
- unknown keys in the `tools` block (previously silently ignored at agent level — agent-level inline `tools:` blocks were not validated at all; they now go through the same validator as the registry level)

### 2. `tools:` on string-reference attachments (cascade level 2)

Agent `mcp_servers` entries can now be a `{id, tools}` mapping referencing a formation-declared (or `mcp/` directory) server, not just a plain string or a full inline definition. The override is carried separately by the loader and chains **after** the referenced server's own `tools` block (`ToolFilterSpec.base`), so an attachment can narrow the catalog but never resurrect registry-pruned tools — consistent with how group-level overrides expand against the post-registry catalog.

Supporting fix: the GBAC chat path (`agent.py`) now feeds group allow-overrides the `_shared` tool registry as the post-registry catalog instead of `mcp_service.tool_registry`. The latter is last-write-wins across per-agent re-registrations, so an attachment override would have narrowed the catalog that group overrides expand against, silently breaking the PRD's group-supersedes-attachment semantics.

## Testing

- `tests/unit/test_mcp_tools_allow_deny.py` (new, 27 tests): alias equivalence, both-permitted semantics, `deny: "*"` shorthand, spec chaining (no resurrection), validator paths for agent inline + reference forms, loader resolution of `{id, tools}` incl. directory-private servers and error cases
- `tests/unit/test_mcp_tool_filter.py` updated for the canonical vocabulary and relaxed mutex (36 tests)
- Full unit suite: 2412 passed, 10 skipped
- New e2e `19_api/test_19x4_tools_vocabulary.py`: live stdio MCP stub with a six-tool catalog; asserts each cascade level (registry allow+deny catalog, `{id, tools}` attachment narrowing via alias spelling, group allow superseding the attachment while registry-pruned tools stay out — via both the resolver and the enforcement helper), plus a fail-fast alias-conflict formation load
- GBAC e2e regression: 19x2 and 19x3 pass (19x2 needs local gitignored `.key` symlinks in the GBAC formation dirs; it fails identically on develop without them — pre-existing environment issue, not from this change)
- `run_random_tests.py 5`: 5/5 passed (1_foundation, 2_memory, 3_multimodal, 5_artifacts, 6_knowledge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)