### PR TITLE
feat: remote knowledge sources - phase 1 core sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## [unreleased]
 
+### Remote knowledge sources - Phase 1 core sync
+
+Agents can now declare url-based knowledge sources next to local paths
+(remote-knowledge-sources PRD, Phase 1):
+
+- ``knowledge.sources[*].url`` supports ``http(s)://`` (single file),
+  ``s3://`` (prefix + glob), ``rsync://`` / ``rsync+ssh://`` (incremental
+  tree sync), and ``file://`` (bind mounts). Credentials go through the
+  existing ``${{ secrets.* }}`` interpolation (``auth`` blocks:
+  ``basic``/``bearer`` for http, ``aws`` for s3, ``ssh_key`` for
+  rsync+ssh; plus http ``headers``).
+- Remote content syncs at formation startup into a per-source local
+  mirror under the runtime knowledge cache dir with manifest-based
+  change detection (ETag / Last-Modified / size+mtime), then feeds the
+  unchanged local ingestion pipeline. ``include``/``exclude`` filters
+  and ``max_files`` / ``max_file_size`` / ``max_total_size`` /
+  ``timeout`` limits are enforced.
+- Failure isolation: a failing sync never blocks formation startup or
+  chat -- sources degrade to previously synced content (stale-wins); on
+  a cold start with an unreachable source the formation still starts
+  with a loud warning. New observability events:
+  ``knowledge.sync.started``, ``knowledge.sync.completed``,
+  ``error.knowledge.sync.failed``.
+- Fail-fast load-time validation of source declarations (schemes, auth
+  shape, limits, cron ``schedule`` syntax). Not yet in Phase 1 (config
+  is rejected or documented accordingly): archive extraction
+  (``extract``), scheduled re-sync (``schedule`` accepted, sync runs at
+  startup only), and ``gs``/``az``/``ftp``/``sftp`` protocols.
+- Formations with only local knowledge sources are untouched (the remote
+  sync machinery is never even imported).
+
 ### RBAC membership via request middleware; server.auth and user_groups removed
 
 MUXI stops storing group memberships (request-middleware PRD). Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,14 @@ Agents can now declare url-based knowledge sources next to local paths
 - Remote content syncs at formation startup into a per-source local
   mirror under the runtime knowledge cache dir with manifest-based
   change detection (ETag / Last-Modified / size+mtime), then feeds the
-  unchanged local ingestion pipeline. ``include``/``exclude`` filters
-  and ``max_files`` / ``max_file_size`` / ``max_total_size`` /
-  ``timeout`` limits are enforced.
+  unchanged local ingestion pipeline. Downloads are atomic (temp file +
+  rename), so a mid-stream failure can never truncate a previously
+  synced good copy. ``include``/``exclude`` filters and ``max_files`` /
+  ``max_file_size`` / ``max_total_size`` / ``timeout`` limits are
+  enforced. For rsync+ssh, SSH host key checking is strict by default;
+  ``accept_new_host_keys: true`` is the explicit opt-in for
+  trust-on-first-use. S3 ``auth: {type: aws}`` without explicit keys
+  uses boto3's default credential chain.
 - Failure isolation: a failing sync never blocks formation startup or
   chat -- sources degrade to previously synced content (stale-wins); on
   a cold start with an unreachable source the formation still starts

--- a/e2e/tests/6_knowledge/formations/formation-remote-degraded/agents/hybrid.yaml
+++ b/e2e/tests/6_knowledge/formations/formation-remote-degraded/agents/hybrid.yaml
@@ -1,0 +1,21 @@
+schema: "1.0.0"
+id: "hybrid"
+name: "Hybrid Knowledge Agent"
+description: "AI assistant with local knowledge plus an unreachable remote source"
+
+system_message: |
+  You are an AI assistant with knowledge about the Aurelian Ledger.
+  Answer questions using your knowledge base.
+
+role: "assistant"
+specialties:
+  - "aurelian_ledger"
+
+knowledge:
+  enabled: true
+  sources:
+    - path: "knowledge/local-facts.md"
+      description: "Aurelian Ledger reference document (local)"
+    - url: "http://127.0.0.1:59721/never-online/docs.md"
+      id: unreachable-docs
+      description: "Intentionally unreachable remote source (failure isolation test)"

--- a/e2e/tests/6_knowledge/formations/formation-remote-degraded/formation.yaml
+++ b/e2e/tests/6_knowledge/formations/formation-remote-degraded/formation.yaml
@@ -1,0 +1,31 @@
+schema: "1.0.0"
+id: "remote-knowledge-degraded-test"
+description: "Formation mixing local knowledge with an unreachable remote source"
+
+llm:
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+    anthropic: "${{ secrets.ANTHROPIC_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+    - embedding: "openai/text-embedding-3-small"
+
+agents:
+  - hybrid
+
+memory:
+  buffer:
+    size: 50
+    multiplier: 10
+    vector_search: false
+
+logging:
+  system:
+    level: "debug"
+    destination: "stdout"
+  conversation:
+    enabled: true
+    streams:
+      - transport: "stdout"
+        level: "info"
+        format: "jsonl"

--- a/e2e/tests/6_knowledge/formations/formation-remote-degraded/knowledge/local-facts.md
+++ b/e2e/tests/6_knowledge/formations/formation-remote-degraded/knowledge/local-facts.md
@@ -1,0 +1,15 @@
+# The Aurelian Ledger
+
+The Aurelian Ledger is the fictional record of accounts maintained by the
+town of Bramblehollow. It has been kept without interruption since the
+year 1203 of the Ember Calendar.
+
+Key facts:
+
+- The ledger is written exclusively in oak-gall ink by the Keeper of Sums.
+- It is stored in the Bramblehollow archive beneath the old mill.
+- Every entry must be witnessed by two members of the Counting Circle.
+- The ledger's pages are bound in green leather embossed with a beehive.
+
+The most famous entry records the purchase of one thousand copper bells
+for the Festival of Quiet Hours in year 1377.

--- a/e2e/tests/6_knowledge/formations/formation-remote-degraded/secrets.enc
+++ b/e2e/tests/6_knowledge/formations/formation-remote-degraded/secrets.enc
@@ -1,0 +1,1 @@
+../../../../assets/secrets.enc

--- a/e2e/tests/6_knowledge/formations/formation-remote-http/agents/zephyria.yaml
+++ b/e2e/tests/6_knowledge/formations/formation-remote-http/agents/zephyria.yaml
@@ -1,0 +1,20 @@
+schema: "1.0.0"
+id: "zephyria"
+name: "Zephyria Agent"
+description: "AI assistant specialized in the Zephyrine Protocol and Zephyria lore"
+
+system_message: |
+  You are an AI assistant with knowledge about the Zephyrine Protocol.
+  Answer questions using your knowledge base.
+
+role: "assistant"
+specialties:
+  - "zephyrine_protocol"
+  - "zephyria"
+
+knowledge:
+  enabled: true
+  sources:
+    - url: "http://127.0.0.1:18931/kb/zephyria-facts.md"
+      id: zephyria-facts
+      description: "Zephyrine Protocol reference document (remote HTTP source)"

--- a/e2e/tests/6_knowledge/formations/formation-remote-http/formation.yaml
+++ b/e2e/tests/6_knowledge/formations/formation-remote-http/formation.yaml
@@ -1,0 +1,31 @@
+schema: "1.0.0"
+id: "remote-knowledge-http-test"
+description: "Formation with an agent whose knowledge syncs from a remote HTTP source"
+
+llm:
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+    anthropic: "${{ secrets.ANTHROPIC_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+    - embedding: "openai/text-embedding-3-small"
+
+agents:
+  - zephyria
+
+memory:
+  buffer:
+    size: 50
+    multiplier: 10
+    vector_search: false
+
+logging:
+  system:
+    level: "debug"
+    destination: "stdout"
+  conversation:
+    enabled: true
+    streams:
+      - transport: "stdout"
+        level: "info"
+        format: "jsonl"

--- a/e2e/tests/6_knowledge/formations/formation-remote-http/remote-content/kb/zephyria-facts.md
+++ b/e2e/tests/6_knowledge/formations/formation-remote-http/remote-content/kb/zephyria-facts.md
@@ -1,0 +1,18 @@
+# The Zephyrine Protocol
+
+The Zephyrine Protocol is the fictional governance charter of the sky-city
+of Windmere. It was ratified in the year 847 of the Gale Calendar.
+
+Key facts:
+
+- The protocol requires a quorum of exactly seven wind-keepers to approve
+  any change to the city's flight path.
+- The command center of the Zephyrine Protocol is located in the city of
+  Windmere, atop the Aetherspire tower.
+- The protocol's founding document is sealed with cobalt wax and stored in
+  the Vault of Currents.
+- Emergency sessions of the wind-keepers are announced by ringing the
+  Bellows Chime three times.
+
+The Zephyrine Protocol has never been suspended, though it came close
+during the Great Stillness of year 902, when no wind blew for eleven days.

--- a/e2e/tests/6_knowledge/formations/formation-remote-http/secrets.enc
+++ b/e2e/tests/6_knowledge/formations/formation-remote-http/secrets.enc
@@ -1,0 +1,1 @@
+../../../../assets/secrets.enc

--- a/e2e/tests/6_knowledge/test_6f1_remote_http_source.py
+++ b/e2e/tests/6_knowledge/test_6f1_remote_http_source.py
@@ -1,0 +1,138 @@
+"""
+Test 6F1: Remote HTTP Knowledge Source (Chat Flow)
+Verify a formation can declare an http:// knowledge source, sync it at load
+time into the local mirror, and answer questions from the synced content.
+
+Fixture: a local stdlib HTTP server (no external infrastructure) serving
+the formations/formation-remote-http/remote-content/ directory.
+"""
+
+import asyncio
+import functools
+import shutil
+import sys
+import threading
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+from muxi.runtime.formation import Formation  # noqa: E402
+
+FORMATION_DIR = Path(__file__).parent / "formations" / "formation-remote-http"
+FORMATION_ID = "remote-knowledge-http-test"
+HTTP_PORT = 18931
+
+
+def ensure_secret_links():
+    """Create .key / secrets.enc symlinks if missing (they are gitignored)."""
+    assets = Path(__file__).parent.parent.parent / "assets"
+    for name in (".key", "secrets.enc"):
+        link = FORMATION_DIR / name
+        if not link.exists():
+            if link.is_symlink():
+                link.unlink()
+            link.symlink_to(Path("..") / ".." / ".." / ".." / "assets" / name)
+        assert (assets / name).exists(), f"e2e/assets/{name} missing"
+
+
+def wipe_remote_mirror():
+    """Remove cached knowledge state so the sync is exercised cold."""
+    knowledge_cache = Path.home() / ".muxi" / FORMATION_ID / "cache" / "knowledge"
+    if knowledge_cache.exists():
+        shutil.rmtree(knowledge_cache, ignore_errors=True)
+
+
+def start_http_server():
+    handler = functools.partial(
+        SimpleHTTPRequestHandler, directory=str(FORMATION_DIR / "remote-content")
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", HTTP_PORT), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def test_remote_http_knowledge_source():
+    async def run_test():
+        server = None
+        try:
+            print("\n=== Test 6F1: Remote HTTP Knowledge Source (Chat Flow) ===")
+
+            ensure_secret_links()
+            wipe_remote_mirror()
+
+            print(f"\nStarting local HTTP fixture server on 127.0.0.1:{HTTP_PORT}...")
+            server = start_http_server()
+
+            print("Loading formation with remote http knowledge source...")
+            formation = Formation()
+            await formation.load(str(FORMATION_DIR / "formation.yaml"))
+
+            print("Starting overlord (syncs the remote source at startup)...")
+            overlord = await formation.start_overlord()
+
+            # The sync must have mirrored the served file locally
+            mirror_root = Path.home() / ".muxi" / FORMATION_ID / "cache" / "knowledge" / "remote"
+            mirrored = list(mirror_root.rglob("zephyria-facts.md"))
+            assert mirrored, f"Synced file not found under {mirror_root}"
+            print(f"Remote file mirrored locally: {mirrored[0]}")
+
+            manifests = list(mirror_root.rglob("manifest.json"))
+            assert manifests, "Sync manifest was not written"
+            manifest_text = manifests[0].read_text(encoding="utf-8")
+            assert '"success"' in manifest_text, f"Manifest not successful: {manifest_text}"
+            print("Sync manifest recorded a successful sync")
+
+            question = "According to your knowledge, what is the Zephyrine Protocol and where is its command center?"  # noqa: E501
+            response = await overlord.chat(
+                question,
+                agent_name="zephyria",
+                user_id="test_user",
+                session_id="test_session_remote_http",
+                stream=False,
+            )
+
+            print(f"\nUser: {question}")
+            if isinstance(response, dict):
+                response_text = response.get("response", str(response))
+            else:
+                response_text = str(response)
+            print(f"Zephyria: {response_text}")
+
+            assert response is not None, "No response from zephyria agent"
+            assert len(response_text) > 50, "Response too short, likely no knowledge used"
+            response_lower = response_text.lower()
+            keywords = ["windmere", "wind-keeper", "wind keeper", "aetherspire"]
+            assert any(k in response_lower for k in keywords), (
+                "Response does not contain facts from the remote knowledge source: "
+                f"{response_text}"
+            )
+            print("Agent answered using content synced from the remote HTTP source")
+
+            await formation.stop_overlord()
+
+            print("\nTest 6F1 passed: remote http source synced at load and used in chat")
+            return True
+
+        except Exception as e:
+            print(f"\nTest 6F1 failed: {str(e)}")
+            import traceback
+
+            traceback.print_exc()
+            return False
+        finally:
+            if server is not None:
+                server.shutdown()
+                server.server_close()
+
+    success = asyncio.run(run_test())
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    import os
+
+    exit_code = test_remote_http_knowledge_source()
+    if exit_code == 0:
+        print("SUCCESS", flush=True)
+    os._exit(exit_code)

--- a/e2e/tests/6_knowledge/test_6f2_remote_source_failure_isolation.py
+++ b/e2e/tests/6_knowledge/test_6f2_remote_source_failure_isolation.py
@@ -1,0 +1,115 @@
+"""
+Test 6F2: Remote Knowledge Source Failure Isolation
+An unreachable remote source must NOT break formation startup or chat.
+
+Cold-start policy under test (documented in mental-model.md): when a remote
+source is unreachable and nothing was ever synced, the formation still
+starts; the source contributes zero knowledge and a loud warning is
+emitted. Agents keep answering from their remaining (local) sources.
+"""
+
+import asyncio
+import shutil
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+from muxi.runtime.formation import Formation  # noqa: E402
+
+FORMATION_DIR = Path(__file__).parent / "formations" / "formation-remote-degraded"
+FORMATION_ID = "remote-knowledge-degraded-test"
+
+
+def ensure_secret_links():
+    """Create .key / secrets.enc symlinks if missing (they are gitignored)."""
+    assets = Path(__file__).parent.parent.parent / "assets"
+    for name in (".key", "secrets.enc"):
+        link = FORMATION_DIR / name
+        if not link.exists():
+            if link.is_symlink():
+                link.unlink()
+            link.symlink_to(Path("..") / ".." / ".." / ".." / "assets" / name)
+        assert (assets / name).exists(), f"e2e/assets/{name} missing"
+
+
+def wipe_remote_mirror():
+    """Guarantee a cold start: no previously synced content for the source."""
+    knowledge_cache = Path.home() / ".muxi" / FORMATION_ID / "cache" / "knowledge"
+    if knowledge_cache.exists():
+        shutil.rmtree(knowledge_cache, ignore_errors=True)
+
+
+def test_remote_source_failure_isolation():
+    async def run_test():
+        try:
+            print("\n=== Test 6F2: Remote Knowledge Source Failure Isolation ===")
+
+            ensure_secret_links()
+            wipe_remote_mirror()
+
+            # NOTE: nothing listens on the remote source's port (59721).
+            print("\nLoading formation with an unreachable remote knowledge source...")
+            formation = Formation()
+            await formation.load(str(FORMATION_DIR / "formation.yaml"))
+
+            print("Starting overlord (remote sync will fail; startup must survive)...")
+            overlord = await formation.start_overlord()
+            print("Formation started despite unreachable remote source")
+
+            question = "According to your knowledge, what is the Aurelian Ledger and where is it stored?"  # noqa: E501
+            response = await overlord.chat(
+                question,
+                agent_name="hybrid",
+                user_id="test_user",
+                session_id="test_session_failure_isolation",
+                stream=False,
+            )
+
+            print(f"\nUser: {question}")
+            if isinstance(response, dict):
+                response_text = response.get("response", str(response))
+            else:
+                response_text = str(response)
+            print(f"Hybrid: {response_text}")
+
+            assert response is not None, "No response from hybrid agent"
+            assert len(response_text) > 50, "Response too short, likely no knowledge used"
+            response_lower = response_text.lower()
+            keywords = ["bramblehollow", "keeper of sums", "oak-gall", "oak gall"]
+            assert any(k in response_lower for k in keywords), (
+                "Response does not contain facts from the local knowledge source: "
+                f"{response_text}"
+            )
+            print("Agent answered from local knowledge despite the failed remote sync")
+
+            # The failed source must have a manifest recording the failure
+            mirror_root = Path.home() / ".muxi" / FORMATION_ID / "cache" / "knowledge" / "remote"
+            manifests = list(mirror_root.rglob("manifest.json"))
+            assert manifests, "Failed sync should still write a manifest"
+            manifest_text = manifests[0].read_text(encoding="utf-8")
+            assert '"failed"' in manifest_text, f"Manifest should record failure: {manifest_text}"
+            print("Manifest recorded the failed sync (degrade state tracked)")
+
+            await formation.stop_overlord()
+
+            print("\nTest 6F2 passed: unreachable remote source did not break startup or chat")
+            return True
+
+        except Exception as e:
+            print(f"\nTest 6F2 failed: {str(e)}")
+            import traceback
+
+            traceback.print_exc()
+            return False
+
+    success = asyncio.run(run_test())
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    import os
+
+    exit_code = test_remote_source_failure_isolation()
+    if exit_code == 0:
+        print("SUCCESS", flush=True)
+    os._exit(exit_code)

--- a/mental-model.md
+++ b/mental-model.md
@@ -629,17 +629,34 @@ different plan instead of returning the failure. Off by default; enable via
   ETag, file:// size+mtime composite, rsync native delta (`sync_tree`
   incremental path; the manifest is rebuilt from the local tree after).
   A missing remote hash forces a re-download (correctness > bandwidth).
+- **Downloads are atomic** (`atomic_download` in `remote/handler.py`):
+  HTTP/S3/file handlers stream into a `.part` temp file in the SAME
+  directory as the destination, fsync, then `os.replace`. A mid-stream
+  failure removes the temp and leaves the previous good copy untouched —
+  this is what makes stale-wins trustworthy (a truncated write would
+  otherwise be served under the manifest's old still-valid hash).
 - **Path safety.** Relative paths from handlers and manifests are
   untrusted: `safe_relative_path` rejects absolute/traversal/backslash
   paths and `resolve_within` re-verifies the resolved (symlink-aware)
   target stays inside the content dir. rsync runs with `--safe-links`.
+- **SSH host keys are strict by default** (rsync+ssh):
+  `StrictHostKeyChecking=yes` — the host must already be in known_hosts
+  or the sync fails, so a MITM on first contact cannot inject knowledge
+  content. `accept_new_host_keys: true` on the source is the explicit
+  opt-in for SSH's trust-on-first-use (`accept-new` still rejects
+  CHANGED keys). Mechanism not policy: safe default, loud escape hatch.
+  The temp file holding `ssh_key` material is 0600 and removed even
+  when setup fails mid-way (write/chmod) — never left behind.
 - **Validation is fail-fast** (`config/validation.py::
   _validate_remote_knowledge_source`): unsupported/planned schemes
   (`gs`, `az`, `ftp`, `sftp` are "planned"), glob on http(s)/rsync URLs,
   malformed auth blocks (`basic`/`bearer` for http, `aws` for s3,
-  `ssh_key` for rsync+ssh), and Phase 2 `extract`/`extract_pattern` keys
-  are load-time errors. Credentials flow through the standard
-  `${{ secrets.* }}` interpolation (resolved before handlers see config).
+  `ssh_key` for rsync+ssh), `accept_new_host_keys` outside rsync+ssh,
+  and Phase 2 `extract`/`extract_pattern` keys are load-time errors.
+  For `aws` auth, `access_key`/`secret_key` are both-or-neither —
+  neither means boto3's default credential chain (env vars, instance
+  profile). Credentials flow through the standard `${{ secrets.* }}`
+  interpolation (resolved before handlers see config).
 - **Phase 1 scope note:** `schedule` is accepted and syntax-validated
   (cron or `@startup`/`@hourly`/`@daily`/`@weekly`) but periodic re-sync
   is Phase 3 — every remote source syncs exactly once at formation

--- a/mental-model.md
+++ b/mental-model.md
@@ -595,6 +595,59 @@ different plan instead of returning the failure. Off by default; enable via
   the for-loop to `asyncio.gather`. There's a `TODO(perf-round-2)`
   comment in `load_sources_from_config` flagging this.
 
