### PR TITLE
perf(embeddings): default CoreML EP off on macOS + halve classifier warmup embed calls

### DIFF
--- a/src/muxi/runtime/services/classification/local_classifier.py
+++ b/src/muxi/runtime/services/classification/local_classifier.py
@@ -181,8 +181,19 @@ class LocalClassifier:
             negative_inputs = [f"query: {t}" for t in spec.negative]
 
             try:
-                pos_vecs = await embed(self.model, positive_inputs)
-                neg_vecs = await embed(self.model, negative_inputs)
+                # Both example sets go out in one embed call and are
+                # split on return — halves the per-call overhead (async
+                # executor hop, provider dispatch) during warmup, which
+                # every formation start pays via the overlord's
+                # classifier preload. The combined batch stays small
+                # (~12-35 rows per intent); do NOT be tempted to batch
+                # ALL intents into one call — ONNX pads every row to
+                # the longest sequence in the batch, and a ~250-row
+                # batch measured 2-15x SLOWER than per-intent calls
+                # under the CoreML execution provider.
+                vectors = await embed(self.model, positive_inputs + negative_inputs)
+                pos_vecs = vectors[: len(positive_inputs)]
+                neg_vecs = vectors[len(positive_inputs) :]
             except Exception as exc:
                 observability.observe(
                     event_type=observability.ErrorEvents.EMBEDDINGS_GENERATION_FAILED,

--- a/src/muxi/runtime/services/memory/embedding.py
+++ b/src/muxi/runtime/services/memory/embedding.py
@@ -80,8 +80,40 @@ They pass through to OneLLM untouched.
 
 from __future__ import annotations
 
+import os
+import sys
+
 import onellm
 from onellm.errors import InvalidRequestError
+
+# macOS default: run local ONNX models on the CPU execution provider.
+#
+# onnxruntime's Darwin/arm64 wheels register CoreMLExecutionProvider by
+# default, but neither of the small encoder models the runtime ships
+# (Nomic v1.5, e5-small) fits CoreML's constraints — the graph splits
+# into ~97 CoreML/CPU partitions and every inference pays the
+# cross-partition round-trips. Measured on an M1 Pro (ORT 1.x, both
+# models warm):
+#
+#   single embed p50   CoreML ~31-35 ms   CPU ~3-12 ms
+#   32-text batch      CoreML ~950 ms     CPU ~400 ms
+#   classifier warmup  CoreML ~6-13 s     CPU ~1.5 s
+#
+# CPU wins on per-request latency (the runtime's stated priority) AND
+# startup, so default CoreML off. ``setdefault`` keeps this a default,
+# not a policy: operators who ship a CoreML-friendly model can export
+# ``ONELLM_COREML_DISABLED=false`` (or any non-truthy value) before
+# startup and OneLLM keeps the CoreML EP. Linux/SIF deployments have
+# no CoreML EP, so this is a Darwin-only concern; the guard just keeps
+# the env var from showing up where it is meaningless.
+#
+# Must run before the first ``onellm`` InferenceSession is constructed
+# — sessions are cached per repo, so a CoreML session created earlier
+# would stick for the process lifetime. This module is the runtime's
+# single embedding chokepoint and is imported before any local model
+# loads, which makes import time here the reliable hook.
+if sys.platform == "darwin":
+    os.environ.setdefault("ONELLM_COREML_DISABLED", "true")
 
 DEFAULT_EMBEDDING_MODEL = "local/nomic-ai/nomic-embed-text-v1.5"
 """Apache-2.0 Nomic v1.5 (768-dim, 8k context, Matryoshka 64-768).


### PR DESCRIPTION
## Context

Follow-up to #257, which noted the local classifier warmup costs ~13s of every formation boot on macOS (~7s CoreML partition negotiation + ~6s sequentially embedding the 11 intent prototype sets). Investigating the "batch the warmup embeds" idea led somewhere better.

## What benchmarking showed (M1 Pro, warm HF cache)

Naively batching all 249 prototype sentences into one embed call made warmup **worse** under CoreML (13–90s, highly variable) — ONNX pads every row to the longest sequence in the batch, and the CoreML EP handles large padded batches pathologically.

The real problem is the CoreML execution provider itself. Neither small encoder the runtime ships fits CoreML's constraints (`Input dim > 16384` on the embedding table), so ORT splits the graph into **~97 CoreML/CPU partitions** — the warnings you've seen during ONNX loads — and every inference pays the cross-partition round-trips:

| | CoreML (default) | CPU-only |
|---|---|---|
| single embed p50 (e5-small) | 30.7 ms | **3.4 ms** |
| single embed p50 (nomic v1.5) | 34.6 ms | **11.8 ms** |
| 32-text batch (nomic) | ~950 ms | **~400 ms** |
| classifier warmup | 6–13 s | **0.7–1.5 s** |
| classifier unit suite | 48.8 s | **7.5 s** |

CPU wins on per-request latency — the runtime's stated priority — *and* startup.

## Changes

1. **`embedding.py`** (the runtime's single embedding chokepoint): `os.environ.setdefault("ONELLM_COREML_DISABLED", "true")` on Darwin, before any ONNX session is constructed. It's a default, not a policy — operators who ship a CoreML-friendly model export the var themselves and `setdefault` never overrides. Linux/SIF deployments have no CoreML EP and are untouched.
2. **`LocalClassifier.register()`**: embeds an intent's positive + negative example sets in one OneLLM call instead of two (22 → 11 warmup calls). Kept per-intent (12–35 rows) rather than one giant batch, per the padding pathology above — there's a comment warning future readers off that cliff.

## Verification

- 45 classifier unit tests pass (and run 6.5× faster)
- ruff + black clean
- e2e area 15: 15a1 (7), 15a2 (9), 15a3 (8) all pass
- `run_random_tests.py 5`: 5/5 (1_foundation, 2_memory, 7_orchestration, 19_api, 21_skills) — the 2_memory draw exercises embedding dimension coexistence on the new CPU path
- Operator override verified: `ONELLM_COREML_DISABLED=false` survives import

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>