### PR TITLE
fix(e2e): stop unit-test 60s pytest-timeout leaking into pytest-based e2e tests

### DIFF
--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -1,0 +1,47 @@
+[pytest]
+# Scoped pytest config for the pytest-based e2e tests (areas 4, 15, 17).
+#
+# Why this file exists: e2e tests are standalone scripts, but a handful
+# drive their test functions through ``pytest.main([__file__])``. Without
+# this file, pytest's rootdir discovery walks up from the test file and
+# lands on the repo-root pytest.ini, whose ``timeout = 60`` is calibrated
+# for *unit* tests. An e2e test function boots a full formation per test
+# (~20s: ONNX classifier warmup alone is ~13s even on a warm HF cache —
+# ~7s CoreML partition negotiation + ~6s embedding the intent prototype
+# sets) and then makes several real-LLM chat turns (~15s each), so the
+# first test in a file needs ~65s and gets killed at 60s.
+#
+# This file becomes the rootdir config for anything under e2e/, giving
+# those tests a per-test ceiling that matches reality. The outer e2e
+# harness (run_all_tests.py) still enforces its own per-file budget, so
+# a genuinely hung test is killed there; this ceiling only needs to be
+# loose enough not to kill healthy tests.
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+# Headroom over the observed worst case: a formation boot plus three
+# sequential real-LLM chat turns is ~65s, but a turn that sends the agent
+# into A2A delegation + sandboxed file generation (itself bounded by a
+# 60s subprocess timeout) can push a single test past 180s (observed in
+# 15a3's business-domain test). timeout_method=thread kills the whole
+# pytest process on expiry, so one slow test aborts the rest of the file
+# — keep this loose; genuinely hung runs are still bounded by the outer
+# harness in CI.
+timeout = 360
+timeout_method = thread
+markers =
+    smoke: quick tests for PR validation
+    regression: full regression suite
+    critical: must-pass tests
+    extended: extended tests (optional)
+    fast: <5 seconds
+    slow: >30 seconds
+    very_slow: >2 minutes
+    requires_postgres: needs a running PostgreSQL
+    requires_faissx: needs a running FAISSx server
+    requires_webhook: needs the webhook test server
+    requires_a2a: needs the A2A registry
+    requires_gpu: needs GPU (multimodal tests)
+    serial: must run sequentially
+    parallel_safe: safe to run in parallel
+    rate_limited: has API rate limits
+    covers: feature-coverage annotation

--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-# Scoped pytest config for the pytest-based e2e tests (areas 4, 15, 17).
+# Scoped pytest config for the pytest-based e2e tests (areas 15, 17).
 #
 # Why this file exists: e2e tests are standalone scripts, but a handful
 # drive their test functions through ``pytest.main([__file__])``. Without
@@ -16,6 +16,14 @@
 # harness (run_all_tests.py) still enforces its own per-file budget, so
 # a genuinely hung test is killed there; this ceiling only needs to be
 # loose enough not to kill healthy tests.
+# Carried over from the root pytest.ini (which no longer applies once this
+# file becomes rootdir config): suppress the importlib DeprecationWarning
+# and pydub's ffmpeg-probe RuntimeWarning (ffmpeg is deliberately absent
+# on CI runners; pydub is an unused transitive of markitdown).
+filterwarnings =
+    ignore::DeprecationWarning:importlib._bootstrap:241
+    ignore::RuntimeWarning:pydub.utils
+
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 # Headroom over the observed worst case: a formation boot plus three


### PR DESCRIPTION
## Problem

`e2e/tests/15_topic_tagging/test_15a3_topic_diversity.py` fails on clean develop with a 60-second timeout, dying during what looks like local ONNX model loading.

## Root cause

Not a cold model download, and not a regression in the classifier init — the e5-small model is cached and warm inference is ~83ms. The failure is a config leak plus compounding startup costs:

- The repo-root `pytest.ini` sets `timeout = 60` (pytest-timeout), added in #155 and calibrated for **unit** tests under `tests/`. The nine e2e scripts that drive their tests through `pytest.main([__file__])` inherit that ceiling via pytest rootdir discovery.
- An e2e test function in 15a3 boots a **full formation per test** (function-scoped fixture, ~20s — of which ~13s is ONNX classifier warmup even on a warm HF cache: ~7s CoreML partition negotiation for the 623-node graph that splits into 97 partitions, plus ~6s embedding the 11 intent prototype sets, both present since the classifier preload landed in `572779fb`) and then makes 3 sequential real-LLM chat turns (~15s each). First test ≈ 65s → killed at 60s.
- `timeout_method = thread` kills the whole pytest process on expiry, so the remaining 7 tests never even ran.

## Fix

New scoped `e2e/pytest.ini` that becomes the rootdir config for anything under `e2e/`:

- same asyncio settings as the root config (`asyncio_mode = auto` is load-bearing for the undecorated async fixtures),
- declares the e2e markers from `tests/common/markers.py`,
- `timeout = 360`: the observed baseline is ~65s/test, but a chat turn that legitimately sends the agent into A2A delegation + sandboxed file generation (itself bounded by a 60s subprocess timeout) pushed 15a3's business-domain test past 180s in verification. Genuinely hung runs stay bounded by the outer harness per-file budgets in CI.

Unit tests are untouched — the root `pytest.ini` keeps its 60s ceiling.

## Verification

- `15a1_topic_extraction`: 7 passed (4:45)
- `15a2_fallback_behavior`: 9 passed
- `15a3_topic_diversity`: 8 passed (9:49) — previously 0 (process killed mid-test-1)
- `run_random_tests.py 5`: 5/5 passed (2_memory, 3_multimodal, 4_mcp, 6_knowledge, 7_orchestration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>