+**Remote Knowledge Sources (Phase 1 core sync, 2026-07-09):**
+- Agents can declare url-based knowledge sources alongside local paths:
+  `knowledge.sources[*].url` with schemes `http(s)://`, `s3://`,
+  `rsync://`, `rsync+ssh://`, `file://` (bind mounts). Everything lives in
+  `formation/agents/knowledge/remote/`: `handler.py` (ProtocolHandler ABC
+  + `SourceConfig`), `protocols/{http,s3,rsync,file}.py`, `manifest.py`
+  (per-source sync state), `sync.py` (SyncManager orchestration).
+- **Architecture: mirror-then-ingest.** `KnowledgeHandler.from_agent_config`
+  partitions sources; remote ones sync into a local mirror at
+  `<get_knowledge_dir()>/remote/<agent_id>/<source_id>/content/` (i.e.
+  `~/.muxi/<formation_id>/cache/knowledge/remote/...`, never inside the
+  formation directory, which may be read-only in SIF). Each remote source
+  is then replaced by a synthetic local `path` source pointing at its
+  mirror, so the existing ingestion pipeline (FileKnowledge chunking,
+  MD5 change detection, embedding disk cache) is completely unchanged
+  downstream. The manifest (`manifest.json`) sits NEXT TO `content/`,
+  never inside it, so it is never ingested as knowledge.
+- **Inert when unconfigured.** Formations with only local `path` sources
+  never import the remote package at all (guarded by an `any(url)` check
+  in `from_agent_config`); `tests/unit/test_remote_knowledge_sync.py::`
+  `TestInertWhenUnconfigured` pins this.
+- **Failure isolation / cold-start policy.** A failing sync NEVER blocks
+  formation startup or chat. Per-file failures keep the previously synced
+  copy (stale-wins, PRD open question #2). Total sync failure degrades to
+  whatever the manifest recorded from earlier runs. Cold start (nothing
+  ever synced + source unreachable): the source contributes zero
+  knowledge, the formation still starts, and the gap is surfaced loudly —
+  an `InitEventFormatter.format_warn` line at startup plus an ERROR-level
+  `KNOWLEDGE_SYNC_FAILED` event (WARNING-level when stale content
+  exists). E2E: `6_knowledge/test_6f2_remote_source_failure_isolation.py`.
+- **Change detection** is protocol-native: HTTP ETag/Last-Modified, S3
+  ETag, file:// size+mtime composite, rsync native delta (`sync_tree`
+  incremental path; the manifest is rebuilt from the local tree after).
+  A missing remote hash forces a re-download (correctness > bandwidth).
+- **Path safety.** Relative paths from handlers and manifests are
+  untrusted: `safe_relative_path` rejects absolute/traversal/backslash
+  paths and `resolve_within` re-verifies the resolved (symlink-aware)
+  target stays inside the content dir. rsync runs with `--safe-links`.
+- **Validation is fail-fast** (`config/validation.py::
+  _validate_remote_knowledge_source`): unsupported/planned schemes
+  (`gs`, `az`, `ftp`, `sftp` are "planned"), glob on http(s)/rsync URLs,
+  malformed auth blocks (`basic`/`bearer` for http, `aws` for s3,
+  `ssh_key` for rsync+ssh), and Phase 2 `extract`/`extract_pattern` keys
+  are load-time errors. Credentials flow through the standard
+  `${{ secrets.* }}` interpolation (resolved before handlers see config).
+- **Phase 1 scope note:** `schedule` is accepted and syntax-validated
+  (cron or `@startup`/`@hourly`/`@daily`/`@weekly`) but periodic re-sync
+  is Phase 3 — every remote source syncs exactly once at formation
+  startup. Archive extraction is Phase 2. HTTP sources are single-file
+  only (no directory listing protocol).
+- Events: `knowledge.sync.started` / `knowledge.sync.completed`
+  (SystemEvents) and `error.knowledge.sync.failed` (ErrorEvents).
+
 **Pre-routing gate ordering (current state, 2026-04-26):**
 ```
 chat() -> _process_sync_chat()
@@ -2485,37 +2538,37 @@ def enable_conversation_logging(formation):
 
 ### Event System
 
-**349 typed events** across 5 categories:
+**418 typed events** across 5 categories:
 
 ```python
 class SystemEvents(Enum):
-    # Infrastructure events (71 events)
+    # Infrastructure events (133 events)
     LLM_INITIALIZED = "llm.initialized"
     MCP_SERVER_REGISTERED = "mcp.server.registration.completed"
     AGENT_INITIALIZED = "agent.initialized"
     # ...
 
 class ConversationEvents(Enum):
-    # User-facing events (183 events)
+    # User-facing events (210 events)
     REQUEST_STARTED = "request.started"
     REQUEST_COMPLETED = "request.completed"
     AGENT_SELECTED = "agent.selected"
     # ...
 
 class ServerEvents(Enum):
-    # API server events (34 events)
+    # API server events (9 events)
     SERVER_STARTED = "server.started"
     REQUEST_RECEIVED = "request.received"
     # ...
 
 class APIEvents(Enum):
-    # API operation events (29 events)
+    # API operation events (2 events)
     ROUTE_MATCHED = "route.matched"
     VALIDATION_PASSED = "validation.passed"
     # ...
 
 class ErrorEvents(Enum):
-    # Error events (32 events)
+    # Error events (64 events)
     VALIDATION_FAILED = "validation.failed"
     LLM_CALL_FAILED = "llm.call.failed"
     # ...

--- a/src/muxi/runtime/datatypes/observability.py
+++ b/src/muxi/runtime/datatypes/observability.py
@@ -395,6 +395,12 @@ class SystemEvents(Enum):
     KNOWLEDGE_SOURCE_FAILED = "knowledge.source.failed"
     # When knowledge source loading fails
 
+    KNOWLEDGE_SYNC_STARTED = "knowledge.sync.started"
+    # When a remote knowledge source sync begins
+
+    KNOWLEDGE_SYNC_COMPLETED = "knowledge.sync.completed"
+    # When a remote knowledge source sync completes (includes partial syncs)
+
     # ===================================================================
     # INFRASTRUCTURE MONITORING (MOVED FROM CONVERSATIONEVENTs)
     # ===================================================================
@@ -1461,6 +1467,9 @@ class ErrorEvents(Enum):
     # ===================================================================
     KNOWLEDGE_SOURCE_MISSING = "error.knowledge.source.missing"
     # When knowledge source file or directory doesn't exist
+
+    KNOWLEDGE_SYNC_FAILED = "error.knowledge.sync.failed"
+    # When a remote knowledge source sync fails (formation degrades to synced state)
 
     MARKITDOWN_INITIALIZATION_FAILED = "error.markitdown.initialization.failed"
     # When MarkItDown document processor initialization fails

--- a/src/muxi/runtime/formation/agents/knowledge/handler.py
+++ b/src/muxi/runtime/formation/agents/knowledge/handler.py
@@ -783,8 +783,25 @@ class KnowledgeHandler:
             # Store embedding function for later use
             handler._generate_embeddings_fn = generate_embeddings_fn
 
+            # Remote knowledge sources (url-based): sync each one into a
+            # local mirror and replace it with a synthetic local source
+            # pointing at the mirror. Formations with only local sources
+            # never touch this path (the remote package is not even
+            # imported), keeping local-only behavior identical. Sync
+            # failures degrade to previously synced content and never
+            # block startup (see remote/sync.py for the policy).
+            sources_to_load = sources_config
+            if any(isinstance(s, dict) and s.get("url") for s in sources_config):
+                from .remote.sync import SyncManager
+
+                sync_manager = SyncManager(
+                    agent_id=agent_id,
+                    formation_id=kwargs.get("formation_id", "default-formation"),
+                )
+                sources_to_load = await sync_manager.prepare_sources(sources_config)
+
             # Load ALL sources with smart invalidation
-            await handler.load_sources_from_config(sources_config, generate_embeddings_fn)
+            await handler.load_sources_from_config(sources_to_load, generate_embeddings_fn)
 
             source_count = len(handler.sources)
             # Get document count from WorkingMemory documents namespace

--- a/src/muxi/runtime/formation/agents/knowledge/remote/__init__.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/__init__.py
@@ -1,0 +1,33 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Remote Knowledge Sources
+# Description:  Sync remote knowledge sources (HTTP, S3, rsync, file) to a
+#               local mirror that feeds the existing knowledge pipeline
+# Role:         Phase 1 core sync infrastructure (PRD: Remote Knowledge Sources)
+# Usage:        Used by KnowledgeHandler.from_agent_config when an agent
+#               declares url-based knowledge sources
+# Author:       Muxi Framework Team
+#
+# Phase 1 scope: protocol handlers (HTTP, S3, rsync, file), manifest-based
+# change detection, and startup-time sync orchestration. Archive extraction
+# (Phase 2), cron scheduling (Phase 3), and additional protocols (Phase 4)
+# are intentionally out of scope; the module layout leaves seams for them.
+# =============================================================================
+
+from .handler import DownloadResult, ProtocolHandler, RemoteFile, RemoteSyncError
+from .manifest import Manifest, safe_relative_path
+from .sync import SyncManager, SyncResult, is_remote_source, partition_sources
+
+__all__ = [
+    "DownloadResult",
+    "Manifest",
+    "ProtocolHandler",
+    "RemoteFile",
+    "RemoteSyncError",
+    "SyncManager",
+    "SyncResult",
+    "is_remote_source",
+    "partition_sources",
+    "safe_relative_path",
+]

--- a/src/muxi/runtime/formation/agents/knowledge/remote/handler.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/handler.py
@@ -1,0 +1,208 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Protocol Handler Base - Remote Knowledge Sources
+# Description:  Abstract base class and datatypes for remote source handlers
+# Role:         Defines the contract every protocol handler implements
+# Usage:        Subclassed by HTTPHandler, S3Handler, RsyncHandler, FileHandler
+# Author:       Muxi Framework Team
+#
+# Two handler styles share this contract:
+#
+# 1. Enumerating handlers (HTTP, S3, file): expose ``list_files`` +
+#    ``download_file`` and let the SyncManager drive per-file change
+#    detection against the manifest.
+# 2. Incremental handlers (rsync): ``supports_incremental()`` returns True
+#    and the SyncManager calls ``sync_tree`` instead, letting the native
+#    tool (rsync) do delta transfer; the manifest is rebuilt from the
+#    local tree afterwards.
+# =============================================================================
+
+import fnmatch
+import hashlib
+import posixpath
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Default per-source limits (PRD section 2). Kept conservative and
+# overridable per source via max_files / max_file_size / max_total_size.
+DEFAULT_MAX_FILES = 100
+DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+DEFAULT_MAX_TOTAL_SIZE = 100 * 1024 * 1024  # 100MB
+DEFAULT_SYNC_TIMEOUT = 300  # seconds
+
+
+class RemoteSyncError(Exception):
+    """Raised when a remote knowledge source operation fails."""
+
+    pass
+
+
+@dataclass
+class RemoteFile:
+    """A file discovered at a remote source.
+
+    Attributes:
+        path: Path relative to the source root. Must be a safe relative
+            path (validated by the SyncManager before use).
+        url: Full URL used to download this specific file.
+        size: Size in bytes when the protocol exposes it, else None.
+        remote_hash: Protocol-native change token (ETag, MD5,
+            size+mtime composite, ...) when available, else None.
+    """
+
+    path: str
+    url: str
+    size: Optional[int] = None
+    remote_hash: Optional[str] = None
+
+
+@dataclass
+class DownloadResult:
+    """Result of downloading a single remote file."""
+
+    path: str
+    local_path: Path
+    size: int
+    local_hash: str
+
+
+@dataclass
+class SourceConfig:
+    """Normalized remote source configuration (secrets already interpolated).
+
+    Built from the raw source dict by ``SourceConfig.from_dict``; protocol
+    handlers read auth/headers/limits from here instead of re-parsing the
+    raw config.
+    """
+
+    url: str
+    source_id: str
+    description: str = ""
+    auth: Dict[str, Any] = field(default_factory=dict)
+    headers: Dict[str, str] = field(default_factory=dict)
+    include: List[str] = field(default_factory=list)
+    exclude: List[str] = field(default_factory=list)
+    max_files: int = DEFAULT_MAX_FILES
+    max_file_size: int = DEFAULT_MAX_FILE_SIZE
+    max_total_size: int = DEFAULT_MAX_TOTAL_SIZE
+    timeout: int = DEFAULT_SYNC_TIMEOUT
+
+    @classmethod
+    def from_dict(cls, config: Dict[str, Any]) -> "SourceConfig":
+        """Create a SourceConfig from a raw knowledge source dict."""
+        url = config["url"]
+        return cls(
+            url=url,
+            source_id=config.get("id") or derive_source_id(url),
+            description=config.get("description", ""),
+            auth=config.get("auth") or {},
+            headers=config.get("headers") or {},
+            include=list(config.get("include") or []),
+            exclude=list(config.get("exclude") or []),
+            max_files=int(config.get("max_files", DEFAULT_MAX_FILES)),
+            max_file_size=int(config.get("max_file_size", DEFAULT_MAX_FILE_SIZE)),
+            max_total_size=int(config.get("max_total_size", DEFAULT_MAX_TOTAL_SIZE)),
+            timeout=int(config.get("timeout", DEFAULT_SYNC_TIMEOUT)),
+        )
+
+
+def derive_source_id(url: str) -> str:
+    """Derive a stable, filesystem-safe source id from a URL.
+
+    Used when the operator does not declare an explicit ``id``. Combines
+    a readable slug with a short hash so two similar URLs never collide.
+    """
+    digest = hashlib.sha256(url.encode("utf-8")).hexdigest()[:10]
+    slug = "".join(c if c.isalnum() or c in "-_" else "-" for c in url.split("://", 1)[-1])
+    slug = slug.strip("-")[:48].rstrip("-") or "source"
+    return f"{slug}-{digest}"
+
+
+class ProtocolHandler(ABC):
+    """Base class for remote knowledge source protocol handlers.
+
+    Handlers are constructed with the normalized :class:`SourceConfig`
+    (auth, headers, limits) and operate on URLs passed per call, matching
+    the PRD interface. All network/disk work is async; blocking SDKs
+    (boto3) must be dispatched to a thread.
+    """
+
+    def __init__(self, config: SourceConfig):
+        self.config = config
+
+    @abstractmethod
+    async def list_files(self, url: str, pattern: Optional[str] = None) -> List[RemoteFile]:
+        """List files matching ``pattern`` at the remote ``url``.
+
+        ``url`` is the source base (glob already split off); ``pattern``
+        is an fnmatch-style pattern or None for a single file / whole tree.
+        """
+
+    @abstractmethod
+    async def download_file(self, url: str, dest: Path) -> DownloadResult:
+        """Download a single file to ``dest`` enforcing ``max_file_size``."""
+
+    async def get_file_hash(self, url: str) -> str:
+        """Get a remote change token for ``url`` ('' when unavailable).
+
+        Default implementation returns '' — enumerating handlers usually
+        surface hashes via :meth:`list_files` instead.
+        """
+        return ""
+
+    def supports_incremental(self) -> bool:
+        """Whether the handler syncs whole trees natively (rsync)."""
+        return False
+
+    async def sync_tree(self, url: str, dest_dir: Path) -> None:
+        """Incrementally sync the remote tree at ``url`` into ``dest_dir``.
+
+        Only implemented by handlers where ``supports_incremental()`` is
+        True; enumerating handlers never receive this call.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support incremental sync")
+
+    async def close(self) -> None:
+        """Release any connections/clients held by the handler."""
+        return None
+
+
+def hash_file_sha256(path: Path) -> str:
+    """Compute the SHA-256 hex digest of a local file."""
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def matches_pattern(rel_path: str, pattern: str) -> bool:
+    """fnmatch ``rel_path`` against ``pattern`` (basename fallback).
+
+    ``*.md`` should match files at any depth (matching rsync/S3 operator
+    expectations), so patterns without a slash also test the basename.
+    """
+    if fnmatch.fnmatch(rel_path, pattern):
+        return True
+    return "/" not in pattern and fnmatch.fnmatch(posixpath.basename(rel_path), pattern)
+
+
+def split_url_pattern(url: str) -> tuple:
+    """Split a source URL into (base_url, pattern).
+
+    The pattern starts at the first path segment containing a glob
+    character (``*``, ``?``, ``[``). Examples:
+
+    - ``s3://bucket/docs/*.md``      -> (``s3://bucket/docs/``, ``*.md``)
+    - ``s3://bucket/docs/**/*.pdf``  -> (``s3://bucket/docs/``, ``**/*.pdf``)
+    - ``https://host/notes.md``      -> (``https://host/notes.md``, None)
+    """
+    glob_chars = ("*", "?", "[")
+    first_glob = min((url.find(c) for c in glob_chars if c in url), default=-1)
+    if first_glob == -1:
+        return url, None
+    split_at = url.rfind("/", 0, first_glob) + 1
+    return url[:split_at], url[split_at:] or None

--- a/src/muxi/runtime/formation/agents/knowledge/remote/handler.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/handler.py
@@ -18,13 +18,16 @@
 #    local tree afterwards.
 # =============================================================================
 
+import contextlib
 import fnmatch
 import hashlib
+import os
 import posixpath
+import tempfile
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 # Default per-source limits (PRD section 2). Kept conservative and
 # overridable per source via max_files / max_file_size / max_total_size.
@@ -89,6 +92,10 @@ class SourceConfig:
     max_file_size: int = DEFAULT_MAX_FILE_SIZE
     max_total_size: int = DEFAULT_MAX_TOTAL_SIZE
     timeout: int = DEFAULT_SYNC_TIMEOUT
+    # rsync+ssh only: opt into SSH's trust-on-first-use for unknown host
+    # keys (StrictHostKeyChecking=accept-new). Default is strict: the
+    # host must already be in known_hosts or the sync fails.
+    accept_new_host_keys: bool = False
 
     @classmethod
     def from_dict(cls, config: Dict[str, Any]) -> "SourceConfig":
@@ -106,6 +113,7 @@ class SourceConfig:
             max_file_size=int(config.get("max_file_size", DEFAULT_MAX_FILE_SIZE)),
             max_total_size=int(config.get("max_total_size", DEFAULT_MAX_TOTAL_SIZE)),
             timeout=int(config.get("timeout", DEFAULT_SYNC_TIMEOUT)),
+            accept_new_host_keys=bool(config.get("accept_new_host_keys", False)),
         )
 
 
@@ -168,6 +176,37 @@ class ProtocolHandler(ABC):
     async def close(self) -> None:
         """Release any connections/clients held by the handler."""
         return None
+
+
+@contextlib.contextmanager
+def atomic_download(dest: Path) -> Iterator[Path]:
+    """Yield a temp path that atomically replaces ``dest`` on success.
+
+    Guards the stale-wins guarantee: handlers must never write directly
+    to the destination, or a mid-stream failure leaves a truncated file
+    behind while the manifest still records the previous hash as valid
+    (silently serving corrupt content). The temp file is created in the
+    SAME directory as ``dest`` (same filesystem, so ``os.replace`` is
+    atomic), fsynced, then swapped in. On any failure the temp file is
+    removed and the previous good ``dest`` — if any — is left untouched.
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=str(dest.parent), prefix=f".{dest.name}.", suffix=".part")
+    os.close(fd)
+    try:
+        yield Path(tmp_path)
+        # Flush written data to disk before the atomic swap. fsync on a
+        # freshly opened fd flushes the file's pages regardless of which
+        # fd wrote them.
+        with open(tmp_path, "rb") as f:
+            os.fsync(f.fileno())
+        os.replace(tmp_path, dest)
+    except BaseException:
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def hash_file_sha256(path: Path) -> str:

--- a/src/muxi/runtime/formation/agents/knowledge/remote/manifest.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/manifest.py
@@ -1,0 +1,198 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Sync Manifest - Remote Knowledge Sources
+# Description:  Tracks per-source sync state (files, hashes, last sync)
+# Role:         Enables incremental change detection and degrade-to-synced
+# Usage:        Loaded/saved by SyncManager around every sync run
+# Author:       Muxi Framework Team
+#
+# The manifest is the source of truth for "what has already been synced".
+# When a remote source becomes unreachable, the formation degrades to the
+# state recorded here (stale-wins policy, PRD open question #2). The file
+# lives NEXT TO the content directory (never inside it) so it is never
+# ingested as knowledge content.
+#
+# Manifest files are treated as untrusted input: entries with unsafe
+# relative paths (absolute, drive-letter, or ``..`` traversal) are dropped
+# on load, and corrupt manifests reset to an empty state instead of
+# breaking formation startup.
+# =============================================================================
+
+import os
+import posixpath
+import tempfile
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from .....utils.fastjson import json
+
+MANIFEST_FILENAME = "manifest.json"
+
+
+def safe_relative_path(rel_path: str) -> bool:
+    """Return True when ``rel_path`` is a safe path relative to a root.
+
+    Rejects absolute paths (POSIX and Windows), drive letters, empty
+    paths, NUL bytes, backslashes, and any ``..`` traversal component.
+    Used to guard both manifest entries loaded from disk and remote file
+    paths reported by protocol handlers, so synced content can never
+    land outside the knowledge directory.
+    """
+    if not rel_path or not isinstance(rel_path, str):
+        return False
+    if "\x00" in rel_path or "\\" in rel_path:
+        return False
+    if rel_path.startswith("/") or rel_path.startswith("~"):
+        return False
+    # Windows drive letters (C:...) and UNC-ish prefixes
+    if ":" in rel_path.split("/", 1)[0]:
+        return False
+    normalized = posixpath.normpath(rel_path)
+    if normalized.startswith("..") or "/../" in f"/{normalized}/":
+        return False
+    return True
+
+
+def resolve_within(root: str, rel_path: str) -> Optional[str]:
+    """Resolve ``rel_path`` under ``root``, returning None if it escapes.
+
+    Defense-in-depth on top of :func:`safe_relative_path` — the resolved
+    absolute path must stay inside ``root`` (symlink-resolved).
+    """
+    if not safe_relative_path(rel_path):
+        return None
+    root_abs = os.path.realpath(root)
+    candidate = os.path.realpath(os.path.join(root_abs, rel_path))
+    if candidate != root_abs and not candidate.startswith(root_abs + os.sep):
+        return None
+    return candidate
+
+
+@dataclass
+class FileRecord:
+    """Sync state for a single file within a source."""
+
+    remote_hash: str = ""
+    local_hash: str = ""
+    size: int = 0
+    synced_at: str = ""
+
+
+@dataclass
+class Manifest:
+    """Per-source sync state (PRD section 3.2)."""
+
+    source_id: str
+    url: str
+    last_sync: str = ""
+    last_sync_duration_ms: int = 0
+    last_sync_status: str = "never"  # never | success | partial | failed
+    last_sync_error: str = ""
+    files: Dict[str, FileRecord] = field(default_factory=dict)
+
+    @property
+    def stats(self) -> Dict[str, int]:
+        return {
+            "total_files": len(self.files),
+            "total_size": sum(record.size for record in self.files.values()),
+        }
+
+    def record_file(self, rel_path: str, remote_hash: str, local_hash: str, size: int) -> None:
+        self.files[rel_path] = FileRecord(
+            remote_hash=remote_hash or "",
+            local_hash=local_hash or "",
+            size=size,
+            synced_at=_utc_now(),
+        )
+
+    def is_unchanged(self, rel_path: str, remote_hash: Optional[str], size: Optional[int]) -> bool:
+        """Whether the remote file matches what was last synced.
+
+        Requires a non-empty remote hash match; when the protocol exposes
+        a size it must match too. Without a remote hash we cannot prove
+        the file is unchanged, so it re-downloads (correctness over
+        bandwidth, per PRD success metric #3).
+        """
+        record = self.files.get(rel_path)
+        if record is None or not remote_hash or record.remote_hash != remote_hash:
+            return False
+        if size is not None and record.size != size:
+            return False
+        return True
+
+    def mark_sync(self, status: str, duration_ms: int, error: str = "") -> None:
+        self.last_sync = _utc_now()
+        self.last_sync_duration_ms = duration_ms
+        self.last_sync_status = status
+        self.last_sync_error = error
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def load(cls, path: str, source_id: str, url: str) -> "Manifest":
+        """Load a manifest from ``path``; tolerant of corruption.
+
+        A missing, corrupt, or mismatched manifest resets to an empty
+        state (the sync will simply re-verify/re-download files) instead
+        of failing formation startup. Unsafe file paths are dropped.
+        """
+        manifest = cls(source_id=source_id, url=url)
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (FileNotFoundError, OSError, ValueError):
+            return manifest
+
+        if not isinstance(data, dict):
+            return manifest
+
+        manifest.last_sync = str(data.get("last_sync", ""))
+        manifest.last_sync_duration_ms = int(data.get("last_sync_duration_ms", 0) or 0)
+        manifest.last_sync_status = str(data.get("last_sync_status", "never"))
+        manifest.last_sync_error = str(data.get("last_sync_error", ""))
+
+        raw_files = data.get("files", {})
+        if isinstance(raw_files, dict):
+            for rel_path, record in raw_files.items():
+                if not safe_relative_path(str(rel_path)) or not isinstance(record, dict):
+                    continue
+                manifest.files[str(rel_path)] = FileRecord(
+                    remote_hash=str(record.get("remote_hash", "")),
+                    local_hash=str(record.get("local_hash", "")),
+                    size=int(record.get("size", 0) or 0),
+                    synced_at=str(record.get("synced_at", "")),
+                )
+        return manifest
+
+    def save(self, path: str) -> None:
+        """Atomically persist the manifest to ``path``."""
+        data: Dict[str, Any] = {
+            "source_id": self.source_id,
+            "url": self.url,
+            "last_sync": self.last_sync,
+            "last_sync_duration_ms": self.last_sync_duration_ms,
+            "last_sync_status": self.last_sync_status,
+            "last_sync_error": self.last_sync_error,
+            "files": {rel: asdict(record) for rel, record in self.files.items()},
+            "stats": self.stats,
+        }
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(path), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(json.dumps(data))
+            os.replace(tmp_path, path)
+        except OSError:
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+            raise
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/src/muxi/runtime/formation/agents/knowledge/remote/protocols/__init__.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/protocols/__init__.py
@@ -1,0 +1,67 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Protocol Registry - Remote Knowledge Sources
+# Description:  Maps URL schemes to protocol handler implementations
+# Role:         Single lookup point for scheme -> handler resolution
+# Usage:        SyncManager calls create_handler(source_config)
+# Author:       Muxi Framework Team
+#
+# Phase 1 protocols: http(s), s3, rsync(+ssh), file. Phase 4 protocols
+# (gs, az, ftp, sftp) are declared in PLANNED_SCHEMES so config validation
+# can distinguish "not yet supported" from "unknown scheme".
+# =============================================================================
+
+from urllib.parse import urlparse
+
+from ..handler import ProtocolHandler, RemoteSyncError, SourceConfig
+
+# Schemes implemented in Phase 1
+SUPPORTED_SCHEMES = frozenset({"http", "https", "s3", "rsync", "rsync+ssh", "file"})
+
+# Schemes on the roadmap (PRD Phase 4) - rejected at validation time with
+# a "planned" message rather than "unknown scheme"
+PLANNED_SCHEMES = frozenset({"gs", "az", "ftp", "sftp"})
+
+
+def get_url_scheme(url: str) -> str:
+    """Extract the lowercase scheme from a source URL ('' if missing)."""
+    return urlparse(url).scheme.lower()
+
+
+def create_handler(config: SourceConfig) -> ProtocolHandler:
+    """Create the protocol handler for a normalized source config.
+
+    Imports are local so optional/heavy protocol dependencies are only
+    touched when a formation actually declares that protocol.
+    """
+    scheme = get_url_scheme(config.url)
+
+    if scheme in ("http", "https"):
+        from .http import HTTPHandler
+
+        return HTTPHandler(config)
+    if scheme == "s3":
+        from .s3 import S3Handler
+
+        return S3Handler(config)
+    if scheme in ("rsync", "rsync+ssh"):
+        from .rsync import RsyncHandler
+
+        return RsyncHandler(config)
+    if scheme == "file":
+        from .file import FileHandler
+
+        return FileHandler(config)
+
+    raise RemoteSyncError(
+        f"Unsupported remote knowledge source scheme '{scheme}' for URL: {config.url}"
+    )
+
+
+__all__ = [
+    "PLANNED_SCHEMES",
+    "SUPPORTED_SCHEMES",
+    "create_handler",
+    "get_url_scheme",
+]

--- a/src/muxi/runtime/formation/agents/knowledge/remote/protocols/file.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/protocols/file.py
@@ -27,6 +27,7 @@ from ..handler import (
     ProtocolHandler,
     RemoteFile,
     RemoteSyncError,
+    atomic_download,
     hash_file_sha256,
     matches_pattern,
 )
@@ -100,8 +101,11 @@ class FileHandler(ProtocolHandler):
             raise RemoteSyncError(
                 f"Remote file exceeds max_file_size ({size} > {self.config.max_file_size}): {src}"
             )
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(src, dest)
+        # Copy into a temp file and atomically swap it in on success: a
+        # mid-copy failure must never truncate a previously synced good
+        # copy (see atomic_download in handler.py).
+        with atomic_download(dest) as tmp_path:
+            shutil.copy2(src, tmp_path)
         return DownloadResult(
             path=dest.name,
             local_path=dest,

--- a/src/muxi/runtime/formation/agents/knowledge/remote/protocols/file.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/protocols/file.py
@@ -1,0 +1,124 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        File Handler - Remote Knowledge Sources
+# Description:  Syncs knowledge from mounted volumes via file:// URLs
+# Role:         Protocol handler for file:// sources (bind mounts)
+# Usage:        Created by the protocol registry for file:// source URLs
+# Author:       Muxi Framework Team
+#
+# Intended for container bind mounts: content that lives OUTSIDE the
+# formation directory (which local ``path`` sources cannot reach by
+# design) but is mounted into the runtime filesystem. Files are copied
+# into the managed knowledge mirror so the ingestion pipeline sees a
+# stable, sandboxed tree. Change detection uses a size+mtime composite
+# (cheap, no full-content hashing of the source tree on every sync).
+# =============================================================================
+
+import asyncio
+import os
+import shutil
+from pathlib import Path
+from typing import List, Optional
+from urllib.parse import unquote, urlparse
+
+from ..handler import (
+    DownloadResult,
+    ProtocolHandler,
+    RemoteFile,
+    RemoteSyncError,
+    hash_file_sha256,
+    matches_pattern,
+)
+
+
+class FileHandler(ProtocolHandler):
+    """Protocol handler for file:// knowledge sources (mounted volumes)."""
+
+    async def list_files(self, url: str, pattern: Optional[str] = None) -> List[RemoteFile]:
+        root = self._local_path(url)
+        return await asyncio.to_thread(self._list_files_sync, root, pattern)
+
+    async def download_file(self, url: str, dest: Path) -> DownloadResult:
+        src = self._local_path(url)
+        return await asyncio.to_thread(self._copy_sync, src, dest)
+
+    async def get_file_hash(self, url: str) -> str:
+        src = self._local_path(url)
+        try:
+            stat = os.stat(src)
+        except OSError:
+            return ""
+        return _stat_token(stat)
+
+    # ------------------------------------------------------------------
+    # Internals (run in a worker thread)
+    # ------------------------------------------------------------------
+
+    def _list_files_sync(self, root: str, pattern: Optional[str]) -> List[RemoteFile]:
+        if os.path.isfile(root):
+            stat = os.stat(root)
+            return [
+                RemoteFile(
+                    path=os.path.basename(root),
+                    url=Path(root).as_uri(),
+                    size=stat.st_size,
+                    remote_hash=_stat_token(stat),
+                )
+            ]
+
+        if not os.path.isdir(root):
+            raise RemoteSyncError(f"file:// knowledge source path does not exist: {root}")
+
+        results: List[RemoteFile] = []
+        for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+            dirnames.sort()
+            for filename in sorted(filenames):
+                full_path = os.path.join(dirpath, filename)
+                if os.path.islink(full_path) or not os.path.isfile(full_path):
+                    continue
+                rel_path = os.path.relpath(full_path, root).replace(os.sep, "/")
+                if pattern and not matches_pattern(rel_path, pattern):
+                    continue
+                stat = os.stat(full_path)
+                results.append(
+                    RemoteFile(
+                        path=rel_path,
+                        url=Path(full_path).as_uri(),
+                        size=stat.st_size,
+                        remote_hash=_stat_token(stat),
+                    )
+                )
+        return results
+
+    def _copy_sync(self, src: str, dest: Path) -> DownloadResult:
+        try:
+            size = os.path.getsize(src)
+        except OSError as e:
+            raise RemoteSyncError(f"file:// knowledge source file unreadable: {src}") from e
+        if size > self.config.max_file_size:
+            raise RemoteSyncError(
+                f"Remote file exceeds max_file_size ({size} > {self.config.max_file_size}): {src}"
+            )
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+        return DownloadResult(
+            path=dest.name,
+            local_path=dest,
+            size=size,
+            local_hash=hash_file_sha256(dest),
+        )
+
+    @staticmethod
+    def _local_path(url: str) -> str:
+        parsed = urlparse(url)
+        if parsed.netloc not in ("", "localhost"):
+            raise RemoteSyncError(f"file:// knowledge sources must be local (file:///path): {url}")
+        path = unquote(parsed.path)
+        if not path or not os.path.isabs(path):
+            raise RemoteSyncError(f"file:// knowledge sources require an absolute path: {url}")
+        return path
+
+
+def _stat_token(stat: os.stat_result) -> str:
+    return f"stat:{stat.st_size}:{stat.st_mtime_ns}"

--- a/src/muxi/runtime/formation/agents/knowledge/remote/protocols/http.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/protocols/http.py
@@ -1,0 +1,185 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        HTTP Handler - Remote Knowledge Sources
+# Description:  Downloads knowledge files from HTTP(S) URLs via aiohttp
+# Role:         Protocol handler for http:// and https:// sources
+# Usage:        Created by the protocol registry for http(s) source URLs
+# Author:       Muxi Framework Team
+#
+# Phase 1 scope: single-file URLs only. HTTP has no standard directory
+# listing, so glob patterns over http(s) are rejected at validation time.
+# Change detection uses ETag / Last-Modified from a HEAD probe; servers
+# that expose neither simply re-download on every sync.
+#
+# Auth: ``headers`` map (already secret-interpolated) plus optional
+# ``auth: {type: basic|bearer, ...}`` block.
+# =============================================================================
+
+import mimetypes
+import posixpath
+from pathlib import Path
+from typing import Dict, List, Optional
+from urllib.parse import unquote, urlparse
+
+import aiohttp
+
+from ..handler import (
+    DownloadResult,
+    ProtocolHandler,
+    RemoteFile,
+    RemoteSyncError,
+    hash_file_sha256,
+)
+
+# Content types we can map to an ingestible extension when the URL path
+# itself has none (extension drives FileKnowledge discovery).
+_CONTENT_TYPE_EXTENSIONS = {
+    "text/markdown": ".md",
+    "text/plain": ".txt",
+    "text/html": ".html",
+    "text/csv": ".csv",
+    "application/json": ".json",
+    "application/pdf": ".pdf",
+    "application/xml": ".xml",
+    "text/xml": ".xml",
+}
+
+
+class HTTPHandler(ProtocolHandler):
+    """Protocol handler for single-file HTTP(S) knowledge sources."""
+
+    async def list_files(self, url: str, pattern: Optional[str] = None) -> List[RemoteFile]:
+        if pattern:
+            raise RemoteSyncError(
+                "HTTP(S) knowledge sources do not support glob patterns in Phase 1: "
+                f"{url}{pattern}"
+            )
+
+        size: Optional[int] = None
+        remote_hash: Optional[str] = None
+        content_type = ""
+
+        async with self._session() as session:
+            try:
+                async with session.head(url, allow_redirects=True) as response:
+                    if response.status < 400:
+                        size = _int_or_none(response.headers.get("Content-Length"))
+                        remote_hash = _change_token(response.headers)
+                        content_type = response.headers.get("Content-Type", "")
+                    elif response.status in (403, 405, 501):
+                        # Server rejects HEAD; fall through with unknown
+                        # metadata and let the GET in download_file decide.
+                        pass
+                    else:
+                        raise RemoteSyncError(
+                            f"HTTP {response.status} probing remote knowledge source: {url}"
+                        )
+            except aiohttp.ClientError as e:
+                raise RemoteSyncError(f"Failed to reach remote knowledge source {url}: {e}") from e
+
+        return [
+            RemoteFile(
+                path=self._relative_name(url, content_type),
+                url=url,
+                size=size,
+                remote_hash=remote_hash,
+            )
+        ]
+
+    async def download_file(self, url: str, dest: Path) -> DownloadResult:
+        max_size = self.config.max_file_size
+        dest.parent.mkdir(parents=True, exist_ok=True)
+
+        async with self._session() as session:
+            try:
+                async with session.get(url, allow_redirects=True) as response:
+                    if response.status >= 400:
+                        raise RemoteSyncError(
+                            f"HTTP {response.status} downloading remote knowledge file: {url}"
+                        )
+                    declared = _int_or_none(response.headers.get("Content-Length"))
+                    if declared is not None and declared > max_size:
+                        raise RemoteSyncError(
+                            f"Remote file exceeds max_file_size ({declared} > {max_size}): {url}"
+                        )
+                    written = 0
+                    with open(dest, "wb") as f:
+                        async for chunk in response.content.iter_chunked(65536):
+                            written += len(chunk)
+                            if written > max_size:
+                                raise RemoteSyncError(
+                                    f"Remote file exceeds max_file_size "
+                                    f"({written} > {max_size}): {url}"
+                                )
+                            f.write(chunk)
+            except aiohttp.ClientError as e:
+                raise RemoteSyncError(f"Failed to download remote knowledge file {url}: {e}") from e
+
+        return DownloadResult(
+            path=dest.name,
+            local_path=dest,
+            size=written,
+            local_hash=hash_file_sha256(dest),
+        )
+
+    async def get_file_hash(self, url: str) -> str:
+        files = await self.list_files(url)
+        return files[0].remote_hash or "" if files else ""
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _session(self) -> aiohttp.ClientSession:
+        timeout = aiohttp.ClientTimeout(total=self.config.timeout)
+        auth = None
+        headers: Dict[str, str] = dict(self.config.headers)
+        auth_config = self.config.auth
+        auth_type = (auth_config.get("type") or "").lower() if auth_config else ""
+        if auth_type == "basic":
+            auth = aiohttp.BasicAuth(
+                auth_config.get("username", ""), auth_config.get("password", "")
+            )
+        elif auth_type == "bearer":
+            headers.setdefault("Authorization", f"Bearer {auth_config.get('token', '')}")
+        return aiohttp.ClientSession(timeout=timeout, headers=headers, auth=auth)
+
+    def _relative_name(self, url: str, content_type: str) -> str:
+        """Derive the local filename for a single-file HTTP source.
+
+        FileKnowledge discovers files by extension, so a URL without one
+        gets an extension inferred from the Content-Type (default .txt).
+        """
+        parsed = urlparse(url)
+        name = posixpath.basename(unquote(parsed.path)) or "document"
+        # Sanitize: the name becomes a path component inside the content dir
+        name = name.replace("/", "_").replace("\\", "_").replace("\x00", "")
+        if name in (".", ".."):
+            name = "document"
+        if not posixpath.splitext(name)[1]:
+            base_type = content_type.split(";", 1)[0].strip().lower()
+            name += (
+                _CONTENT_TYPE_EXTENSIONS.get(base_type)
+                or mimetypes.guess_extension(base_type)
+                or ".txt"
+            )
+        return name
+
+
+def _int_or_none(value: Optional[str]) -> Optional[int]:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _change_token(headers) -> Optional[str]:
+    """Build a change-detection token from ETag / Last-Modified headers."""
+    etag = headers.get("ETag", "").strip('"')
+    last_modified = headers.get("Last-Modified", "")
+    if etag:
+        return f"etag:{etag}"
+    if last_modified:
+        return f"modified:{last_modified}"
+    return None

--- a/src/muxi/runtime/formation/agents/knowledge/remote/protocols/http.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/protocols/http.py
@@ -29,6 +29,7 @@ from ..handler import (
     ProtocolHandler,
     RemoteFile,
     RemoteSyncError,
+    atomic_download,
     hash_file_sha256,
 )
 
@@ -89,32 +90,38 @@ class HTTPHandler(ProtocolHandler):
 
     async def download_file(self, url: str, dest: Path) -> DownloadResult:
         max_size = self.config.max_file_size
-        dest.parent.mkdir(parents=True, exist_ok=True)
 
-        async with self._session() as session:
-            try:
-                async with session.get(url, allow_redirects=True) as response:
-                    if response.status >= 400:
-                        raise RemoteSyncError(
-                            f"HTTP {response.status} downloading remote knowledge file: {url}"
-                        )
-                    declared = _int_or_none(response.headers.get("Content-Length"))
-                    if declared is not None and declared > max_size:
-                        raise RemoteSyncError(
-                            f"Remote file exceeds max_file_size ({declared} > {max_size}): {url}"
-                        )
-                    written = 0
-                    with open(dest, "wb") as f:
-                        async for chunk in response.content.iter_chunked(65536):
-                            written += len(chunk)
-                            if written > max_size:
-                                raise RemoteSyncError(
-                                    f"Remote file exceeds max_file_size "
-                                    f"({written} > {max_size}): {url}"
-                                )
-                            f.write(chunk)
-            except aiohttp.ClientError as e:
-                raise RemoteSyncError(f"Failed to download remote knowledge file {url}: {e}") from e
+        # Stream into a temp file and atomically swap it in on success:
+        # a mid-stream failure must never truncate a previously synced
+        # good copy (see atomic_download in handler.py).
+        with atomic_download(dest) as tmp_path:
+            async with self._session() as session:
+                try:
+                    async with session.get(url, allow_redirects=True) as response:
+                        if response.status >= 400:
+                            raise RemoteSyncError(
+                                f"HTTP {response.status} downloading remote knowledge file: {url}"
+                            )
+                        declared = _int_or_none(response.headers.get("Content-Length"))
+                        if declared is not None and declared > max_size:
+                            raise RemoteSyncError(
+                                f"Remote file exceeds max_file_size "
+                                f"({declared} > {max_size}): {url}"
+                            )
+                        written = 0
+                        with open(tmp_path, "wb") as f:
+                            async for chunk in response.content.iter_chunked(65536):
+                                written += len(chunk)
+                                if written > max_size:
+                                    raise RemoteSyncError(
+                                        f"Remote file exceeds max_file_size "
+                                        f"({written} > {max_size}): {url}"
+                                    )
+                                f.write(chunk)
+                except aiohttp.ClientError as e:
+                    raise RemoteSyncError(
+                        f"Failed to download remote knowledge file {url}: {e}"
+                    ) from e
 
         return DownloadResult(
             path=dest.name,

--- a/src/muxi/runtime/formation/agents/knowledge/remote/protocols/rsync.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/protocols/rsync.py
@@ -126,19 +126,42 @@ class RsyncHandler(ProtocolHandler):
         path = unquote(parsed.path) or "/"
         source = f"{user_prefix}{host}:{path if path.endswith('/') else path + '/'}"
 
-        ssh_parts = ["ssh", "-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new"]
+        # Host key policy: strict by default (the host must already be in
+        # known_hosts, or the sync fails) so a MITM on first contact
+        # cannot inject knowledge content. Operators can opt into SSH's
+        # trust-on-first-use with `accept_new_host_keys: true` on the
+        # source (accept-new still rejects CHANGED keys).
+        host_key_policy = "accept-new" if self.config.accept_new_host_keys else "yes"
+        ssh_parts = [
+            "ssh",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            f"StrictHostKeyChecking={host_key_policy}",
+        ]
         if parsed.port:
             ssh_parts.extend(["-p", str(parsed.port)])
 
         key_file: Optional[str] = None
         auth = self.config.auth or {}
         if (auth.get("type") or "").lower() == "ssh_key" and auth.get("key"):
+            # mkstemp already creates the file 0600; the explicit chmod is
+            # belt-and-braces. Any failure after creation (write, chmod)
+            # must remove the written key material immediately - the
+            # caller's finally only covers paths it has received.
             fd, key_file = tempfile.mkstemp(prefix="muxi-rsync-key-")
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(auth["key"])
-                if not auth["key"].endswith("\n"):
-                    f.write("\n")
-            os.chmod(key_file, 0o600)
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(auth["key"])
+                    if not auth["key"].endswith("\n"):
+                        f.write("\n")
+                os.chmod(key_file, 0o600)
+            except BaseException:
+                try:
+                    os.remove(key_file)
+                except OSError:
+                    pass
+                raise
             ssh_parts.extend(["-i", key_file])
 
         return source, " ".join(ssh_parts), key_file

--- a/src/muxi/runtime/formation/agents/knowledge/remote/protocols/rsync.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/protocols/rsync.py
@@ -1,0 +1,144 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Rsync Handler - Remote Knowledge Sources
+# Description:  Incrementally syncs knowledge trees via the rsync binary
+# Role:         Protocol handler for rsync:// and rsync+ssh:// sources
+# Usage:        Created by the protocol registry for rsync source URLs
+# Author:       Muxi Framework Team
+#
+# This is the one incremental handler in Phase 1: rsync transfers deltas
+# natively, so the SyncManager calls ``sync_tree`` (whole-tree sync into
+# the content directory) instead of the list/download loop, then rebuilds
+# the manifest from the resulting local tree.
+#
+# Auth: ``auth: {type: ssh_key, key: <private key material>}`` for
+# rsync+ssh:// sources. The key (already secret-interpolated) is written
+# to a 0600 temp file for the duration of the sync and removed afterwards.
+# =============================================================================
+
+import asyncio
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import List, Optional
+from urllib.parse import unquote, urlparse
+
+from ..handler import DownloadResult, ProtocolHandler, RemoteFile, RemoteSyncError
+
+
+class RsyncHandler(ProtocolHandler):
+    """Protocol handler for rsync:// and rsync+ssh:// knowledge sources."""
+
+    def supports_incremental(self) -> bool:
+        return True
+
+    async def list_files(self, url: str, pattern: Optional[str] = None) -> List[RemoteFile]:
+        raise NotImplementedError("RsyncHandler syncs whole trees incrementally; use sync_tree()")
+
+    async def download_file(self, url: str, dest: Path) -> DownloadResult:
+        raise NotImplementedError("RsyncHandler syncs whole trees incrementally; use sync_tree()")
+
+    async def sync_tree(self, url: str, dest_dir: Path) -> None:
+        rsync_bin = shutil.which("rsync")
+        if rsync_bin is None:
+            raise RemoteSyncError("rsync:// knowledge sources require the rsync binary on PATH")
+
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        key_file: Optional[str] = None
+        try:
+            command, key_file = self._build_command(rsync_bin, url, dest_dir)
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                _, stderr = await asyncio.wait_for(
+                    process.communicate(), timeout=self.config.timeout
+                )
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.wait()
+                raise RemoteSyncError(f"rsync timed out after {self.config.timeout}s syncing {url}")
+            if process.returncode != 0:
+                detail = (stderr or b"").decode("utf-8", errors="replace").strip()
+                raise RemoteSyncError(
+                    f"rsync exited with code {process.returncode} syncing {url}: {detail}"
+                )
+        finally:
+            if key_file:
+                try:
+                    os.remove(key_file)
+                except OSError:
+                    pass
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _build_command(self, rsync_bin: str, url: str, dest_dir: Path) -> tuple:
+        """Build the rsync argv for ``url`` -> ``dest_dir`` (returns key file).
+
+        - ``--delete`` mirrors remote deletions locally (remote wins).
+        - ``--safe-links`` refuses symlinks that point outside the tree.
+        - ``--max-size`` enforces the per-file size limit natively.
+        - include/exclude config maps to rsync filter rules.
+        """
+        command = [
+            rsync_bin,
+            "-rtz",
+            "--delete",
+            "--safe-links",
+            f"--timeout={self.config.timeout}",
+            f"--max-size={self.config.max_file_size}",
+        ]
+        for pattern in self.config.include:
+            command.append(f"--include={pattern}")
+        if self.config.include:
+            # rsync include semantics: keep directories traversable, then
+            # drop everything not explicitly included.
+            command.append("--include=*/")
+            command.append("--exclude=*")
+        for pattern in self.config.exclude:
+            command.append(f"--exclude={pattern}")
+
+        key_file: Optional[str] = None
+        parsed = urlparse(url)
+        if parsed.scheme == "rsync+ssh":
+            source, ssh_command, key_file = self._ssh_source(parsed)
+            command.extend(["-e", ssh_command])
+        else:
+            # Native rsync daemon URL: pass through as-is (rsync://host/module/path)
+            source = url if url.endswith("/") else url + "/"
+
+        command.append(source)
+        command.append(str(dest_dir) + os.sep)
+        return command, key_file
+
+    def _ssh_source(self, parsed) -> tuple:
+        """Convert rsync+ssh://user@host[:port]/path into rsync-over-ssh args."""
+        host = parsed.hostname or ""
+        if not host:
+            raise RemoteSyncError("rsync+ssh:// knowledge source URL is missing a host")
+        user_prefix = f"{parsed.username}@" if parsed.username else ""
+        path = unquote(parsed.path) or "/"
+        source = f"{user_prefix}{host}:{path if path.endswith('/') else path + '/'}"
+
+        ssh_parts = ["ssh", "-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new"]
+        if parsed.port:
+            ssh_parts.extend(["-p", str(parsed.port)])
+
+        key_file: Optional[str] = None
+        auth = self.config.auth or {}
+        if (auth.get("type") or "").lower() == "ssh_key" and auth.get("key"):
+            fd, key_file = tempfile.mkstemp(prefix="muxi-rsync-key-")
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(auth["key"])
+                if not auth["key"].endswith("\n"):
+                    f.write("\n")
+            os.chmod(key_file, 0o600)
+            ssh_parts.extend(["-i", key_file])
+
+        return source, " ".join(ssh_parts), key_file

--- a/src/muxi/runtime/formation/agents/knowledge/remote/protocols/s3.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/protocols/s3.py
@@ -28,6 +28,7 @@ from ..handler import (
     RemoteFile,
     RemoteSyncError,
     SourceConfig,
+    atomic_download,
     hash_file_sha256,
     matches_pattern,
 )
@@ -115,18 +116,21 @@ class S3Handler(ProtocolHandler):
 
     def _download_sync(self, bucket: str, key: str, dest: Path) -> DownloadResult:
         client = self._get_client()
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            head = client.head_object(Bucket=bucket, Key=key)
-            size = int(head.get("ContentLength", 0))
-            if size > self.config.max_file_size:
-                raise RemoteSyncError(
-                    f"Remote file exceeds max_file_size "
-                    f"({size} > {self.config.max_file_size}): s3://{bucket}/{key}"
-                )
-            client.download_file(bucket, key, str(dest))
-        except (BotoCoreError, ClientError) as e:
-            raise RemoteSyncError(f"Failed to download s3://{bucket}/{key}: {e}") from e
+        # Download into a temp file and atomically swap it in on success:
+        # a mid-transfer failure must never truncate a previously synced
+        # good copy (see atomic_download in handler.py).
+        with atomic_download(dest) as tmp_path:
+            try:
+                head = client.head_object(Bucket=bucket, Key=key)
+                size = int(head.get("ContentLength", 0))
+                if size > self.config.max_file_size:
+                    raise RemoteSyncError(
+                        f"Remote file exceeds max_file_size "
+                        f"({size} > {self.config.max_file_size}): s3://{bucket}/{key}"
+                    )
+                client.download_file(bucket, key, str(tmp_path))
+            except (BotoCoreError, ClientError) as e:
+                raise RemoteSyncError(f"Failed to download s3://{bucket}/{key}: {e}") from e
         return DownloadResult(
             path=dest.name,
             local_path=dest,

--- a/src/muxi/runtime/formation/agents/knowledge/remote/protocols/s3.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/protocols/s3.py
@@ -1,0 +1,158 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        S3 Handler - Remote Knowledge Sources
+# Description:  Syncs knowledge files from AWS S3 buckets
+# Role:         Protocol handler for s3:// sources
+# Usage:        Created by the protocol registry for s3:// source URLs
+# Author:       Muxi Framework Team
+#
+# Uses boto3 (already a core runtime dependency for the OneLLM Bedrock
+# provider) dispatched to worker threads — boto3 is synchronous and must
+# never block the event loop. Change detection uses S3 ETags.
+#
+# Auth: optional ``auth: {type: aws, access_key, secret_key, region}``
+# block (values already secret-interpolated). Without it, boto3's default
+# credential chain applies (env vars, instance profile, ...).
+# =============================================================================
+
+import asyncio
+import posixpath
+from pathlib import Path
+from typing import Any, List, Optional
+from urllib.parse import urlparse
+
+from ..handler import (
+    DownloadResult,
+    ProtocolHandler,
+    RemoteFile,
+    RemoteSyncError,
+    SourceConfig,
+    hash_file_sha256,
+    matches_pattern,
+)
+
+try:  # pragma: no cover - import guard mirrors the kafka optional-dep pattern
+    import boto3
+    from botocore.exceptions import BotoCoreError, ClientError
+
+    BOTO3_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    boto3 = None
+    BotoCoreError = ClientError = Exception
+    BOTO3_AVAILABLE = False
+
+
+class S3Handler(ProtocolHandler):
+    """Protocol handler for s3:// knowledge sources."""
+
+    def __init__(self, config: SourceConfig):
+        super().__init__(config)
+        if not BOTO3_AVAILABLE:
+            raise RemoteSyncError(
+                "s3:// knowledge sources require the boto3 library. "
+                "Install it with: pip install boto3"
+            )
+        self._client: Optional[Any] = None
+
+    async def list_files(self, url: str, pattern: Optional[str] = None) -> List[RemoteFile]:
+        bucket, prefix = _parse_s3_url(url)
+        return await asyncio.to_thread(self._list_files_sync, bucket, prefix, pattern)
+
+    async def download_file(self, url: str, dest: Path) -> DownloadResult:
+        bucket, key = _parse_s3_url(url)
+        return await asyncio.to_thread(self._download_sync, bucket, key, dest)
+
+    async def get_file_hash(self, url: str) -> str:
+        bucket, key = _parse_s3_url(url)
+        return await asyncio.to_thread(self._head_hash_sync, bucket, key)
+
+    # ------------------------------------------------------------------
+    # Internals (run in a worker thread)
+    # ------------------------------------------------------------------
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            auth = self.config.auth or {}
+            kwargs = {}
+            if (auth.get("type") or "").lower() == "aws":
+                if auth.get("access_key") and auth.get("secret_key"):
+                    kwargs["aws_access_key_id"] = auth["access_key"]
+                    kwargs["aws_secret_access_key"] = auth["secret_key"]
+                if auth.get("region"):
+                    kwargs["region_name"] = auth["region"]
+            self._client = boto3.client("s3", **kwargs)
+        return self._client
+
+    def _list_files_sync(
+        self, bucket: str, prefix: str, pattern: Optional[str]
+    ) -> List[RemoteFile]:
+        client = self._get_client()
+        results: List[RemoteFile] = []
+        try:
+            paginator = client.get_paginator("list_objects_v2")
+            for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+                for obj in page.get("Contents", []):
+                    key = obj["Key"]
+                    if key.endswith("/"):
+                        continue  # zero-byte "directory" marker
+                    rel_path = key.removeprefix(prefix).lstrip("/") if prefix else key
+                    if not rel_path:
+                        rel_path = posixpath.basename(key)
+                    if pattern and not matches_pattern(rel_path, pattern):
+                        continue
+                    results.append(
+                        RemoteFile(
+                            path=rel_path,
+                            url=f"s3://{bucket}/{key}",
+                            size=int(obj.get("Size", 0)),
+                            remote_hash=_etag_token(obj.get("ETag")),
+                        )
+                    )
+        except (BotoCoreError, ClientError) as e:
+            raise RemoteSyncError(f"Failed to list s3://{bucket}/{prefix}: {e}") from e
+        return results
+
+    def _download_sync(self, bucket: str, key: str, dest: Path) -> DownloadResult:
+        client = self._get_client()
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            head = client.head_object(Bucket=bucket, Key=key)
+            size = int(head.get("ContentLength", 0))
+            if size > self.config.max_file_size:
+                raise RemoteSyncError(
+                    f"Remote file exceeds max_file_size "
+                    f"({size} > {self.config.max_file_size}): s3://{bucket}/{key}"
+                )
+            client.download_file(bucket, key, str(dest))
+        except (BotoCoreError, ClientError) as e:
+            raise RemoteSyncError(f"Failed to download s3://{bucket}/{key}: {e}") from e
+        return DownloadResult(
+            path=dest.name,
+            local_path=dest,
+            size=size,
+            local_hash=hash_file_sha256(dest),
+        )
+
+    def _head_hash_sync(self, bucket: str, key: str) -> str:
+        client = self._get_client()
+        try:
+            head = client.head_object(Bucket=bucket, Key=key)
+        except (BotoCoreError, ClientError):
+            return ""
+        return _etag_token(head.get("ETag")) or ""
+
+
+def _parse_s3_url(url: str) -> tuple:
+    """Split s3://bucket/key-or-prefix into (bucket, key)."""
+    parsed = urlparse(url)
+    bucket = parsed.netloc
+    if not bucket:
+        raise RemoteSyncError(f"s3:// knowledge source URL is missing a bucket: {url}")
+    return bucket, parsed.path.lstrip("/")
+
+
+def _etag_token(etag: Optional[str]) -> Optional[str]:
+    if not etag:
+        return None
+    return f"etag:{etag.strip(chr(34))}"

--- a/src/muxi/runtime/formation/agents/knowledge/remote/sync.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/sync.py
@@ -1,0 +1,461 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Sync Manager - Remote Knowledge Sources
+# Description:  Orchestrates syncing remote sources into local mirrors
+# Role:         Bridges url-based sources into the local knowledge pipeline
+# Usage:        KnowledgeHandler.from_agent_config calls prepare_sources()
+# Author:       Muxi Framework Team
+#
+# Design (Phase 1):
+# - Remote content is mirrored under the runtime knowledge cache dir
+#   (never inside the formation directory, which may be read-only):
+#   <knowledge_dir>/remote/<agent_id>/<source_id>/content/
+#   with the manifest one level up (so it is never ingested as content).
+# - Each remote source becomes a synthetic local ``path`` source pointing
+#   at its content mirror, feeding the unchanged local ingestion pipeline.
+# - Failure isolation / cold-start policy: a failing sync NEVER blocks
+#   formation startup or chat. The source degrades to whatever the
+#   manifest says was previously synced (stale-wins, PRD open question
+#   #2). On a cold start (nothing synced yet + source unreachable) the
+#   source contributes zero knowledge; a loud init warning plus an
+#   ERROR-level KNOWLEDGE_SYNC_FAILED event surface the gap.
+# - Scheduling is Phase 3: every remote source syncs once at formation
+#   startup regardless of its declared ``schedule``.
+#
+# Path safety: relative paths from handlers and manifests are validated
+# (safe_relative_path + resolve_within) so synced files can never land
+# outside the per-source content directory.
+# =============================================================================
+
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from .....services import observability
+from .....utils.user_dirs import get_knowledge_dir
+from .handler import (
+    ProtocolHandler,
+    RemoteFile,
+    RemoteSyncError,
+    SourceConfig,
+    hash_file_sha256,
+    matches_pattern,
+    split_url_pattern,
+)
+from .manifest import MANIFEST_FILENAME, Manifest, resolve_within
+from .protocols import create_handler
+
+
+def is_remote_source(source_config: Any) -> bool:
+    """Whether a knowledge source config declares a remote URL."""
+    return isinstance(source_config, dict) and bool(source_config.get("url"))
+
+
+def partition_sources(sources_config: List[Any]) -> Tuple[List[Any], List[Dict[str, Any]]]:
+    """Split knowledge sources into (local, remote) preserving order.
+
+    Formations without remote sources get their original list back
+    untouched, keeping the local-only path byte-for-byte identical.
+    """
+    local: List[Any] = []
+    remote: List[Dict[str, Any]] = []
+    for source in sources_config:
+        (remote if is_remote_source(source) else local).append(source)
+    return local, remote
+
+
+@dataclass
+class SyncResult:
+    """Outcome of syncing one remote source."""
+
+    source_id: str
+    url: str
+    status: str  # success | partial | failed
+    content_dir: str
+    files_added: int = 0
+    files_modified: int = 0
+    files_deleted: int = 0
+    files_failed: int = 0
+    bytes_downloaded: int = 0
+    duration_ms: int = 0
+    error: str = ""
+    skipped_files: List[str] = field(default_factory=list)
+
+    @property
+    def has_local_content(self) -> bool:
+        """Whether any synced content exists locally (current or stale)."""
+        try:
+            for _, _, filenames in os.walk(self.content_dir):
+                if filenames:
+                    return True
+        except OSError:
+            pass
+        return False
+
+
+class SyncManager:
+    """Orchestrates remote knowledge source syncs for one agent.
+
+    Phase 1 syncs at formation startup only (scheduling is Phase 3);
+    the per-source manifest keeps re-syncs incremental across restarts.
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        formation_id: str = "default-formation",
+        root_dir: Optional[str] = None,
+    ):
+        self.agent_id = agent_id
+        self.formation_id = formation_id
+        self.root_dir = root_dir or os.path.join(get_knowledge_dir(), "remote", agent_id)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def prepare_sources(self, sources_config: List[Any]) -> List[Any]:
+        """Sync remote sources and return a fully-local source list.
+
+        Local sources pass through untouched. Each remote source syncs
+        into its content mirror and is replaced by a synthetic local
+        source pointing at the mirror. Sources with no local content at
+        all (cold start + unreachable) are dropped with a loud warning.
+        """
+        local_sources, remote_sources = partition_sources(sources_config)
+        if not remote_sources:
+            return sources_config
+
+        prepared = list(local_sources)
+        for raw_source in remote_sources:
+            config = SourceConfig.from_dict(raw_source)
+            result = await self.sync_source(raw_source)
+            if result.has_local_content:
+                prepared.append(self._synthetic_local_source(config, result))
+            else:
+                from .....datatypes.observability import InitEventFormatter
+
+                print(
+                    InitEventFormatter.format_warn(
+                        f"Remote knowledge source '{config.source_id}' has no local content",
+                        f"{result.error or 'sync failed before any content was mirrored'} "
+                        f"- agent '{self.agent_id}' starts without this source",
+                    )
+                )
+        return prepared
+
+    async def sync_source(self, raw_source: Dict[str, Any], trigger: str = "startup") -> SyncResult:
+        """Sync a single remote source, degrading to synced state on failure."""
+        config = SourceConfig.from_dict(raw_source)
+        source_dir = os.path.join(self.root_dir, config.source_id)
+        content_dir = os.path.join(source_dir, "content")
+        manifest_path = os.path.join(source_dir, MANIFEST_FILENAME)
+        os.makedirs(content_dir, exist_ok=True)
+
+        observability.observe(
+            event_type=observability.SystemEvents.KNOWLEDGE_SYNC_STARTED,
+            level=observability.EventLevel.INFO,
+            description="Remote knowledge source sync started",
+            data={
+                "source_id": config.source_id,
+                "url": config.url,
+                "agent_id": self.agent_id,
+                "trigger": trigger,
+            },
+        )
+
+        manifest = Manifest.load(manifest_path, config.source_id, config.url)
+        started = time.time()
+        handler: Optional[ProtocolHandler] = None
+        try:
+            handler = create_handler(config)
+            if handler.supports_incremental():
+                result = await self._sync_incremental(handler, config, content_dir, manifest)
+            else:
+                result = await self._sync_enumerated(handler, config, content_dir, manifest)
+        except Exception as e:
+            duration_ms = int((time.time() - started) * 1000)
+            result = SyncResult(
+                source_id=config.source_id,
+                url=config.url,
+                status="failed",
+                content_dir=content_dir,
+                duration_ms=duration_ms,
+                error=str(e),
+            )
+            manifest.mark_sync("failed", duration_ms, error=str(e))
+            self._save_manifest(manifest, manifest_path)
+            observability.observe(
+                event_type=observability.ErrorEvents.KNOWLEDGE_SYNC_FAILED,
+                level=(
+                    observability.EventLevel.WARNING
+                    if result.has_local_content
+                    else observability.EventLevel.ERROR
+                ),
+                description="Remote knowledge source sync failed - degrading to synced state",
+                data={
+                    "source_id": config.source_id,
+                    "url": config.url,
+                    "agent_id": self.agent_id,
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                    "has_local_content": result.has_local_content,
+                    "trigger": trigger,
+                },
+            )
+            return result
+        finally:
+            if handler is not None:
+                try:
+                    await handler.close()
+                except Exception:
+                    pass
+
+        result.duration_ms = int((time.time() - started) * 1000)
+        manifest.mark_sync(result.status, result.duration_ms, error=result.error)
+        self._save_manifest(manifest, manifest_path)
+
+        observability.observe(
+            event_type=observability.SystemEvents.KNOWLEDGE_SYNC_COMPLETED,
+            level=observability.EventLevel.INFO,
+            description="Remote knowledge source sync completed",
+            data={
+                "source_id": config.source_id,
+                "url": config.url,
+                "agent_id": self.agent_id,
+                "status": result.status,
+                "duration_ms": result.duration_ms,
+                "files_added": result.files_added,
+                "files_modified": result.files_modified,
+                "files_deleted": result.files_deleted,
+                "files_failed": result.files_failed,
+                "bytes_downloaded": result.bytes_downloaded,
+                "trigger": trigger,
+            },
+        )
+        return result
+
+    # ------------------------------------------------------------------
+    # Sync strategies
+    # ------------------------------------------------------------------
+
+    async def _sync_enumerated(
+        self,
+        handler: ProtocolHandler,
+        config: SourceConfig,
+        content_dir: str,
+        manifest: Manifest,
+    ) -> SyncResult:
+        """List/compare/download sync for enumerating handlers (HTTP, S3, file)."""
+        base_url, pattern = split_url_pattern(config.url)
+        remote_files = await handler.list_files(base_url, pattern)
+
+        result = SyncResult(
+            source_id=config.source_id, url=config.url, status="success", content_dir=content_dir
+        )
+
+        selected: List[RemoteFile] = []
+        total_size = 0
+        for remote_file in sorted(remote_files, key=lambda f: f.path):
+            if not self._passes_filters(remote_file.path, config):
+                continue
+            local_path = resolve_within(content_dir, remote_file.path)
+            if local_path is None:
+                # Path traversal guard: never let remote paths escape the mirror
+                result.skipped_files.append(remote_file.path)
+                result.files_failed += 1
+                continue
+            if remote_file.size is not None and remote_file.size > config.max_file_size:
+                result.skipped_files.append(remote_file.path)
+                continue
+            if len(selected) >= config.max_files:
+                result.skipped_files.append(remote_file.path)
+                continue
+            if remote_file.size is not None:
+                if total_size + remote_file.size > config.max_total_size:
+                    result.skipped_files.append(remote_file.path)
+                    continue
+                total_size += remote_file.size
+            selected.append(remote_file)
+
+        seen_paths = set()
+        new_files: Dict[str, Any] = {}
+        for remote_file in selected:
+            rel_path = remote_file.path
+            seen_paths.add(rel_path)
+            local_path = resolve_within(content_dir, rel_path)
+            existing = manifest.files.get(rel_path)
+
+            if manifest.is_unchanged(
+                rel_path, remote_file.remote_hash, remote_file.size
+            ) and os.path.isfile(local_path):
+                new_files[rel_path] = existing
+                continue
+
+            try:
+                download = await handler.download_file(remote_file.url, Path(local_path))
+            except Exception as e:
+                result.files_failed += 1
+                if existing is not None and os.path.isfile(local_path):
+                    # Stale-wins: keep the previously synced copy
+                    new_files[rel_path] = existing
+                observability.observe(
+                    event_type=observability.ErrorEvents.KNOWLEDGE_SYNC_FAILED,
+                    level=observability.EventLevel.WARNING,
+                    description="Remote knowledge file download failed",
+                    data={
+                        "source_id": config.source_id,
+                        "file": rel_path,
+                        "error": str(e),
+                        "stale_copy_kept": existing is not None,
+                    },
+                )
+                continue
+
+            manifest.record_file(
+                rel_path,
+                remote_hash=remote_file.remote_hash or "",
+                local_hash=download.local_hash,
+                size=download.size,
+            )
+            new_files[rel_path] = manifest.files[rel_path]
+            result.bytes_downloaded += download.size
+            if existing is None:
+                result.files_added += 1
+            else:
+                result.files_modified += 1
+
+        # Remote deletions: drop local files whose manifest entry vanished
+        for rel_path in list(manifest.files.keys()):
+            if rel_path in seen_paths:
+                continue
+            local_path = resolve_within(content_dir, rel_path)
+            if local_path and os.path.isfile(local_path):
+                try:
+                    os.remove(local_path)
+                    result.files_deleted += 1
+                except OSError:
+                    pass
+
+        manifest.files = {rel: record for rel, record in new_files.items() if record is not None}
+        _prune_empty_dirs(content_dir)
+
+        if result.files_failed:
+            result.status = "partial"
+            result.error = f"{result.files_failed} file(s) failed to sync"
+        return result
+
+    async def _sync_incremental(
+        self,
+        handler: ProtocolHandler,
+        config: SourceConfig,
+        content_dir: str,
+        manifest: Manifest,
+    ) -> SyncResult:
+        """Whole-tree sync for incremental handlers (rsync)."""
+        before = _snapshot_tree(content_dir)
+        await handler.sync_tree(config.url, Path(content_dir))
+        after = _snapshot_tree(content_dir)
+
+        result = SyncResult(
+            source_id=config.source_id, url=config.url, status="success", content_dir=content_dir
+        )
+
+        manifest.files.clear()
+        for rel_path, (size, token) in after.items():
+            local_path = resolve_within(content_dir, rel_path)
+            if local_path is None:
+                # Never index a path that resolves outside the mirror
+                try:
+                    os.remove(os.path.join(content_dir, rel_path))
+                except OSError:
+                    pass
+                result.skipped_files.append(rel_path)
+                continue
+            previous = before.get(rel_path)
+            if previous is None:
+                result.files_added += 1
+                result.bytes_downloaded += size
+            elif previous != (size, token):
+                result.files_modified += 1
+                result.bytes_downloaded += size
+            manifest.record_file(
+                rel_path,
+                remote_hash=token,
+                local_hash=hash_file_sha256(Path(local_path)),
+                size=size,
+            )
+
+        result.files_deleted = len(set(before) - set(after))
+        return result
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _passes_filters(self, rel_path: str, config: SourceConfig) -> bool:
+        if config.include and not any(
+            matches_pattern(rel_path, pattern) for pattern in config.include
+        ):
+            return False
+        return not any(matches_pattern(rel_path, pattern) for pattern in config.exclude)
+
+    def _synthetic_local_source(self, config: SourceConfig, result: SyncResult) -> Dict[str, Any]:
+        """Build the local ``path`` source config for a synced mirror."""
+        return {
+            "path": result.content_dir,
+            "name": config.source_id,
+            "description": config.description or f"Remote knowledge source: {config.url}",
+            "max_files": config.max_files,
+            "max_file_size": config.max_file_size,
+            "recursive": True,
+        }
+
+    def _save_manifest(self, manifest: Manifest, manifest_path: str) -> None:
+        try:
+            manifest.save(manifest_path)
+        except OSError as e:
+            observability.observe(
+                event_type=observability.ErrorEvents.KNOWLEDGE_SYNC_FAILED,
+                level=observability.EventLevel.WARNING,
+                description="Failed to persist remote knowledge manifest",
+                data={"source_id": manifest.source_id, "error": str(e)},
+            )
+
+
+def _snapshot_tree(root: str) -> Dict[str, Tuple[int, str]]:
+    """Map rel_path -> (size, stat token) for every file under ``root``."""
+    snapshot: Dict[str, Tuple[int, str]] = {}
+    for dirpath, _, filenames in os.walk(root, followlinks=False):
+        for filename in filenames:
+            full_path = os.path.join(dirpath, filename)
+            if os.path.islink(full_path) or not os.path.isfile(full_path):
+                continue
+            rel_path = os.path.relpath(full_path, root).replace(os.sep, "/")
+            stat = os.stat(full_path)
+            snapshot[rel_path] = (stat.st_size, f"stat:{stat.st_size}:{stat.st_mtime_ns}")
+    return snapshot
+
+
+def _prune_empty_dirs(root: str) -> None:
+    """Remove empty directories left behind by deletions (keep ``root``)."""
+    for dirpath, dirnames, filenames in os.walk(root, topdown=False):
+        if dirpath == root or dirnames or filenames:
+            continue
+        try:
+            os.rmdir(dirpath)
+        except OSError:
+            pass
+
+
+# Re-exported for convenience in tests and callers
+__all__ = [
+    "RemoteSyncError",
+    "SyncManager",
+    "SyncResult",
+    "is_remote_source",
+    "partition_sources",
+]

--- a/src/muxi/runtime/formation/config/validation.py
+++ b/src/muxi/runtime/formation/config/validation.py
@@ -1072,9 +1072,17 @@ class FormationValidator:
                 self.result.add_error("Knowledge sources must be a list")
                 return
 
+            seen_source_ids: set = set()
             for i, source in enumerate(sources):
                 if not isinstance(source, dict):
                     self.result.add_error(f"Knowledge source {i} must be a dictionary")
+                    continue
+
+                # Remote (url-based) sources have their own validation path
+                if "url" in source:
+                    self._validate_remote_knowledge_source(
+                        source, f"Knowledge source {i}", seen_source_ids
+                    )
                     continue
 
                 # Check for path
@@ -1111,16 +1119,29 @@ class FormationValidator:
                 self.result.add_error("Agent knowledge 'sources' must be a list")
                 return
 
+            seen_source_ids: set = set()
             for i, source in enumerate(sources):
                 if not isinstance(source, dict):
                     self.result.add_error(f"Agent knowledge source {i} must be a dictionary")
                     continue
 
+                subject = f"Agent knowledge source {i}"
+
+                # A source is either local (path) or remote (url), never both
+                if "path" in source and "url" in source:
+                    self.result.add_error(
+                        f"{subject} must declare either 'path' or 'url', not both"
+                    )
+                    continue
+
+                if "url" in source:
+                    self._validate_remote_knowledge_source(source, subject, seen_source_ids)
+                    self._validate_knowledge_source_description(source, subject)
+                    continue
+
                 # Validate required fields for each source
                 if "path" not in source:
-                    self.result.add_error(
-                        f"Agent knowledge source {i} missing required field: 'path'"
-                    )
+                    self.result.add_error(f"{subject} missing required field: 'path' or 'url'")
                 else:
                     path = source["path"]
                     if not isinstance(path, str):
@@ -1128,22 +1149,217 @@ class FormationValidator:
                     elif not path.strip():
                         self.result.add_error(f"Agent knowledge source {i} 'path' cannot be empty")
 
-                if "description" not in source:
-                    self.result.add_error(
-                        f"Agent knowledge source {i} missing required field: 'description'"
-                    )
-                else:
-                    description = source["description"]
-                    if not isinstance(description, str):
-                        self.result.add_error(
-                            f"Agent knowledge source {i} 'description' must be a string"
-                        )
-                    elif not description.strip():
-                        self.result.add_error(
-                            f"Agent knowledge source {i} 'description' cannot be empty"
-                        )
+                self._validate_knowledge_source_description(source, subject)
 
         # Allow any additional fields users might want to add for knowledge configuration
+
+    def _validate_knowledge_source_description(self, source: Dict[str, Any], subject: str) -> None:
+        """Validate the required 'description' field on a knowledge source."""
+        if "description" not in source:
+            self.result.add_error(f"{subject} missing required field: 'description'")
+            return
+        description = source["description"]
+        if not isinstance(description, str):
+            self.result.add_error(f"{subject} 'description' must be a string")
+        elif not description.strip():
+            self.result.add_error(f"{subject} 'description' cannot be empty")
+
+    # URL schemes accepted for remote knowledge sources in Phase 1, and
+    # schemes from the PRD roadmap that are recognized but not built yet.
+    REMOTE_KNOWLEDGE_SUPPORTED_SCHEMES = {"http", "https", "s3", "rsync", "rsync+ssh", "file"}
+    REMOTE_KNOWLEDGE_PLANNED_SCHEMES = {"gs", "az", "ftp", "sftp"}
+    REMOTE_KNOWLEDGE_SCHEDULE_ALIASES = {"@startup", "@hourly", "@daily", "@weekly"}
+
+    def _validate_remote_knowledge_source(
+        self, source: Dict[str, Any], subject: str, seen_source_ids: set
+    ) -> None:
+        """Validate a remote (url-based) knowledge source declaration.
+
+        Fail-fast at load time: unsupported schemes, malformed URLs,
+        incomplete auth blocks, and Phase 2+ options (archive extraction)
+        are configuration errors. Credentials should be referenced via
+        ``${{ secrets.* }}`` interpolation, which resolves before the
+        handlers ever see the config.
+        """
+        from urllib.parse import urlparse
+
+        url = source.get("url")
+        if not isinstance(url, str) or not url.strip():
+            self.result.add_error(f"{subject} 'url' must be a non-empty string")
+            return
+
+        parsed = urlparse(url)
+        scheme = parsed.scheme.lower()
+
+        if scheme in self.REMOTE_KNOWLEDGE_PLANNED_SCHEMES:
+            self.result.add_error(
+                f"{subject} scheme '{scheme}://' is not yet supported (planned). "
+                f"Supported schemes: "
+                f"{', '.join(sorted(self.REMOTE_KNOWLEDGE_SUPPORTED_SCHEMES))}"
+            )
+            return
+        if scheme not in self.REMOTE_KNOWLEDGE_SUPPORTED_SCHEMES:
+            self.result.add_error(
+                f"{subject} has unsupported URL scheme '{scheme or '(none)'}'. "
+                f"Supported schemes: "
+                f"{', '.join(sorted(self.REMOTE_KNOWLEDGE_SUPPORTED_SCHEMES))}"
+            )
+            return
+
+        # Scheme-specific structural checks
+        has_glob = any(c in url for c in "*?[")
+        if scheme in ("http", "https"):
+            if not parsed.netloc:
+                self.result.add_error(f"{subject} '{scheme}://' URL is missing a host")
+            if has_glob:
+                self.result.add_error(
+                    f"{subject} glob patterns are not supported for {scheme}:// sources "
+                    "(HTTP has no directory listing); point at a single file"
+                )
+        elif scheme == "s3":
+            if not parsed.netloc:
+                self.result.add_error(f"{subject} 's3://' URL is missing a bucket name")
+        elif scheme in ("rsync", "rsync+ssh"):
+            if not parsed.netloc:
+                self.result.add_error(f"{subject} '{scheme}://' URL is missing a host")
+            if has_glob:
+                self.result.add_error(
+                    f"{subject} glob patterns are not supported for {scheme}:// sources; "
+                    "use 'include'/'exclude' filters instead"
+                )
+        elif scheme == "file":
+            if parsed.netloc not in ("", "localhost"):
+                self.result.add_error(
+                    f"{subject} 'file://' sources must be local paths (file:///path)"
+                )
+            elif not parsed.path or not parsed.path.startswith("/"):
+                self.result.add_error(
+                    f"{subject} 'file://' sources require an absolute path (file:///path)"
+                )
+
+        # Optional identifier: non-empty and unique per sources list
+        if "id" in source:
+            source_id = source["id"]
+            if not isinstance(source_id, str) or not source_id.strip():
+                self.result.add_error(f"{subject} 'id' must be a non-empty string")
+            elif source_id in seen_source_ids:
+                self.result.add_error(f"{subject} duplicate remote source id: '{source_id}'")
+            else:
+                seen_source_ids.add(source_id)
+
+        # Phase 2 surface: archive extraction is not implemented yet.
+        # Fail fast rather than silently ingesting the raw archive.
+        for phase2_key in ("extract", "extract_pattern"):
+            if phase2_key in source:
+                self.result.add_error(
+                    f"{subject} '{phase2_key}' (archive extraction) is not yet supported"
+                )
+
+        self._validate_remote_knowledge_auth(source, subject, scheme)
+        self._validate_remote_knowledge_options(source, subject, scheme)
+
+    def _validate_remote_knowledge_auth(
+        self, source: Dict[str, Any], subject: str, scheme: str
+    ) -> None:
+        """Validate the optional 'auth' block of a remote knowledge source."""
+        if "auth" not in source:
+            return
+        auth = source["auth"]
+        if not isinstance(auth, dict):
+            self.result.add_error(f"{subject} 'auth' must be a mapping with a 'type' field")
+            return
+
+        auth_type = auth.get("type")
+        if not isinstance(auth_type, str) or not auth_type.strip():
+            self.result.add_error(f"{subject} 'auth' requires a 'type' field")
+            return
+        auth_type = auth_type.lower()
+
+        valid_types_by_scheme = {
+            "http": {"basic", "bearer"},
+            "https": {"basic", "bearer"},
+            "s3": {"aws"},
+            "rsync": set(),
+            "rsync+ssh": {"ssh_key"},
+            "file": set(),
+        }
+        valid_types = valid_types_by_scheme.get(scheme, set())
+        if auth_type not in valid_types:
+            allowed = ", ".join(sorted(valid_types)) if valid_types else "none"
+            self.result.add_error(
+                f"{subject} auth type '{auth_type}' is not valid for "
+                f"'{scheme}://' sources (allowed: {allowed})"
+            )
+            return
+
+        required_fields = {
+            "basic": ["username", "password"],
+            "bearer": ["token"],
+            "aws": ["access_key", "secret_key"],
+            "ssh_key": ["key"],
+        }[auth_type]
+        for auth_field in required_fields:
+            value = auth.get(auth_field)
+            if not isinstance(value, str) or not value.strip():
+                self.result.add_error(
+                    f"{subject} auth type '{auth_type}' requires a non-empty "
+                    f"'{auth_field}' field (use ${{{{ secrets.* }}}} for credentials)"
+                )
+
+    def _validate_remote_knowledge_options(
+        self, source: Dict[str, Any], subject: str, scheme: str
+    ) -> None:
+        """Validate optional filter/limit/schedule fields of a remote source."""
+        # headers: HTTP(S) only, string -> string map
+        if "headers" in source:
+            headers = source["headers"]
+            if scheme not in ("http", "https"):
+                self.result.add_error(f"{subject} 'headers' is only valid for http(s):// sources")
+            elif not isinstance(headers, dict) or not all(
+                isinstance(k, str) and isinstance(v, str) for k, v in headers.items()
+            ):
+                self.result.add_error(
+                    f"{subject} 'headers' must be a map of string keys to string values"
+                )
+
+        # include / exclude: lists of non-empty fnmatch patterns
+        for filter_key in ("include", "exclude"):
+            if filter_key not in source:
+                continue
+            patterns = source[filter_key]
+            if not isinstance(patterns, list) or not all(
+                isinstance(p, str) and p.strip() for p in patterns
+            ):
+                self.result.add_error(
+                    f"{subject} '{filter_key}' must be a list of non-empty string patterns"
+                )
+
+        # size / count / timeout limits: positive integers
+        for limit_key in ("max_files", "max_file_size", "max_total_size", "timeout"):
+            if limit_key not in source:
+                continue
+            value = source[limit_key]
+            if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+                self.result.add_error(f"{subject} '{limit_key}' must be a positive integer")
+
+        # schedule: accepted and syntax-checked in Phase 1, but periodic
+        # re-sync lands in a later phase — every remote source syncs at
+        # formation startup regardless of the declared schedule.
+        if "schedule" in source:
+            schedule = source["schedule"]
+            if not isinstance(schedule, str) or not schedule.strip():
+                self.result.add_error(f"{subject} 'schedule' must be a non-empty string")
+            elif schedule.strip() not in self.REMOTE_KNOWLEDGE_SCHEDULE_ALIASES:
+                try:
+                    import croniter
+
+                    croniter.croniter(schedule.strip())
+                except Exception:
+                    aliases = ", ".join(sorted(self.REMOTE_KNOWLEDGE_SCHEDULE_ALIASES))
+                    self.result.add_error(
+                        f"{subject} 'schedule' must be a valid cron expression "
+                        f"or one of: {aliases}"
+                    )
 
     def _validate_agent_mcp_servers(
         self, mcp_servers: List[Dict[str, Any]], agent_identifier: Union[str, int]

--- a/src/muxi/runtime/formation/config/validation.py
+++ b/src/muxi/runtime/formation/config/validation.py
@@ -1292,12 +1292,28 @@ class FormationValidator:
             )
             return
 
-        required_fields = {
-            "basic": ["username", "password"],
-            "bearer": ["token"],
-            "aws": ["access_key", "secret_key"],
-            "ssh_key": ["key"],
-        }[auth_type]
+        if auth_type == "aws":
+            # Explicit credentials are optional: without them the handler
+            # falls through to boto3's default credential chain (env vars,
+            # instance profile, ...). But access_key and secret_key only
+            # make sense together - one without the other is a config bug.
+            has_access = "access_key" in auth
+            has_secret = "secret_key" in auth
+            if has_access != has_secret:
+                missing = "secret_key" if has_access else "access_key"
+                self.result.add_error(
+                    f"{subject} auth type 'aws' declares "
+                    f"'{'access_key' if has_access else 'secret_key'}' without "
+                    f"'{missing}' - provide both explicit credentials or neither "
+                    "(neither uses boto3's default credential chain)"
+                )
+            required_fields = ["access_key", "secret_key"] if has_access and has_secret else []
+        else:
+            required_fields = {
+                "basic": ["username", "password"],
+                "bearer": ["token"],
+                "ssh_key": ["key"],
+            }[auth_type]
         for auth_field in required_fields:
             value = auth.get(auth_field)
             if not isinstance(value, str) or not value.strip():
@@ -1341,6 +1357,20 @@ class FormationValidator:
             value = source[limit_key]
             if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
                 self.result.add_error(f"{subject} '{limit_key}' must be a positive integer")
+
+        # accept_new_host_keys: rsync+ssh only. Opts into SSH's
+        # trust-on-first-use (StrictHostKeyChecking=accept-new) instead of
+        # the strict default that requires the host in known_hosts. TOFU
+        # means a MITM on FIRST contact could inject knowledge content -
+        # hence explicit opt-in, never the default.
+        if "accept_new_host_keys" in source:
+            value = source["accept_new_host_keys"]
+            if scheme != "rsync+ssh":
+                self.result.add_error(
+                    f"{subject} 'accept_new_host_keys' is only valid for " "rsync+ssh:// sources"
+                )
+            elif not isinstance(value, bool):
+                self.result.add_error(f"{subject} 'accept_new_host_keys' must be a boolean")
 
         # schedule: accepted and syntax-checked in Phase 1, but periodic
         # re-sync lands in a later phase — every remote source syncs at

--- a/tests/unit/test_remote_knowledge_handlers.py
+++ b/tests/unit/test_remote_knowledge_handlers.py
@@ -1,0 +1,378 @@
+"""Unit tests for the remote knowledge protocol handlers.
+
+Handlers are exercised against local fixtures (temp dirs, an in-process
+aiohttp server) and mocked SDK clients (boto3) — no real S3/rsync
+infrastructure is required.
+"""
+
+import hashlib
+import os
+import stat as stat_module
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+from muxi.runtime.formation.agents.knowledge.remote.handler import (
+    RemoteSyncError,
+    SourceConfig,
+    derive_source_id,
+    matches_pattern,
+    split_url_pattern,
+)
+from muxi.runtime.formation.agents.knowledge.remote.protocols import (
+    PLANNED_SCHEMES,
+    SUPPORTED_SCHEMES,
+    create_handler,
+)
+from muxi.runtime.formation.agents.knowledge.remote.protocols.file import FileHandler
+from muxi.runtime.formation.agents.knowledge.remote.protocols.http import HTTPHandler
+from muxi.runtime.formation.agents.knowledge.remote.protocols.rsync import RsyncHandler
+from muxi.runtime.formation.agents.knowledge.remote.protocols.s3 import S3Handler
+
+
+def make_config(url, **overrides):
+    return SourceConfig.from_dict({"url": url, **overrides})
+
+
+class TestUrlHelpers:
+    def test_split_url_pattern(self):
+        assert split_url_pattern("https://host/notes.md") == ("https://host/notes.md", None)
+        assert split_url_pattern("s3://bucket/docs/*.md") == ("s3://bucket/docs/", "*.md")
+        assert split_url_pattern("s3://bucket/docs/**/*.pdf") == ("s3://bucket/docs/", "**/*.pdf")
+        assert split_url_pattern("s3://bucket/prefix/*") == ("s3://bucket/prefix/", "*")
+
+    def test_matches_pattern_basename_fallback(self):
+        assert matches_pattern("nested/dir/file.md", "*.md")
+        assert matches_pattern("file.md", "*.md")
+        assert not matches_pattern("file.txt", "*.md")
+        assert matches_pattern("nested/dir/file.md", "nested/*/*.md")
+        assert not matches_pattern("other/file.md", "nested/*")
+
+    def test_derive_source_id_stable_and_safe(self):
+        a = derive_source_id("https://example.com/docs/a.md")
+        b = derive_source_id("https://example.com/docs/b.md")
+        assert a == derive_source_id("https://example.com/docs/a.md")
+        assert a != b
+        assert "/" not in a and ":" not in a
+
+    def test_registry_scheme_sets_are_disjoint(self):
+        assert not (SUPPORTED_SCHEMES & PLANNED_SCHEMES)
+
+    def test_create_handler_dispatch(self):
+        assert isinstance(create_handler(make_config("https://h/x.md")), HTTPHandler)
+        assert isinstance(create_handler(make_config("file:///tmp/x")), FileHandler)
+        assert isinstance(create_handler(make_config("rsync://h/mod/x/")), RsyncHandler)
+        with pytest.raises(RemoteSyncError):
+            create_handler(make_config("ftp://h/x"))
+
+
+class TestFileHandler:
+    async def test_list_and_download_directory(self, tmp_path):
+        src = tmp_path / "mount"
+        (src / "sub").mkdir(parents=True)
+        (src / "a.md").write_text("alpha", encoding="utf-8")
+        (src / "sub" / "b.md").write_text("beta", encoding="utf-8")
+        (src / "c.txt").write_text("gamma", encoding="utf-8")
+
+        handler = FileHandler(make_config(src.as_uri()))
+        files = await handler.list_files(src.as_uri(), "*.md")
+        assert sorted(f.path for f in files) == ["a.md", "sub/b.md"]
+        assert all(f.remote_hash.startswith("stat:") for f in files)
+
+        dest = tmp_path / "mirror" / "a.md"
+        result = await handler.download_file(files[0].url, dest)
+        assert dest.read_text(encoding="utf-8") == "alpha"
+        assert result.size == 5
+        assert result.local_hash == hashlib.sha256(b"alpha").hexdigest()
+
+    async def test_single_file_source(self, tmp_path):
+        src = tmp_path / "single.md"
+        src.write_text("solo", encoding="utf-8")
+        handler = FileHandler(make_config(src.as_uri()))
+        files = await handler.list_files(src.as_uri())
+        assert [f.path for f in files] == ["single.md"]
+        assert files[0].size == 4
+
+    async def test_missing_path_raises(self, tmp_path):
+        url = (tmp_path / "nope").as_uri()
+        handler = FileHandler(make_config(url))
+        with pytest.raises(RemoteSyncError):
+            await handler.list_files(url)
+
+    async def test_max_file_size_enforced(self, tmp_path):
+        src = tmp_path / "big.md"
+        src.write_text("x" * 100, encoding="utf-8")
+        handler = FileHandler(make_config(src.as_uri(), max_file_size=10))
+        with pytest.raises(RemoteSyncError, match="max_file_size"):
+            await handler.download_file(src.as_uri(), tmp_path / "out.md")
+
+    async def test_relative_file_url_rejected(self):
+        handler = FileHandler(make_config("file://remote-host/path"))
+        with pytest.raises(RemoteSyncError):
+            await handler.list_files("file://remote-host/path")
+
+    async def test_symlinked_files_skipped(self, tmp_path):
+        src = tmp_path / "mount"
+        src.mkdir()
+        (src / "real.md").write_text("real", encoding="utf-8")
+        (tmp_path / "outside.md").write_text("outside", encoding="utf-8")
+        (src / "link.md").symlink_to(tmp_path / "outside.md")
+        handler = FileHandler(make_config(src.as_uri()))
+        files = await handler.list_files(src.as_uri())
+        assert [f.path for f in files] == ["real.md"]
+
+
+class TestHTTPHandler:
+    @pytest.fixture
+    async def http_server(self, tmp_path):
+        content = b"# Remote doc\nThe capital of Zephyria is Windmere.\n"
+
+        async def doc(request):
+            return web.Response(
+                body=content,
+                headers={"Content-Type": "text/markdown", "ETag": '"v1"'},
+            )
+
+        async def flaky_head(request):
+            if request.method == "HEAD":
+                return web.Response(status=405)
+            return web.Response(body=b"no-head body", headers={"Content-Type": "text/plain"})
+
+        async def huge(request):
+            return web.Response(body=b"y" * 4096, headers={"Content-Type": "text/plain"})
+
+        app = web.Application()
+        app.router.add_route("*", "/docs/guide.md", doc)
+        app.router.add_route("*", "/no-head", flaky_head)
+        app.router.add_route("*", "/huge.txt", huge)
+        server = TestServer(app)
+        await server.start_server()
+        yield server, content
+        await server.close()
+
+    async def test_list_single_file(self, http_server):
+        server, content = http_server
+        url = str(server.make_url("/docs/guide.md"))
+        handler = HTTPHandler(make_config(url))
+        files = await handler.list_files(url)
+        assert len(files) == 1
+        assert files[0].path == "guide.md"
+        assert files[0].size == len(content)
+        assert files[0].remote_hash == "etag:v1"
+
+    async def test_download_file(self, http_server, tmp_path):
+        server, content = http_server
+        url = str(server.make_url("/docs/guide.md"))
+        handler = HTTPHandler(make_config(url))
+        dest = tmp_path / "guide.md"
+        result = await handler.download_file(url, dest)
+        assert dest.read_bytes() == content
+        assert result.local_hash == hashlib.sha256(content).hexdigest()
+
+    async def test_head_unsupported_falls_back(self, http_server):
+        server, _ = http_server
+        url = str(server.make_url("/no-head"))
+        handler = HTTPHandler(make_config(url))
+        files = await handler.list_files(url)
+        assert len(files) == 1
+        # No extension in the URL: extension inferred from Content-Type
+        assert files[0].path == "no-head.txt"
+        assert files[0].remote_hash is None
+
+    async def test_glob_pattern_rejected(self):
+        handler = HTTPHandler(make_config("https://host/docs/"))
+        with pytest.raises(RemoteSyncError, match="glob"):
+            await handler.list_files("https://host/docs/", "*.md")
+
+    async def test_404_raises(self, http_server):
+        server, _ = http_server
+        url = str(server.make_url("/missing.md"))
+        handler = HTTPHandler(make_config(url))
+        with pytest.raises(RemoteSyncError, match="404"):
+            await handler.list_files(url)
+        with pytest.raises(RemoteSyncError, match="404"):
+            await handler.download_file(url, Path("/tmp/never-written.md"))
+
+    async def test_max_file_size_enforced_mid_stream(self, http_server, tmp_path):
+        server, _ = http_server
+        url = str(server.make_url("/huge.txt"))
+        handler = HTTPHandler(make_config(url, max_file_size=64))
+        with pytest.raises(RemoteSyncError, match="max_file_size"):
+            await handler.download_file(url, tmp_path / "huge.txt")
+
+    async def test_unreachable_host_raises(self, tmp_path):
+        url = "http://127.0.0.1:59991/nope.md"
+        handler = HTTPHandler(make_config(url, timeout=2))
+        with pytest.raises(RemoteSyncError):
+            await handler.list_files(url)
+
+
+class TestS3Handler:
+    def _handler_with_client(self, url, client, **overrides):
+        handler = S3Handler(make_config(url, **overrides))
+        handler._client = client
+        return handler
+
+    def _paginator(self, pages):
+        paginator = mock.Mock()
+        paginator.paginate.return_value = pages
+        return paginator
+
+    async def test_list_files_with_pattern(self):
+        client = mock.Mock()
+        client.get_paginator.return_value = self._paginator(
+            [
+                {
+                    "Contents": [
+                        {"Key": "docs/a.md", "Size": 10, "ETag": '"e1"'},
+                        {"Key": "docs/skip.txt", "Size": 5, "ETag": '"e2"'},
+                        {"Key": "docs/nested/b.md", "Size": 20, "ETag": '"e3"'},
+                        {"Key": "docs/dir/", "Size": 0, "ETag": '"e4"'},
+                    ]
+                }
+            ]
+        )
+        handler = self._handler_with_client("s3://bucket/docs/*.md", client)
+        files = await handler.list_files("s3://bucket/docs/", "*.md")
+        assert sorted(f.path for f in files) == ["a.md", "nested/b.md"]
+        by_path = {f.path: f for f in files}
+        assert by_path["a.md"].remote_hash == "etag:e1"
+        assert by_path["a.md"].url == "s3://bucket/docs/a.md"
+        client.get_paginator.return_value.paginate.assert_called_once_with(
+            Bucket="bucket", Prefix="docs/"
+        )
+
+    async def test_download_file(self, tmp_path):
+        client = mock.Mock()
+        client.head_object.return_value = {"ContentLength": 5}
+
+        def fake_download(bucket, key, dest):
+            Path(dest).write_bytes(b"hello")
+
+        client.download_file.side_effect = fake_download
+        handler = self._handler_with_client("s3://bucket/docs/a.md", client)
+        result = await handler.download_file("s3://bucket/docs/a.md", tmp_path / "a.md")
+        assert result.size == 5
+        assert (tmp_path / "a.md").read_bytes() == b"hello"
+
+    async def test_download_size_limit(self, tmp_path):
+        client = mock.Mock()
+        client.head_object.return_value = {"ContentLength": 999999}
+        handler = self._handler_with_client("s3://bucket/a.md", client, max_file_size=10)
+        with pytest.raises(RemoteSyncError, match="max_file_size"):
+            await handler.download_file("s3://bucket/a.md", tmp_path / "a.md")
+
+    async def test_missing_bucket_raises(self):
+        handler = S3Handler(make_config("s3://bucket/x"))
+        with pytest.raises(RemoteSyncError, match="bucket"):
+            await handler.list_files("s3:///prefix/")
+
+    async def test_explicit_credentials_passed_to_client(self):
+        config = make_config(
+            "s3://bucket/docs/",
+            auth={
+                "type": "aws",
+                "access_key": "AKIA123",
+                "secret_key": "shhh",
+                "region": "eu-west-1",
+            },
+        )
+        handler = S3Handler(config)
+        with mock.patch(
+            "muxi.runtime.formation.agents.knowledge.remote.protocols.s3.boto3"
+        ) as boto3_mock:
+            handler._get_client()
+            boto3_mock.client.assert_called_once_with(
+                "s3",
+                aws_access_key_id="AKIA123",
+                aws_secret_access_key="shhh",
+                region_name="eu-west-1",
+            )
+
+
+class TestRsyncHandler:
+    def test_supports_incremental(self):
+        handler = RsyncHandler(make_config("rsync://server/docs/"))
+        assert handler.supports_incremental()
+
+    async def test_enumerating_methods_not_implemented(self):
+        handler = RsyncHandler(make_config("rsync://server/docs/"))
+        with pytest.raises(NotImplementedError):
+            await handler.list_files("rsync://server/docs/")
+        with pytest.raises(NotImplementedError):
+            await handler.download_file("rsync://server/docs/a.md", Path("/tmp/a.md"))
+
+    def test_build_command_daemon_url(self, tmp_path):
+        handler = RsyncHandler(
+            make_config("rsync://server/docs", include=["*.md"], exclude=["drafts/*"], timeout=30)
+        )
+        command, key_file = handler._build_command(
+            "/usr/bin/rsync", "rsync://server/docs", tmp_path
+        )
+        assert key_file is None
+        assert command[0] == "/usr/bin/rsync"
+        assert "--delete" in command
+        assert "--safe-links" in command
+        assert "--timeout=30" in command
+        assert "--include=*.md" in command
+        assert "--exclude=*" in command  # include-mode drops everything else
+        assert "--exclude=drafts/*" in command
+        assert command[-2] == "rsync://server/docs/"
+        assert command[-1] == str(tmp_path) + os.sep
+
+    def test_build_command_ssh_with_key(self, tmp_path):
+        handler = RsyncHandler(
+            make_config(
+                "rsync+ssh://deploy@server.example.com/knowledge/",
+                auth={"type": "ssh_key", "key": "PRIVATE KEY MATERIAL"},
+            )
+        )
+        command, key_file = handler._build_command(
+            "/usr/bin/rsync", "rsync+ssh://deploy@server.example.com/knowledge/", tmp_path
+        )
+        try:
+            assert key_file is not None
+            mode = stat_module.S_IMODE(os.stat(key_file).st_mode)
+            assert mode == 0o600
+            assert Path(key_file).read_text(encoding="utf-8").startswith("PRIVATE KEY MATERIAL")
+            ssh_index = command.index("-e")
+            assert f"-i {key_file}" in command[ssh_index + 1]
+            assert command[-2] == "deploy@server.example.com:/knowledge/"
+        finally:
+            os.remove(key_file)
+
+    async def test_sync_tree_success_with_fake_rsync(self, tmp_path):
+        fake_rsync = tmp_path / "fake-rsync"
+        fake_rsync.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        fake_rsync.chmod(0o755)
+        handler = RsyncHandler(make_config("rsync://server/docs/"))
+        with mock.patch(
+            "muxi.runtime.formation.agents.knowledge.remote.protocols.rsync.shutil.which",
+            return_value=str(fake_rsync),
+        ):
+            await handler.sync_tree("rsync://server/docs/", tmp_path / "mirror")
+        assert (tmp_path / "mirror").is_dir()
+
+    async def test_sync_tree_failure_raises(self, tmp_path):
+        fake_rsync = tmp_path / "fake-rsync"
+        fake_rsync.write_text('#!/bin/sh\necho "connection refused" >&2\nexit 10\n', "utf-8")
+        fake_rsync.chmod(0o755)
+        handler = RsyncHandler(make_config("rsync://server/docs/"))
+        with mock.patch(
+            "muxi.runtime.formation.agents.knowledge.remote.protocols.rsync.shutil.which",
+            return_value=str(fake_rsync),
+        ):
+            with pytest.raises(RemoteSyncError, match="code 10"):
+                await handler.sync_tree("rsync://server/docs/", tmp_path / "mirror")
+
+    async def test_missing_rsync_binary(self, tmp_path):
+        handler = RsyncHandler(make_config("rsync://server/docs/"))
+        with mock.patch(
+            "muxi.runtime.formation.agents.knowledge.remote.protocols.rsync.shutil.which",
+            return_value=None,
+        ):
+            with pytest.raises(RemoteSyncError, match="rsync binary"):
+                await handler.sync_tree("rsync://server/docs/", tmp_path / "mirror")

--- a/tests/unit/test_remote_knowledge_handlers.py
+++ b/tests/unit/test_remote_knowledge_handlers.py
@@ -8,6 +8,7 @@ infrastructure is required.
 import hashlib
 import os
 import stat as stat_module
+import tempfile
 from pathlib import Path
 from unittest import mock
 
@@ -109,6 +110,30 @@ class TestFileHandler:
         with pytest.raises(RemoteSyncError, match="max_file_size"):
             await handler.download_file(src.as_uri(), tmp_path / "out.md")
 
+    async def test_mid_copy_failure_leaves_previous_file_intact(self, tmp_path):
+        """Atomicity: a failed copy must not clobber the previous good
+        copy or leak temp files."""
+        src = tmp_path / "src.md"
+        src.write_text("new content", encoding="utf-8")
+        dest_dir = tmp_path / "mirror"
+        dest_dir.mkdir()
+        dest = dest_dir / "src.md"
+        dest.write_bytes(b"previous good content")
+
+        def partial_then_fail(source, target, **kwargs):
+            Path(target).write_bytes(b"trunc")
+            raise OSError("disk error mid-copy")
+
+        handler = FileHandler(make_config(src.as_uri()))
+        with mock.patch(
+            "muxi.runtime.formation.agents.knowledge.remote.protocols.file.shutil.copy2",
+            side_effect=partial_then_fail,
+        ):
+            with pytest.raises(OSError, match="mid-copy"):
+                await handler.download_file(src.as_uri(), dest)
+        assert dest.read_bytes() == b"previous good content"
+        assert not list(dest_dir.glob("*.part")), "temp download file leaked"
+
     async def test_relative_file_url_rejected(self):
         handler = FileHandler(make_config("file://remote-host/path"))
         with pytest.raises(RemoteSyncError):
@@ -203,6 +228,19 @@ class TestHTTPHandler:
         with pytest.raises(RemoteSyncError, match="max_file_size"):
             await handler.download_file(url, tmp_path / "huge.txt")
 
+    async def test_mid_stream_failure_leaves_previous_file_intact(self, http_server, tmp_path):
+        """Atomicity: a failed download must never truncate the previous
+        good copy (which the manifest still records as valid)."""
+        server, _ = http_server
+        url = str(server.make_url("/huge.txt"))
+        dest = tmp_path / "huge.txt"
+        dest.write_bytes(b"previous good content")
+        handler = HTTPHandler(make_config(url, max_file_size=64))
+        with pytest.raises(RemoteSyncError, match="max_file_size"):
+            await handler.download_file(url, dest)
+        assert dest.read_bytes() == b"previous good content"
+        assert not list(tmp_path.glob("*.part")), "temp download file leaked"
+
     async def test_unreachable_host_raises(self, tmp_path):
         url = "http://127.0.0.1:59991/nope.md"
         handler = HTTPHandler(make_config(url, timeout=2))
@@ -264,6 +302,28 @@ class TestS3Handler:
         handler = self._handler_with_client("s3://bucket/a.md", client, max_file_size=10)
         with pytest.raises(RemoteSyncError, match="max_file_size"):
             await handler.download_file("s3://bucket/a.md", tmp_path / "a.md")
+
+    async def test_mid_transfer_failure_leaves_previous_file_intact(self, tmp_path):
+        """Atomicity: a partial transfer that errors must not clobber the
+        previous good copy or leak temp files."""
+        from botocore.exceptions import BotoCoreError
+
+        dest = tmp_path / "a.md"
+        dest.write_bytes(b"previous good content")
+
+        client = mock.Mock()
+        client.head_object.return_value = {"ContentLength": 5}
+
+        def partial_then_fail(bucket, key, path):
+            Path(path).write_bytes(b"trunc")
+            raise BotoCoreError()
+
+        client.download_file.side_effect = partial_then_fail
+        handler = self._handler_with_client("s3://bucket/a.md", client)
+        with pytest.raises(RemoteSyncError):
+            await handler.download_file("s3://bucket/a.md", dest)
+        assert dest.read_bytes() == b"previous good content"
+        assert not list(tmp_path.glob("*.part")), "temp download file leaked"
 
     async def test_missing_bucket_raises(self):
         handler = S3Handler(make_config("s3://bucket/x"))
@@ -343,6 +403,59 @@ class TestRsyncHandler:
             assert command[-2] == "deploy@server.example.com:/knowledge/"
         finally:
             os.remove(key_file)
+
+    def test_ssh_host_key_checking_strict_by_default(self, tmp_path):
+        """Security default: unknown host keys fail the sync (no TOFU)."""
+        handler = RsyncHandler(make_config("rsync+ssh://deploy@server/knowledge/"))
+        command, key_file = handler._build_command(
+            "/usr/bin/rsync", "rsync+ssh://deploy@server/knowledge/", tmp_path
+        )
+        assert key_file is None
+        ssh_command = command[command.index("-e") + 1]
+        assert "StrictHostKeyChecking=yes" in ssh_command
+        assert "accept-new" not in ssh_command
+
+    def test_ssh_host_key_tofu_requires_explicit_opt_in(self, tmp_path):
+        """accept_new_host_keys: true opts into trust-on-first-use."""
+        handler = RsyncHandler(
+            make_config("rsync+ssh://deploy@server/knowledge/", accept_new_host_keys=True)
+        )
+        command, _ = handler._build_command(
+            "/usr/bin/rsync", "rsync+ssh://deploy@server/knowledge/", tmp_path
+        )
+        ssh_command = command[command.index("-e") + 1]
+        assert "StrictHostKeyChecking=accept-new" in ssh_command
+
+    def test_chmod_failure_removes_key_material(self, tmp_path):
+        """Security: if chmod fails after the key is written, the temp key
+        file must be removed immediately (no orphaned key material)."""
+        handler = RsyncHandler(
+            make_config(
+                "rsync+ssh://deploy@server/knowledge/",
+                auth={"type": "ssh_key", "key": "PRIVATE KEY MATERIAL"},
+            )
+        )
+
+        real_mkstemp = tempfile.mkstemp
+
+        def mkstemp_in_tmp(*args, **kwargs):
+            kwargs["dir"] = str(tmp_path)
+            return real_mkstemp(*args, **kwargs)
+
+        with mock.patch(
+            "muxi.runtime.formation.agents.knowledge.remote.protocols.rsync.tempfile.mkstemp",
+            side_effect=mkstemp_in_tmp,
+        ):
+            with mock.patch(
+                "muxi.runtime.formation.agents.knowledge.remote.protocols.rsync.os.chmod",
+                side_effect=OSError("chmod denied"),
+            ):
+                with pytest.raises(OSError, match="chmod denied"):
+                    handler._build_command(
+                        "/usr/bin/rsync", "rsync+ssh://deploy@server/knowledge/", tmp_path / "m"
+                    )
+        leftovers = [p for p in tmp_path.iterdir() if p.name.startswith("muxi-rsync-key-")]
+        assert leftovers == [], f"SSH key material leaked: {leftovers}"
 
     async def test_sync_tree_success_with_fake_rsync(self, tmp_path):
         fake_rsync = tmp_path / "fake-rsync"

--- a/tests/unit/test_remote_knowledge_manifest.py
+++ b/tests/unit/test_remote_knowledge_manifest.py
@@ -1,0 +1,129 @@
+"""Unit tests for remote knowledge manifest tracking and path safety."""
+
+import json
+import os
+
+from muxi.runtime.formation.agents.knowledge.remote.manifest import (
+    Manifest,
+    resolve_within,
+    safe_relative_path,
+)
+
+SOURCE_ID = "test-source"
+URL = "https://example.com/docs.md"
+
+
+class TestSafeRelativePath:
+    def test_accepts_simple_and_nested_paths(self):
+        assert safe_relative_path("docs.md")
+        assert safe_relative_path("nested/dir/file.txt")
+        assert safe_relative_path("with-dash_and.dots.md")
+
+    def test_rejects_traversal_and_absolute_paths(self):
+        assert not safe_relative_path("../escape.md")
+        assert not safe_relative_path("nested/../../escape.md")
+        assert not safe_relative_path("/etc/passwd")
+        assert not safe_relative_path("~/secrets")
+        assert not safe_relative_path("C:/windows/system32")
+        assert not safe_relative_path("back\\slash.md")
+        assert not safe_relative_path("nul\x00byte.md")
+        assert not safe_relative_path("")
+        assert not safe_relative_path(None)
+
+    def test_rejects_traversal_hidden_by_normalization(self):
+        assert not safe_relative_path("a/b/../../../escape.md")
+        assert not safe_relative_path("..")
+
+
+class TestResolveWithin:
+    def test_resolves_inside_root(self, tmp_path):
+        resolved = resolve_within(str(tmp_path), "sub/file.md")
+        assert resolved is not None
+        assert resolved.startswith(os.path.realpath(str(tmp_path)) + os.sep)
+
+    def test_rejects_escaping_paths(self, tmp_path):
+        assert resolve_within(str(tmp_path), "../outside.md") is None
+        assert resolve_within(str(tmp_path), "/abs/path.md") is None
+
+    def test_rejects_symlink_escape(self, tmp_path):
+        root = tmp_path / "root"
+        outside = tmp_path / "outside"
+        root.mkdir()
+        outside.mkdir()
+        (root / "link").symlink_to(outside)
+        assert resolve_within(str(root), "link/file.md") is None
+
+
+class TestManifestStateTransitions:
+    def test_fresh_manifest_state(self, tmp_path):
+        manifest = Manifest.load(str(tmp_path / "manifest.json"), SOURCE_ID, URL)
+        assert manifest.last_sync_status == "never"
+        assert manifest.files == {}
+        assert not manifest.is_unchanged("docs.md", "etag:abc", 10)
+
+    def test_record_then_unchanged(self, tmp_path):
+        manifest = Manifest(source_id=SOURCE_ID, url=URL)
+        manifest.record_file("docs.md", remote_hash="etag:abc", local_hash="sha", size=10)
+        assert manifest.is_unchanged("docs.md", "etag:abc", 10)
+        assert not manifest.is_unchanged("docs.md", "etag:def", 10)  # hash changed
+        assert not manifest.is_unchanged("docs.md", "etag:abc", 11)  # size changed
+        assert not manifest.is_unchanged("other.md", "etag:abc", 10)  # unknown file
+
+    def test_missing_remote_hash_forces_redownload(self):
+        manifest = Manifest(source_id=SOURCE_ID, url=URL)
+        manifest.record_file("docs.md", remote_hash="", local_hash="sha", size=10)
+        assert not manifest.is_unchanged("docs.md", "", 10)
+        assert not manifest.is_unchanged("docs.md", None, 10)
+
+    def test_mark_sync_lifecycle(self):
+        manifest = Manifest(source_id=SOURCE_ID, url=URL)
+        manifest.mark_sync("success", 123)
+        assert manifest.last_sync_status == "success"
+        assert manifest.last_sync_duration_ms == 123
+        assert manifest.last_sync_error == ""
+        manifest.mark_sync("failed", 456, error="boom")
+        assert manifest.last_sync_status == "failed"
+        assert manifest.last_sync_error == "boom"
+
+    def test_save_and_load_roundtrip(self, tmp_path):
+        path = str(tmp_path / "sub" / "manifest.json")
+        manifest = Manifest(source_id=SOURCE_ID, url=URL)
+        manifest.record_file("a/b.md", remote_hash="etag:1", local_hash="h1", size=5)
+        manifest.mark_sync("success", 42)
+        manifest.save(path)
+
+        loaded = Manifest.load(path, SOURCE_ID, URL)
+        assert loaded.last_sync_status == "success"
+        assert loaded.last_sync_duration_ms == 42
+        assert loaded.files["a/b.md"].remote_hash == "etag:1"
+        assert loaded.files["a/b.md"].size == 5
+        assert loaded.stats == {"total_files": 1, "total_size": 5}
+
+    def test_corrupt_manifest_resets_to_empty(self, tmp_path):
+        path = tmp_path / "manifest.json"
+        path.write_text("{not valid json", encoding="utf-8")
+        loaded = Manifest.load(str(path), SOURCE_ID, URL)
+        assert loaded.files == {}
+        assert loaded.last_sync_status == "never"
+
+    def test_non_dict_manifest_resets_to_empty(self, tmp_path):
+        path = tmp_path / "manifest.json"
+        path.write_text(json.dumps(["not", "a", "dict"]), encoding="utf-8")
+        loaded = Manifest.load(str(path), SOURCE_ID, URL)
+        assert loaded.files == {}
+
+    def test_load_drops_unsafe_paths(self, tmp_path):
+        path = tmp_path / "manifest.json"
+        data = {
+            "source_id": SOURCE_ID,
+            "url": URL,
+            "last_sync_status": "success",
+            "files": {
+                "../escape.md": {"remote_hash": "x", "local_hash": "y", "size": 1},
+                "/abs/path.md": {"remote_hash": "x", "local_hash": "y", "size": 1},
+                "safe.md": {"remote_hash": "x", "local_hash": "y", "size": 1},
+            },
+        }
+        path.write_text(json.dumps(data), encoding="utf-8")
+        loaded = Manifest.load(str(path), SOURCE_ID, URL)
+        assert list(loaded.files.keys()) == ["safe.md"]

--- a/tests/unit/test_remote_knowledge_sync.py
+++ b/tests/unit/test_remote_knowledge_sync.py
@@ -1,0 +1,437 @@
+"""Unit tests for the remote knowledge SyncManager orchestration.
+
+Uses a stub in-memory protocol handler so sync behavior (change
+detection, degrade paths, path safety, limits) is tested without any
+network dependency.
+"""
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+from unittest import mock
+
+from muxi.runtime.formation.agents.knowledge.remote.handler import (
+    DownloadResult,
+    ProtocolHandler,
+    RemoteFile,
+    RemoteSyncError,
+    SourceConfig,
+)
+from muxi.runtime.formation.agents.knowledge.remote.manifest import MANIFEST_FILENAME, Manifest
+from muxi.runtime.formation.agents.knowledge.remote.sync import (
+    SyncManager,
+    is_remote_source,
+    partition_sources,
+)
+
+
+class StubHandler(ProtocolHandler):
+    """In-memory enumerating handler: path -> bytes, with failure knobs."""
+
+    def __init__(
+        self,
+        config: SourceConfig,
+        files: Dict[str, bytes],
+        fail_downloads=None,
+        fail_listing: bool = False,
+    ):
+        super().__init__(config)
+        self.files = files
+        self.fail_downloads = set(fail_downloads or [])
+        self.fail_listing = fail_listing
+        self.download_calls: List[str] = []
+
+    async def list_files(self, url: str, pattern: Optional[str] = None) -> List[RemoteFile]:
+        if self.fail_listing:
+            raise RemoteSyncError("remote unreachable")
+        return [
+            RemoteFile(
+                path=path,
+                url=f"stub://{path}",
+                size=len(content),
+                remote_hash=f"hash:{hashlib.sha256(content).hexdigest()[:8]}",
+            )
+            for path, content in self.files.items()
+        ]
+
+    async def download_file(self, url: str, dest: Path) -> DownloadResult:
+        path = url.replace("stub://", "")
+        self.download_calls.append(path)
+        if path in self.fail_downloads:
+            raise RemoteSyncError(f"download failed: {path}")
+        content = self.files[path]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(content)
+        return DownloadResult(
+            path=dest.name,
+            local_path=dest,
+            size=len(content),
+            local_hash=hashlib.sha256(content).hexdigest(),
+        )
+
+
+class StubIncrementalHandler(ProtocolHandler):
+    """Incremental handler that materializes ``files`` into the dest tree."""
+
+    def __init__(self, config: SourceConfig, files: Dict[str, bytes]):
+        super().__init__(config)
+        self.files = files
+
+    async def list_files(self, url, pattern=None):
+        raise NotImplementedError
+
+    async def download_file(self, url, dest):
+        raise NotImplementedError
+
+    def supports_incremental(self) -> bool:
+        return True
+
+    async def sync_tree(self, url: str, dest_dir: Path) -> None:
+        existing = set()
+        for dirpath, _, filenames in os.walk(dest_dir):
+            for name in filenames:
+                rel = os.path.relpath(os.path.join(dirpath, name), dest_dir)
+                existing.add(rel.replace(os.sep, "/"))
+        for rel in existing - set(self.files):
+            os.remove(os.path.join(dest_dir, rel))
+        for rel, content in self.files.items():
+            target = dest_dir / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if not target.exists() or target.read_bytes() != content:
+                target.write_bytes(content)
+
+
+def make_manager(tmp_path, handler_factory):
+    manager = SyncManager(agent_id="agent-x", root_dir=str(tmp_path / "remote-root"))
+    patcher = mock.patch(
+        "muxi.runtime.formation.agents.knowledge.remote.sync.create_handler",
+        side_effect=handler_factory,
+    )
+    return manager, patcher
+
+
+SOURCE = {
+    "url": "stub://source",
+    "id": "stub-source",
+    "description": "stub remote source",
+}
+
+
+class TestPartitioning:
+    def test_is_remote_source(self):
+        assert is_remote_source({"url": "s3://bucket/x"})
+        assert not is_remote_source({"path": "knowledge/docs/"})
+        assert not is_remote_source({"url": ""})
+        assert not is_remote_source("knowledge/docs/")
+
+    def test_partition_preserves_order_and_identity(self):
+        local1 = {"path": "a/"}
+        remote1 = {"url": "s3://b/x"}
+        local2 = {"path": "c/"}
+        local, remote = partition_sources([local1, remote1, local2])
+        assert local == [local1, local2]
+        assert remote == [remote1]
+        assert local[0] is local1  # same objects, not copies
+
+    async def test_prepare_sources_local_only_is_inert(self, tmp_path):
+        """Formations with only local sources get the same list object back."""
+        manager = SyncManager(agent_id="agent-x", root_dir=str(tmp_path))
+        sources = [{"path": "knowledge/docs/", "description": "local"}]
+        result = await manager.prepare_sources(sources)
+        assert result is sources  # untouched, no sync side effects
+        assert not (tmp_path / "content").exists()
+
+
+class TestInertWhenUnconfigured:
+    async def test_local_only_formation_never_imports_remote_sync(self, tmp_path):
+        """Pin: KnowledgeHandler.from_agent_config with only local sources
+        must never touch the remote sync machinery."""
+        from muxi.runtime.formation.agents.knowledge.handler import KnowledgeHandler
+
+        knowledge_file = tmp_path / "facts.md"
+        knowledge_file.write_text("Local knowledge only.", encoding="utf-8")
+
+        working_memory = mock.MagicMock()
+        working_memory.get_items_by_metadata.return_value = []
+
+        async def fake_embeddings(texts):
+            return [[0.0] * 8 for _ in texts]
+
+        # Temporarily remove any already-imported remote modules so a
+        # fresh import during the call would be observable; restore them
+        # afterwards so other tests keep their module identity.
+        removed = {
+            name: sys.modules.pop(name) for name in list(sys.modules) if ".knowledge.remote" in name
+        }
+        try:
+            with mock.patch.object(
+                KnowledgeHandler, "load_sources_from_config", autospec=True
+            ) as load_mock:
+                handler = await KnowledgeHandler.from_agent_config(
+                    agent_id="local-agent",
+                    knowledge_config={
+                        "enabled": True,
+                        "sources": [{"path": str(knowledge_file), "description": "facts"}],
+                    },
+                    generate_embeddings_fn=fake_embeddings,
+                    embedding_dimension=8,
+                    working_memory=working_memory,
+                    cache_dir=str(tmp_path / "cache"),
+                )
+
+            assert handler is not None
+            # The exact same list object flows through - identical local path
+            passed_sources = load_mock.call_args[0][1]
+            assert passed_sources == [
+                {
+                    "path": str(knowledge_file),
+                    "description": "facts",
+                    "max_files": 100,
+                    "max_file_size": 10 * 1024 * 1024,
+                }
+            ]
+            assert not any(".knowledge.remote" in name for name in sys.modules)
+        finally:
+            sys.modules.update(removed)
+
+
+class TestEnumeratedSync:
+    async def test_cold_sync_downloads_everything(self, tmp_path):
+        files = {"a.md": b"alpha", "nested/b.md": b"beta"}
+        manager, patcher = make_manager(tmp_path, lambda cfg: StubHandler(cfg, files))
+        with patcher:
+            result = await manager.sync_source(dict(SOURCE))
+
+        assert result.status == "success"
+        assert result.files_added == 2
+        assert result.files_modified == 0
+        assert result.bytes_downloaded == 9
+        content_dir = Path(result.content_dir)
+        assert (content_dir / "a.md").read_bytes() == b"alpha"
+        assert (content_dir / "nested" / "b.md").read_bytes() == b"beta"
+
+        manifest = Manifest.load(
+            str(content_dir.parent / MANIFEST_FILENAME), "stub-source", SOURCE["url"]
+        )
+        assert manifest.last_sync_status == "success"
+        assert set(manifest.files) == {"a.md", "nested/b.md"}
+
+    async def test_unchanged_files_not_redownloaded(self, tmp_path):
+        files = {"a.md": b"alpha"}
+        handlers = []
+
+        def factory(cfg):
+            handler = StubHandler(cfg, files)
+            handlers.append(handler)
+            return handler
+
+        manager, patcher = make_manager(tmp_path, factory)
+        with patcher:
+            await manager.sync_source(dict(SOURCE))
+            result = await manager.sync_source(dict(SOURCE))
+
+        assert result.files_added == 0
+        assert result.files_modified == 0
+        assert handlers[1].download_calls == []
+
+    async def test_modified_file_redownloaded_and_deleted_file_removed(self, tmp_path):
+        first = {"a.md": b"alpha", "b.md": b"beta"}
+        second = {"a.md": b"ALPHA v2"}
+        state = {"files": first}
+
+        def factory(cfg):
+            return StubHandler(cfg, state["files"])
+
+        manager, patcher = make_manager(tmp_path, factory)
+        with patcher:
+            await manager.sync_source(dict(SOURCE))
+            state["files"] = second
+            result = await manager.sync_source(dict(SOURCE))
+
+        assert result.files_modified == 1
+        assert result.files_deleted == 1
+        content_dir = Path(result.content_dir)
+        assert (content_dir / "a.md").read_bytes() == b"ALPHA v2"
+        assert not (content_dir / "b.md").exists()
+
+    async def test_partial_failure_keeps_stale_copy(self, tmp_path):
+        files = {"a.md": b"alpha", "b.md": b"beta"}
+        state = {"files": dict(files), "fail": set()}
+
+        def factory(cfg):
+            return StubHandler(cfg, state["files"], fail_downloads=state["fail"])
+
+        manager, patcher = make_manager(tmp_path, factory)
+        with patcher:
+            await manager.sync_source(dict(SOURCE))
+            # b.md changes remotely but its download now fails
+            state["files"] = {"a.md": b"alpha", "b.md": b"beta v2"}
+            state["fail"] = {"b.md"}
+            result = await manager.sync_source(dict(SOURCE))
+
+        assert result.status == "partial"
+        assert result.files_failed == 1
+        # Stale-wins: previous copy still present and still indexed
+        content_dir = Path(result.content_dir)
+        assert (content_dir / "b.md").read_bytes() == b"beta"
+        manifest = Manifest.load(
+            str(content_dir.parent / MANIFEST_FILENAME), "stub-source", SOURCE["url"]
+        )
+        assert "b.md" in manifest.files
+        assert manifest.last_sync_status == "partial"
+
+    async def test_total_failure_degrades_to_synced_state(self, tmp_path):
+        state = {"fail_listing": False}
+
+        def factory(cfg):
+            return StubHandler(cfg, {"a.md": b"alpha"}, fail_listing=state["fail_listing"])
+
+        manager, patcher = make_manager(tmp_path, factory)
+        with patcher:
+            first = await manager.sync_source(dict(SOURCE))
+            state["fail_listing"] = True
+            result = await manager.sync_source(dict(SOURCE))
+
+        assert first.status == "success"
+        assert result.status == "failed"
+        assert "unreachable" in result.error
+        assert result.has_local_content  # stale mirror survives
+        assert (Path(result.content_dir) / "a.md").read_bytes() == b"alpha"
+        manifest = Manifest.load(
+            str(Path(result.content_dir).parent / MANIFEST_FILENAME),
+            "stub-source",
+            SOURCE["url"],
+        )
+        assert manifest.last_sync_status == "failed"
+
+    async def test_cold_start_failure_yields_no_content(self, tmp_path):
+        manager, patcher = make_manager(
+            tmp_path, lambda cfg: StubHandler(cfg, {}, fail_listing=True)
+        )
+        with patcher:
+            result = await manager.sync_source(dict(SOURCE))
+        assert result.status == "failed"
+        assert not result.has_local_content
+
+    async def test_path_traversal_files_never_written(self, tmp_path):
+        files = {
+            "../evil.md": b"escape",
+            "/abs/evil.md": b"escape",
+            "safe.md": b"ok",
+        }
+        manager, patcher = make_manager(tmp_path, lambda cfg: StubHandler(cfg, files))
+        with patcher:
+            result = await manager.sync_source(dict(SOURCE))
+
+        content_dir = Path(result.content_dir)
+        assert (content_dir / "safe.md").exists()
+        assert not (tmp_path / "remote-root" / "stub-source" / "evil.md").exists()
+        assert not (tmp_path / "evil.md").exists()
+        assert not Path("/abs/evil.md").exists()
+        assert result.files_failed == 2
+        assert sorted(result.skipped_files) == ["../evil.md", "/abs/evil.md"]
+
+    async def test_limits_and_filters(self, tmp_path):
+        files = {
+            "keep-1.md": b"a" * 10,
+            "keep-2.md": b"b" * 10,
+            "drafts/skip.md": b"c" * 10,
+            "too-big.md": b"d" * 1000,
+            "notes.txt": b"e" * 10,
+        }
+        source = {
+            **SOURCE,
+            "include": ["*.md"],
+            "exclude": ["drafts/*"],
+            "max_file_size": 100,
+        }
+        manager, patcher = make_manager(tmp_path, lambda cfg: StubHandler(cfg, files))
+        with patcher:
+            result = await manager.sync_source(source)
+
+        content_dir = Path(result.content_dir)
+        synced = sorted(
+            os.path.relpath(os.path.join(d, f), content_dir)
+            for d, _, names in os.walk(content_dir)
+            for f in names
+        )
+        assert synced == ["keep-1.md", "keep-2.md"]
+
+    async def test_max_files_limit(self, tmp_path):
+        files = {f"f{i}.md": b"x" for i in range(5)}
+        source = {**SOURCE, "max_files": 2}
+        manager, patcher = make_manager(tmp_path, lambda cfg: StubHandler(cfg, files))
+        with patcher:
+            result = await manager.sync_source(source)
+        assert result.files_added == 2
+        assert len(result.skipped_files) == 3
+
+
+class TestIncrementalSync:
+    async def test_incremental_add_modify_delete(self, tmp_path):
+        state = {"files": {"a.md": b"alpha", "b.md": b"beta"}}
+
+        def factory(cfg):
+            return StubIncrementalHandler(cfg, state["files"])
+
+        manager, patcher = make_manager(tmp_path, factory)
+        with patcher:
+            first = await manager.sync_source(dict(SOURCE))
+            state["files"] = {"a.md": b"alpha v2", "c.md": b"gamma"}
+            second = await manager.sync_source(dict(SOURCE))
+
+        assert first.files_added == 2
+        assert second.files_added == 1  # c.md
+        assert second.files_modified == 1  # a.md
+        assert second.files_deleted == 1  # b.md
+        content_dir = Path(second.content_dir)
+        assert sorted(p.name for p in content_dir.iterdir()) == ["a.md", "c.md"]
+        manifest = Manifest.load(
+            str(content_dir.parent / MANIFEST_FILENAME), "stub-source", SOURCE["url"]
+        )
+        assert set(manifest.files) == {"a.md", "c.md"}
+
+
+class TestPrepareSources:
+    async def test_mixed_sources_yield_local_plus_synthetic(self, tmp_path):
+        local = {"path": "/formation/knowledge/faq/", "description": "faq"}
+        remote = dict(SOURCE)
+        manager, patcher = make_manager(tmp_path, lambda cfg: StubHandler(cfg, {"a.md": b"alpha"}))
+        with patcher:
+            prepared = await manager.prepare_sources([local, remote])
+
+        assert prepared[0] is local
+        synthetic = prepared[1]
+        assert synthetic["name"] == "stub-source"
+        assert synthetic["description"] == "stub remote source"
+        assert synthetic["path"].endswith(os.path.join("stub-source", "content"))
+        assert os.path.isfile(os.path.join(synthetic["path"], "a.md"))
+
+    async def test_cold_start_unreachable_source_dropped_with_warning(self, tmp_path, capsys):
+        remote = dict(SOURCE)
+        manager, patcher = make_manager(
+            tmp_path, lambda cfg: StubHandler(cfg, {}, fail_listing=True)
+        )
+        with patcher:
+            prepared = await manager.prepare_sources([remote])
+
+        assert prepared == []
+        captured = capsys.readouterr()
+        assert "no local content" in captured.out
+
+    async def test_degraded_source_still_prepared_from_stale_mirror(self, tmp_path):
+        state = {"fail_listing": False}
+
+        def factory(cfg):
+            return StubHandler(cfg, {"a.md": b"alpha"}, fail_listing=state["fail_listing"])
+
+        manager, patcher = make_manager(tmp_path, factory)
+        with patcher:
+            await manager.prepare_sources([dict(SOURCE)])
+            state["fail_listing"] = True
+            prepared = await manager.prepare_sources([dict(SOURCE)])
+
+        assert len(prepared) == 1
+        assert os.path.isfile(os.path.join(prepared[0]["path"], "a.md"))

--- a/tests/unit/test_remote_knowledge_sync.py
+++ b/tests/unit/test_remote_knowledge_sync.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from typing import Dict, List, Optional
 from unittest import mock
 
+import pytest
+
 from muxi.runtime.formation.agents.knowledge.remote.handler import (
     DownloadResult,
     ProtocolHandler,
@@ -314,6 +316,46 @@ class TestEnumeratedSync:
             result = await manager.sync_source(dict(SOURCE))
         assert result.status == "failed"
         assert not result.has_local_content
+
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="chmod-based unreadability does not apply to root",
+    )
+    async def test_stale_wins_serves_previous_good_content_end_to_end(self, tmp_path):
+        """Real handlers (no stubs): a mid-download failure after a remote
+        change must leave the previous good bytes on disk AND in the
+        manifest - atomic downloads are what make stale-wins trustworthy."""
+        src_dir = tmp_path / "served"
+        src_dir.mkdir()
+        (src_dir / "a.md").write_text("good v1", encoding="utf-8")
+        source = {
+            "url": src_dir.as_uri(),
+            "id": "file-src",
+            "description": "file source",
+        }
+        manager = SyncManager(agent_id="agent-x", root_dir=str(tmp_path / "root"))
+
+        first = await manager.sync_source(dict(source))
+        assert first.status == "success"
+
+        # File changes remotely (new stat token) but becomes unreadable,
+        # so the re-download fails mid-sync.
+        (src_dir / "a.md").write_text("corrupted v2", encoding="utf-8")
+        os.chmod(src_dir / "a.md", 0)
+        try:
+            second = await manager.sync_source(dict(source))
+        finally:
+            os.chmod(src_dir / "a.md", 0o644)
+
+        assert second.status == "partial"
+        assert second.files_failed == 1
+        mirrored = Path(second.content_dir) / "a.md"
+        assert mirrored.read_text(encoding="utf-8") == "good v1"
+        manifest = Manifest.load(
+            str(Path(second.content_dir).parent / MANIFEST_FILENAME), "file-src", source["url"]
+        )
+        assert manifest.files["a.md"].local_hash == hashlib.sha256(b"good v1").hexdigest()
+        assert not list(Path(second.content_dir).glob("*.part")), "temp download file leaked"
 
     async def test_path_traversal_files_never_written(self, tmp_path):
         files = {

--- a/tests/unit/test_remote_knowledge_validation.py
+++ b/tests/unit/test_remote_knowledge_validation.py
@@ -1,0 +1,252 @@
+"""Unit tests for remote knowledge source config validation (fail-fast)."""
+
+import pytest
+
+from muxi.runtime.formation.config.validation import FormationValidator
+
+
+@pytest.fixture
+def validator():
+    return FormationValidator()
+
+
+def validate_sources(validator, sources):
+    validator._validate_agent_knowledge_config({"enabled": True, "sources": sources})
+    return validator.result
+
+
+def remote(url, **fields):
+    return {"url": url, "description": "remote source", **fields}
+
+
+class TestLocalSourcesUnchanged:
+    def test_local_path_source_still_valid(self, validator):
+        result = validate_sources(validator, [{"path": "knowledge/faq/", "description": "faq"}])
+        assert result.is_valid
+
+    def test_local_source_missing_path_still_fails(self, validator):
+        result = validate_sources(validator, [{"description": "faq"}])
+        assert not result.is_valid
+        assert any("'path' or 'url'" in e for e in result.errors)
+
+    def test_path_and_url_together_rejected(self, validator):
+        result = validate_sources(
+            validator,
+            [{"path": "knowledge/", "url": "https://x.com/d.md", "description": "d"}],
+        )
+        assert not result.is_valid
+        assert any("not both" in e for e in result.errors)
+
+
+class TestUrlSchemes:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://wiki.company.com/export/docs.md",
+            "http://internal.corp/files/notes.txt",
+            "s3://acme-bucket/policies/*",
+            "rsync://docs-server/knowledge/",
+            "rsync+ssh://docs@server.com/knowledge/",
+            "file:///mounted/path/",
+        ],
+    )
+    def test_supported_schemes_accepted(self, validator, url):
+        result = validate_sources(validator, [remote(url)])
+        assert result.is_valid, result.errors
+
+    @pytest.mark.parametrize(
+        "url", ["gs://bucket/x", "az://container/x", "ftp://h/x", "sftp://u@h/x"]
+    )
+    def test_planned_schemes_rejected_as_not_yet_supported(self, validator, url):
+        result = validate_sources(validator, [remote(url)])
+        assert not result.is_valid
+        assert any("not yet supported" in e for e in result.errors)
+
+    def test_unknown_scheme_rejected(self, validator):
+        result = validate_sources(validator, [remote("gopher://host/x")])
+        assert not result.is_valid
+        assert any("unsupported URL scheme" in e for e in result.errors)
+
+    def test_empty_url_rejected(self, validator):
+        result = validate_sources(validator, [remote("  ")])
+        assert not result.is_valid
+
+    def test_http_glob_rejected(self, validator):
+        result = validate_sources(validator, [remote("https://host/docs/*.md")])
+        assert not result.is_valid
+        assert any("glob" in e for e in result.errors)
+
+    def test_s3_without_bucket_rejected(self, validator):
+        result = validate_sources(validator, [remote("s3:///prefix/*")])
+        assert not result.is_valid
+        assert any("bucket" in e for e in result.errors)
+
+    def test_file_requires_absolute_local_path(self, validator):
+        result = validate_sources(validator, [remote("file://host/share")])
+        assert not result.is_valid
+        result2 = validate_sources(FormationValidator(), [remote("file:relative")])
+        assert not result2.is_valid
+
+    def test_description_required_for_remote_sources(self, validator):
+        result = validate_sources(validator, [{"url": "https://h/x.md"}])
+        assert not result.is_valid
+        assert any("description" in e for e in result.errors)
+
+
+class TestSourceIds:
+    def test_duplicate_ids_rejected(self, validator):
+        result = validate_sources(
+            validator,
+            [
+                remote("https://h/a.md", id="docs"),
+                remote("https://h/b.md", id="docs"),
+            ],
+        )
+        assert not result.is_valid
+        assert any("duplicate" in e for e in result.errors)
+
+    def test_empty_id_rejected(self, validator):
+        result = validate_sources(validator, [remote("https://h/a.md", id="  ")])
+        assert not result.is_valid
+
+
+class TestAuthBlocks:
+    def test_http_basic_auth_valid(self, validator):
+        result = validate_sources(
+            validator,
+            [
+                remote(
+                    "https://h/a.md",
+                    auth={"type": "basic", "username": "u", "password": "p"},
+                )
+            ],
+        )
+        assert result.is_valid, result.errors
+
+    def test_http_basic_auth_missing_password(self, validator):
+        result = validate_sources(
+            validator, [remote("https://h/a.md", auth={"type": "basic", "username": "u"})]
+        )
+        assert not result.is_valid
+        assert any("password" in e for e in result.errors)
+
+    def test_bearer_requires_token(self, validator):
+        result = validate_sources(validator, [remote("https://h/a.md", auth={"type": "bearer"})])
+        assert not result.is_valid
+
+    def test_s3_aws_auth_valid(self, validator):
+        result = validate_sources(
+            validator,
+            [
+                remote(
+                    "s3://bucket/docs/*",
+                    auth={
+                        "type": "aws",
+                        "access_key": "${{ secrets.AWS_ACCESS_KEY }}",
+                        "secret_key": "${{ secrets.AWS_SECRET_KEY }}",
+                        "region": "us-east-1",
+                    },
+                )
+            ],
+        )
+        assert result.is_valid, result.errors
+
+    def test_s3_aws_auth_missing_secret_key(self, validator):
+        result = validate_sources(
+            validator, [remote("s3://bucket/x", auth={"type": "aws", "access_key": "k"})]
+        )
+        assert not result.is_valid
+        assert any("secret_key" in e for e in result.errors)
+
+    def test_auth_type_scheme_mismatch(self, validator):
+        result = validate_sources(
+            validator,
+            [remote("s3://bucket/x", auth={"type": "basic", "username": "u", "password": "p"})],
+        )
+        assert not result.is_valid
+        assert any("not valid for" in e for e in result.errors)
+
+    def test_ssh_key_auth_for_rsync_ssh(self, validator):
+        result = validate_sources(
+            validator,
+            [
+                remote(
+                    "rsync+ssh://user@host/path/",
+                    auth={"type": "ssh_key", "key": "${{ secrets.RSYNC_SSH_KEY }}"},
+                )
+            ],
+        )
+        assert result.is_valid, result.errors
+
+    def test_auth_without_type_rejected(self, validator):
+        result = validate_sources(validator, [remote("https://h/a.md", auth={"token": "x"})])
+        assert not result.is_valid
+        assert any("'type'" in e for e in result.errors)
+
+
+class TestOptions:
+    def test_headers_valid_for_http(self, validator):
+        result = validate_sources(
+            validator,
+            [remote("https://h/a.md", headers={"Authorization": "Bearer ${{ secrets.T }}"})],
+        )
+        assert result.is_valid, result.errors
+
+    def test_headers_rejected_for_s3(self, validator):
+        result = validate_sources(validator, [remote("s3://bucket/x", headers={"X-Custom": "v"})])
+        assert not result.is_valid
+
+    def test_headers_must_be_string_map(self, validator):
+        result = validate_sources(validator, [remote("https://h/a.md", headers={"K": 5})])
+        assert not result.is_valid
+
+    def test_include_exclude_patterns(self, validator):
+        result = validate_sources(
+            validator,
+            [remote("s3://bucket/docs/*", include=["*.md"], exclude=["drafts/*"])],
+        )
+        assert result.is_valid, result.errors
+
+    def test_invalid_include_rejected(self, validator):
+        result = validate_sources(validator, [remote("s3://bucket/x", include="*.md")])
+        assert not result.is_valid
+
+    @pytest.mark.parametrize("key", ["max_files", "max_file_size", "max_total_size", "timeout"])
+    def test_limits_must_be_positive_integers(self, validator, key):
+        result = validate_sources(validator, [remote("s3://bucket/x", **{key: 0})])
+        assert not result.is_valid
+        result2 = validate_sources(FormationValidator(), [remote("s3://bucket/x", **{key: "10"})])
+        assert not result2.is_valid
+
+    def test_extract_rejected_in_phase_1(self, validator):
+        result = validate_sources(validator, [remote("https://h/a.zip", extract=True)])
+        assert not result.is_valid
+        assert any("extraction" in e for e in result.errors)
+
+    def test_schedule_cron_and_aliases_accepted(self, validator):
+        result = validate_sources(
+            validator,
+            [
+                remote("s3://bucket/a/*", schedule="*/15 * * * *"),
+                remote("s3://bucket/b/*", schedule="@daily"),
+                remote("s3://bucket/c/*", schedule="@startup"),
+            ],
+        )
+        assert result.is_valid, result.errors
+
+    def test_invalid_schedule_rejected(self, validator):
+        result = validate_sources(
+            validator, [remote("s3://bucket/x", schedule="whenever I feel like it")]
+        )
+        assert not result.is_valid
+        assert any("schedule" in e for e in result.errors)
+
+
+class TestFormationLevelKnowledge:
+    def test_formation_knowledge_accepts_remote_sources(self, tmp_path, validator):
+        validator._validate_knowledge_config({"sources": [remote("https://h/a.md")]}, tmp_path)
+        assert validator.result.is_valid, validator.result.errors
+
+    def test_formation_knowledge_rejects_bad_scheme(self, tmp_path, validator):
+        validator._validate_knowledge_config({"sources": [remote("gopher://h/a.md")]}, tmp_path)
+        assert not validator.result.is_valid

--- a/tests/unit/test_remote_knowledge_validation.py
+++ b/tests/unit/test_remote_knowledge_validation.py
@@ -158,6 +158,25 @@ class TestAuthBlocks:
         assert not result.is_valid
         assert any("secret_key" in e for e in result.errors)
 
+    def test_s3_aws_auth_secret_key_without_access_key(self, validator):
+        result = validate_sources(
+            validator, [remote("s3://bucket/x", auth={"type": "aws", "secret_key": "s"})]
+        )
+        assert not result.is_valid
+        assert any("access_key" in e for e in result.errors)
+
+    def test_s3_aws_auth_default_credential_chain(self, validator):
+        """No explicit keys: boto3's default credential chain applies."""
+        result = validate_sources(
+            validator,
+            [remote("s3://bucket/docs/*", auth={"type": "aws", "region": "us-east-1"})],
+        )
+        assert result.is_valid, result.errors
+
+    def test_s3_aws_auth_type_only(self, validator):
+        result = validate_sources(validator, [remote("s3://bucket/x", auth={"type": "aws"})])
+        assert result.is_valid, result.errors
+
     def test_auth_type_scheme_mismatch(self, validator):
         result = validate_sources(
             validator,
@@ -217,6 +236,26 @@ class TestOptions:
         assert not result.is_valid
         result2 = validate_sources(FormationValidator(), [remote("s3://bucket/x", **{key: "10"})])
         assert not result2.is_valid
+
+    def test_accept_new_host_keys_valid_for_rsync_ssh(self, validator):
+        result = validate_sources(
+            validator,
+            [remote("rsync+ssh://user@host/path/", accept_new_host_keys=True)],
+        )
+        assert result.is_valid, result.errors
+
+    def test_accept_new_host_keys_rejected_for_other_schemes(self, validator):
+        result = validate_sources(validator, [remote("s3://bucket/x", accept_new_host_keys=True)])
+        assert not result.is_valid
+        assert any("accept_new_host_keys" in e for e in result.errors)
+
+    def test_accept_new_host_keys_must_be_boolean(self, validator):
+        result = validate_sources(
+            validator,
+            [remote("rsync+ssh://user@host/path/", accept_new_host_keys="yes")],
+        )
+        assert not result.is_valid
+        assert any("boolean" in e for e in result.errors)
 
     def test_extract_rejected_in_phase_1(self, validator):
         result = validate_sources(validator, [remote("https://h/a.zip", extract=True)])


### PR DESCRIPTION
## Summary

Phase 1 ("Core Infrastructure") of the Remote Knowledge Sources PRD: agents can declare url-based knowledge sources that sync into a local mirror at formation startup and feed the existing (unchanged) ingestion pipeline.

### What's in

- **`formation/agents/knowledge/remote/`** (new package)
  - `handler.py` - `ProtocolHandler` ABC, `SourceConfig`, `RemoteFile`/`DownloadResult` datatypes, URL glob splitting
  - `protocols/http.py` - `HTTPHandler` (aiohttp; single-file URLs; ETag/Last-Modified change detection; basic/bearer auth + headers)
  - `protocols/s3.py` - `S3Handler` (boto3 in worker threads; prefix + glob listing; ETag change detection; `auth: {type: aws}` or default credential chain)
  - `protocols/rsync.py` - `RsyncHandler` (subprocess rsync, incremental `sync_tree` path, `--delete --safe-links --max-size`, rsync+ssh with `ssh_key` auth via 0600 temp key file)
  - `protocols/file.py` - `FileHandler` (bind mounts; size+mtime change detection; symlinks skipped)
  - `manifest.py` - per-source sync state (files, hashes, last_sync status), atomic writes, corruption-tolerant loads, unsafe-path filtering
  - `sync.py` - `SyncManager`: startup sync orchestration, include/exclude filters, max_files/max_file_size/max_total_size limits, degrade policies, observability events
- **Integration**: `KnowledgeHandler.from_agent_config` partitions sources; remote ones sync to `~/.muxi/<formation>/cache/knowledge/remote/<agent>/<source_id>/content/` and are replaced by synthetic local `path` sources. 19-line diff in the shared handler; no changes to the ingestion/query path (concurrent reasoning-RAG work is unaffected).
- **Validation** (fail-fast at load): scheme allow-list, scheme-specific URL shape, auth block shape per scheme, headers/include/exclude/limit types, cron `schedule` syntax, duplicate source ids. Credentials via existing `${{ secrets.* }}` interpolation.
- **Observability**: `knowledge.sync.started`, `knowledge.sync.completed` (SystemEvents), `error.knowledge.sync.failed` (ErrorEvents). `validate_events.py` at 100%.
- **Docs**: mental-model.md section (architecture, policies, seams); CHANGELOG `[unreleased]` entry.

### Cold-start / failure-isolation policy (documented in mental-model.md)

A failing sync never blocks formation startup or chat:

- Per-file failure: keep the previously synced copy (stale-wins, PRD open question #2), sync marked `partial`.
- Total failure with prior syncs: degrade to the manifest's recorded state (WARNING event).
- Cold start (nothing synced yet + unreachable): formation still starts; the source contributes zero knowledge; surfaced loudly via an `[ WARN ]` init line plus an ERROR-level `error.knowledge.sync.failed` event. The PRD proposed stale-wins but was silent on cold start; we chose start-and-warn-loudly over fail-fast so one flaky remote cannot take down a formation.

### Deviations / decisions

- **HTTP globs rejected** at validation time (PRD spec shows `https://example.com/docs/*.md`, but HTTP has no directory-listing protocol; Phase 1 supports single-file http(s) sources).
- **`schedule` accepted + syntax-validated but not acted on**: scheduling is PRD Phase 3; every remote source syncs once at startup (a superset of `@startup`). Documented in mental-model + changelog.
- **`extract` / `extract_pattern` are load-time errors** (Phase 2) rather than silently ingesting raw archives.
- **`gs`/`az`/`ftp`/`sftp`** rejected with a "planned" message (Phase 4); unknown schemes rejected as unsupported.
- **boto3 used directly** (already a core dependency for the OneLLM Bedrock provider) via `asyncio.to_thread` instead of adding aioboto3; the import guard still follows the kafka optional-dep pattern for belt-and-braces.
- **Handler method signatures** follow the PRD interface (`list_files(url, pattern)`, `download_file(url, dest)`), with auth/limits carried on a normalized `SourceConfig` given to the constructor; incremental handlers (rsync) add `sync_tree(url, dest_dir)` since per-file enumeration doesn't fit rsync.
- Event-count references in mental-model.md's observability section were stale (349; actually 418 with the three new events) and were corrected in passing.

### Review follow-ups (Greptile round 1, second commit)

- **Atomic downloads**: HTTP/S3/file handlers now stream into a `.part` temp file in the destination's directory, fsync, then `os.replace` — a mid-stream failure removes the temp and leaves the previous good copy (and its manifest hash) intact, making stale-wins trustworthy. Per-handler atomicity tests + an end-to-end stale-wins test with real handlers.
- **SSH host keys strict by default** (rsync+ssh): `StrictHostKeyChecking=yes` — unknown hosts fail the sync. New per-source opt-in `accept_new_host_keys: true` (bool, rsync+ssh only, load-time validated) enables SSH's trust-on-first-use for those who want it; `accept-new` still rejects changed keys. Documented in mental-model.md with the MITM risk.
- **SSH key temp-file leak fixed**: cleanup now covers failures during write/chmod of the 0600 key file, not just the post-command path (tested by forcing `os.chmod` to raise).
- **AWS auth supports the default credential chain**: `auth: {type: aws}` (optionally with `region`) is now valid — `access_key`/`secret_key` are both-or-neither, matching what `S3Handler` actually supports.

### Sandboxing / path safety

- Synced content can only land inside the per-source content dir: `safe_relative_path` (rejects absolute paths, drive letters, backslashes, NUL, `..` traversal) + `resolve_within` (symlink-resolved containment check) guard both handler-reported paths and manifest entries loaded from disk. Manifests live next to (never inside) the content dir so they are never ingested.
- rsync runs with `--safe-links`; file:// listing skips symlinks.

### Deferred (later phases, seams left)

- Archive extraction (Phase 2) - `extract*` keys fail validation; extraction slots into `SyncManager._sync_enumerated` post-download.
- Cron scheduling (Phase 3) - `schedule` already validated; `SyncManager.sync_source(trigger=...)` takes a trigger label; croniter is already a core dep.
- GCS/Azure/FTP/SFTP (Phase 4) - protocol registry has a `PLANNED_SCHEMES` set; adding a handler is one module + one registry branch.
- Retry/backoff config, bandwidth limits, admin sync API (Phase 3/5).

## Evidence

- Unit suite: **2580 passed, 10 skipped** (after review fixes) (`uv run --extra dev python -m pytest tests/unit -q`), including 117 new tests across `test_remote_knowledge_{manifest,handlers,sync,validation}.py` (handler contracts against local fixtures/mocked boto3/fake rsync, manifest state transitions, sync orchestration + degrade paths, path-traversal guards, config validation, inert-when-unconfigured pin).
- E2E (new, standalone, print SUCCESS / exit 0):
  - `6_knowledge/test_6f1_remote_http_source.py` - local stdlib HTTP fixture server, formation declares an `http://` source, sync at load verified via mirror + manifest, agent answers from the synced content. PASSED.
  - `6_knowledge/test_6f2_remote_source_failure_isolation.py` - unreachable source on a cold start; formation starts, agent answers from its local source, manifest records the failure. PASSED.
- Regression: `cd e2e && uv run python run_random_tests.py 5` - **5/5 PASS** (19_api/test_19f1_agents_crud, 3_multimodal/test_3d2, 3_multimodal/test_3h2, 8_clarification/test_8a2_memory_storage_check, 8_clarification/test_8a2_simple_recall).
- `python scripts/validate_events.py`: 1340/1340 observe() calls valid (100%).
- Lint: black/isort/ruff/flake8 clean on all touched files (two pre-existing ruff I001 findings in `tests/unit/test_mcp_default_parameters.py` are untouched/out of scope).

### Note for reviewers

`.key` symlinks are gitignored; the two new e2e formations create their `.key`/`secrets.enc` symlinks at runtime if missing (pointing at `e2e/assets/`), so the tests are self-sufficient on a fresh checkout with provisioned assets. `secrets.enc` symlinks are committed, matching the other 67 tracked formation symlinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
