### PR TITLE
feat: event substrate - projections, provenance, rebuild (2b-2d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 ## [unreleased]
 
+### Memory event substrate - projections, provenance, rebuild (Phases 2b-2d)
+
+The immutable memory event log (memory-event-substrate PRD) now covers the
+full write-path story on top of the shipped core log + dual-write:
+
+- Incremental projection builders (2b): per-(projection, user) cursors in
+  ``projection_checkpoints`` drive ``project_pending`` (catch a cursor up
+  to the log tail; idempotent, poison events are skipped and reconciled by
+  rebuild) and ``apply_event`` (project one just-appended event). A new
+  artifact-metadata projector rebuilds ``artifacts`` rows from
+  ``artifact.saved`` events (v2 payloads carry the full metadata; v1
+  events are reconstructed deterministically - builders handle every
+  historical payload version); blobs are never touched and pre-substrate
+  rows survive resets.
+- Event-first cutover groundwork (Phase C, flag-gated, DEFAULT OFF):
+  ``memory.events.event_first: true`` makes the extractor, knowledge
+  graph, captain's log, ingestion, and shared-scope write paths append
+  the event and derive the projection through the substrate (synchronous
+  apply + background applier as crash recovery, with cursor snapshots
+  guarding dual-written history). Dual-write remains the default until
+  cutover.
+- Provenance (2c): ``GET /v1/memories/provenance?entity=X`` answers "why
+  do you think X?" - the knowledge graph entity, every fact touching it
+  (contradicted/superseded included), and per-fact causation chains from
+  the event log back to the originating interaction turn or ingestion
+  item. ``?event_id=`` traces a single event. The ``artifacts`` table
+  gains an additive ``derived_from_event_id`` provenance column.
+- Decay at query time (2c): ``memory.decay`` settings (default half-life
+  180d, volatile TTL 24h, per-relationship-type ``half_lives`` map).
+  Volatile events without an explicit expiry are stamped at write time;
+  an hourly maintenance sweep soft-deletes expired volatile events so
+  rebuilds drop their projections. Context-block ranking re-weights
+  facts by half-life age for configured types (no-op by default - the
+  hot read path pays nothing unless the formation opts in).
+- Contradiction audit (2c): knowledge-graph writes that conflict with or
+  supersede an existing exclusive fact now record ``fact.contradicted``
+  events (idempotent per fact pair, ``caused_by``-linked to the
+  extraction) plus a ``memory.fact.contradicted`` observability event.
+  Replay re-marks rows but never re-records audit events.
+- Rebuild & migration (2d): ``POST /memory/rebuild`` (admin) runs as a
+  background job by default (202 + job id, pollable at
+  ``GET /memory/rebuild/{job_id}``; ``background: false`` blocks) - this
+  backs ``muxi memory rebuild --user <id>``. ``POST /memory/backfill``
+  synthesizes idempotent ``source='legacy'`` events for pre-event-log
+  rows (KG entities/relationships, captain's log entries/lessons,
+  artifacts, orphan flat facts); ``rebuild`` accepts ``backfill: true``
+  to do both. ``POST /memory/forget`` is the GDPR flow: soft-delete a
+  source's events (reversible for the retention grace period; the
+  hard-purge worker then removes them), record the ``user.deletion``
+  audit event, and rebuild projections as if the source never existed.
+- Ops: per-user event-log size-cap alert
+  (``memory.events.retention.max_events_per_user``, alert-only per the
+  PRD's SQLite posture), projection lag alerts
+  (``memory.projections.lag_alert_threshold_seconds``), and new
+  observability events (``memory.projection.lagging``,
+  ``memory.event.expired``, ``memory.event.size_cap_exceeded``,
+  ``memory.fact.contradicted``, ``memory.backfill.started/completed``).
+  All new config keys fail-fast validated at load.
+
 ### Knowledge reasoning RAG - Method A tree retrieval (Phase 1)
 
 Large knowledge files are now indexed as hierarchical trees navigated by an

--- a/e2e/tests/2_memory/test_2s1_memory_event_substrate.py
+++ b/e2e/tests/2_memory/test_2s1_memory_event_substrate.py
@@ -151,9 +151,10 @@ class TestMemoryEventSubstrate(BaseMemoryTest):
                     all_passed = False
 
                 registered = sorted(memory_events.projectors)
-                if registered == ["captains_log", "flat_facts", "knowledge_graph"]:
+                core = {"captains_log", "flat_facts", "knowledge_graph"}
+                if core.issubset(set(registered)):
                     print(f"  ✓ Projectors registered: {registered}")
-                    checks_passed.append("All three projectors registered")
+                    checks_passed.append("Core projectors registered")
                 else:
                     print(f"  ✗ Unexpected projector registry: {registered}")
                     all_passed = False
@@ -212,8 +213,7 @@ class TestMemoryEventSubstrate(BaseMemoryTest):
                     all_passed = False
 
                 scoped = all(
-                    e["scope_type"] == "user" and e["scope_id"] == effective_user_id
-                    for e in events
+                    e["scope_type"] == "user" and e["scope_id"] == effective_user_id for e in events
                 )
                 if events and scoped:
                     print("  ✓ Every event carries the forward-compatible user scope")
@@ -274,14 +274,19 @@ class TestMemoryEventSubstrate(BaseMemoryTest):
                 print(f"  ✗ Projection wipe left rows behind: {wiped}")
                 all_passed = False
 
-            # Check 6: full rebuild replays every projection from events
+            # Check 6: full rebuild replays every projection from events.
+            # The three core projections must have replayed events; other
+            # registered projections (artifact_metadata) may legitimately
+            # have none in this conversation but must not fail.
             report = await memory_events.rebuild(effective_user_id)
             print(f"  Rebuild report: {report}")
+            core = {"knowledge_graph", "captains_log", "flat_facts"}
             replayed = all(
-                section["applied"] > 0 and section["failed"] == 0 for section in report.values()
+                report[name]["applied"] > 0 and report[name]["failed"] == 0 for name in core
             )
-            if set(report) == {"knowledge_graph", "captains_log", "flat_facts"} and replayed:
-                print("  ✓ Rebuild replayed events into all three projections")
+            clean = all(section["failed"] == 0 for section in report.values())
+            if core.issubset(set(report)) and replayed and clean:
+                print("  ✓ Rebuild replayed events into all core projections")
                 checks_passed.append("Rebuild replays all projections")
             else:
                 print("  ✗ Rebuild report incomplete or contains failures")

--- a/e2e/tests/2_memory/test_2s2_provenance_and_rebuild.py
+++ b/e2e/tests/2_memory/test_2s2_provenance_and_rebuild.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Test 2S2: Memory Provenance, GDPR Forgetting, and Legacy Backfill
+
+Memory Event Substrate Phases 2b-2d, exercised on a real conversation:
+1. A conversation produces knowledge graph facts whose provenance chains
+   resolve back to the interaction.turn events that caused them
+   ("why do you think X?")
+2. Rebuild-from-events reproduces the prior projections (wipe-and-replay
+   equality on the knowledge graph after real chat traffic)
+3. GDPR selective forgetting: soft-deleting an imported source's events
+   and rebuilding removes exactly that source's derived facts while
+   conversation-derived facts survive
+4. Legacy backfill: a pre-event-log row (direct write, no provenance)
+   gets a synthetic legacy event and becomes replayable
+"""
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+from base_memory_test import BaseMemoryTest  # noqa: E402
+
+
+async def snapshot_graph(knowledge_graph, user_id):
+    """Structural knowledge-graph state keyed by entity names."""
+    entities = await knowledge_graph.storage.list_entities(user_id, status=None, limit=1000)
+    names = {e["id"]: (e["type"], e["name"]) for e in entities}
+    relationships = await knowledge_graph.storage.list_relationships(
+        user_id, status=None, limit=1000
+    )
+    return (
+        {names[e["id"]]: (e["confidence"], e["status"]) for e in entities},
+        {
+            (names[r["from_entity_id"]], r["type"], names[r["to_entity_id"]]): (
+                r["confidence"],
+                r["status"],
+            )
+            for r in relationships
+        },
+    )
+
+
+class TestMemoryProvenanceAndRebuild(BaseMemoryTest):
+    """Provenance chains, GDPR forgetting, and legacy backfill end to end."""
+
+    async def test_provenance_and_rebuild(self):
+        test_name = "2s2_provenance_and_rebuild"
+        self.print_test_header(
+            test_name, "Test provenance chains, GDPR forgetting, and legacy backfill"
+        )
+
+        start_time = time.time()
+        checks_passed = []
+        transcript = []
+        all_passed = True
+        user_id = "provenance_test_user"
+
+        try:
+            # Fresh database for deterministic assertions.
+            for suffix in ("", "-wal", "-shm"):
+                stale = Path.cwd() / f"memory_test.db{suffix}"
+                if stale.exists():
+                    stale.unlink()
+
+            print("\n📝 Phase 1: Conversation producing graph facts...")
+            await self.setup_memory_formation("sqlite")
+            effective_user_id = user_id if self.overlord.is_multi_user else "0"
+
+            memory_events = getattr(self.overlord, "memory_events", None)
+            knowledge_graph = getattr(self.overlord, "knowledge_graph", None)
+            if memory_events is None or knowledge_graph is None:
+                print("  ✗ Memory event substrate or knowledge graph missing")
+                raise RuntimeError("substrate not wired")
+
+            user_msg = (
+                "My name is Jordan and I live in London. I founded a company "
+                "called Automaze and we are building the MUXI project."
+            )
+            response = await self.overlord.chat(
+                user_msg, user_id=user_id, use_async=False, stream=False
+            )
+            response_text = response.content if hasattr(response, "content") else str(response)
+            transcript.append((user_msg, response_text))
+            print(f"User: {user_msg}")
+            print(f"Assistant: {response_text[:200]}...")
+
+            # Extraction is fire-and-forget; wait for graph events to land.
+            graph_events = []
+            for _ in range(12):
+                await asyncio.sleep(5)
+                graph_events = await memory_events.list_events(
+                    effective_user_id, event_types=["graph.extracted"]
+                )
+                if graph_events:
+                    break
+
+            if graph_events:
+                print(f"  ✓ Conversation produced {len(graph_events)} graph.extracted event(s)")
+                checks_passed.append("Graph extraction events recorded")
+            else:
+                print("  ✗ No graph.extracted events recorded")
+                all_passed = False
+
+            # Check 1: provenance query on a real conversation entity.
+            print("\n🔎 Phase 2: Provenance query ('why do you think X?')...")
+            from muxi.runtime.services.memory.events.provenance import entity_provenance
+
+            entities = await knowledge_graph.storage.list_entities(effective_user_id, limit=100)
+            target = next(
+                (e for e in entities if e["name"].lower() != "user"),
+                entities[0] if entities else None,
+            )
+            provenance = None
+            if target is not None:
+                provenance = await entity_provenance(
+                    memory_events,
+                    knowledge_graph,
+                    effective_user_id,
+                    target["name"],
+                    decay=memory_events.decay,
+                )
+            if provenance is not None and provenance["entity"]["events"]:
+                print(
+                    f"  ✓ Entity '{target['name']}' resolves to "
+                    f"{len(provenance['entity']['events'])} event chain(s)"
+                )
+                checks_passed.append("Entity provenance resolves to events")
+            else:
+                print(f"  ✗ No provenance for entity {target}")
+                all_passed = False
+
+            chain_ok = False
+            if provenance is not None:
+                for chains in [provenance["entity"]["events"]] + [
+                    fact["events"] for fact in provenance["facts"]
+                ]:
+                    for chain in chains:
+                        types = [event["event_type"] for event in chain]
+                        if types[0] == "interaction.turn" and types[-1] == "graph.extracted":
+                            chain_ok = True
+                            print(f"  ✓ Causation chain root-first: {' -> '.join(types)}")
+                            break
+                    if chain_ok:
+                        break
+            if chain_ok:
+                checks_passed.append("Chain traces fact to its interaction turn")
+            else:
+                print("  ✗ No chain traced back to an interaction.turn event")
+                all_passed = False
+
+            # Check 2: rebuild-from-events reproduces the projections.
+            print("\n🔄 Phase 3: Rebuild reproduces prior projections...")
+            before = await snapshot_graph(knowledge_graph, effective_user_id)
+            report = await memory_events.rebuild(effective_user_id, projection="knowledge_graph")
+            after = await snapshot_graph(knowledge_graph, effective_user_id)
+            if report["knowledge_graph"]["failed"] == 0 and after == before:
+                print(
+                    f"  ✓ Rebuild replayed {report['knowledge_graph']['applied']} events "
+                    "into an identical graph"
+                )
+                checks_passed.append("Rebuild reproduces prior projections")
+            else:
+                print(f"  ✗ Rebuild diverged: {report}\n    {before}\n    {after}")
+                all_passed = False
+
+            # Check 3: GDPR selective forgetting of an imported source.
+            print("\n🗑  Phase 4: GDPR forgetting of an imported source...")
+            await knowledge_graph.store_extraction(
+                effective_user_id,
+                {
+                    "entities": [{"name": "MailCorp", "type": "company", "confidence": 0.9}],
+                    "relationships": [],
+                },
+                source="gmail",
+            )
+            stored = await knowledge_graph.storage.get_entity(
+                effective_user_id, "company", "MailCorp"
+            )
+            if stored is not None:
+                checks_passed.append("Imported source fact stored")
+            else:
+                print("  ✗ Imported fact did not store")
+                all_passed = False
+
+            forget = await memory_events.forget_source(effective_user_id, "gmail", reason="gdpr")
+            await memory_events.rebuild(effective_user_id, projection="knowledge_graph")
+            gone = await knowledge_graph.storage.get_entity(
+                effective_user_id, "company", "MailCorp"
+            )
+            survivors = await knowledge_graph.storage.list_entities(effective_user_id, limit=100)
+            audit = await memory_events.list_events(
+                effective_user_id, event_types=["user.deletion"]
+            )
+            if forget["deleted_events"] >= 1 and gone is None and survivors and audit:
+                print(
+                    f"  ✓ Forgot {forget['deleted_events']} gmail event(s); rebuild removed "
+                    f"the derived fact; {len(survivors)} conversation facts survive; "
+                    "audit event recorded"
+                )
+                checks_passed.append("GDPR forget + rebuild removes derived state")
+            else:
+                print(
+                    f"  ✗ Forgetting failed (deleted={forget['deleted_events']}, "
+                    f"gone={gone is None}, survivors={len(survivors)}, audit={len(audit)})"
+                )
+                all_passed = False
+
+            # Check 4: legacy backfill makes a pre-event-log row replayable.
+            print("\n🧱 Phase 5: Legacy backfill (synthetic events)...")
+            legacy_row = await knowledge_graph.storage.upsert_entity(
+                effective_user_id, "company", "LegacyCorp", confidence=0.8
+            )
+            if not legacy_row["derived_from_event_ids"]:
+                checks_passed.append("Legacy row created without provenance")
+            backfill_report = await memory_events.backfill_user(effective_user_id)
+            stamped = await knowledge_graph.storage.get_entity(
+                effective_user_id, "company", "LegacyCorp"
+            )
+            legacy_events = await memory_events.list_events(effective_user_id, source="legacy")
+            if (
+                backfill_report.get("knowledge_graph", 0) >= 1
+                and stamped["derived_from_event_ids"]
+                and legacy_events
+            ):
+                print(
+                    f"  ✓ Backfill synthesized {backfill_report['knowledge_graph']} legacy "
+                    "event(s) and stamped provenance in place"
+                )
+                checks_passed.append("Backfill synthesizes legacy events")
+            else:
+                print(f"  ✗ Backfill failed: {backfill_report}, row={stamped}")
+                all_passed = False
+
+            await memory_events.rebuild(effective_user_id, projection="knowledge_graph")
+            replayed = await knowledge_graph.storage.get_entity(
+                effective_user_id, "company", "LegacyCorp"
+            )
+            if replayed is not None and replayed["confidence"] == 0.8:
+                print("  ✓ Rebuild reproduced the legacy row from its synthetic event")
+                checks_passed.append("Legacy row survives rebuild via synthetic event")
+            else:
+                print(f"  ✗ Legacy row lost on rebuild: {replayed}")
+                all_passed = False
+
+            # Check 5: recall still works after all the rebuilds.
+            recall_msg = "Which company did I found?"
+            recall = await self.overlord.chat(
+                recall_msg, user_id=user_id, use_async=False, stream=False
+            )
+            recall_text = recall.content if hasattr(recall, "content") else str(recall)
+            transcript.append((recall_msg, recall_text))
+            print(f"\nUser: {recall_msg}")
+            print(f"Assistant: {recall_text[:300]}...")
+            if "automaze" in recall_text.lower():
+                print("  ✓ Recall intact after forget + backfill + rebuilds")
+                checks_passed.append("Recall intact after rebuild cycle")
+            else:
+                print("  ✗ Recall failed after rebuild cycle")
+                all_passed = False
+
+        except Exception as e:
+            import traceback
+
+            print(f"  ✗ Test failed with error: {e}")
+            traceback.print_exc()
+            all_passed = False
+
+        finally:
+            await self.cleanup()
+
+        duration = time.time() - start_time
+        self.print_test_result(test_name, all_passed, checks_passed, transcript, duration)
+
+        return all_passed
+
+    async def run_test(self):
+        """Run all test cases."""
+        print("\n" + "=" * 60)
+        print("🧾 AREA 2S2: MEMORY PROVENANCE, FORGETTING, AND BACKFILL")
+        print("=" * 60)
+
+        all_passed = await self.test_provenance_and_rebuild()
+
+        print("\n" + "=" * 60)
+        print(
+            f"🎯 OVERALL RESULT: {'✅ ALL TESTS PASSED' if all_passed else '❌ SOME TESTS FAILED'}"
+        )
+        print("=" * 60)
+
+        print("\n💡 KEY INSIGHTS:")
+        print("- 'Why do you think X?' resolves any graph fact to its interaction turn")
+        print("- Forgetting a source + rebuild recomputes memory as if it never existed")
+        print("- Legacy rows become replayable through synthetic backfill events")
+
+        if all_passed:
+            print("SUCCESS", flush=True)
+        return all_passed
+
+
+def main():
+    """Main entry point."""
+    test = TestMemoryProvenanceAndRebuild()
+    result = asyncio.run(test.run_test())
+    os._exit(0 if result else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/mental-model.md
+++ b/mental-model.md
@@ -1489,6 +1489,112 @@ per-source `retrieval:` accepts `vector`/`tree`, rejects the reserved
 both on `formations/formation-tree-reasoning/` (the 6f slot went to the
 remote-knowledge-sources tests that merged concurrently).
 
+### Memory Event Substrate (2026-07-09, Phases 2b-2d)
+
+**Location:** `src/muxi/runtime/services/memory/events/`
+
+The immutable event log underneath every memory projection
+(memory-event-substrate PRD). Every memory-producing write first becomes a
+row in `memory_events`; the knowledge graph, captain's log (+lessons), flat
+facts, and artifact metadata are DERIVED state, rebuildable by replaying
+events in append order.
+
+**Files:**
+- `models.py` — `MemoryEvent` / `ProjectionCheckpoint` tables, the versioned
+  `EVENT_SCHEMAS` payload registry (validated at write), source vocabulary,
+  decay-rate constants. Integer PK doubles as the replay cursor; a partial
+  unique index on `(formation_id, user_id, source, source_id)` is the
+  idempotency key (soft-deleting re-allows a source_id).
+- `storage.py` — append-only persistence: append (idempotent + race-safe),
+  replay listings, soft-delete/hard-purge, volatile expiry, checkpoints.
+  No update surface, ever (pinned by a unit test that enumerates methods).
+- `service.py` — `MemoryEventService`: failure-isolated `record()` (never
+  raises into a write path), projector registry, `apply_event` /
+  `project_pending` (incremental, cursor-gated), `rebuild` (reset -> replay
+  -> checkpoint), `backfill_user`, `forget_source`, `provenance_chain`,
+  and the background loops (hourly maintenance: volatile expiry + hard
+  purge + size-cap alert; event-first applier).
+- `projectors.py` — one projector per projection (`knowledge_graph`,
+  `captains_log`, `flat_facts`, `artifact_metadata`), each with
+  `apply` / `reset` / `event_types` (+ optional `backfill`). `apply` must be
+  a PURE function of the event — no LLM calls, no event recording — so
+  replay is deterministic. It may RETURN info (e.g. contradictions); the
+  live path records derived audit events from it, replay ignores it.
+- `decay.py` — `DecaySettings` (`memory.decay`: default half-life 180d,
+  volatile TTL 24h, per-relationship-type `half_lives`) and the pure math
+  (`0.5 ** (age/half_life)` — true half-life semantics; the PRD sketched
+  `exp(-age/half_life)` under the same parameter name). Applied at QUERY
+  time only; stored confidences never change.
+- `provenance.py` — "why do you think X?" assembly: entity -> facts (any
+  status) -> `derived_from_event_ids` -> `caused_by` chains root-first.
+  Served by `GET /v1/memories/provenance?entity=X` (client route).
+
+**Write posture (dual-write, default):** each write path (extractor,
+graph service, captain's log, ingestion, shared-scope API) appends its
+event first (failure-isolated: append failure never blocks the projection
+write or the turn), then performs its own projection write through the
+SAME apply function the replay uses. Shared-scope API writes are the one
+event-FIRST path even in dual-write mode (no event -> 503, no row), since
+a shared row without provenance would silently survive every rebuild.
+
+**Event-first cutover (`memory.events.event_first: true`, DEFAULT OFF):**
+write paths append the event and derive the projection through
+`apply_event` (synchronous; cursor advances so the background applier
+never double-applies). The applier loop (`memory.projections.
+apply_interval_seconds`, default 5s) is crash recovery; on startup it
+snapshots missing cursors to the log tail so dual-written history is
+never replayed into projections (flat facts would duplicate — their write
+path inserts, it does not upsert). Lag past
+`memory.projections.lag_alert_threshold_seconds` (default 300) emits
+`memory.projection.lagging`.
+
+**Provenance:** every projection row carries `derived_from_event_ids`
+(JSON list; artifacts use a singular additive `derived_from_event_id`
+column). `fact.contradicted` audit events are recorded when a KG write
+conflicts with / supersedes an exclusive fact (idempotent per fact pair,
+`caused_by`-linked to the extraction event) — the marking itself lives in
+`graph/storage.upsert_relationship`, which returns the detections.
+
+**GDPR / forgetting:** `forget_source` soft-deletes a source's live
+events + records `user.deletion`; replay skips soft-deleted events, so a
+rebuild recomputes state as if the source never existed. Reversible until
+the grace period (`memory.events.retention.grace_period_days`, 30d)
+elapses and the hard purge removes the rows. Admin flow:
+`POST /memory/forget {user_id, source, reason, rebuild}`.
+
+**Rebuild & backfill (admin API, backs `muxi memory rebuild`):**
+`POST /memory/rebuild {user_id, projection?, dry_run?, background?,
+backfill?}` — background by default (202 + job id via the request
+tracker, poll `GET /memory/rebuild/{job_id}`). `POST /memory/backfill`
+synthesizes idempotent `source='legacy'` events for pre-event-log rows
+(per-row source_ids like `legacy/kg_entity/<public_id>`); graph/log/
+artifact rows are stamped in place, orphan flat facts become
+provenance-complete on the next rebuild.
+
+**Gotchas:**
+1. **Projector `apply` purity is the whole ballgame.** Recording events
+   inside a projector would duplicate them on every rebuild. Derived
+   audit events (contradictions) are recorded by the CALLER on live
+   paths only.
+2. **Flat-fact applies are inserts, not upserts** — idempotency comes
+   from the cursor, never from re-applying. That is why cursors snapshot
+   to tail before the event-first applier starts, and why the flat-fact
+   backfill does not apply (rebuild stamps provenance instead).
+3. **`artifact.saved` has two payload versions.** v1 (pre-2b) lacks
+   summary/compressed_bytes; the projector reconstructs them
+   deterministically. Builders must keep handling ALL historical
+   versions until events are hard-purged (PRD open question 3).
+4. **Registration order:** the artifact-metadata projector registers
+   inside `_initialize_artifact_memory` (the service exists only then),
+   not in `_register_memory_projectors` with the other three.
+
+**Unit tests:** `tests/unit/test_memory_events_*.py` (schema, storage,
+service, replay, projection cursors, decay, provenance, contradiction,
+backfill, GDPR). **E2E:** `2_memory/test_2s1_memory_event_substrate.py`
+(dual-write + wipe-and-replay equality) and
+`test_2s2_provenance_and_rebuild.py` (provenance chains on a real
+conversation, GDPR forget + rebuild, legacy backfill).
+
 ---
 
 ## 4. LLM Layer

--- a/src/muxi/runtime/datatypes/observability.py
+++ b/src/muxi/runtime/datatypes/observability.py
@@ -839,6 +839,25 @@ class ConversationEvents(Enum):
     MEMORY_DELETION_HARD_PURGED = "memory.deletion.hard_purged"
     # When the post-grace-period hard purge removes soft-deleted events
 
+    # Memory event substrate Phases 2b-2d (projections, provenance, rebuild)
+    MEMORY_PROJECTION_LAGGING = "memory.projection.lagging"
+    # When a projection cursor falls behind the event tail past the threshold
+
+    MEMORY_EVENT_EXPIRED = "memory.event.expired"
+    # When the maintenance sweep soft-deletes expired volatile events
+
+    MEMORY_EVENT_SIZE_CAP_EXCEEDED = "memory.event.size_cap_exceeded"
+    # When a user's event log exceeds the configured per-user size cap
+
+    MEMORY_FACT_CONTRADICTED = "memory.fact.contradicted"
+    # When a knowledge graph write contradicts an existing exclusive fact
+
+    MEMORY_BACKFILL_STARTED = "memory.backfill.started"
+    # When a legacy backfill (synthetic events for pre-event-log rows) starts
+
+    MEMORY_BACKFILL_COMPLETED = "memory.backfill.completed"
+    # When a legacy backfill finishes (per-projection counts attached)
+
     # Memory ingestion pipeline (Memory Ingestion Phase 3a)
     MEMORY_INGESTION_ACCEPTED = "memory.ingestion.accepted"
     # When POST /v1/memories(/batch) accepts items and enqueues processing

--- a/src/muxi/runtime/formation/initialization.py
+++ b/src/muxi/runtime/formation/initialization.py
@@ -763,7 +763,7 @@ def initialize_memory_systems(formation) -> None:
                 # Initialize the memory event substrate first: the knowledge
                 # graph and captain's log dual-write through it, so it must
                 # exist before they are constructed.
-                _initialize_memory_events(formation, memory_config.get("events", {}) or {})
+                _initialize_memory_events(formation, memory_config)
 
                 # Initialize the knowledge graph service (Memory Revamp Phase 1).
                 # Placed after table creation (kg_entities/kg_relationships must
@@ -789,25 +789,37 @@ def initialize_memory_systems(formation) -> None:
                 _initialize_artifact_memory(formation)
 
 
-def _initialize_memory_events(formation, events_config: Dict[str, Any]) -> None:
-    """Initialize the memory event substrate on top of persistent memory."""
+def _initialize_memory_events(formation, memory_config: Dict[str, Any]) -> None:
+    """Initialize the memory event substrate on top of persistent memory.
+
+    Reads three sibling sections of the memory config: ``events`` (the
+    substrate itself: retention, event_first cutover flag), ``projections``
+    (incremental applier interval + lag alerting), and ``decay``
+    (query-time decay settings, also shared with the knowledge graph).
+    Configuration errors fail fast (ValueError from the service/decay
+    constructors) and disable the substrate with a logged warning.
+    """
+    events_config = memory_config.get("events", {}) or {}
     if events_config.get("enabled", True) is False:
         formation._memory_events = None
         return
 
     try:
-        from ..services.memory.events import MemoryEventService
+        from ..services.memory.events import DecaySettings, MemoryEventService
 
         formation_id = getattr(formation, "formation_id", "default-formation")
         formation._memory_events = MemoryEventService(
             db_manager=formation._db_manager,
             formation_id=formation_id,
             config=events_config,
+            projections_config=memory_config.get("projections", {}) or {},
+            decay=DecaySettings(memory_config.get("decay", {}) or {}),
         )
+        posture = "event-first" if formation._memory_events.event_first else "dual-write"
         print(
             InitEventFormatter.format_ok(
                 "Initializing memory event substrate",
-                f"grace period {formation._memory_events.grace_period_days}d",
+                f"{posture}, grace period {formation._memory_events.grace_period_days}d",
             )
         )
     except Exception as e:
@@ -846,6 +858,15 @@ def _initialize_artifact_memory(formation) -> None:
             formation_dir=formation_dir,
             memory_events=getattr(formation, "_memory_events", None),
         )
+        # Register the artifact-metadata projection with the substrate
+        # (Memory Substrate Phase 2b). Registered here rather than in
+        # _register_memory_projectors because the artifact service is
+        # constructed after the other projections.
+        memory_events = getattr(formation, "_memory_events", None)
+        if memory_events is not None:
+            from ..services.memory.events import ArtifactMetadataProjector
+
+            memory_events.register_projector(ArtifactMetadataProjector(formation._artifact_memory))
         settings = formation._artifact_memory.settings
         retention = f"{settings.retention_days}d" if settings.retention_days else "forever"
         print(
@@ -903,11 +924,13 @@ def _initialize_knowledge_graph(formation, graph_config: Dict[str, Any]) -> None
         from ..services.memory.graph import KnowledgeGraphService
 
         formation_id = getattr(formation, "formation_id", "default-formation")
+        memory_events = getattr(formation, "_memory_events", None)
         formation._knowledge_graph = KnowledgeGraphService(
             db_manager=formation._db_manager,
             formation_id=formation_id,
             config=graph_config,
-            event_log=getattr(formation, "_memory_events", None),
+            event_log=memory_events,
+            decay=getattr(memory_events, "decay", None),
         )
         backend = "pgRouting" if formation._knowledge_graph.pgrouting_available else "NetworkX"
         print(InitEventFormatter.format_ok("Initializing knowledge graph", f"{backend} backend"))
@@ -1251,6 +1274,40 @@ def _migrate_add_derived_from_event_ids_column(db_manager, table_name: str) -> N
         pass  # Table may not exist yet on first run; create_tables handles it
 
 
+def _migrate_add_derived_from_event_id_column(db_manager, table_name: str) -> None:
+    """Add the singular provenance column to tables from older schema versions.
+
+    Additive migration (Memory Substrate Phase 2c): the column stays NULL
+    on existing rows until a legacy backfill stamps them; rows written
+    after this migration carry the artifact.saved event id they derive
+    from.
+    """
+    from sqlalchemy import text
+
+    try:
+        with db_manager.engine.connect() as conn:
+            if db_manager.database_type == "postgresql":
+                conn.execute(
+                    text(
+                        f"ALTER TABLE {table_name} ADD COLUMN IF NOT EXISTS "
+                        f"derived_from_event_id INTEGER"
+                    )
+                )
+            else:
+                # SQLite: check if column exists via PRAGMA, add if missing
+                result = conn.execute(text(f"PRAGMA table_info({table_name})"))
+                columns = [row[1] for row in result]
+                if "derived_from_event_id" not in columns:
+                    conn.execute(
+                        text(
+                            f"ALTER TABLE {table_name} ADD COLUMN " f"derived_from_event_id INTEGER"
+                        )
+                    )
+            conn.commit()
+    except Exception:
+        pass  # Table may not exist yet on first run; create_tables handles it
+
+
 def _migrate_add_scope_columns(db_manager, table_name: str) -> None:
     """Add the memory-namespaces scope columns to memories tables from older schema versions.
 
@@ -1407,6 +1464,10 @@ def _create_all_database_tables(db_manager, embedding_dimension: int = 1536) -> 
         # created before the memory event substrate shipped
         for projection_table in ("kg_entities", "kg_relationships", "captains_log", "lessons"):
             _migrate_add_derived_from_event_ids_column(db_manager, projection_table)
+        # Migrate: ensure the singular provenance column exists on the
+        # artifacts table created before the artifact-metadata projection
+        # shipped (Memory Substrate Phase 2c, additive)
+        _migrate_add_derived_from_event_id_column(db_manager, "artifacts")
         # Migrate: ensure the memory-namespaces scope columns exist on
         # memories tables created before the scope substrate shipped.
         # Covers ALL memories_{dim} tables, not just the active dimension's:

--- a/src/muxi/runtime/formation/server/routes/admin/memory.py
+++ b/src/muxi/runtime/formation/server/routes/admin/memory.py
@@ -40,11 +40,45 @@ class MemoryItemUpdate(BaseModel):
 
 
 class MemoryRebuildRequest(BaseModel):
-    """Model for a memory projection rebuild request."""
+    """Model for a memory projection rebuild request.
+
+    ``background`` (default True, the PRD's recommended posture) runs the
+    rebuild as a tracked background job and returns a ``job_id`` pollable
+    at GET /memory/rebuild/{job_id}; ``background: false`` blocks until
+    the rebuild finishes and returns the report inline (the CLI's forced
+    rebuild). ``backfill`` first synthesizes legacy events for
+    pre-event-log rows (Phase B migration) so the rebuild reproduces them.
+    """
 
     user_id: str
     projection: Optional[str] = None
     dry_run: bool = False
+    background: bool = True
+    backfill: bool = False
+
+
+class MemoryBackfillRequest(BaseModel):
+    """Model for a legacy memory backfill request (Phase B migration)."""
+
+    user_id: str
+
+
+class MemoryForgetRequest(BaseModel):
+    """Model for a GDPR / selective-forgetting request.
+
+    Soft-deletes every live memory event from ``source`` for the user and
+    records the user.deletion audit event. With ``rebuild`` (default
+    True) the projections are recomputed immediately, so derived state
+    reflects the forgetting; otherwise the events stay excluded from any
+    later rebuild. Soft-deleted events are reversible until the
+    retention grace period elapses and the hard-purge worker removes
+    them.
+    """
+
+    user_id: str
+    source: str
+    reason: str = "user_request"
+    rebuild: bool = True
 
 
 @router.get("/memory", response_model=APIResponse)
@@ -146,6 +180,33 @@ async def get_buffer_stats(request: Request) -> JSONResponse:
     return JSONResponse(content=response.model_dump(), status_code=200)
 
 
+def _memory_events_or_error(request: Request, request_id):
+    """Resolve the overlord's memory event service, or a formed 503."""
+    formation = request.app.state.formation
+    overlord = getattr(formation, "_overlord", None)
+    memory_events = getattr(overlord, "memory_events", None) if overlord else None
+    if memory_events is None:
+        response = create_error_response(
+            "SERVICE_UNAVAILABLE",
+            "Memory event substrate is not available",
+            None,
+            request_id,
+        )
+        return None, None, JSONResponse(content=response.model_dump(), status_code=503)
+    return memory_events, overlord, None
+
+
+async def _run_memory_job(memory_events, job: MemoryRebuildRequest) -> Dict[str, Any]:
+    """One rebuild (optionally backfill-first) pass; returns the report."""
+    data: Dict[str, Any] = {"user_id": job.user_id, "dry_run": job.dry_run}
+    if job.backfill and not job.dry_run:
+        data["backfill"] = await memory_events.backfill_user(job.user_id)
+    data["projections"] = await memory_events.rebuild(
+        job.user_id, projection=job.projection, dry_run=job.dry_run
+    )
+    return data
+
+
 @router.post("/memory/rebuild", response_model=APIResponse, operation_id="rebuild_memory")
 async def rebuild_memory_projections(
     request: Request, rebuild: MemoryRebuildRequest
@@ -157,25 +218,65 @@ async def rebuild_memory_projections(
     memory events through the projection builders. Omit ``projection`` to
     rebuild every registered projection; set ``dry_run`` to report the
     event counts that would be replayed without touching derived state.
-    """
-    formation = request.app.state.formation
-    request_id = getattr(request.state, "request_id", None)
 
-    overlord = getattr(formation, "_overlord", None)
-    memory_events = getattr(overlord, "memory_events", None) if overlord else None
-    if memory_events is None:
+    By default the rebuild runs as a background job (202 + ``job_id``,
+    pollable at GET /memory/rebuild/{job_id}); ``background: false``
+    blocks and returns the report inline. This endpoint backs the
+    ``muxi memory rebuild --user <id>`` CLI command.
+    """
+    request_id = getattr(request.state, "request_id", None)
+    memory_events, overlord, error_response = _memory_events_or_error(request, request_id)
+    if error_response:
+        return error_response
+
+    if rebuild.projection is not None and rebuild.projection not in memory_events.projectors:
         response = create_error_response(
-            "SERVICE_UNAVAILABLE",
-            "Memory event substrate is not available",
+            "INVALID_PARAMS",
+            f"Unknown projection {rebuild.projection!r}; "
+            f"registered: {sorted(memory_events.projectors)}",
             None,
             request_id,
         )
-        return JSONResponse(content=response.model_dump(), status_code=503)
+        return JSONResponse(content=response.model_dump(), status_code=422)
+
+    if rebuild.background and not rebuild.dry_run:
+        import asyncio
+        import time
+
+        from .....utils.id_generator import get_default_nanoid
+        from ....background.request_tracker import RequestState, RequestStatus
+
+        job_id = f"rebuild_{get_default_nanoid()}"
+        tracker = overlord.request_tracker
+        state = RequestState(
+            id=job_id,
+            status=RequestStatus.PROCESSING,
+            start_time=time.time(),
+            user_id=rebuild.user_id,
+        )
+        await tracker.track_request(job_id, state)
+
+        async def _job():
+            try:
+                result = await _run_memory_job(memory_events, rebuild)
+                await tracker.update_request(job_id, status=RequestStatus.COMPLETED, result=result)
+            except Exception as e:
+                await tracker.update_request(job_id, status=RequestStatus.FAILED, error=str(e))
+
+        state.task_ref = asyncio.create_task(_job())
+        data = {
+            "user_id": rebuild.user_id,
+            "job_id": job_id,
+            "status": "processing",
+            "status_url": f"/memory/rebuild/{job_id}",
+        }
+        response = create_success_response(
+            APIObjectType.MEMORY, APIEventType.MEMORY_RETRIEVED, data, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=202)
 
     try:
-        report = await memory_events.rebuild(
-            rebuild.user_id, projection=rebuild.projection, dry_run=rebuild.dry_run
-        )
+        data = await _run_memory_job(memory_events, rebuild)
     except ValueError as e:
         response = create_error_response("INVALID_PARAMS", str(e), None, request_id)
         return JSONResponse(content=response.model_dump(), status_code=422)
@@ -185,9 +286,122 @@ async def rebuild_memory_projections(
         )
         return JSONResponse(content=response.model_dump(), status_code=500)
 
-    data = {"user_id": rebuild.user_id, "dry_run": rebuild.dry_run, "projections": report}
     response = create_success_response(
         APIObjectType.MEMORY, APIEventType.MEMORY_RETRIEVED, data, request_id
+    )
+    return JSONResponse(content=response.model_dump(), status_code=200)
+
+
+@router.get(
+    "/memory/rebuild/{job_id}",
+    response_model=APIResponse,
+    operation_id="get_memory_rebuild_status",
+)
+async def get_memory_rebuild_status(request: Request, job_id: str) -> JSONResponse:
+    """Poll a background memory rebuild job (completed reports attached)."""
+    request_id = getattr(request.state, "request_id", None)
+    formation = request.app.state.formation
+    overlord = getattr(formation, "_overlord", None)
+    if overlord is None:
+        response = create_error_response(
+            "SERVICE_UNAVAILABLE", "Overlord service is not available", None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=503)
+
+    state = await overlord.request_tracker.get_request(job_id)
+    if state is None:
+        response = create_error_response(
+            "NOT_FOUND", f"Unknown or expired rebuild job '{job_id}'", None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=404)
+
+    data: Dict[str, Any] = {"job_id": job_id, "status": state.status.value}
+    if state.error:
+        data["error"] = state.error
+    if isinstance(state.result, dict):
+        data.update(state.result)
+    response = create_success_response(
+        APIObjectType.MEMORY, APIEventType.MEMORY_RETRIEVED, data, request_id
+    )
+    return JSONResponse(content=response.model_dump(), status_code=200)
+
+
+@router.post("/memory/backfill", response_model=APIResponse, operation_id="backfill_memory")
+async def backfill_memory_events(request: Request, backfill: MemoryBackfillRequest) -> JSONResponse:
+    """
+    Synthesize legacy memory events for pre-event-log rows (Phase B).
+
+    Scans the user's projections for rows without event provenance and
+    appends ``source='legacy'`` events keyed per row -- idempotent, so
+    re-running never duplicates. Graph, log, and artifact rows are
+    stamped in place; flat-fact rows become provenance-complete on the
+    next rebuild (POST /memory/rebuild with ``backfill: true`` does both
+    in one call).
+    """
+    request_id = getattr(request.state, "request_id", None)
+    memory_events, _overlord, error_response = _memory_events_or_error(request, request_id)
+    if error_response:
+        return error_response
+
+    try:
+        report = await memory_events.backfill_user(backfill.user_id)
+    except ValueError as e:
+        response = create_error_response("INVALID_PARAMS", str(e), None, request_id)
+        return JSONResponse(content=response.model_dump(), status_code=422)
+    except Exception as e:
+        response = create_error_response(
+            "INTERNAL_ERROR", f"Failed to backfill memory events: {str(e)}", None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=500)
+
+    data = {"user_id": backfill.user_id, "synthesized": report}
+    response = create_success_response(
+        APIObjectType.MEMORY, APIEventType.MEMORY_RETRIEVED, data, request_id
+    )
+    return JSONResponse(content=response.model_dump(), status_code=200)
+
+
+@router.post("/memory/forget", response_model=APIResponse, operation_id="forget_memory_source")
+async def forget_memory_source(request: Request, forget: MemoryForgetRequest) -> JSONResponse:
+    """
+    Forget every memory derived from a source (GDPR / selective forgetting).
+
+    Soft-deletes the user's live events from ``source`` (reversible until
+    the retention grace period elapses; the hard-purge worker then
+    removes them permanently), records the user.deletion audit event,
+    and -- unless ``rebuild: false`` -- recomputes the projections so
+    derived state reflects a world where the source was never imported.
+    """
+    request_id = getattr(request.state, "request_id", None)
+    memory_events, _overlord, error_response = _memory_events_or_error(request, request_id)
+    if error_response:
+        return error_response
+
+    try:
+        result = await memory_events.forget_source(
+            forget.user_id, forget.source, reason=forget.reason
+        )
+        data: Dict[str, Any] = {
+            "user_id": forget.user_id,
+            "source": forget.source,
+            "deleted_events": result["deleted_events"],
+            "grace_period_days": memory_events.grace_period_days,
+        }
+        if forget.rebuild:
+            data["projections"] = await memory_events.rebuild(forget.user_id)
+        else:
+            data["rebuild_required"] = result["rebuild_required"]
+    except ValueError as e:
+        response = create_error_response("INVALID_PARAMS", str(e), None, request_id)
+        return JSONResponse(content=response.model_dump(), status_code=422)
+    except Exception as e:
+        response = create_error_response(
+            "INTERNAL_ERROR", f"Failed to forget memory source: {str(e)}", None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=500)
+
+    response = create_success_response(
+        APIObjectType.MEMORY, APIEventType.MEMORY_DELETED, data, request_id
     )
     return JSONResponse(content=response.model_dump(), status_code=200)
 

--- a/src/muxi/runtime/formation/server/routes/client/memory.py
+++ b/src/muxi/runtime/formation/server/routes/client/memory.py
@@ -382,6 +382,12 @@ async def _write_shared_memory(
         )
         return None, JSONResponse(content=response.model_dump(), status_code=503)
 
+    if getattr(memory_events, "event_first", False):
+        # Event-first cutover (flag-gated, default off): route the apply
+        # through the substrate so the projection cursor advances and the
+        # background applier never re-applies (duplicates) this fact.
+        await memory_events.apply_event(event)
+        return None, None
     memory_id = await apply_fact_event(
         overlord.long_term_memory,
         user_id,
@@ -953,6 +959,105 @@ async def get_ingestion_status(
 
     response = create_success_response(
         APIObjectType.MEMORY_INGESTION, APIEventType.MEMORY_INGESTION_STATUS, data, request_id
+    )
+    return JSONResponse(content=response.model_dump(), status_code=200)
+
+
+@router.get(
+    "/memories/provenance", response_model=APIResponse, operation_id="get_memory_provenance"
+)
+async def get_memory_provenance(
+    request: Request,
+    x_user_id: Optional[str] = Header(None, alias="X-Muxi-User-ID"),
+    entity: Optional[str] = Query(
+        None, description="Knowledge graph entity name to explain (e.g. 'London')"
+    ),
+    event_id: Optional[str] = Query(
+        None, description="Public id of a memory event to trace instead of an entity"
+    ),
+) -> JSONResponse:
+    """
+    Answer "why do you think X?" (Memory Event Substrate Phase 2c).
+
+    With ``entity``: returns the knowledge graph entity, every fact
+    (relationship) touching it -- including contradicted and superseded
+    facts, so disagreements stay explainable -- and, per fact, the full
+    causation chains from the immutable event log (extraction events back
+    to the interaction turn or ingestion item that produced them).
+    Confidence is reported both as stored and as the query-time effective
+    value after decay.
+
+    With ``event_id``: returns that event's causation chain directly.
+    """
+    formation = request.app.state.formation
+    request_id = getattr(request.state, "request_id", None)
+
+    user_id, error_response = _get_user_id(x_user_id, request_id)
+    if error_response:
+        return error_response
+
+    if not entity and not event_id:
+        response = create_error_response(
+            "INVALID_PARAMS",
+            "Provide 'entity' (a knowledge graph entity name) or 'event_id'",
+            None,
+            request_id,
+        )
+        return JSONResponse(content=response.model_dump(), status_code=422)
+
+    overlord = getattr(formation, "_overlord", None)
+    memory_events = getattr(overlord, "memory_events", None) if overlord else None
+    knowledge_graph = getattr(overlord, "knowledge_graph", None) if overlord else None
+    if memory_events is None:
+        response = create_error_response(
+            "SERVICE_UNAVAILABLE",
+            "Memory event substrate is not available",
+            None,
+            request_id,
+        )
+        return JSONResponse(content=response.model_dump(), status_code=503)
+
+    # Same identity pipeline as the other memory reads (middleware may
+    # rewrite the identity; RBAC may reject).
+    user_id, _permissions, error_response = await _run_request_pipeline(
+        formation, user_id, request_id, "/v1/memories/provenance"
+    )
+    if error_response:
+        return error_response
+
+    from .....services.memory.events.provenance import entity_provenance, event_provenance
+
+    try:
+        if entity:
+            if knowledge_graph is None:
+                response = create_error_response(
+                    "SERVICE_UNAVAILABLE",
+                    "Knowledge graph is not available",
+                    None,
+                    request_id,
+                )
+                return JSONResponse(content=response.model_dump(), status_code=503)
+            data = await entity_provenance(
+                memory_events, knowledge_graph, user_id, entity, decay=memory_events.decay
+            )
+            missing = f"Unknown entity '{entity}'"
+        else:
+            data = await event_provenance(
+                memory_events, user_id, event_id, decay=memory_events.decay
+            )
+            missing = f"Unknown event '{event_id}'"
+    except Exception as e:
+        response = create_error_response(
+            "INTERNAL_ERROR", f"Failed to resolve provenance: {str(e)}", None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=500)
+
+    if data is None:
+        response = create_error_response("NOT_FOUND", missing, None, request_id)
+        return JSONResponse(content=response.model_dump(), status_code=404)
+
+    response = create_success_response(
+        APIObjectType.MEMORY, APIEventType.MEMORY_RETRIEVED, data, request_id
     )
     return JSONResponse(content=response.model_dump(), status_code=200)
 

--- a/src/muxi/runtime/services/memory/artifacts/models.py
+++ b/src/muxi/runtime/services/memory/artifacts/models.py
@@ -94,6 +94,12 @@ class Artifact(Base, AsyncModelMixin):
     # Soft delete: metadata is retained for audit, the blob is removed.
     deleted_at = Column(DateTime, nullable=True)
 
+    # Provenance bridge (Memory Event Substrate Phase 2c): the
+    # artifact.saved memory event this row derives from. NULL on
+    # pre-substrate rows until a legacy backfill stamps them; rows with a
+    # value are event-sourced and are wiped/recreated by rebuilds.
+    derived_from_event_id = Column(Integer, nullable=True)
+
     __table_args__ = (
         # Chain-head integrity: at most one live latest version per
         # (formation, user, name). This is the multi-process backstop for
@@ -159,4 +165,5 @@ class Artifact(Base, AsyncModelMixin):
             ),
             "expires_at": self.expires_at.isoformat() if self.expires_at else None,
             "deleted_at": self.deleted_at.isoformat() if self.deleted_at else None,
+            "derived_from_event_id": self.derived_from_event_id,
         }

--- a/src/muxi/runtime/services/memory/artifacts/service.py
+++ b/src/muxi/runtime/services/memory/artifacts/service.py
@@ -492,9 +492,14 @@ class ArtifactMemoryService:
             )
 
     async def _record_saved_event_inner(self, row: Dict[str, Any]) -> None:
-        await self.memory_events.record(
+        # v2 payload (Memory Substrate Phase 2b): carries the full
+        # metadata column set so the artifact-metadata projector can
+        # rebuild the row losslessly. The row is then stamped with its
+        # provenance bridge, marking it event-sourced (rebuildable).
+        event = await self.memory_events.record(
             user_id=row["user_id"],
             event_type=EVENT_ARTIFACT_SAVED,
+            event_version=2,
             payload={
                 "artifact_id": row["public_id"],
                 "name": row["name"],
@@ -504,12 +509,17 @@ class ArtifactMemoryService:
                 "size_bytes": row["size_bytes"],
                 "checksum_sha256": row["checksum_sha256"],
                 "storage_ref": row["storage_ref"],
+                "tags": row["tags"],
+                "summary": row["summary"],
+                "compressed_bytes": row["compressed_bytes"],
             },
             source=SOURCE_ARTIFACT_MEMORY,
             source_id=f"artifact/{row['public_id']}",
             agent_id=row["agent_id"],
             conversation_id=row["conversation_id"],
         )
+        if event is not None:
+            await self.storage.set_derived_event(row["id"], event["id"])
 
     # ------------------------------------------------------------------
     # Reads (round-trip verification / future retrieval surface)

--- a/src/muxi/runtime/services/memory/artifacts/storage.py
+++ b/src/muxi/runtime/services/memory/artifacts/storage.py
@@ -105,6 +105,8 @@ class ArtifactMemoryStorage:
         agent_id: Optional[str] = None,
         conversation_id: Optional[str] = None,
         expires_at: Optional[datetime] = None,
+        created_at: Optional[datetime] = None,
+        derived_from_event_id: Optional[int] = None,
     ) -> Dict[str, Any]:
         """
         Insert one artifact row, extending the version chain on name match.
@@ -116,6 +118,10 @@ class ArtifactMemoryStorage:
         IntegrityError the transaction is rolled back and re-run once
         against the re-read head; a second loss propagates to the
         failure-isolated capture path.
+
+        ``created_at`` / ``derived_from_event_id`` are the replay path's
+        stamps (artifact-metadata projector): a rebuilt row keeps its
+        original capture time and its provenance bridge into the event log.
 
         Returns the inserted row as a dict (version/parent_id reflect the
         chain position).
@@ -135,6 +141,8 @@ class ArtifactMemoryStorage:
             "agent_id": agent_id,
             "conversation_id": conversation_id,
             "expires_at": expires_at,
+            "created_at": created_at,
+            "derived_from_event_id": derived_from_event_id,
         }
         try:
             return await self._insert_version(**fields)
@@ -157,6 +165,8 @@ class ArtifactMemoryStorage:
         agent_id: Optional[str],
         conversation_id: Optional[str],
         expires_at: Optional[datetime],
+        created_at: Optional[datetime] = None,
+        derived_from_event_id: Optional[int] = None,
     ) -> Dict[str, Any]:
         """One read-head -> demote -> insert transaction (see save_artifact)."""
         async with self.db_manager.get_async_session() as session:
@@ -203,7 +213,12 @@ class ArtifactMemoryStorage:
                 compressed_bytes=compressed_bytes,
                 checksum_sha256=checksum_sha256,
                 expires_at=expires_at,
+                derived_from_event_id=derived_from_event_id,
             )
+            if created_at is not None:
+                artifact.created_at = created_at
+                artifact.updated_at = created_at
+                artifact.last_accessed_at = created_at
             session.add(artifact)
             await session.flush()
             return artifact.to_dict()
@@ -258,6 +273,47 @@ class ArtifactMemoryStorage:
             if expires_at is not None:
                 artifact.expires_at = expires_at
             await session.flush()
+
+    # ------------------------------------------------------------------
+    # Event substrate support (provenance stamping + rebuild)
+    # ------------------------------------------------------------------
+
+    async def set_derived_event(self, artifact_id: int, event_id: int) -> None:
+        """Stamp a row's provenance bridge into the memory event log.
+
+        Idempotent: an already-stamped row keeps its original event id
+        (the first artifact.saved event is the row's origin; replays and
+        backfills must not rewrite history).
+        """
+        async with self.db_manager.get_async_session() as session:
+            artifact = await session.get(Artifact, artifact_id)
+            if artifact is None or artifact.derived_from_event_id is not None:
+                return
+            artifact.derived_from_event_id = event_id
+            await session.flush()
+
+    async def delete_event_sourced_for_user(self, user_id: str) -> int:
+        """
+        Delete the user's event-sourced metadata rows (rebuild support).
+
+        Only rows carrying a ``derived_from_event_id`` are removed --
+        replaying artifact.saved events recreates exactly those. Blobs
+        are never touched: they live in artifact storage and are not a
+        projection. Pre-substrate rows (NULL provenance) survive so a
+        rebuild can never orphan a blob's only metadata. Returns the
+        number of rows deleted.
+        """
+        from sqlalchemy import delete as sql_delete
+
+        async with self.db_manager.get_async_session() as session:
+            stmt = (
+                sql_delete(Artifact)
+                .where(Artifact.user_id == str(user_id))
+                .where(Artifact.formation_id == self.formation_id)
+                .where(Artifact.derived_from_event_id.is_not(None))
+            )
+            result = await session.execute(stmt)
+            return int(result.rowcount or 0)
 
     # ------------------------------------------------------------------
     # Retention (soft delete of expired rows)

--- a/src/muxi/runtime/services/memory/events/__init__.py
+++ b/src/muxi/runtime/services/memory/events/__init__.py
@@ -8,7 +8,10 @@
 # Author:       Muxi Framework Team
 # =============================================================================
 
+from .decay import DecaySettings
 from .models import (
+    EVENT_ARTIFACT_SAVED,
+    EVENT_FACT_CONTRADICTED,
     EVENT_FACT_EXTRACTED,
     EVENT_GRAPH_EXTRACTED,
     EVENT_INGESTION_FILTERED,
@@ -22,6 +25,7 @@ from .models import (
     append_event_id,
 )
 from .projectors import (
+    ArtifactMetadataProjector,
     CaptainsLogProjector,
     FlatFactProjector,
     KnowledgeGraphProjector,
@@ -31,6 +35,8 @@ from .service import MemoryEventService
 from .storage import MemoryEventStorage
 
 __all__ = [
+    "EVENT_ARTIFACT_SAVED",
+    "EVENT_FACT_CONTRADICTED",
     "EVENT_FACT_EXTRACTED",
     "EVENT_GRAPH_EXTRACTED",
     "EVENT_INGESTION_FILTERED",
@@ -42,7 +48,9 @@ __all__ = [
     "MemoryEvent",
     "ProjectionCheckpoint",
     "append_event_id",
+    "ArtifactMetadataProjector",
     "CaptainsLogProjector",
+    "DecaySettings",
     "FlatFactProjector",
     "KnowledgeGraphProjector",
     "apply_fact_event",

--- a/src/muxi/runtime/services/memory/events/decay.py
+++ b/src/muxi/runtime/services/memory/events/decay.py
@@ -1,0 +1,169 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Memory Decay - Query-Time Confidence Weighting
+# Description:  Exponential half-life decay for memory events and projections
+# Role:         Pure decay math + validated settings (Memory Substrate 2c)
+# Usage:        DecaySettings built in formation init, applied at query time
+# Author:       Muxi Framework Team
+#
+# Memory Event Substrate Phase 2c (PRD "Decay Model"). Decay is applied at
+# QUERY time only -- stored confidences are never rewritten, so decay
+# changes take effect immediately and retroactively:
+#
+# - ``static`` events/facts never fade.
+# - ``decaying`` events/facts lose confidence exponentially:
+#   effective = confidence * 0.5 ** (age_days / half_life_days).
+#   (True half-life semantics: at age == half_life the confidence has
+#   halved. The PRD sketches exp(-age/half_life); the parameter is named
+#   half_life, so the mathematically honest form is used.)
+# - ``volatile`` events expire entirely at ``expires_at`` (defaulted to
+#   occurred_at + volatile_default_ttl_hours at write time); after expiry
+#   their effective confidence is 0.0 and the maintenance sweep
+#   soft-deletes them so rebuilds drop their projections.
+#
+# Projection rows do not carry a decay declaration -- which knowledge
+# graph relationship types decay (and how fast) is formation policy,
+# configured under ``memory.decay.half_lives`` (type -> days). MUXI ships
+# the mechanism; the default is an empty map, so nothing decays unless
+# the formation says so.
+# =============================================================================
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from ....utils.datetime_utils import utc_now_naive
+from .models import DECAY_DECAYING, DECAY_VOLATILE
+
+# PRD defaults (Configuration Reference -> memory.decay).
+DEFAULT_HALF_LIFE_DAYS = 180.0
+DEFAULT_VOLATILE_TTL_HOURS = 24.0
+
+_SECONDS_PER_DAY = 86400.0
+
+
+class DecaySettings:
+    """Validated ``memory.decay`` configuration (fail-fast on bad values)."""
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None):
+        """
+        Parse and validate the ``memory.decay`` formation config section.
+
+        Raises:
+            ValueError: On non-positive half-lives or TTLs.
+        """
+        config = config or {}
+        self.enabled = bool(config.get("enabled", True))
+        self.default_half_life_days = _positive_number(
+            config.get("default_half_life_days", DEFAULT_HALF_LIFE_DAYS),
+            "memory.decay.default_half_life_days",
+        )
+        self.volatile_ttl_hours = _positive_number(
+            config.get("volatile_default_ttl_hours", DEFAULT_VOLATILE_TTL_HOURS),
+            "memory.decay.volatile_default_ttl_hours",
+        )
+        half_lives = config.get("half_lives") or {}
+        if not isinstance(half_lives, dict):
+            raise ValueError("memory.decay.half_lives must be a mapping of type -> days")
+        self.half_lives: Dict[str, float] = {
+            str(key).strip().lower(): _positive_number(value, f"memory.decay.half_lives.{key}")
+            for key, value in half_lives.items()
+        }
+
+    def half_life_for(self, fact_type: Optional[str]) -> Optional[float]:
+        """Half-life in days for a projection fact type, or None (static)."""
+        if not self.enabled or not fact_type:
+            return None
+        return self.half_lives.get(str(fact_type).strip().lower())
+
+
+def decayed_confidence(confidence: float, age_days: float, half_life_days: float) -> float:
+    """Exponential half-life decay: halves every ``half_life_days``."""
+    if age_days <= 0:
+        return confidence
+    return confidence * 0.5 ** (age_days / half_life_days)
+
+
+def effective_event_confidence(
+    event: Dict[str, Any],
+    decay: Optional[DecaySettings] = None,
+    now: Optional[datetime] = None,
+) -> float:
+    """
+    Query-time effective confidence for one memory event dict.
+
+    static -> stored source_confidence; decaying -> half-life weighted by
+    age since occurred_at (default half-life when settings are absent);
+    volatile -> 0.0 once expired. Disabled decay settings return the
+    stored confidence unchanged.
+    """
+    confidence = float(event.get("source_confidence") or 0.0)
+    if decay is not None and not decay.enabled:
+        return confidence
+
+    now = now or utc_now_naive()
+    rate = event.get("decay_rate")
+
+    if rate == DECAY_VOLATILE:
+        expires_at = _parse(event.get("expires_at"))
+        if expires_at is not None and expires_at <= now:
+            return 0.0
+        return confidence
+
+    if rate == DECAY_DECAYING:
+        occurred_at = _parse(event.get("occurred_at"))
+        if occurred_at is None:
+            return confidence
+        half_life = decay.default_half_life_days if decay else DEFAULT_HALF_LIFE_DAYS
+        age_days = max(0.0, (now - occurred_at).total_seconds() / _SECONDS_PER_DAY)
+        return decayed_confidence(confidence, age_days, half_life)
+
+    return confidence
+
+
+def effective_fact_confidence(
+    fact: Dict[str, Any],
+    decay: Optional[DecaySettings],
+    now: Optional[datetime] = None,
+) -> float:
+    """
+    Query-time effective confidence for one projection row dict.
+
+    ``fact`` is a kg_relationships (or kg_entities) row dict with
+    ``type``, ``confidence``, and ``updated_at``. Types without a
+    configured half-life are static. Reinforcement resets the age for
+    free: every contributing upsert refreshes ``updated_at``.
+    """
+    confidence = float(fact.get("confidence") or 0.0)
+    half_life = decay.half_life_for(fact.get("type")) if decay else None
+    if half_life is None:
+        return confidence
+    updated_at = _parse(fact.get("updated_at")) or _parse(fact.get("created_at"))
+    if updated_at is None:
+        return confidence
+    now = now or utc_now_naive()
+    age_days = max(0.0, (now - updated_at).total_seconds() / _SECONDS_PER_DAY)
+    return decayed_confidence(confidence, age_days, half_life)
+
+
+def _positive_number(value: Any, label: str) -> float:
+    """Coerce a config value to a positive float, failing fast otherwise."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{label} must be a positive number, got {value!r}")
+    if number <= 0:
+        raise ValueError(f"{label} must be a positive number, got {value!r}")
+    return number
+
+
+def _parse(value: Any) -> Optional[datetime]:
+    """Parse an ISO timestamp (or pass through a datetime), else None."""
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    return None

--- a/src/muxi/runtime/services/memory/events/models.py
+++ b/src/muxi/runtime/services/memory/events/models.py
@@ -79,10 +79,18 @@ EVENT_MEMORY_INGESTED = "memory.ingested"
 EVENT_INGESTION_FILTERED = "ingestion.filtered"
 
 # One artifact captured into artifact memory (Artifact Memory Phase 1).
-# Metadata-only audit event: the blob lives in artifact storage and is
-# not replayable from the log, so this event has no projector -- the
-# artifacts table is the system of record, not a projection.
+# The blob lives in artifact storage and never enters the log; the
+# metadata row IS a projection (Phase 2b): the artifact-metadata
+# projector rebuilds rows from these events (v2 carries the full
+# metadata; v1 events are reconstructed best-effort).
 EVENT_ARTIFACT_SAVED = "artifact.saved"
+
+# One contradiction detected by the knowledge graph writer (Phase 2c):
+# a new fact on an exclusive predicate conflicted with (or superseded)
+# an existing fact. Audit/provenance only -- the conflict marking itself
+# is part of the deterministic graph apply, so this event has no
+# projector and is never replayed into state.
+EVENT_FACT_CONTRADICTED = "fact.contradicted"
 
 # Versioned payload schemas. "required" keys must be present; keys outside
 # required + optional are rejected -- schema evolution happens by adding a
@@ -152,6 +160,39 @@ EVENT_SCHEMAS: Dict[str, Dict[int, Dict[str, tuple]]] = {
                 "storage_ref",
                 "tags",
             ),
+        },
+        # v2 (Phase 2b): carries the remaining metadata columns so the
+        # artifact-metadata projector can rebuild rows losslessly. The
+        # projector still applies v1 events (summary and compressed size
+        # are reconstructed deterministically) -- builders handle every
+        # historical version until events are hard-purged.
+        2: {
+            "required": ("artifact_id", "name", "version", "content_type"),
+            "optional": (
+                "category",
+                "size_bytes",
+                "checksum_sha256",
+                "storage_ref",
+                "tags",
+                "summary",
+                "compressed_bytes",
+            ),
+        },
+    },
+    EVENT_FACT_CONTRADICTED: {
+        1: {
+            # detection: 'superseded' (new fact auto-replaced the old one)
+            # or 'conflicted' (both retained, cross-referenced). The
+            # public ids point at kg_relationships rows as they existed
+            # when the contradiction was detected.
+            "required": ("relationship_type", "detection"),
+            "optional": (
+                "new_relationship_public_id",
+                "existing_relationship_public_id",
+                "from_entity",
+                "new_object",
+                "existing_object",
+            ),
         }
     },
 }
@@ -185,6 +226,7 @@ SOURCE_CAPTAINS_LOG = "captains_log"  # digest-derived writes (entries, lessons,
 SOURCE_TOOL = "tool"  # the record_lesson agent tool
 SOURCE_USER_EDIT = "user_edit"  # user-initiated corrections/deletions
 SOURCE_ARTIFACT_MEMORY = "artifact_memory"  # artifact capture audit events
+SOURCE_LEGACY = "legacy"  # synthetic events backfilled for pre-event-log rows (Phase B)
 
 # Scope shape recorded for forward compatibility with memory namespaces.
 from ..base import SCOPE_TYPE_USER  # noqa: E402 -- canonical scope constants

--- a/src/muxi/runtime/services/memory/events/projectors.py
+++ b/src/muxi/runtime/services/memory/events/projectors.py
@@ -2,35 +2,48 @@
 # FRONTMATTER
 # =============================================================================
 # Title:        Memory Projectors - Event-to-Projection Builders
-# Description:  Projector registry contract and the three built-in projectors
-# Role:         Rebuild derived memory state (KG, log, flat facts) from events
+# Description:  Projector registry contract and the four built-in projectors
+# Role:         Rebuild derived memory state (KG, log, facts, artifacts)
 # Usage:        Registered with MemoryEventService during formation init
 # Author:       Muxi Framework Team
 #
 # Memory Event Substrate. A projector owns one projection: it knows which
 # event types feed it, how to apply one event, and how to wipe its derived
 # state for a user. ``MemoryEventService.rebuild`` drives the contract:
-# reset -> replay events in append order -> checkpoint.
+# reset -> replay events in append order -> checkpoint. The incremental
+# path (``project_pending`` / ``apply_event``) drives the same ``apply``
+# with a per-(projection, user) cursor instead of a reset.
 #
 # Determinism contract: ``apply`` must be a pure function of the event (no
 # LLM calls, no clock reads beyond what storage layers stamp identically on
 # the incremental path). Every projector routes through the exact same
 # storage upserts the live dual-write path uses, so a full replay converges
-# to the same state as incremental writes.
+# to the same state as incremental writes. ``apply`` may RETURN information
+# (e.g. detected contradictions) -- recording derived events from that
+# information is the caller's job on the live path only, never on replay.
+#
+# Legacy backfill (Phase B): projectors that can synthesize events for
+# pre-event-log rows expose ``backfill(user_id, event_service)``. Synthetic
+# events carry source='legacy' with a per-row source_id, so the backfill is
+# idempotent through the substrate's own (source, source_id) key.
 #
 # Extensibility: adding a projection (e.g. the deferred Knowledge Index) is
-# a new class with these three members plus a service.register_projector
-# call -- no schema changes to the event log.
+# a new class with these members plus a service.register_projector call --
+# no schema changes to the event log.
 # =============================================================================
 
-from typing import Any, Dict, Optional, Tuple
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
 
 from ..base import SCOPE_TYPE_USER
 from .models import (
+    EVENT_ARTIFACT_SAVED,
     EVENT_FACT_EXTRACTED,
     EVENT_GRAPH_EXTRACTED,
     EVENT_LESSON_RECORDED,
     EVENT_LOG_ENTRY,
+    SOURCE_ARTIFACT_MEMORY,
+    SOURCE_LEGACY,
 )
 
 # Metadata key linking a flat-fact memory row back to its originating event
@@ -50,6 +63,19 @@ def event_scope(event: Dict[str, Any]) -> Optional[Tuple[str, str]]:
     if not scope_type or scope_type == SCOPE_TYPE_USER:
         return None
     return (scope_type, event.get("scope_id"))
+
+
+def contradiction_payloads(result: Any) -> List[Dict[str, Any]]:
+    """fact.contradicted payloads for one apply result.
+
+    Shared by the dual-write path (graph service records after its own
+    apply) and the incremental applier (records after projecting an
+    event) so both stamp identical audit events. Returns [] when the
+    result is not a dict or carries no contradictions.
+    """
+    if not isinstance(result, dict):
+        return []
+    return list(result.get("contradictions") or [])
 
 
 async def apply_fact_event(
@@ -98,9 +124,14 @@ class KnowledgeGraphProjector:
     def __init__(self, knowledge_graph_service):
         self.service = knowledge_graph_service
 
-    async def apply(self, event: Dict[str, Any]) -> None:
-        """Apply one extraction batch through the service's upsert path."""
-        await self.service.apply_extraction(
+    async def apply(self, event: Dict[str, Any]) -> Dict[str, Any]:
+        """Apply one extraction batch through the service's upsert path.
+
+        Returns the apply result (counts + detected contradictions) so
+        the live incremental path can record fact.contradicted audit
+        events; rebuild replay ignores the return value.
+        """
+        return await self.service.apply_extraction(
             event["user_id"], event["payload"], event_id=event["id"]
         )
 
@@ -108,6 +139,82 @@ class KnowledgeGraphProjector:
         """Wipe the user's graph and invalidate the algorithms cache."""
         await self.service.storage.delete_all_for_user(user_id)
         self.service.algorithms.invalidate(str(user_id))
+
+    async def backfill(self, user_id: str, event_service) -> int:
+        """Synthesize graph.extracted events for pre-event-log rows.
+
+        One event per entity/relationship without provenance, keyed
+        ``legacy/kg_entity/<public_id>`` / ``legacy/kg_rel/<public_id>``,
+        dated to the row's creation. Each synthetic event is applied
+        immediately: the upsert merges into the existing row (a no-op for
+        content) and stamps its ``derived_from_event_ids`` bridge.
+        Returns the number of events synthesized.
+        """
+        user_id = str(user_id)
+        storage = self.service.storage
+        synthesized = 0
+
+        entities = await storage.list_entities(user_id, status=None, limit=100000)
+        names = {entity["id"]: entity for entity in entities}
+        for entity in entities:
+            if entity["derived_from_event_ids"]:
+                continue
+            event = await event_service.record(
+                user_id=user_id,
+                event_type=EVENT_GRAPH_EXTRACTED,
+                payload={
+                    "entities": [
+                        {
+                            "type": entity["type"],
+                            "name": entity["name"],
+                            "attributes": entity["attributes"],
+                            "confidence": entity["confidence"],
+                        }
+                    ],
+                    "relationships": [],
+                },
+                source=SOURCE_LEGACY,
+                source_id=f"legacy/kg_entity/{entity['public_id']}",
+                occurred_at=_parse_iso(entity["created_at"]),
+            )
+            if event is None:
+                continue
+            await self.apply({"user_id": user_id, "id": event["id"], "payload": event["payload"]})
+            synthesized += 1
+
+        for rel in await storage.list_relationships(user_id, status=None, limit=100000):
+            if rel["derived_from_event_ids"]:
+                continue
+            from_entity = names.get(rel["from_entity_id"])
+            to_entity = names.get(rel["to_entity_id"])
+            if from_entity is None or to_entity is None:
+                continue
+            event = await event_service.record(
+                user_id=user_id,
+                event_type=EVENT_GRAPH_EXTRACTED,
+                payload={
+                    "entities": [],
+                    "relationships": [
+                        {
+                            "from": from_entity["name"],
+                            "from_type": from_entity["type"],
+                            "to": to_entity["name"],
+                            "to_type": to_entity["type"],
+                            "type": rel["type"],
+                            "attributes": rel["attributes"],
+                            "confidence": rel["confidence"],
+                        }
+                    ],
+                },
+                source=SOURCE_LEGACY,
+                source_id=f"legacy/kg_rel/{rel['public_id']}",
+                occurred_at=_parse_iso(rel["created_at"]),
+            )
+            if event is None:
+                continue
+            await self.apply({"user_id": user_id, "id": event["id"], "payload": event["payload"]})
+            synthesized += 1
+        return synthesized
 
 
 class CaptainsLogProjector:
@@ -119,16 +226,20 @@ class CaptainsLogProjector:
     def __init__(self, captains_log_service):
         self.service = captains_log_service
 
-    async def apply(self, event: Dict[str, Any]) -> None:
-        """Apply one log-entry or lesson event through the service."""
+    async def apply(self, event: Dict[str, Any]):
+        """Apply one log-entry or lesson event through the service.
+
+        Returns the underlying apply result (entry/source counts or
+        lesson/created) so event-first callers can report on the row
+        they just wrote; replay ignores the return value.
+        """
         if event["event_type"] == EVENT_LOG_ENTRY:
-            await self.service.apply_log_entry_event(
+            return await self.service.apply_log_entry_event(
                 event["user_id"], event["payload"], event_id=event["id"]
             )
-        else:
-            await self.service.apply_lesson_event(
-                event["user_id"], event["payload"], event_id=event["id"]
-            )
+        return await self.service.apply_lesson_event(
+            event["user_id"], event["payload"], event_id=event["id"]
+        )
 
     async def reset(self, user_id: str) -> None:
         """Wipe the user's lessons, log entries, and source lineage.
@@ -139,6 +250,83 @@ class CaptainsLogProjector:
         """
         await self.service.lessons.delete_all_for_user(user_id)
         await self.service.storage.delete_all_for_user(user_id)
+
+    async def backfill(self, user_id: str, event_service) -> int:
+        """Synthesize log.entry / lesson.recorded events for legacy rows.
+
+        Entries are keyed ``legacy/captains_log/<public_id>``, lessons
+        ``legacy/lesson/<public_id>``; both dated to the row's creation
+        and applied immediately to stamp provenance. Returns the number
+        of events synthesized.
+        """
+        user_id = str(user_id)
+        synthesized = 0
+
+        entries = await self.service.storage.list_entries(user_id, limit=100000)
+        sources = await self.service.storage.get_sources_for_logs([e["id"] for e in entries])
+        dates_by_id = {entry["id"]: entry["date"] for entry in entries}
+        for entry in entries:
+            if entry["derived_from_event_ids"]:
+                continue
+            event = await event_service.record(
+                user_id=user_id,
+                event_type=EVENT_LOG_ENTRY,
+                payload={
+                    "date": entry["date"],
+                    "summary": entry["summary"],
+                    "decisions": entry["decisions"],
+                    "projects": entry["projects"],
+                    "context": entry["context"],
+                    "sources": [
+                        {"source_type": s["source_type"], "source_id": s["source_id"]}
+                        for s in sources.get(entry["id"], [])
+                    ],
+                },
+                source=SOURCE_LEGACY,
+                source_id=f"legacy/captains_log/{entry['public_id']}",
+                occurred_at=_parse_iso(entry["created_at"]),
+            )
+            if event is None:
+                continue
+            await self.apply(
+                {
+                    "user_id": user_id,
+                    "id": event["id"],
+                    "event_type": EVENT_LOG_ENTRY,
+                    "payload": event["payload"],
+                }
+            )
+            synthesized += 1
+
+        for lesson in await self.service.lessons.list_all_for_user(user_id):
+            if lesson["derived_from_event_ids"]:
+                continue
+            event = await event_service.record(
+                user_id=user_id,
+                event_type=EVENT_LESSON_RECORDED,
+                payload={
+                    "agent_id": lesson["agent_id"],
+                    "rule": lesson["rule"],
+                    "context": lesson["context"],
+                    "confidence": lesson["confidence"],
+                    "source_log_date": dates_by_id.get(lesson["source_log_id"]),
+                },
+                source=SOURCE_LEGACY,
+                source_id=f"legacy/lesson/{lesson['public_id']}",
+                occurred_at=_parse_iso(lesson["created_at"]),
+            )
+            if event is None:
+                continue
+            await self.apply(
+                {
+                    "user_id": user_id,
+                    "id": event["id"],
+                    "event_type": EVENT_LESSON_RECORDED,
+                    "payload": event["payload"],
+                }
+            )
+            synthesized += 1
+        return synthesized
 
 
 class FlatFactProjector:
@@ -177,3 +365,171 @@ class FlatFactProjector:
         Returns the number of memories deleted.
         """
         return await self.long_term_memory.delete_extracted_memories(str(user_id))
+
+    async def backfill(self, user_id: str, event_service) -> int:
+        """Synthesize fact.extracted events for pre-event-log extraction rows.
+
+        Keyed ``legacy/memory/<row id>``, dated to the row's creation. The
+        rows are NOT re-applied here (the flat-fact write path inserts, it
+        does not upsert, so applying would duplicate them); the provenance
+        bridge lands on the next rebuild, whose reset already wipes
+        extraction rows and whose replay recreates them from these events.
+        Returns the number of events synthesized.
+        """
+        user_id = str(user_id)
+        synthesized = 0
+        for row in await self.long_term_memory.list_extracted_orphan_memories(user_id):
+            source_id = f"legacy/memory/{row['id']}"
+            # The row stays orphaned until the next rebuild stamps it, so
+            # a re-run sees it again -- the per-row idempotency key keeps
+            # the re-run from double-counting (or double-recording).
+            existing = await event_service.storage.find_by_source_id(
+                user_id, SOURCE_LEGACY, source_id
+            )
+            if existing is not None:
+                continue
+            metadata = {
+                key: value
+                for key, value in (row.get("metadata") or {}).items()
+                if key != FACT_EVENT_METADATA_KEY
+            }
+            event = await event_service.record(
+                user_id=user_id,
+                event_type=EVENT_FACT_EXTRACTED,
+                payload={
+                    "memory": row["text"],
+                    "collection": row["collection"],
+                    "metadata": metadata,
+                },
+                source=SOURCE_LEGACY,
+                source_id=source_id,
+                occurred_at=_parse_iso(row.get("created_at")),
+            )
+            if event is not None:
+                synthesized += 1
+        return synthesized
+
+
+class ArtifactMetadataProjector:
+    """Rebuilds artifact metadata rows from artifact.saved events.
+
+    The blob is NOT a projection -- it lives in artifact storage and never
+    enters the event log. Only the metadata row is derived state: replay
+    recreates it (version chain included, because events replay in capture
+    order) pointing at the same ``storage_ref``. Rows without a
+    ``derived_from_event_id`` (pre-substrate captures) are left alone by
+    ``reset`` so a rebuild can never orphan a blob's metadata.
+    """
+
+    name = "artifact_metadata"
+    event_types = (EVENT_ARTIFACT_SAVED,)
+
+    def __init__(self, artifact_service):
+        self.service = artifact_service
+
+    async def apply(self, event: Dict[str, Any]) -> None:
+        """Upsert one artifact metadata row from an artifact.saved event.
+
+        Handles every historical payload version: v1 events lack summary
+        and compressed size, which are reconstructed deterministically
+        (the same helper the capture path used). An existing row (matched
+        by public id) is only stamped with provenance -- the artifacts
+        table remains authoritative for rows that already exist.
+        """
+        payload = event["payload"]
+        user_id = str(event["user_id"])
+        storage = self.service.storage
+
+        existing = await storage.get_by_public_id(
+            user_id, payload["artifact_id"], include_deleted=True
+        )
+        if existing is not None:
+            await storage.set_derived_event(existing["id"], event["id"])
+            return
+
+        size_bytes = int(payload.get("size_bytes") or 0)
+        summary = payload.get("summary") or self.service._build_summary(
+            payload["name"], payload["content_type"], size_bytes, event.get("agent_id")
+        )
+        await storage.save_artifact(
+            user_id=user_id,
+            public_id=payload["artifact_id"],
+            name=payload["name"],
+            content_type=payload["content_type"],
+            summary=summary,
+            storage_ref=payload.get("storage_ref") or "",
+            size_bytes=size_bytes,
+            compressed_bytes=int(payload.get("compressed_bytes") or size_bytes),
+            checksum_sha256=payload.get("checksum_sha256") or "",
+            category=payload.get("category"),
+            tags=payload.get("tags"),
+            agent_id=event.get("agent_id"),
+            conversation_id=event.get("conversation_id"),
+            expires_at=self.service._compute_expiry(),
+            created_at=_parse_iso(event.get("occurred_at")),
+            derived_from_event_id=event["id"],
+        )
+
+    async def reset(self, user_id: str) -> int:
+        """Delete the user's event-sourced metadata rows (blobs untouched).
+
+        Only rows carrying a ``derived_from_event_id`` are wiped: replay
+        recreates exactly those. Pre-substrate rows survive until a
+        backfill stamps them. Returns the number of rows deleted.
+        """
+        return await self.service.storage.delete_event_sourced_for_user(str(user_id))
+
+    async def backfill(self, user_id: str, event_service) -> int:
+        """Synthesize artifact.saved events for pre-substrate metadata rows.
+
+        Uses the live capture path's ``artifact/<public_id>`` idempotency
+        key, so rows that already have an audit event reuse it instead of
+        duplicating; either way the row is stamped with its provenance
+        bridge. Returns the number of rows stamped.
+        """
+        user_id = str(user_id)
+        stamped = 0
+        rows = await self.service.storage.list_artifacts(
+            user_id, latest_only=False, include_deleted=True
+        )
+        for row in rows:
+            if row.get("derived_from_event_id") is not None:
+                continue
+            event = await event_service.record(
+                user_id=user_id,
+                event_type=EVENT_ARTIFACT_SAVED,
+                event_version=2,
+                payload={
+                    "artifact_id": row["public_id"],
+                    "name": row["name"],
+                    "version": row["version"],
+                    "content_type": row["content_type"],
+                    "category": row["category"],
+                    "size_bytes": row["size_bytes"],
+                    "checksum_sha256": row["checksum_sha256"],
+                    "storage_ref": row["storage_ref"],
+                    "tags": row["tags"],
+                    "summary": row["summary"],
+                    "compressed_bytes": row["compressed_bytes"],
+                },
+                source=SOURCE_ARTIFACT_MEMORY,
+                source_id=f"artifact/{row['public_id']}",
+                occurred_at=_parse_iso(row["created_at"]),
+                agent_id=row["agent_id"],
+                conversation_id=row["conversation_id"],
+            )
+            if event is None:
+                continue
+            await self.service.storage.set_derived_event(row["id"], event["id"])
+            stamped += 1
+        return stamped
+
+
+def _parse_iso(value):
+    """Parse an ISO timestamp string to a datetime (passthrough otherwise)."""
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    return value if isinstance(value, datetime) else None

--- a/src/muxi/runtime/services/memory/events/provenance.py
+++ b/src/muxi/runtime/services/memory/events/provenance.py
@@ -1,0 +1,155 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Memory Provenance - "Why Do You Think X?" Query Assembly
+# Description:  Resolves projection rows to their event causation chains
+# Role:         Read-side provenance surface (Memory Substrate Phase 2c)
+# Usage:        Called by the client memory routes and e2e tests
+# Author:       Muxi Framework Team
+#
+# Provenance is the substrate's read-side promise: any knowledge graph
+# fact can be traced, in one query surface, back through the events that
+# produced it -- typically fact/graph extraction events whose ``caused_by``
+# links reach the originating interaction.turn (or raw ingestion event).
+#
+# The assembly is intentionally projection-first: the caller names an
+# entity (the thing the agent "thinks" something about); we collect the
+# entity row, every relationship touching it, and each row's
+# ``derived_from_event_ids``, then expand every event into its causation
+# chain via ``MemoryEventService.provenance_chain``. Decay is applied at
+# query time so the answer carries today's effective confidence, not the
+# confidence at write time.
+# =============================================================================
+
+from typing import Any, Dict, List, Optional
+
+from .decay import DecaySettings, effective_event_confidence, effective_fact_confidence
+
+# Ancestor chains longer than this are cut (defensive; real chains are
+# interaction.turn -> extraction -> contradiction, depth 2-3).
+MAX_CHAIN_DEPTH = 10
+
+
+def render_event(event: Dict[str, Any], decay: Optional[DecaySettings] = None) -> Dict[str, Any]:
+    """One provenance-facing view of a memory event.
+
+    Exposes the public id (the integer id stays internal), the source
+    coordinates, and the query-time effective confidence.
+    """
+    return {
+        "event_id": event["public_id"],
+        "event_type": event["event_type"],
+        "source": event["source"],
+        "source_id": event["source_id"],
+        "source_confidence": event["source_confidence"],
+        "effective_confidence": round(effective_event_confidence(event, decay), 4),
+        "decay_rate": event["decay_rate"],
+        "occurred_at": event["occurred_at"],
+        "agent_id": event["agent_id"],
+        "conversation_id": event["conversation_id"],
+        "payload": event["payload"],
+        "deleted_at": event["deleted_at"],
+    }
+
+
+async def event_chains(
+    memory_events,
+    user_id: str,
+    event_ids: List[int],
+    decay: Optional[DecaySettings] = None,
+) -> List[List[Dict[str, Any]]]:
+    """Causation chains (root-first) for a row's derived event ids."""
+    chains = []
+    for event_id in event_ids:
+        chain = await memory_events.provenance_chain(user_id, event_id, max_depth=MAX_CHAIN_DEPTH)
+        if chain:
+            chains.append([render_event(event, decay) for event in chain])
+    return chains
+
+
+async def entity_provenance(
+    memory_events,
+    knowledge_graph,
+    user_id: str,
+    entity_name: str,
+    decay: Optional[DecaySettings] = None,
+    limit: int = 25,
+) -> Optional[Dict[str, Any]]:
+    """
+    Full provenance for one knowledge graph entity.
+
+    Returns None when the entity is unknown. Otherwise: the entity (with
+    its own event chains) plus every relationship touching it -- any
+    status, so contradicted and superseded facts stay explainable --
+    each rendered as a statement with stored + effective confidence and
+    its event chains.
+    """
+    user_id = str(user_id)
+    entity = await knowledge_graph._find_entity_by_name(user_id, entity_name)
+    if entity is None:
+        return None
+
+    facts: List[Dict[str, Any]] = []
+    seen_ids = set()
+    outgoing = await knowledge_graph.storage.list_relationships(
+        user_id, from_entity_id=entity["id"], status=None, limit=limit
+    )
+    incoming = await knowledge_graph.storage.list_relationships(
+        user_id, to_entity_id=entity["id"], status=None, limit=limit
+    )
+    for rel in list(outgoing) + list(incoming):
+        if rel["id"] in seen_ids:
+            continue
+        seen_ids.add(rel["id"])
+        from_entity = await knowledge_graph.storage.get_entity_by_id(rel["from_entity_id"])
+        to_entity = await knowledge_graph.storage.get_entity_by_id(rel["to_entity_id"])
+        facts.append(
+            {
+                "statement": (
+                    f"{from_entity['name'] if from_entity else '?'} "
+                    f"-[{rel['type']}]-> "
+                    f"{to_entity['name'] if to_entity else '?'}"
+                ),
+                "relationship_type": rel["type"],
+                "status": rel["status"],
+                "confidence": rel["confidence"],
+                "effective_confidence": round(effective_fact_confidence(rel, decay), 4),
+                "updated_at": rel["updated_at"],
+                "events": await event_chains(
+                    memory_events, user_id, rel["derived_from_event_ids"], decay
+                ),
+            }
+        )
+
+    return {
+        "entity": {
+            "name": entity["name"],
+            "type": entity["type"],
+            "status": entity["status"],
+            "confidence": entity["confidence"],
+            "attributes": entity["attributes"],
+            "events": await event_chains(
+                memory_events, user_id, entity["derived_from_event_ids"], decay
+            ),
+        },
+        "facts": facts,
+        "count": len(facts),
+    }
+
+
+async def event_provenance(
+    memory_events,
+    user_id: str,
+    public_event_id: str,
+    decay: Optional[DecaySettings] = None,
+) -> Optional[Dict[str, Any]]:
+    """Causation chain for one event addressed by its public id."""
+    user_id = str(user_id)
+    event = await memory_events.storage.get_event_by_public_id(user_id, public_event_id)
+    if event is None:
+        return None
+    chain = await memory_events.provenance_chain(user_id, event["id"], max_depth=MAX_CHAIN_DEPTH)
+    return {
+        "event": render_event(event, decay),
+        "chain": [render_event(item, decay) for item in chain],
+    }

--- a/src/muxi/runtime/services/memory/events/service.py
+++ b/src/muxi/runtime/services/memory/events/service.py
@@ -2,7 +2,7 @@
 # FRONTMATTER
 # =============================================================================
 # Title:        Memory Event Service - Substrate Coordination
-# Description:  Failure-isolated event recording, projector registry, rebuild
+# Description:  Failure-isolated event recording, projection, rebuild, GDPR
 # Role:         Formation-level service owning the memory event substrate
 # Usage:        Created in formation initialization, driven by the Overlord
 # Author:       Muxi Framework Team
@@ -16,36 +16,67 @@
 # 2. Projector registry: projections register a projector (apply + reset +
 #    event_types); the registry is the extension point for later
 #    projections (Knowledge Index) without event-schema changes.
-# 3. Rebuild: full re-projection per user -- wipe the projection, replay
+# 3. Incremental projection (Phase 2b): per-(projection, user) cursors in
+#    ``projection_checkpoints``. ``apply_event`` projects one event on the
+#    event-first write path; ``project_pending`` catches a cursor up to the
+#    log tail (crash recovery / background applier). Both are idempotent at
+#    the cursor level: an event behind the cursor is never re-applied.
+# 4. Event-first cutover (Phase C groundwork, flag-gated, DEFAULT OFF):
+#    with ``memory.events.event_first: true`` the write paths append the
+#    event and skip their direct projection write; projections are derived
+#    exclusively through the projectors. Dual-write remains the default
+#    until cutover.
+# 5. Rebuild: full re-projection per user -- wipe the projection, replay
 #    its events in append order through the same upsert code the live path
 #    uses, then checkpoint. This is the PRD's replay promise.
-# 4. Selective forgetting: ``forget_source`` soft-deletes every live event
-#    from a source and records the user.deletion audit event; a background
-#    hard-purge loop (Phase 1 lifecycle pattern: started by the Overlord
-#    next to the scheduler, cancelled on shutdown) removes soft-deleted
-#    events after the retention grace period.
+# 6. Provenance (Phase 2c): ``provenance_chain`` walks caused_by links so
+#    "why do you think X?" resolves any projection row to the interaction
+#    (or ingestion) that produced it.
+# 7. Selective forgetting / GDPR: ``forget_source`` soft-deletes every live
+#    event from a source and records the user.deletion audit event; replay
+#    skips soft-deleted events, so a rebuild recomputes projections as if
+#    the source never existed. The maintenance loop expires volatile
+#    events, hard-purges soft-deleted events past the retention grace
+#    period, and raises the per-user event-log size-cap alert.
+# 8. Legacy backfill (Phase B): ``backfill_user`` asks each projector to
+#    synthesize ``source='legacy'`` events for pre-event-log rows so old
+#    data becomes replayable and provenance-complete.
 # =============================================================================
 
 import asyncio
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 from ... import observability
-from .models import DECAY_STATIC, EVENT_USER_DELETION, SOURCE_USER_EDIT
+from .decay import DecaySettings
+from .models import DECAY_STATIC, DECAY_VOLATILE, EVENT_USER_DELETION, SOURCE_USER_EDIT
+from .projectors import contradiction_payloads
 from .storage import MemoryEventStorage
 
 # PRD defaults (Configuration Reference -> memory.events.retention).
 DEFAULT_GRACE_PERIOD_DAYS = 30
 
-# Hard-purge cadence. Soft-deleted events only become purgeable after the
-# multi-day grace period, so a daily sweep is more than frequent enough.
-PURGE_INTERVAL_SECONDS = 86400.0
+# Maintenance cadence (volatile expiry + hard purge + size-cap check).
+# Volatile TTLs default to 24h, so an hourly sweep keeps expiry timely;
+# purgeable rows only appear after the multi-day grace period.
+MAINTENANCE_INTERVAL_SECONDS = 3600.0
+
+# Incremental applier defaults (memory.projections in the formation YAML).
+DEFAULT_APPLY_INTERVAL_SECONDS = 5.0
+DEFAULT_LAG_ALERT_THRESHOLD_SECONDS = 300.0
 
 
 class MemoryEventService:
     """Owns the memory event log, projector registry, and rebuild path."""
 
-    def __init__(self, db_manager, formation_id: str, config: Optional[Dict[str, Any]] = None):
+    def __init__(
+        self,
+        db_manager,
+        formation_id: str,
+        config: Optional[Dict[str, Any]] = None,
+        projections_config: Optional[Dict[str, Any]] = None,
+        decay: Optional[DecaySettings] = None,
+    ):
         """
         Initialize the memory event service.
 
@@ -53,18 +84,47 @@ class MemoryEventService:
             db_manager: Shared DatabaseManager (PostgreSQL or SQLite).
             formation_id: Formation identifier scoping all event rows.
             config: The ``memory.events`` formation config section.
+            projections_config: The ``memory.projections`` section
+                (incremental applier interval + lag alert threshold).
+            decay: Validated ``memory.decay`` settings (built in formation
+                init; a default instance is created when omitted).
+
+        Raises:
+            ValueError: On invalid configuration (fail-fast policy).
         """
         config = config or {}
         retention = config.get("retention") or {}
+        projections_config = projections_config or {}
 
         self.formation_id = formation_id
         self.enabled = config.get("enabled", True)
+        self.event_first = bool(config.get("event_first", False))
         self.grace_period_days = int(retention.get("grace_period_days", DEFAULT_GRACE_PERIOD_DAYS))
+        if self.grace_period_days < 0:
+            raise ValueError("memory.events.retention.grace_period_days must be >= 0")
+        self.max_events_per_user = _optional_positive_int(
+            retention.get("max_events_per_user"), "memory.events.retention.max_events_per_user"
+        )
+        self.apply_interval_seconds = _positive_float(
+            projections_config.get("apply_interval_seconds", DEFAULT_APPLY_INTERVAL_SECONDS),
+            "memory.projections.apply_interval_seconds",
+        )
+        self.lag_alert_threshold_seconds = _positive_float(
+            projections_config.get(
+                "lag_alert_threshold_seconds", DEFAULT_LAG_ALERT_THRESHOLD_SECONDS
+            ),
+            "memory.projections.lag_alert_threshold_seconds",
+        )
+        self.decay = decay if decay is not None else DecaySettings()
 
         self.db_manager = db_manager
         self.storage = MemoryEventStorage(db_manager, formation_id)
         self.projectors: Dict[str, Any] = {}
-        self._purge_task: Optional[asyncio.Task] = None
+        self._maintenance_task: Optional[asyncio.Task] = None
+        self._applier_task: Optional[asyncio.Task] = None
+        # Serializes projection application (incremental vs applier vs
+        # rebuild) so one event is never applied twice concurrently.
+        self._projection_lock = asyncio.Lock()
 
     # ------------------------------------------------------------------
     # Projector registry
@@ -73,6 +133,13 @@ class MemoryEventService:
     def register_projector(self, projector) -> None:
         """Register a projection builder under its ``name``."""
         self.projectors[projector.name] = projector
+
+    def _projector_for_event(self, event_type: str):
+        """The registered projector consuming ``event_type``, or None."""
+        for projector in self.projectors.values():
+            if event_type in projector.event_types:
+                return projector
+        return None
 
     # ------------------------------------------------------------------
     # Recording (failure-isolated dual-write append)
@@ -86,6 +153,7 @@ class MemoryEventService:
         source: str,
         source_id: Optional[str] = None,
         source_confidence: float = 1.0,
+        event_version: int = 1,
         occurred_at: Optional[datetime] = None,
         caused_by: Optional[int] = None,
         decay_rate: str = DECAY_STATIC,
@@ -101,6 +169,8 @@ class MemoryEventService:
         ``scope_type`` / ``scope_id`` record the memory namespace of the
         projection write (shared-scope writes pass their true scope so
         replay reproduces scoped rows); None keeps the implicit user scope.
+        Volatile events without an explicit ``expires_at`` default to
+        occurred_at + memory.decay.volatile_default_ttl_hours.
 
         Returns the event dict (existing one on an idempotent duplicate),
         or None when the substrate is disabled or the append failed. A
@@ -108,6 +178,11 @@ class MemoryEventService:
         """
         if not self.enabled:
             return None
+        if decay_rate == DECAY_VOLATILE and expires_at is None:
+            from ....utils.datetime_utils import utc_now_naive
+
+            base = occurred_at or utc_now_naive()
+            expires_at = base + timedelta(hours=self.decay.volatile_ttl_hours)
         try:
             event, created = await self.storage.append(
                 user_id=str(user_id),
@@ -116,6 +191,7 @@ class MemoryEventService:
                 source=source,
                 source_id=source_id,
                 source_confidence=source_confidence,
+                event_version=event_version,
                 occurred_at=occurred_at,
                 caused_by=caused_by,
                 decay_rate=decay_rate,
@@ -168,6 +244,230 @@ class MemoryEventService:
         return event
 
     # ------------------------------------------------------------------
+    # Incremental projection (Phase 2b: cursors + event-first apply)
+    # ------------------------------------------------------------------
+
+    async def apply_event(self, event: Dict[str, Any]):
+        """
+        Project one just-appended event on the event-first write path.
+
+        Failure-isolated: an apply failure is logged and the cursor is NOT
+        advanced, leaving the event pending for the background applier's
+        next ``project_pending`` pass. Contradictions detected during the
+        apply are recorded as fact.contradicted audit events.
+
+        Returns the projector's apply result on success (True when the
+        event type has no projector or the cursor already passed it), or
+        None on failure.
+        """
+        projector = self._projector_for_event(event["event_type"])
+        if projector is None:
+            return True
+        name = projector.name
+        user_id = str(event["user_id"])
+        try:
+            async with self._projection_lock:
+                checkpoint = await self.storage.get_checkpoint(name, user_id)
+                if checkpoint is not None and checkpoint["last_event_id"] >= event["id"]:
+                    return True  # already applied (cursor-level idempotency)
+                result = await projector.apply(event)
+                await self.storage.set_checkpoint(name, user_id, last_event_id=event["id"])
+            await self.record_contradictions(event, result)
+            observability.observe(
+                event_type=observability.ConversationEvents.MEMORY_PROJECTION_APPLIED,
+                level=observability.EventLevel.DEBUG,
+                data={
+                    "user_id": user_id,
+                    "projection": name,
+                    "memory_event_id": event["id"],
+                    "memory_event_type": event["event_type"],
+                },
+                description=f"Applied event {event['id']} to {name}",
+            )
+            return result if result is not None else True
+        except Exception as e:
+            observability.observe(
+                event_type=observability.ConversationEvents.MEMORY_PROJECTION_FAILED,
+                level=observability.EventLevel.WARNING,
+                data={
+                    "user_id": user_id,
+                    "projection": name,
+                    "memory_event_id": event["id"],
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                },
+                description=f"Applying event {event['id']} to {name} failed: {e}",
+            )
+            return None
+
+    async def project_pending(self, user_id: Optional[Any] = None) -> Dict[str, Dict[str, Any]]:
+        """
+        Catch every projection cursor up to the event-log tail.
+
+        For each registered projector (and each user, unless one is
+        given): read the cursor, apply the projector's live events past
+        it in append order, advance the cursor. A missing cursor means
+        "from the start" -- ``start()`` snapshots cursors to the log tail
+        before enabling the event-first applier, so dual-written history
+        is never re-applied. Per-event failures are logged and skipped
+        (the cursor still advances; a rebuild reconciles), keeping one
+        poison event from wedging the projection forever.
+
+        Returns {projection: {user: {"events": n, "applied": n, "failed": n}}}.
+        """
+        users = [str(user_id)] if user_id is not None else await self.storage.list_event_user_ids()
+        report: Dict[str, Dict[str, Any]] = {}
+        for name in sorted(self.projectors):
+            projector = self.projectors[name]
+            per_user: Dict[str, Any] = {}
+            for uid in users:
+                async with self._projection_lock:
+                    checkpoint = await self.storage.get_checkpoint(name, uid)
+                    after_id = checkpoint["last_event_id"] if checkpoint else None
+                    events = await self.storage.list_events(
+                        uid, event_types=list(projector.event_types), after_id=after_id
+                    )
+                    applied = failed = 0
+                    for event in events:
+                        try:
+                            result = await projector.apply(event)
+                            applied += 1
+                        except Exception as e:
+                            failed += 1
+                            result = None
+                            observability.observe(
+                                event_type=(
+                                    observability.ConversationEvents.MEMORY_PROJECTION_FAILED
+                                ),
+                                level=observability.EventLevel.WARNING,
+                                data={
+                                    "user_id": uid,
+                                    "projection": name,
+                                    "memory_event_id": event["id"],
+                                    "error": str(e),
+                                    "error_type": type(e).__name__,
+                                },
+                                description=f"Applying event {event['id']} to {name} failed: {e}",
+                            )
+                        if result:
+                            await self.record_contradictions(event, result)
+                    if events:
+                        await self.storage.set_checkpoint(name, uid, last_event_id=events[-1]["id"])
+                if events:
+                    per_user[uid] = {"events": len(events), "applied": applied, "failed": failed}
+            if per_user:
+                report[name] = per_user
+        return report
+
+    async def record_contradictions(
+        self, event: Dict[str, Any], result: Optional[Dict[str, Any]]
+    ) -> None:
+        """Record fact.contradicted audit events from one apply result.
+
+        Live-path only (never called on rebuild replay): the conflict
+        marking itself is part of the deterministic apply, so these events
+        are provenance, not state. Idempotent through a per-pair
+        source_id.
+        """
+        from .models import EVENT_FACT_CONTRADICTED
+
+        for payload in contradiction_payloads(result):
+            source_id = (
+                "contradiction/"
+                f"{payload.get('existing_relationship_public_id')}/"
+                f"{payload.get('new_relationship_public_id')}"
+            )
+            await self.record(
+                user_id=event["user_id"],
+                event_type=EVENT_FACT_CONTRADICTED,
+                payload=payload,
+                source=event["source"],
+                source_id=source_id,
+                caused_by=event["id"],
+            )
+            observability.observe(
+                event_type=observability.ConversationEvents.MEMORY_FACT_CONTRADICTED,
+                level=observability.EventLevel.INFO,
+                data={"user_id": str(event["user_id"]), **payload},
+                description=(
+                    f"Contradiction on {payload.get('relationship_type')!r}: "
+                    f"{payload.get('detection')}"
+                ),
+            )
+
+    async def snapshot_cursors_to_tail(self) -> None:
+        """Initialize missing cursors to the current log tail.
+
+        Event-first cutover guard: every event already in the log was
+        dual-written directly to its projection, so the applier must not
+        replay it (the flat-fact projection would duplicate rows).
+        Cursors that already exist are left alone.
+        """
+        tail = await self.storage.max_event_id()
+        for uid in await self.storage.list_event_user_ids():
+            for name in self.projectors:
+                if await self.storage.get_checkpoint(name, uid) is None:
+                    await self.storage.set_checkpoint(name, uid, last_event_id=tail)
+
+    async def _applier_loop(self) -> None:
+        """Background incremental applier (event-first mode only)."""
+        while True:
+            await asyncio.sleep(self.apply_interval_seconds)
+            try:
+                await self.project_pending()
+                await self._check_projection_lag()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                observability.observe(
+                    event_type=observability.ErrorEvents.INTERNAL_ERROR,
+                    level=observability.EventLevel.WARNING,
+                    data={"error": str(e), "error_type": type(e).__name__, "pass": "applier"},
+                    description=f"Memory projection applier pass failed: {e}",
+                )
+
+    async def _check_projection_lag(self) -> None:
+        """Alert when a projection cursor falls behind the event tail."""
+        from ....utils.datetime_utils import utc_now_naive
+
+        now = utc_now_naive()
+        for uid in await self.storage.list_event_user_ids():
+            for name, projector in self.projectors.items():
+                checkpoint = await self.storage.get_checkpoint(name, uid)
+                after_id = checkpoint["last_event_id"] if checkpoint else None
+                pending = await self.storage.list_events(
+                    uid, event_types=list(projector.event_types), after_id=after_id, limit=1
+                )
+                if not pending:
+                    continue
+                oldest = pending[0]
+                ingested_at = oldest.get("ingested_at")
+                if isinstance(ingested_at, str):
+                    try:
+                        ingested_at = datetime.fromisoformat(ingested_at)
+                    except ValueError:
+                        continue
+                if ingested_at is None:
+                    continue
+                lag = (now - ingested_at).total_seconds()
+                if lag >= self.lag_alert_threshold_seconds:
+                    observability.observe(
+                        event_type=observability.ConversationEvents.MEMORY_PROJECTION_LAGGING,
+                        level=observability.EventLevel.WARNING,
+                        data={
+                            "user_id": uid,
+                            "projection": name,
+                            "oldest_pending_event_id": oldest["id"],
+                            "lag_seconds": round(lag, 1),
+                            "threshold_seconds": self.lag_alert_threshold_seconds,
+                        },
+                        description=(
+                            f"Projection {name} is {lag:.0f}s behind the event log "
+                            f"for user {uid}"
+                        ),
+                    )
+
+    # ------------------------------------------------------------------
     # Rebuild (full re-projection from the event log)
     # ------------------------------------------------------------------
 
@@ -213,50 +513,56 @@ class MemoryEventService:
         report: Dict[str, Dict[str, Any]] = {}
         for name in names:
             projector = self.projectors[name]
-            events = await self.storage.list_events(
-                user_id, event_types=list(projector.event_types)
-            )
-            if dry_run:
-                report[name] = {"events": len(events), "applied": 0, "failed": 0, "dry_run": True}
-                continue
+            async with self._projection_lock:
+                events = await self.storage.list_events(
+                    user_id, event_types=list(projector.event_types)
+                )
+                if dry_run:
+                    report[name] = {
+                        "events": len(events),
+                        "applied": 0,
+                        "failed": 0,
+                        "dry_run": True,
+                    }
+                    continue
 
-            await projector.reset(user_id)
-            await self.storage.reset_checkpoint(name, user_id)
+                await projector.reset(user_id)
+                await self.storage.reset_checkpoint(name, user_id)
 
-            applied = 0
-            failed = 0
-            for event in events:
-                try:
-                    await projector.apply(event)
-                    applied += 1
-                    observability.observe(
-                        event_type=observability.ConversationEvents.MEMORY_PROJECTION_APPLIED,
-                        level=observability.EventLevel.DEBUG,
-                        data={
-                            "user_id": user_id,
-                            "projection": name,
-                            "memory_event_id": event["id"],
-                            "memory_event_type": event["event_type"],
-                        },
-                        description=f"Replayed event {event['id']} into {name}",
-                    )
-                except Exception as e:
-                    failed += 1
-                    observability.observe(
-                        event_type=observability.ConversationEvents.MEMORY_PROJECTION_FAILED,
-                        level=observability.EventLevel.WARNING,
-                        data={
-                            "user_id": user_id,
-                            "projection": name,
-                            "memory_event_id": event["id"],
-                            "error": str(e),
-                            "error_type": type(e).__name__,
-                        },
-                        description=f"Replay of event {event['id']} into {name} failed: {e}",
-                    )
-            if events:
-                await self.storage.set_checkpoint(name, user_id, last_event_id=events[-1]["id"])
-            report[name] = {"events": len(events), "applied": applied, "failed": failed}
+                applied = 0
+                failed = 0
+                for event in events:
+                    try:
+                        await projector.apply(event)
+                        applied += 1
+                        observability.observe(
+                            event_type=observability.ConversationEvents.MEMORY_PROJECTION_APPLIED,
+                            level=observability.EventLevel.DEBUG,
+                            data={
+                                "user_id": user_id,
+                                "projection": name,
+                                "memory_event_id": event["id"],
+                                "memory_event_type": event["event_type"],
+                            },
+                            description=f"Replayed event {event['id']} into {name}",
+                        )
+                    except Exception as e:
+                        failed += 1
+                        observability.observe(
+                            event_type=observability.ConversationEvents.MEMORY_PROJECTION_FAILED,
+                            level=observability.EventLevel.WARNING,
+                            data={
+                                "user_id": user_id,
+                                "projection": name,
+                                "memory_event_id": event["id"],
+                                "error": str(e),
+                                "error_type": type(e).__name__,
+                            },
+                            description=f"Replay of event {event['id']} into {name} failed: {e}",
+                        )
+                if events:
+                    await self.storage.set_checkpoint(name, user_id, last_event_id=events[-1]["id"])
+                report[name] = {"events": len(events), "applied": applied, "failed": failed}
 
         observability.observe(
             event_type=observability.ConversationEvents.MEMORY_REBUILD_COMPLETED,
@@ -267,7 +573,80 @@ class MemoryEventService:
         return report
 
     # ------------------------------------------------------------------
-    # Selective forgetting (GDPR groundwork)
+    # Legacy backfill (Phase B: synthetic events for pre-event-log rows)
+    # ------------------------------------------------------------------
+
+    async def backfill_user(self, user_id: Any) -> Dict[str, int]:
+        """
+        Synthesize legacy events for a user's pre-event-log projection rows.
+
+        Each projector that supports backfill scans its projection for
+        rows without event provenance and appends ``source='legacy'``
+        events keyed per row, so re-running is idempotent. Graph, log,
+        and artifact rows are stamped in place; flat-fact rows become
+        provenance-complete on the next rebuild (their write path inserts
+        rather than upserts).
+
+        Returns {projection_name: synthesized_event_count}.
+
+        Raises:
+            ValueError: When the substrate is disabled.
+        """
+        if not self.enabled:
+            raise ValueError("Memory event substrate is disabled for this formation")
+        user_id = str(user_id)
+        observability.observe(
+            event_type=observability.ConversationEvents.MEMORY_BACKFILL_STARTED,
+            level=observability.EventLevel.INFO,
+            data={"user_id": user_id, "projections": sorted(self.projectors)},
+            description=f"Legacy memory backfill started for user {user_id}",
+        )
+        report: Dict[str, int] = {}
+        for name in sorted(self.projectors):
+            backfill = getattr(self.projectors[name], "backfill", None)
+            if backfill is None:
+                continue
+            report[name] = await backfill(user_id, self)
+        observability.observe(
+            event_type=observability.ConversationEvents.MEMORY_BACKFILL_COMPLETED,
+            level=observability.EventLevel.INFO,
+            data={"user_id": user_id, "report": report},
+            description=f"Legacy memory backfill completed for user {user_id}",
+        )
+        return report
+
+    # ------------------------------------------------------------------
+    # Provenance (Phase 2c: "why do you think X?")
+    # ------------------------------------------------------------------
+
+    async def provenance_chain(
+        self, user_id: Any, event_id: int, max_depth: int = 10
+    ) -> List[Dict[str, Any]]:
+        """
+        The causation chain for one event, root-first.
+
+        Walks ``caused_by`` links up to ``max_depth`` ancestors (cycles
+        and cross-user references are cut). The returned list ends with
+        the requested event; earlier entries are its causes, so the first
+        entry is the origin (typically the interaction.turn or raw
+        ingestion event).
+        """
+        user_id = str(user_id)
+        chain: List[Dict[str, Any]] = []
+        seen = set()
+        current: Optional[int] = event_id
+        while current is not None and current not in seen and len(chain) < max_depth:
+            seen.add(current)
+            event = await self.storage.get_event(current)
+            if event is None or str(event["user_id"]) != user_id:
+                break
+            chain.append(event)
+            current = event.get("caused_by")
+        chain.reverse()
+        return chain
+
+    # ------------------------------------------------------------------
+    # Selective forgetting (GDPR)
     # ------------------------------------------------------------------
 
     async def forget_source(
@@ -307,42 +686,77 @@ class MemoryEventService:
         }
 
     # ------------------------------------------------------------------
-    # Hard-purge background loop (Phase 1 lifecycle pattern)
+    # Background loops (Phase 1 lifecycle pattern)
     # ------------------------------------------------------------------
 
     def start(self) -> None:
-        """Start the periodic hard-purge loop for soft-deleted events."""
+        """Start the maintenance loop (and, event-first, the applier)."""
         if not self.enabled:
             return
-        if self._purge_task is not None and not self._purge_task.done():
-            return
-        self._purge_task = asyncio.create_task(self._purge_loop())
+        if self._maintenance_task is None or self._maintenance_task.done():
+            self._maintenance_task = asyncio.create_task(self._maintenance_loop())
+        if self.event_first and (self._applier_task is None or self._applier_task.done()):
+            self._applier_task = asyncio.create_task(self._start_applier())
+
+    async def _start_applier(self) -> None:
+        """Snapshot cursors past dual-written history, then apply forever."""
+        try:
+            await self.snapshot_cursors_to_tail()
+        except Exception as e:
+            observability.observe(
+                event_type=observability.ErrorEvents.INTERNAL_ERROR,
+                level=observability.EventLevel.WARNING,
+                data={"error": str(e), "error_type": type(e).__name__, "pass": "cursor_snapshot"},
+                description=f"Projection cursor snapshot failed: {e}",
+            )
+        await self._applier_loop()
 
     async def stop(self) -> None:
-        """Cancel the hard-purge loop, if running."""
-        if self._purge_task is not None:
-            self._purge_task.cancel()
-            try:
-                await self._purge_task
-            except asyncio.CancelledError:
-                pass
-            self._purge_task = None
+        """Cancel the background loops, if running."""
+        for attribute in ("_maintenance_task", "_applier_task"):
+            task = getattr(self, attribute)
+            if task is not None:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                setattr(self, attribute, None)
 
-    async def _purge_loop(self) -> None:
-        """Sleep-run loop for the retention hard purge."""
+    async def _maintenance_loop(self) -> None:
+        """Sleep-run loop: volatile expiry, hard purge, size-cap alert."""
         while True:
-            await asyncio.sleep(PURGE_INTERVAL_SECONDS)
+            await asyncio.sleep(MAINTENANCE_INTERVAL_SECONDS)
             try:
-                await self.run_hard_purge()
+                await self.run_maintenance()
             except asyncio.CancelledError:
                 raise
             except Exception as e:
                 observability.observe(
                     event_type=observability.ErrorEvents.INTERNAL_ERROR,
                     level=observability.EventLevel.WARNING,
-                    data={"error": str(e), "error_type": type(e).__name__, "pass": "hard_purge"},
-                    description=f"Memory event hard purge failed: {e}",
+                    data={"error": str(e), "error_type": type(e).__name__, "pass": "maintenance"},
+                    description=f"Memory event maintenance failed: {e}",
                 )
+
+    async def run_maintenance(self) -> Dict[str, int]:
+        """One maintenance pass; returns {"expired": n, "purged": n}."""
+        expired = await self.run_volatile_expiry()
+        purged = await self.run_hard_purge()
+        await self._check_size_caps()
+        return {"expired": expired, "purged": purged}
+
+    async def run_volatile_expiry(self) -> int:
+        """Soft-delete volatile events past their expiry."""
+        expired = await self.storage.expire_volatile()
+        if expired:
+            observability.observe(
+                event_type=observability.ConversationEvents.MEMORY_EVENT_EXPIRED,
+                level=observability.EventLevel.INFO,
+                data={"expired_events": expired},
+                description=f"Expired {expired} volatile memory events",
+            )
+        return expired
 
     async def run_hard_purge(self) -> int:
         """Hard-delete soft-deleted events past the grace period."""
@@ -356,6 +770,32 @@ class MemoryEventService:
             )
         return purged
 
+    async def _check_size_caps(self) -> None:
+        """Alert on users whose event logs exceed the configured cap.
+
+        The PRD's SQLite posture (open question 1): a single event table
+        with a size-cap ALERT -- the substrate never blocks writes or
+        prunes silently; capacity policy is the operator's call.
+        """
+        if self.max_events_per_user is None:
+            return
+        for uid in await self.storage.list_event_user_ids():
+            count = await self.storage.count_events(uid)
+            if count > self.max_events_per_user:
+                observability.observe(
+                    event_type=observability.ConversationEvents.MEMORY_EVENT_SIZE_CAP_EXCEEDED,
+                    level=observability.EventLevel.WARNING,
+                    data={
+                        "user_id": uid,
+                        "events": count,
+                        "max_events_per_user": self.max_events_per_user,
+                    },
+                    description=(
+                        f"Memory event log for user {uid} has {count} events "
+                        f"(cap {self.max_events_per_user})"
+                    ),
+                )
+
     # ------------------------------------------------------------------
     # Read surface (event listing for tests / provenance drill-down)
     # ------------------------------------------------------------------
@@ -363,3 +803,27 @@ class MemoryEventService:
     async def list_events(self, user_id: Any, **kwargs) -> List[Dict[str, Any]]:
         """List a user's events in append order (see storage.list_events)."""
         return await self.storage.list_events(str(user_id), **kwargs)
+
+
+def _optional_positive_int(value: Any, label: str) -> Optional[int]:
+    """None passes through; anything else must be a positive integer."""
+    if value is None:
+        return None
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{label} must be a positive integer or null, got {value!r}")
+    if number <= 0:
+        raise ValueError(f"{label} must be a positive integer or null, got {value!r}")
+    return number
+
+
+def _positive_float(value: Any, label: str) -> float:
+    """Coerce a config value to a positive float, failing fast otherwise."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{label} must be a positive number, got {value!r}")
+    if number <= 0:
+        raise ValueError(f"{label} must be a positive number, got {value!r}")
+    return number

--- a/src/muxi/runtime/services/memory/events/storage.py
+++ b/src/muxi/runtime/services/memory/events/storage.py
@@ -27,7 +27,7 @@
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
-from sqlalchemy import delete as sql_delete, select
+from sqlalchemy import delete as sql_delete, func, select
 from sqlalchemy.exc import IntegrityError
 
 from ....utils.datetime_utils import utc_now_naive
@@ -198,6 +198,43 @@ class MemoryEventStorage:
                 return None
             return event.to_dict()
 
+    async def get_event_by_public_id(
+        self, user_id: str, public_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """Return the user's event with the given public id, or None."""
+        async with self.db_manager.get_async_session() as session:
+            stmt = select(MemoryEvent).filter_by(
+                user_id=str(user_id), formation_id=self.formation_id, public_id=public_id
+            )
+            event = (await session.execute(stmt)).scalars().first()
+            return event.to_dict() if event else None
+
+    async def list_event_user_ids(self) -> List[str]:
+        """Distinct user ids with events in this formation's log."""
+        async with self.db_manager.get_async_session() as session:
+            stmt = select(MemoryEvent.user_id).filter_by(formation_id=self.formation_id).distinct()
+            return [str(row[0]) for row in (await session.execute(stmt)).all()]
+
+    async def count_events(self, user_id: str, include_deleted: bool = True) -> int:
+        """Number of events in a user's log (size-cap accounting)."""
+        async with self.db_manager.get_async_session() as session:
+            stmt = (
+                select(func.count())
+                .select_from(MemoryEvent)
+                .filter_by(user_id=str(user_id), formation_id=self.formation_id)
+            )
+            if not include_deleted:
+                stmt = stmt.filter(MemoryEvent.deleted_at.is_(None))
+            return int((await session.execute(stmt)).scalar() or 0)
+
+    async def max_event_id(self, user_id: Optional[str] = None) -> int:
+        """Highest event id in the log (0 when empty); optionally per user."""
+        async with self.db_manager.get_async_session() as session:
+            stmt = select(func.max(MemoryEvent.id)).filter_by(formation_id=self.formation_id)
+            if user_id is not None:
+                stmt = stmt.filter_by(user_id=str(user_id))
+            return int((await session.execute(stmt)).scalar() or 0)
+
     async def list_events(
         self,
         user_id: str,
@@ -253,6 +290,35 @@ class MemoryEventStorage:
                 marked += 1
             await session.flush()
         return marked
+
+    async def expire_volatile(self, now: Optional[datetime] = None) -> int:
+        """
+        Soft-delete live volatile events past their ``expires_at``.
+
+        The expiry worker's write half (PRD "Decay Model"): once expired,
+        a volatile event is filtered from replay listings exactly like a
+        forgotten event, so the next rebuild drops whatever it projected.
+        The soft-delete keeps the audit trail until the retention hard
+        purge removes the row. Returns the number of events expired.
+        """
+        now = now or utc_now_naive()
+        expired = 0
+        async with self.db_manager.get_async_session() as session:
+            stmt = (
+                select(MemoryEvent)
+                .filter_by(formation_id=self.formation_id)
+                .filter(
+                    MemoryEvent.expires_at.is_not(None),
+                    MemoryEvent.expires_at <= now,
+                    MemoryEvent.deleted_at.is_(None),
+                )
+            )
+            for event in (await session.execute(stmt)).scalars().all():
+                event.deleted_at = now
+                event.deleted_reason = "expired"
+                expired += 1
+            await session.flush()
+        return expired
 
     async def hard_purge(self, grace_period_days: int) -> int:
         """

--- a/src/muxi/runtime/services/memory/extractor.py
+++ b/src/muxi/runtime/services/memory/extractor.py
@@ -698,6 +698,11 @@ class MemoryExtractor:
                 caused_by=caused_by_event_id,
                 agent_id=memory_metadata["agent_id"],
             )
+            if event is not None and getattr(memory_events, "event_first", False):
+                # Event-first cutover (flag-gated, default off): the append
+                # is the write; the substrate applies the projection.
+                await memory_events.apply_event(event)
+                return
 
         await apply_fact_event(
             self.overlord.long_term_memory,

--- a/src/muxi/runtime/services/memory/graph/service.py
+++ b/src/muxi/runtime/services/memory/graph/service.py
@@ -55,6 +55,7 @@ class KnowledgeGraphService:
         formation_id: str,
         config: Optional[Dict[str, Any]] = None,
         event_log=None,
+        decay=None,
     ):
         """
         Initialize the knowledge graph service.
@@ -67,7 +68,13 @@ class KnowledgeGraphService:
                 extraction batch is appended to the memory event log before
                 the projection write (dual-write; append failures are
                 isolated inside the event service and never block the
-                graph write).
+                graph write). With ``memory.events.event_first`` enabled
+                the direct write is skipped and the substrate's applier
+                projects the event instead.
+            decay: DecaySettings (or None). When present, context-block
+                ranking weights fact confidence by age at query time for
+                relationship types with a configured half-life
+                (memory.decay.half_lives).
         """
         config = config or {}
         extraction_config = config.get("extraction") or {}
@@ -90,6 +97,7 @@ class KnowledgeGraphService:
         self.storage = KnowledgeGraphStorage(db_manager, formation_id)
         self.extractor = KnowledgeGraphExtractor(confidence_threshold=self.realtime_confidence)
         self.event_log = event_log
+        self.decay = decay
 
         # Backend selection: pgRouting on PostgreSQL when the extension is
         # installable, NetworkX on SQLite and as the safe fallback when the
@@ -213,7 +221,13 @@ class KnowledgeGraphService:
         Captain's Log digest integration. Appends a ``graph.extracted``
         event to the memory event log first (failure-isolated inside the
         event service), then applies the same result through the upsert
-        path the replay rebuild uses.
+        path the replay rebuild uses. With ``memory.events.event_first``
+        enabled and the event durably appended, the direct apply is
+        skipped -- the substrate's applier projects the event (Phase C
+        cutover semantics, flag-gated, default off).
+
+        Contradictions detected during the apply are recorded as
+        ``fact.contradicted`` audit events linked to the extraction event.
         """
         event = None
         if self.event_log is not None and (result.get("entities") or result.get("relationships")):
@@ -227,7 +241,21 @@ class KnowledgeGraphService:
                 source=source,
                 caused_by=caused_by,
             )
-        return await self.apply_extraction(user_id, result, event_id=event["id"] if event else None)
+            if event is not None and self.event_log.event_first:
+                # Event-first cutover: the append is the write; the
+                # incremental applier derives the projection (and records
+                # the contradiction audit events) from the event.
+                await self.event_log.apply_event(event)
+                return {
+                    "entities": len(result.get("entities", [])),
+                    "relationships": len(result.get("relationships", [])),
+                }
+        stored = await self.apply_extraction(
+            user_id, result, event_id=event["id"] if event else None
+        )
+        if event is not None and stored.get("contradictions"):
+            await self.event_log.record_contradictions(event, stored)
+        return stored
 
     async def apply_extraction(
         self,
@@ -239,12 +267,17 @@ class KnowledgeGraphService:
 
         Deterministic projection write shared by the live dual-write path
         and the event-replay rebuild: given the same result batches in the
-        same order it converges to the same graph state.
+        same order it converges to the same graph state. Contradictions
+        detected by the storage layer are returned under the
+        ``contradictions`` key (only when any occurred) so the LIVE caller
+        can record fact.contradicted audit events -- this method itself
+        never writes to the event log, keeping replay pure.
         """
         user_id = str(user_id)
         entity_ids: Dict[Tuple[str, str], int] = {}
         stored_entities = 0
         stored_relationships = 0
+        contradictions: List[Dict[str, Any]] = []
 
         for item in result.get("entities", []):
             entity = await self.storage.upsert_entity(
@@ -272,7 +305,7 @@ class KnowledgeGraphService:
             )
             if from_id is None or to_id is None or from_id == to_id:
                 continue
-            await self.storage.upsert_relationship(
+            stored = await self.storage.upsert_relationship(
                 user_id=user_id,
                 from_entity_id=from_id,
                 to_entity_id=to_id,
@@ -281,12 +314,19 @@ class KnowledgeGraphService:
                 confidence=item["confidence"],
                 event_id=event_id,
             )
+            contradictions.extend(stored.get("contradictions") or [])
             stored_relationships += 1
 
         if stored_entities or stored_relationships:
             self.algorithms.invalidate(user_id)
 
-        return {"entities": stored_entities, "relationships": stored_relationships}
+        result_counts: Dict[str, Any] = {
+            "entities": stored_entities,
+            "relationships": stored_relationships,
+        }
+        if contradictions:
+            result_counts["contradictions"] = contradictions
+        return result_counts
 
     async def _resolve_endpoint(
         self,
@@ -439,6 +479,11 @@ class KnowledgeGraphService:
         query mentions a known entity, multi-hop exploration via the
         GraphAlgorithms backend appends the entities most strongly
         connected to it. Returns "" when the graph is empty or on error.
+
+        Decay (Memory Substrate Phase 2c): when the formation configures
+        half-lives (memory.decay.half_lives), facts are re-ranked by their
+        query-time effective confidence -- stale decaying facts sink below
+        fresh ones without any stored value changing.
         """
         if not self.enabled:
             return ""
@@ -447,6 +492,7 @@ class KnowledgeGraphService:
             relationships = await self.storage.list_relationships(user_id, limit=limit)
             if not relationships:
                 return ""
+            relationships = self._rank_with_decay(relationships)
 
             names = await self._entity_names(
                 {r["from_entity_id"] for r in relationships}
@@ -511,6 +557,23 @@ class KnowledgeGraphService:
                 relationship = await self.storage.get_relationship_by_id(edge_id)
                 parts.append(f"-[{relationship['type'] if relationship else '?'}]->")
         return " ".join(parts)
+
+    def _rank_with_decay(self, relationships: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Re-rank facts by query-time effective confidence.
+
+        A no-op (stable order) when decay is disabled or no relationship
+        type has a configured half-life -- the default posture, so the
+        hot read path pays nothing unless the formation opts in.
+        """
+        if self.decay is None or not self.decay.enabled or not self.decay.half_lives:
+            return relationships
+        from ..events.decay import effective_fact_confidence
+
+        return sorted(
+            relationships,
+            key=lambda rel: effective_fact_confidence(rel, self.decay),
+            reverse=True,
+        )
 
     async def _entity_names(self, entity_ids: set) -> Dict[int, str]:
         """Map entity ids to display names (single batched query)."""

--- a/src/muxi/runtime/services/memory/graph/storage.py
+++ b/src/muxi/runtime/services/memory/graph/storage.py
@@ -210,7 +210,12 @@ class KnowledgeGraphStorage:
         provenance list (idempotently).
 
         Returns:
-            Dict representation of the stored relationship.
+            Dict representation of the stored relationship. When the
+            write contradicted existing facts, the dict additionally
+            carries a ``contradictions`` list (one entry per affected
+            fact: detection kind + the public ids of both rows) so the
+            caller can record fact.contradicted audit events -- the
+            marking itself already happened in this transaction.
         """
         rel_type = normalize_type(rel_type)
         user_id = str(user_id)
@@ -265,19 +270,33 @@ class KnowledgeGraphStorage:
                 await session.flush()
 
                 conflicted_ids = []
+                contradictions = []
                 for old in conflicting:
                     if old.status == STATUS_SUPERSEDED:
                         old.superseded_by = relationship.id
+                        detection = "superseded"
                     else:
                         old.contradicted_by = relationship.id
                         conflicted_ids.append(old.id)
+                        detection = "conflicted"
+                    contradictions.append(
+                        {
+                            "relationship_type": rel_type,
+                            "detection": detection,
+                            "existing_relationship_public_id": old.public_id,
+                            "new_relationship_public_id": relationship.public_id,
+                        }
+                    )
                 if conflicted_ids:
                     # Deterministic back-link: point at the most recent
                     # conflicting fact rather than whichever row the loop
                     # happened to visit last.
                     relationship.contradicted_by = max(conflicted_ids)
                 await session.flush()
-                return relationship.to_dict()
+                stored = relationship.to_dict()
+                if contradictions:
+                    stored["contradictions"] = contradictions
+                return stored
 
             session.add(relationship)
             await session.flush()
@@ -294,6 +313,7 @@ class KnowledgeGraphStorage:
         user_id: str,
         rel_type: Optional[str] = None,
         from_entity_id: Optional[int] = None,
+        to_entity_id: Optional[int] = None,
         status: Optional[str] = STATUS_ACTIVE,
         limit: int = 200,
     ) -> List[Dict[str, Any]]:
@@ -306,6 +326,8 @@ class KnowledgeGraphStorage:
                 stmt = stmt.filter_by(type=normalize_type(rel_type))
             if from_entity_id is not None:
                 stmt = stmt.filter_by(from_entity_id=from_entity_id)
+            if to_entity_id is not None:
+                stmt = stmt.filter_by(to_entity_id=to_entity_id)
             if status:
                 stmt = stmt.filter_by(status=status)
             stmt = stmt.order_by(KGRelationship.confidence.desc(), KGRelationship.id.desc())

--- a/src/muxi/runtime/services/memory/ingest/service.py
+++ b/src/muxi/runtime/services/memory/ingest/service.py
@@ -693,6 +693,11 @@ class MemoryIngestionService:
             raise IngestionUnavailableError(
                 "The memory event substrate rejected the fact append; " "the item was not stored"
             )
+        if getattr(memory_events, "event_first", False):
+            # Event-first cutover (flag-gated, default off): the append is
+            # the write; the substrate's applier projects the fact.
+            await memory_events.apply_event(fact_event)
+            return {"facts_extracted": 1}
         memory_id = await apply_fact_event(
             self.overlord.long_term_memory,
             user_id,

--- a/src/muxi/runtime/services/memory/log/service.py
+++ b/src/muxi/runtime/services/memory/log/service.py
@@ -331,9 +331,16 @@ class CaptainsLogService:
                 payload=entry_payload,
                 source=SOURCE_CAPTAINS_LOG,
             )
-        entry, source_counts = await self.apply_log_entry_event(
-            user_id, entry_payload, event_id=event["id"] if event else None
-        )
+        if event is not None and self.event_log.event_first:
+            # Event-first cutover (flag-gated, default off): the append is
+            # the write; the substrate applies the projection.
+            await self.event_log.apply_event(event)
+            entry = {"date": entry_payload["date"]}
+            source_counts = {"added": len(entry_payload["sources"])}
+        else:
+            entry, source_counts = await self.apply_log_entry_event(
+                user_id, entry_payload, event_id=event["id"] if event else None
+            )
 
         lessons_stored = 0
         if extract_lessons:
@@ -419,6 +426,11 @@ class CaptainsLogService:
                     payload=payload,
                     source=SOURCE_CAPTAINS_LOG,
                 )
+            if event is not None and self.event_log.event_first:
+                # Event-first cutover: the substrate applies the lesson.
+                await self.event_log.apply_event(event)
+                stored += 1
+                continue
             lesson, created = await self.apply_lesson_event(
                 user_id, payload, event_id=event["id"] if event else None
             )
@@ -525,9 +537,17 @@ class CaptainsLogService:
                 source=SOURCE_TOOL,
                 agent_id=str(agent_id),
             )
-        lesson, created = await self.apply_lesson_event(
-            str(user_id), payload, event_id=event["id"] if event else None
-        )
+        if event is not None and self.event_log.event_first:
+            # Event-first cutover: the substrate applies the projection;
+            # its apply result is the same (lesson, created) tuple.
+            applied = await self.event_log.apply_event(event)
+            if not isinstance(applied, tuple):
+                raise ValueError("Lesson write failed; the event is retained for replay")
+            lesson, created = applied
+        else:
+            lesson, created = await self.apply_lesson_event(
+                str(user_id), payload, event_id=event["id"] if event else None
+            )
         observability.observe(
             event_type=observability.ConversationEvents.MEMORY_LESSON_RECORDED,
             level=observability.EventLevel.DEBUG,

--- a/src/muxi/runtime/services/memory/log/storage.py
+++ b/src/muxi/runtime/services/memory/log/storage.py
@@ -384,6 +384,22 @@ class LessonStorage:
             await session.flush()
             return lesson.to_dict(), True
 
+    async def list_all_for_user(self, user_id: str) -> List[Dict[str, Any]]:
+        """Every lesson for a user (any archived state), oldest first.
+
+        Legacy backfill support (Memory Substrate Phase 2d): the backfill
+        scans the full projection for rows without event provenance, so
+        archived lessons are included -- replay must reproduce them too.
+        """
+        async with self.db_manager.get_async_session() as session:
+            stmt = (
+                select(Lesson)
+                .filter_by(user_id=str(user_id), formation_id=self.formation_id)
+                .order_by(Lesson.id.asc())
+            )
+            rows = (await session.execute(stmt)).scalars().all()
+            return [row.to_dict() for row in rows]
+
     async def list_active(
         self,
         user_id: str,

--- a/src/muxi/runtime/services/memory/long_term.py
+++ b/src/muxi/runtime/services/memory/long_term.py
@@ -1636,6 +1636,42 @@ class LongTermMemory:
                 for m in memories
             ]
 
+    async def list_extracted_orphan_memories(
+        self, external_user_id: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Extraction rows without event provenance (legacy backfill support).
+
+        Rows whose metadata says ``source == 'extraction'`` but carries no
+        ``derived_from_event_id`` predate the memory event substrate; the
+        backfill synthesizes fact.extracted events for exactly these so a
+        rebuild can recreate them. Non-extraction rows are never listed.
+        """
+        internal_user_id = await self._resolve_user_id_async(external_user_id)
+        source_marker = type_coerce(self.MemoryModel.meta_data, JSON)["source"].as_string()
+        event_marker = type_coerce(self.MemoryModel.meta_data, JSON)[
+            "derived_from_event_id"
+        ].as_string()
+        async with self.AsyncSession() as session:
+            query = (
+                select(self.MemoryModel)
+                .where(self.MemoryModel.user_id == internal_user_id)
+                .where(source_marker == "extraction")
+                .where(event_marker.is_(None))
+                .order_by(self.MemoryModel.created_at, self.MemoryModel.id)
+            )
+            rows = (await session.execute(query)).scalars().all()
+            return [
+                {
+                    "id": row.id,
+                    "text": row.text,
+                    "collection": row.collection,
+                    "metadata": row.meta_data or {},
+                    "created_at": row.created_at.isoformat() if row.created_at else None,
+                }
+                for row in rows
+            ]
+
     async def delete_extracted_memories(self, external_user_id: Optional[str] = None) -> int:
         """
         Delete every event-sourced memory for a user (all collections).

--- a/src/muxi/runtime/services/memory/memobase.py
+++ b/src/muxi/runtime/services/memory/memobase.py
@@ -535,6 +535,22 @@ class Memobase:
             return 0
         return await self.long_term_memory.delete_extracted_memories(external_user_id)
 
+    async def list_extracted_orphan_memories(
+        self, external_user_id: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Extraction rows without event provenance (legacy backfill support).
+
+        Delegates to the wrapped LongTermMemory. Anonymous users store
+        nothing, so the call returns [] for them.
+        """
+        external_user_id = (
+            external_user_id if external_user_id is not None else self.default_external_user_id
+        )
+        if external_user_id in ["default", "anonymous", "0"]:
+            return []
+        return await self.long_term_memory.list_extracted_orphan_memories(external_user_id)
+
     def clear_user_memory(self, external_user_id: Optional[str] = None) -> None:
         """
         Clear memory for a specific user by recreating their collection.

--- a/src/muxi/runtime/services/memory/sqlite.py
+++ b/src/muxi/runtime/services/memory/sqlite.py
@@ -647,6 +647,46 @@ class SQLiteMemory(BaseMemory):
 
         return memory_id
 
+    async def list_extracted_orphan_memories(
+        self, user_id: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Extraction rows without event provenance (legacy backfill support).
+
+        Rows whose metadata says ``source == 'extraction'`` but carries no
+        ``derived_from_event_id`` predate the memory event substrate; the
+        backfill synthesizes fact.extracted events for exactly these so a
+        rebuild can recreate them. Non-extraction rows (conversations,
+        manual user memories, knowledge uploads) are not event-sourced and
+        are never listed.
+        """
+        await self._ensure_dim()
+        if user_id:
+            internal_user_id = await self.get_or_create_user(str(user_id))
+        else:
+            internal_user_id = self.default_user_id
+        rows = self.conn.execute(
+            f"""
+            SELECT id, text, collection, metadata, created_at
+            FROM {self.memories_table}
+            WHERE user_id = ?
+              AND json_extract(metadata, '$.source') = 'extraction'
+              AND json_extract(metadata, '$.derived_from_event_id') IS NULL
+            ORDER BY created_at, id
+            """,
+            (internal_user_id,),
+        ).fetchall()
+        return [
+            {
+                "id": row[0],
+                "text": row[1],
+                "collection": row[2],
+                "metadata": json.loads(row[3]) if row[3] else {},
+                "created_at": row[4],
+            }
+            for row in rows
+        ]
+
     async def delete_extracted_memories(self, user_id: Optional[str] = None) -> int:
         """
         Delete every event-sourced memory for a user (all collections).

--- a/tests/unit/test_artifact_memory_schema.py
+++ b/tests/unit/test_artifact_memory_schema.py
@@ -107,6 +107,7 @@ class TestTableCreation:
             "last_accessed_at",
             "expires_at",
             "deleted_at",
+            "derived_from_event_id",
         }
 
     def test_system_config_columns(self, engine):

--- a/tests/unit/test_memory_events_backfill.py
+++ b/tests/unit/test_memory_events_backfill.py
@@ -1,0 +1,257 @@
+"""Legacy backfill tests (Memory Substrate Phase 2d / PRD Phase B).
+
+Pre-event-log rows (created before the substrate shipped, so without any
+``derived_from_event_ids`` provenance) get synthetic ``source='legacy'``
+events keyed per row. Covers: synthesis + in-place provenance stamping
+for graph/log rows, event synthesis for orphan flat facts, idempotent
+re-runs, and the rebuild-after-backfill path that makes legacy data
+replayable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.events import (
+    CaptainsLogProjector,
+    FlatFactProjector,
+    KnowledgeGraphProjector,
+    MemoryEventService,
+)
+from muxi.runtime.services.memory.events.models import SOURCE_LEGACY
+from muxi.runtime.services.memory.graph.service import KnowledgeGraphService
+from muxi.runtime.services.memory.log.service import CaptainsLogService
+
+FORMATION_ID = "backfill-test-formation"
+USER = "u1"
+
+
+class FakeLongTermMemory:
+    """Vector-store double with the orphan-listing backfill surface."""
+
+    def __init__(self):
+        self.rows = {}
+        self._counter = 0
+
+    async def add(self, content, metadata=None, user_id=None, collection=None, scope=None):
+        self._counter += 1
+        memory_id = f"m{self._counter}"
+        self.rows[memory_id] = {
+            "id": memory_id,
+            "text": content,
+            "metadata": dict(metadata or {}),
+            "user_id": str(user_id),
+            "collection": collection,
+            "scope": scope,
+            "created_at": "2025-06-01T00:00:00",
+        }
+        return memory_id
+
+    async def delete_extracted_memories(self, user_id):
+        doomed = [
+            memory_id
+            for memory_id, row in self.rows.items()
+            if row["user_id"] == str(user_id)
+            and (
+                row["metadata"].get("source") == "extraction"
+                or row["metadata"].get("derived_from_event_id") is not None
+            )
+        ]
+        for memory_id in doomed:
+            del self.rows[memory_id]
+        return len(doomed)
+
+    async def list_extracted_orphan_memories(self, user_id):
+        return [
+            dict(row)
+            for row in self.rows.values()
+            if row["user_id"] == str(user_id)
+            and row["metadata"].get("source") == "extraction"
+            and row["metadata"].get("derived_from_event_id") is None
+        ]
+
+
+@pytest.fixture
+def db_manager(tmp_path):
+    manager = DatabaseManager(f"sqlite:///{tmp_path}/backfill.db")
+    manager.create_tables(Base.metadata)
+    yield manager
+    manager.engine.dispose()
+
+
+@pytest.fixture
+def events(db_manager):
+    return MemoryEventService(db_manager, FORMATION_ID)
+
+
+async def seed_legacy_graph(db_manager):
+    """A pre-substrate subgraph: direct writes, no event log involved."""
+    graph = KnowledgeGraphService(db_manager, FORMATION_ID, event_log=None)
+    user = await graph.storage.upsert_entity(USER, "person", "User", confidence=0.95)
+    london = await graph.storage.upsert_entity(
+        USER, "location", "London", confidence=0.9, attributes={"country": "UK"}
+    )
+    await graph.storage.upsert_relationship(
+        USER, user["id"], london["id"], "lives_in", confidence=0.9
+    )
+    return graph
+
+
+class TestKnowledgeGraphBackfill:
+    async def test_synthesizes_and_stamps_provenance(self, db_manager, events):
+        graph = await seed_legacy_graph(db_manager)
+        events.register_projector(KnowledgeGraphProjector(graph))
+
+        report = await events.backfill_user(USER)
+        assert report["knowledge_graph"] == 3  # 2 entities + 1 relationship
+
+        legacy = await events.list_events(USER, source=SOURCE_LEGACY)
+        assert len(legacy) == 3
+        assert all(e["source_id"].startswith("legacy/kg_") for e in legacy)
+
+        # Rows stamped in place; content untouched.
+        london = await graph.storage.get_entity(USER, "location", "London")
+        assert london["derived_from_event_ids"]
+        assert london["attributes"] == {"country": "UK"}
+        relationships = await graph.storage.list_relationships(USER)
+        assert all(r["derived_from_event_ids"] for r in relationships)
+
+    async def test_backfill_is_idempotent(self, db_manager, events):
+        graph = await seed_legacy_graph(db_manager)
+        events.register_projector(KnowledgeGraphProjector(graph))
+
+        first = await events.backfill_user(USER)
+        second = await events.backfill_user(USER)
+        assert first["knowledge_graph"] == 3
+        assert second["knowledge_graph"] == 0  # everything already stamped
+        assert len(await events.list_events(USER, source=SOURCE_LEGACY)) == 3
+
+    async def test_rebuild_after_backfill_reproduces_legacy_rows(self, db_manager, events):
+        graph = await seed_legacy_graph(db_manager)
+        events.register_projector(KnowledgeGraphProjector(graph))
+        await events.backfill_user(USER)
+
+        entities_before = {
+            (e["type"], e["name"]): (e["confidence"], e["attributes"])
+            for e in await graph.storage.list_entities(USER, status=None)
+        }
+        report = await events.rebuild(USER, projection="knowledge_graph")
+        assert report["knowledge_graph"]["failed"] == 0
+        entities_after = {
+            (e["type"], e["name"]): (e["confidence"], e["attributes"])
+            for e in await graph.storage.list_entities(USER, status=None)
+        }
+        assert entities_after == entities_before
+        relationships = await graph.storage.list_relationships(USER)
+        assert len(relationships) == 1
+        assert relationships[0]["type"] == "lives_in"
+
+
+class TestCaptainsLogBackfill:
+    async def seed_legacy_log(self, db_manager):
+        """Pre-substrate entries + lessons: direct writes, no events."""
+        from datetime import date
+
+        log = CaptainsLogService(db_manager, FORMATION_ID, event_log=None)
+        entry = await log.storage.upsert_entry(
+            USER,
+            date(2025, 6, 1),
+            summary="Founded Automaze.",
+            decisions=["Ship the runtime"],
+            projects=["MUXI"],
+            context="Launch week.",
+        )
+        await log.storage.add_sources(
+            USER, entry["id"], [{"source_type": "buffer_item", "source_id": "t1"}]
+        )
+        await log.lessons.upsert_lesson(
+            user_id=USER,
+            agent_id="overlord",
+            rule="Prefer reportlab over fpdf",
+            source_log_id=entry["id"],
+        )
+        return log
+
+    async def test_synthesizes_and_stamps(self, db_manager, events):
+        log = await self.seed_legacy_log(db_manager)
+        events.register_projector(CaptainsLogProjector(log))
+
+        report = await events.backfill_user(USER)
+        assert report["captains_log"] == 2  # 1 entry + 1 lesson
+
+        entries = await log.storage.list_entries(USER)
+        assert entries[0]["derived_from_event_ids"]
+        lessons = await log.lessons.list_all_for_user(USER)
+        assert lessons[0]["derived_from_event_ids"]
+        # Lesson hits untouched by the stamping confirmation? The apply
+        # bumps hits (confirmation semantics); what matters is the rule
+        # set and lineage are unchanged.
+        assert lessons[0]["rule"] == "Prefer reportlab over fpdf"
+
+        assert await events.backfill_user(USER) == {"captains_log": 0}
+
+    async def test_rebuild_after_backfill_reproduces_entries(self, db_manager, events):
+        log = await self.seed_legacy_log(db_manager)
+        events.register_projector(CaptainsLogProjector(log))
+        await events.backfill_user(USER)
+
+        report = await events.rebuild(USER, projection="captains_log")
+        assert report["captains_log"]["failed"] == 0
+        entries = await log.storage.list_entries(USER)
+        assert len(entries) == 1
+        assert entries[0]["summary"] == "Founded Automaze."
+        sources = await log.storage.get_sources(entries[0]["id"])
+        assert [(s["source_type"], s["source_id"]) for s in sources] == [("buffer_item", "t1")]
+        lessons = await log.lessons.list_all_for_user(USER)
+        assert len(lessons) == 1
+        assert lessons[0]["source_log_id"] == entries[0]["id"]  # re-linked by date
+
+
+class TestFlatFactBackfill:
+    async def test_synthesizes_events_for_orphan_rows(self, events):
+        long_term = FakeLongTermMemory()
+        events.register_projector(FlatFactProjector(long_term))
+        # Legacy extraction row (no provenance) + a manual row (never event-sourced).
+        await long_term.add(
+            content="Likes tea",
+            metadata={"source": "extraction", "confidence": 0.9},
+            user_id=USER,
+            collection="preferences",
+        )
+        await long_term.add(
+            content="manual note",
+            metadata={"source": "user"},
+            user_id=USER,
+            collection="context",
+        )
+
+        report = await events.backfill_user(USER)
+        assert report["flat_facts"] == 1
+        legacy = await events.list_events(USER, source=SOURCE_LEGACY)
+        assert len(legacy) == 1
+        assert legacy[0]["payload"]["memory"] == "Likes tea"
+
+        assert await events.backfill_user(USER) == {"flat_facts": 0}  # idempotent? no:
+        # the row is still orphaned (stamping happens on rebuild), but the
+        # per-row legacy source_id makes the re-run an idempotent skip.
+
+    async def test_rebuild_after_backfill_stamps_provenance(self, events):
+        long_term = FakeLongTermMemory()
+        events.register_projector(FlatFactProjector(long_term))
+        await long_term.add(
+            content="Likes tea",
+            metadata={"source": "extraction", "confidence": 0.9},
+            user_id=USER,
+            collection="preferences",
+        )
+        await events.backfill_user(USER)
+
+        report = await events.rebuild(USER, projection="flat_facts")
+        assert report["flat_facts"] == {"events": 1, "applied": 1, "failed": 0}
+        rows = [row for row in long_term.rows.values() if row["user_id"] == USER]
+        assert len(rows) == 1
+        assert rows[0]["text"] == "Likes tea"
+        assert rows[0]["metadata"]["derived_from_event_id"] is not None
+        # Now provenance-complete: nothing left to backfill.
+        assert await events.backfill_user(USER) == {"flat_facts": 0}

--- a/tests/unit/test_memory_events_contradiction.py
+++ b/tests/unit/test_memory_events_contradiction.py
@@ -1,0 +1,116 @@
+"""Contradiction-detection audit tests (Memory Substrate Phase 2c).
+
+The knowledge graph already marks conflicting/superseded facts at write
+time; the substrate now records each detection as a ``fact.contradicted``
+event linked (caused_by) to the extraction that triggered it. Replay
+purity: rebuilds re-mark the rows but never re-record the audit events.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.events import KnowledgeGraphProjector, MemoryEventService
+from muxi.runtime.services.memory.events.models import EVENT_FACT_CONTRADICTED
+from muxi.runtime.services.memory.graph.service import KnowledgeGraphService
+
+FORMATION_ID = "contradiction-test-formation"
+USER = "u1"
+
+
+@pytest.fixture
+def db_manager(tmp_path):
+    manager = DatabaseManager(f"sqlite:///{tmp_path}/contradiction.db")
+    manager.create_tables(Base.metadata)
+    yield manager
+    manager.engine.dispose()
+
+
+@pytest.fixture
+def events(db_manager):
+    return MemoryEventService(db_manager, FORMATION_ID)
+
+
+@pytest.fixture
+def graph(db_manager, events):
+    service = KnowledgeGraphService(db_manager, FORMATION_ID, event_log=events)
+    events.register_projector(KnowledgeGraphProjector(service))
+    return service
+
+
+def residence(city, confidence):
+    return {
+        "entities": [{"name": city, "type": "location", "confidence": 0.9}],
+        "relationships": [
+            {
+                "from": "User",
+                "from_type": "person",
+                "to": city,
+                "to_type": "location",
+                "type": "lives_in",
+                "confidence": confidence,
+            }
+        ],
+    }
+
+
+class TestContradictionEvents:
+    async def test_conflict_records_fact_contradicted_event(self, events, graph):
+        await graph.store_extraction(USER, residence("London", 0.9))
+        await graph.store_extraction(USER, residence("Berlin", 0.88))
+
+        recorded = await events.list_events(USER, event_types=[EVENT_FACT_CONTRADICTED])
+        assert len(recorded) == 1
+        payload = recorded[0]["payload"]
+        assert payload["relationship_type"] == "lives_in"
+        assert payload["detection"] == "conflicted"
+        assert payload["existing_relationship_public_id"]
+        assert payload["new_relationship_public_id"]
+        # Audit event links back to the extraction that triggered it.
+        graph_events = await events.list_events(USER, event_types=["graph.extracted"])
+        assert recorded[0]["caused_by"] == graph_events[-1]["id"]
+
+    async def test_supersede_records_detection_kind(self, events, graph):
+        await graph.store_extraction(USER, residence("London", 0.5))
+        await graph.store_extraction(USER, residence("Berlin", 0.95))
+
+        recorded = await events.list_events(USER, event_types=[EVENT_FACT_CONTRADICTED])
+        assert len(recorded) == 1
+        assert recorded[0]["payload"]["detection"] == "superseded"
+
+    async def test_projection_rows_marked(self, events, graph):
+        await graph.store_extraction(USER, residence("London", 0.9))
+        await graph.store_extraction(USER, residence("Berlin", 0.88))
+        relationships = await graph.storage.list_relationships(USER, status=None)
+        statuses = sorted(r["status"] for r in relationships)
+        assert statuses == ["conflicted", "conflicted"]
+
+    async def test_duplicate_fact_is_not_a_contradiction(self, events, graph):
+        await graph.store_extraction(USER, residence("London", 0.9))
+        await graph.store_extraction(USER, residence("London", 0.92))
+        assert await events.list_events(USER, event_types=[EVENT_FACT_CONTRADICTED]) == []
+
+    async def test_rebuild_replays_marking_without_new_audit_events(self, events, graph):
+        await graph.store_extraction(USER, residence("London", 0.9))
+        await graph.store_extraction(USER, residence("Berlin", 0.88))
+        before = await events.list_events(USER, event_types=[EVENT_FACT_CONTRADICTED])
+
+        await events.rebuild(USER, projection="knowledge_graph")
+
+        after = await events.list_events(USER, event_types=[EVENT_FACT_CONTRADICTED])
+        assert [e["id"] for e in after] == [e["id"] for e in before]  # replay purity
+        relationships = await graph.storage.list_relationships(USER, status=None)
+        assert sorted(r["status"] for r in relationships) == ["conflicted", "conflicted"]
+
+    async def test_event_first_path_records_contradictions(self, db_manager):
+        events = MemoryEventService(db_manager, FORMATION_ID, config={"event_first": True})
+        graph = KnowledgeGraphService(db_manager, FORMATION_ID, event_log=events)
+        events.register_projector(KnowledgeGraphProjector(graph))
+
+        await graph.store_extraction(USER, residence("London", 0.9))
+        await graph.store_extraction(USER, residence("Berlin", 0.88))
+
+        recorded = await events.list_events(USER, event_types=[EVENT_FACT_CONTRADICTED])
+        assert len(recorded) == 1
+        assert recorded[0]["payload"]["detection"] == "conflicted"

--- a/tests/unit/test_memory_events_decay.py
+++ b/tests/unit/test_memory_events_decay.py
@@ -1,0 +1,225 @@
+"""Decay tests for the Memory Event Substrate (Phase 2c).
+
+Covers the pure decay math (half-life semantics), fail-fast settings
+validation, the volatile default TTL stamped at write time, the volatile
+expiry sweep (soft-delete -> excluded from replay), and query-time
+re-ranking in the knowledge graph context block.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.events import DecaySettings, MemoryEventService
+from muxi.runtime.services.memory.events.decay import (
+    decayed_confidence,
+    effective_event_confidence,
+    effective_fact_confidence,
+)
+from muxi.runtime.services.memory.events.models import (
+    DECAY_DECAYING,
+    DECAY_STATIC,
+    DECAY_VOLATILE,
+    EVENT_FACT_EXTRACTED,
+)
+from muxi.runtime.utils.datetime_utils import utc_now_naive
+
+FORMATION_ID = "decay-test-formation"
+USER = "u1"
+
+
+@pytest.fixture
+def service(tmp_path):
+    db_manager = DatabaseManager(f"sqlite:///{tmp_path}/decay.db")
+    db_manager.create_tables(Base.metadata)
+    yield MemoryEventService(db_manager, FORMATION_ID)
+    db_manager.engine.dispose()
+
+
+class TestDecayMath:
+    def test_zero_age_keeps_confidence(self):
+        assert decayed_confidence(0.9, 0.0, 90.0) == 0.9
+
+    def test_one_half_life_halves(self):
+        assert decayed_confidence(0.8, 90.0, 90.0) == pytest.approx(0.4)
+
+    def test_two_half_lives_quarter(self):
+        assert decayed_confidence(0.8, 180.0, 90.0) == pytest.approx(0.2)
+
+    def test_static_event_never_fades(self):
+        event = {
+            "source_confidence": 0.9,
+            "decay_rate": DECAY_STATIC,
+            "occurred_at": (utc_now_naive() - timedelta(days=1000)).isoformat(),
+        }
+        assert effective_event_confidence(event) == 0.9
+
+    def test_decaying_event_fades_with_default_half_life(self):
+        decay = DecaySettings({"default_half_life_days": 100})
+        event = {
+            "source_confidence": 1.0,
+            "decay_rate": DECAY_DECAYING,
+            "occurred_at": (utc_now_naive() - timedelta(days=100)).isoformat(),
+        }
+        assert effective_event_confidence(event, decay) == pytest.approx(0.5, abs=0.01)
+
+    def test_volatile_event_zero_after_expiry(self):
+        event = {
+            "source_confidence": 1.0,
+            "decay_rate": DECAY_VOLATILE,
+            "expires_at": (utc_now_naive() - timedelta(hours=1)).isoformat(),
+        }
+        assert effective_event_confidence(event) == 0.0
+
+    def test_volatile_event_full_before_expiry(self):
+        event = {
+            "source_confidence": 0.7,
+            "decay_rate": DECAY_VOLATILE,
+            "expires_at": (utc_now_naive() + timedelta(hours=1)).isoformat(),
+        }
+        assert effective_event_confidence(event) == 0.7
+
+    def test_disabled_settings_return_stored_confidence(self):
+        decay = DecaySettings({"enabled": False})
+        event = {
+            "source_confidence": 1.0,
+            "decay_rate": DECAY_DECAYING,
+            "occurred_at": (utc_now_naive() - timedelta(days=1000)).isoformat(),
+        }
+        assert effective_event_confidence(event, decay) == 1.0
+
+    def test_fact_without_configured_half_life_is_static(self):
+        decay = DecaySettings({})
+        fact = {
+            "type": "lives_in",
+            "confidence": 0.9,
+            "updated_at": (utc_now_naive() - timedelta(days=1000)).isoformat(),
+        }
+        assert effective_fact_confidence(fact, decay) == 0.9
+
+    def test_fact_with_configured_half_life_fades(self):
+        decay = DecaySettings({"half_lives": {"works_at": 90}})
+        fact = {
+            "type": "works_at",
+            "confidence": 0.8,
+            "updated_at": (utc_now_naive() - timedelta(days=90)).isoformat(),
+        }
+        assert effective_fact_confidence(fact, decay) == pytest.approx(0.4, abs=0.01)
+
+
+class TestDecaySettingsValidation:
+    def test_defaults(self):
+        decay = DecaySettings()
+        assert decay.enabled is True
+        assert decay.default_half_life_days == 180.0
+        assert decay.volatile_ttl_hours == 24.0
+        assert decay.half_lives == {}
+
+    def test_invalid_half_life_fails_fast(self):
+        with pytest.raises(ValueError):
+            DecaySettings({"default_half_life_days": 0})
+
+    def test_invalid_ttl_fails_fast(self):
+        with pytest.raises(ValueError):
+            DecaySettings({"volatile_default_ttl_hours": "soon"})
+
+    def test_invalid_type_half_life_fails_fast(self):
+        with pytest.raises(ValueError):
+            DecaySettings({"half_lives": {"works_at": -1}})
+
+    def test_non_mapping_half_lives_fails_fast(self):
+        with pytest.raises(ValueError):
+            DecaySettings({"half_lives": ["works_at"]})
+
+
+class TestVolatileLifecycle:
+    async def test_volatile_default_expiry_stamped_at_write(self, service):
+        event = await service.record(
+            user_id=USER,
+            event_type=EVENT_FACT_EXTRACTED,
+            payload={"memory": "User is tired today", "collection": "context"},
+            source="interaction",
+            decay_rate=DECAY_VOLATILE,
+        )
+        assert event["expires_at"] is not None
+
+    async def test_expiry_sweep_soft_deletes_and_replay_excludes(self, service):
+        now = utc_now_naive()
+        expired = await service.record(
+            user_id=USER,
+            event_type=EVENT_FACT_EXTRACTED,
+            payload={"memory": "User is tired today", "collection": "context"},
+            source="interaction",
+            decay_rate=DECAY_VOLATILE,
+            expires_at=now - timedelta(hours=1),
+        )
+        fresh = await service.record(
+            user_id=USER,
+            event_type=EVENT_FACT_EXTRACTED,
+            payload={"memory": "User is on a deadline this week", "collection": "context"},
+            source="interaction",
+            decay_rate=DECAY_VOLATILE,
+            expires_at=now + timedelta(days=2),
+        )
+
+        assert await service.run_volatile_expiry() == 1
+        live = await service.list_events(USER)
+        assert [event["id"] for event in live] == [fresh["id"]]
+
+        # The audit trail survives until the retention hard purge.
+        gone = await service.storage.get_event(expired["id"])
+        assert gone["deleted_at"] is not None
+        assert gone["deleted_reason"] == "expired"
+
+    async def test_static_events_never_swept(self, service):
+        await service.record(
+            user_id=USER,
+            event_type=EVENT_FACT_EXTRACTED,
+            payload={"memory": "Lives in London", "collection": "user_identity"},
+            source="interaction",
+        )
+        assert await service.run_volatile_expiry() == 0
+        assert len(await service.list_events(USER)) == 1
+
+
+class TestContextBlockDecayRanking:
+    async def test_stale_decaying_fact_sinks_below_fresh_one(self, tmp_path):
+        from muxi.runtime.services.memory.graph.service import KnowledgeGraphService
+
+        db_manager = DatabaseManager(f"sqlite:///{tmp_path}/decay-graph.db")
+        db_manager.create_tables(Base.metadata)
+        try:
+            decay = DecaySettings({"half_lives": {"works_at": 30}})
+            graph = KnowledgeGraphService(db_manager, FORMATION_ID, decay=decay)
+
+            user = await graph.storage.upsert_entity(USER, "person", "User", confidence=0.95)
+            acme = await graph.storage.upsert_entity(USER, "company", "Acme", confidence=0.9)
+            topic = await graph.storage.upsert_entity(USER, "topic", "chess", confidence=0.9)
+            stale = await graph.storage.upsert_relationship(
+                USER, user["id"], acme["id"], "works_at", confidence=0.95
+            )
+            await graph.storage.upsert_relationship(
+                USER, user["id"], topic["id"], "interested_in", confidence=0.6
+            )
+            # Age the works_at fact by a year (well past its 30d half-life).
+            from sqlalchemy import text
+
+            with db_manager.engine.connect() as conn:
+                conn.execute(
+                    text("UPDATE kg_relationships SET updated_at = :ts WHERE id = :id"),
+                    {
+                        "ts": utc_now_naive() - timedelta(days=365),
+                        "id": stale["id"],
+                    },
+                )
+                conn.commit()
+
+            block = await graph.get_context_block(USER)
+            lines = block.splitlines()
+            assert lines[0].startswith("User -[interested_in]->")  # fresh fact ranks first
+            assert any("works_at" in line for line in lines)  # stale fact still present
+        finally:
+            db_manager.engine.dispose()

--- a/tests/unit/test_memory_events_gdpr.py
+++ b/tests/unit/test_memory_events_gdpr.py
@@ -1,0 +1,127 @@
+"""GDPR / selective-forgetting tests (Memory Substrate Phase 2d).
+
+Deletion is a write: forgetting a source soft-deletes its events
+(reversible during the grace period), records the user.deletion audit
+event, and a rebuild recomputes projections as if the source was never
+imported. The hard-purge worker later removes the soft-deleted rows.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.events import KnowledgeGraphProjector, MemoryEventService
+from muxi.runtime.services.memory.graph.service import KnowledgeGraphService
+from muxi.runtime.utils.datetime_utils import utc_now_naive
+
+FORMATION_ID = "gdpr-test-formation"
+USER = "u1"
+
+
+@pytest.fixture
+def db_manager(tmp_path):
+    manager = DatabaseManager(f"sqlite:///{tmp_path}/gdpr.db")
+    manager.create_tables(Base.metadata)
+    yield manager
+    manager.engine.dispose()
+
+
+@pytest.fixture
+def events(db_manager):
+    return MemoryEventService(db_manager, FORMATION_ID)
+
+
+@pytest.fixture
+def graph(db_manager, events):
+    service = KnowledgeGraphService(db_manager, FORMATION_ID, event_log=events)
+    events.register_projector(KnowledgeGraphProjector(service))
+    return service
+
+
+def extraction(company):
+    return {
+        "entities": [{"name": company, "type": "company", "confidence": 0.9}],
+        "relationships": [],
+    }
+
+
+async def seed_two_sources(graph):
+    """Facts from a chat turn and from an imported source (gmail)."""
+    await graph.store_extraction(USER, extraction("Acme"), source="interaction")
+    await graph.store_extraction(USER, extraction("MailCorp"), source="gmail")
+
+
+class TestForgetAndRebuild:
+    async def test_rebuild_after_forget_removes_derived_state(self, events, graph):
+        await seed_two_sources(graph)
+        assert await graph.storage.get_entity(USER, "company", "MailCorp") is not None
+
+        result = await events.forget_source(USER, "gmail", reason="gdpr")
+        assert result["deleted_events"] == 1
+        assert "knowledge_graph" in result["rebuild_required"]
+
+        await events.rebuild(USER, projection="knowledge_graph")
+
+        # The gmail-derived fact is gone; the interaction fact survives.
+        assert await graph.storage.get_entity(USER, "company", "MailCorp") is None
+        assert await graph.storage.get_entity(USER, "company", "Acme") is not None
+
+    async def test_deletion_is_reversible_during_grace_period(self, events, graph):
+        """Un-forgetting = clearing the soft delete; the next rebuild
+        restores the derived state (the PRD's grace-period undo)."""
+        await seed_two_sources(graph)
+        await events.forget_source(USER, "gmail", reason="user_request")
+        await events.rebuild(USER, projection="knowledge_graph")
+        assert await graph.storage.get_entity(USER, "company", "MailCorp") is None
+
+        # Undo within the grace period: the event content is intact.
+        deleted = await events.list_events(USER, source="gmail", include_deleted=True)
+        assert len(deleted) == 1 and deleted[0]["deleted_at"] is not None
+        from sqlalchemy import text
+
+        with events.db_manager.engine.connect() as conn:
+            conn.execute(
+                text(
+                    "UPDATE memory_events SET deleted_at = NULL, deleted_reason = NULL "
+                    "WHERE id = :id"
+                ),
+                {"id": deleted[0]["id"]},
+            )
+            conn.commit()
+
+        await events.rebuild(USER, projection="knowledge_graph")
+        assert await graph.storage.get_entity(USER, "company", "MailCorp") is not None
+
+    async def test_audit_trail_event_recorded(self, events, graph):
+        await seed_two_sources(graph)
+        await events.forget_source(USER, "gmail", reason="gdpr")
+        audit = await events.list_events(USER, event_types=["user.deletion"])
+        assert len(audit) == 1
+        assert audit[0]["payload"]["reason"] == "gdpr"
+        assert audit[0]["payload"]["source"] == "gmail"
+        assert len(audit[0]["payload"]["target_event_ids"]) == 1
+
+    async def test_hard_purge_removes_after_grace_period(self, events, graph):
+        await seed_two_sources(graph)
+        await events.forget_source(USER, "gmail", reason="gdpr")
+
+        # Inside the grace period: nothing purged.
+        assert await events.run_hard_purge() == 0
+
+        # Age the soft delete past the grace period.
+        from sqlalchemy import text
+
+        cutoff = utc_now_naive() - timedelta(days=events.grace_period_days + 1)
+        with events.db_manager.engine.connect() as conn:
+            conn.execute(
+                text("UPDATE memory_events SET deleted_at = :ts WHERE deleted_at IS NOT NULL"),
+                {"ts": cutoff},
+            )
+            conn.commit()
+
+        assert await events.run_hard_purge() == 1
+        remaining = await events.list_events(USER, include_deleted=True)
+        assert all(e["source"] != "gmail" for e in remaining)

--- a/tests/unit/test_memory_events_projection.py
+++ b/tests/unit/test_memory_events_projection.py
@@ -1,0 +1,411 @@
+"""Incremental projection tests for the Memory Event Substrate (Phase 2b).
+
+Covers the per-(projection, user) cursor contract: ``project_pending``
+applies only events past the cursor (idempotent re-projection), cursor
+resume across passes, the event-first write posture (append + substrate
+apply, no direct projection write), the cursor tail snapshot that guards
+dual-written history, and the artifact-metadata projector's
+wipe-and-replay.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.artifacts.models import Artifact  # noqa: F401 -- registers table
+from muxi.runtime.services.memory.artifacts.storage import ArtifactMemoryStorage
+from muxi.runtime.services.memory.events import (
+    ArtifactMetadataProjector,
+    FlatFactProjector,
+    KnowledgeGraphProjector,
+    MemoryEventService,
+)
+from muxi.runtime.services.memory.events.models import EVENT_FACT_EXTRACTED
+from muxi.runtime.services.memory.graph.service import KnowledgeGraphService
+
+FORMATION_ID = "projection-test-formation"
+USER = "u1"
+
+
+class FakeLongTermMemory:
+    """Vector-store double implementing the flat-fact projection contract."""
+
+    def __init__(self):
+        self.rows = {}
+        self._counter = 0
+
+    async def add(self, content, metadata=None, user_id=None, collection=None, scope=None):
+        self._counter += 1
+        memory_id = f"m{self._counter}"
+        self.rows[memory_id] = {
+            "content": content,
+            "metadata": dict(metadata or {}),
+            "user_id": str(user_id),
+            "collection": collection,
+            "scope": scope,
+        }
+        return memory_id
+
+    async def delete_extracted_memories(self, user_id):
+        doomed = [
+            memory_id
+            for memory_id, row in self.rows.items()
+            if row["user_id"] == str(user_id)
+            and (
+                row["metadata"].get("source") == "extraction"
+                or row["metadata"].get("derived_from_event_id") is not None
+            )
+        ]
+        for memory_id in doomed:
+            del self.rows[memory_id]
+        return len(doomed)
+
+
+@pytest.fixture
+def db_manager(tmp_path):
+    manager = DatabaseManager(f"sqlite:///{tmp_path}/projection.db")
+    manager.create_tables(Base.metadata)
+    yield manager
+    manager.engine.dispose()
+
+
+@pytest.fixture
+def events(db_manager):
+    return MemoryEventService(db_manager, FORMATION_ID)
+
+
+async def record_fact(events, memory, user_id=USER, **kwargs):
+    return await events.record(
+        user_id=user_id,
+        event_type=EVENT_FACT_EXTRACTED,
+        payload={
+            "memory": memory,
+            "collection": "preferences",
+            "metadata": {"source": "extraction"},
+        },
+        source="interaction",
+        **kwargs,
+    )
+
+
+class TestProjectPending:
+    async def test_applies_pending_and_advances_cursor(self, events):
+        long_term = FakeLongTermMemory()
+        events.register_projector(FlatFactProjector(long_term))
+        first = await record_fact(events, "Likes tea")
+        second = await record_fact(events, "Likes scones")
+
+        report = await events.project_pending(USER)
+        assert report["flat_facts"][USER] == {"events": 2, "applied": 2, "failed": 0}
+        assert len(long_term.rows) == 2
+
+        checkpoint = await events.storage.get_checkpoint("flat_facts", USER)
+        assert checkpoint["last_event_id"] == second["id"]
+        assert first["id"] < second["id"]
+
+    async def test_second_pass_applies_nothing(self, events):
+        """Idempotent re-projection: the cursor gates re-application."""
+        long_term = FakeLongTermMemory()
+        events.register_projector(FlatFactProjector(long_term))
+        await record_fact(events, "Likes tea")
+
+        await events.project_pending(USER)
+        report = await events.project_pending(USER)
+        assert report == {}  # nothing pending
+        assert len(long_term.rows) == 1
+
+    async def test_cursor_resume_applies_only_new_events(self, events):
+        long_term = FakeLongTermMemory()
+        events.register_projector(FlatFactProjector(long_term))
+        await record_fact(events, "Likes tea")
+        await events.project_pending(USER)
+
+        await record_fact(events, "Likes scones")
+        report = await events.project_pending(USER)
+        assert report["flat_facts"][USER]["events"] == 1
+        assert len(long_term.rows) == 2
+
+    async def test_discovers_users_without_explicit_id(self, events):
+        long_term = FakeLongTermMemory()
+        events.register_projector(FlatFactProjector(long_term))
+        await record_fact(events, "Likes tea", user_id="u1")
+        await record_fact(events, "Likes coffee", user_id="u2")
+
+        report = await events.project_pending()
+        assert set(report["flat_facts"]) == {"u1", "u2"}
+
+    async def test_poison_event_is_skipped_and_cursor_advances(self, events, monkeypatch):
+        long_term = FakeLongTermMemory()
+        projector = FlatFactProjector(long_term)
+        events.register_projector(projector)
+        poison = await record_fact(events, "poison")
+        good = await record_fact(events, "good")
+
+        original_apply = projector.apply
+
+        async def flaky_apply(event):
+            if event["id"] == poison["id"]:
+                raise RuntimeError("projector exploded")
+            return await original_apply(event)
+
+        monkeypatch.setattr(projector, "apply", flaky_apply)
+        report = await events.project_pending(USER)
+        assert report["flat_facts"][USER] == {"events": 2, "applied": 1, "failed": 1}
+        checkpoint = await events.storage.get_checkpoint("flat_facts", USER)
+        assert checkpoint["last_event_id"] == good["id"]  # not wedged
+
+
+class TestApplyEvent:
+    async def test_apply_event_projects_and_checkpoints(self, events):
+        long_term = FakeLongTermMemory()
+        events.register_projector(FlatFactProjector(long_term))
+        event = await record_fact(events, "Likes tea")
+
+        assert await events.apply_event(event)
+        assert len(long_term.rows) == 1
+        checkpoint = await events.storage.get_checkpoint("flat_facts", USER)
+        assert checkpoint["last_event_id"] == event["id"]
+
+    async def test_apply_event_is_idempotent_behind_cursor(self, events):
+        long_term = FakeLongTermMemory()
+        events.register_projector(FlatFactProjector(long_term))
+        event = await record_fact(events, "Likes tea")
+
+        await events.apply_event(event)
+        assert await events.apply_event(event) is True  # cursor skip
+        assert len(long_term.rows) == 1
+
+    async def test_apply_event_without_projector_is_noop(self, events):
+        turn = await events.record(
+            user_id=USER,
+            event_type="interaction.turn",
+            payload={"user_message": "hello"},
+            source="interaction",
+        )
+        assert await events.apply_event(turn) is True
+
+    async def test_apply_failure_leaves_cursor_for_retry(self, events, monkeypatch):
+        long_term = FakeLongTermMemory()
+        projector = FlatFactProjector(long_term)
+        events.register_projector(projector)
+        event = await record_fact(events, "Likes tea")
+
+        async def broken_apply(_event):
+            raise RuntimeError("down")
+
+        monkeypatch.setattr(projector, "apply", broken_apply)
+        assert await events.apply_event(event) is None
+        assert await events.storage.get_checkpoint("flat_facts", USER) is None
+
+        # The background applier's pass recovers the event.
+        monkeypatch.undo()
+        report = await events.project_pending(USER)
+        assert report["flat_facts"][USER]["applied"] == 1
+
+
+class TestCursorSnapshot:
+    async def test_snapshot_guards_dual_written_history(self, events):
+        """Dual-written events are never re-applied after a cutover."""
+        long_term = FakeLongTermMemory()
+        events.register_projector(FlatFactProjector(long_term))
+        # Simulate dual-write history: events exist AND rows were written
+        # directly (here: one row, one event, no cursor).
+        await record_fact(events, "Likes tea")
+        await long_term.add(
+            content="Likes tea",
+            metadata={"source": "extraction"},
+            user_id=USER,
+            collection="preferences",
+        )
+
+        await events.snapshot_cursors_to_tail()
+        report = await events.project_pending(USER)
+        assert report == {}  # history skipped, no duplicate row
+        assert len(long_term.rows) == 1
+
+    async def test_snapshot_leaves_existing_cursors(self, events):
+        long_term = FakeLongTermMemory()
+        events.register_projector(FlatFactProjector(long_term))
+        first = await record_fact(events, "Likes tea")
+        await events.storage.set_checkpoint("flat_facts", USER, last_event_id=first["id"])
+        await record_fact(events, "Likes scones")
+
+        await events.snapshot_cursors_to_tail()
+        report = await events.project_pending(USER)
+        # The pre-existing cursor still owns its position: only the second
+        # event was pending and it gets applied, not skipped.
+        assert report["flat_facts"][USER]["applied"] == 1
+
+
+class TestEventFirstWrites:
+    async def test_graph_event_first_skips_direct_write_but_projects(self, db_manager, tmp_path):
+        events = MemoryEventService(db_manager, FORMATION_ID, config={"event_first": True})
+        graph = KnowledgeGraphService(db_manager, FORMATION_ID, event_log=events)
+        events.register_projector(KnowledgeGraphProjector(graph))
+
+        stored = await graph.store_extraction(
+            USER,
+            {
+                "entities": [{"name": "Acme", "type": "company", "confidence": 0.9}],
+                "relationships": [],
+            },
+        )
+        assert stored == {"entities": 1, "relationships": 0}
+        # The projection was derived from the event (synchronous apply)...
+        entity = await graph.storage.get_entity(USER, "company", "Acme")
+        assert entity is not None
+        assert entity["derived_from_event_ids"]  # provenance stamped
+        # ...and the cursor advanced, so the applier will not re-apply.
+        checkpoint = await events.storage.get_checkpoint("knowledge_graph", USER)
+        graph_events = await events.list_events(USER)
+        assert checkpoint["last_event_id"] == graph_events[-1]["id"]
+
+    async def test_dual_write_default_unchanged(self, db_manager):
+        events = MemoryEventService(db_manager, FORMATION_ID)
+        assert events.event_first is False
+        graph = KnowledgeGraphService(db_manager, FORMATION_ID, event_log=events)
+        events.register_projector(KnowledgeGraphProjector(graph))
+        await graph.store_extraction(
+            USER,
+            {
+                "entities": [{"name": "Acme", "type": "company", "confidence": 0.9}],
+                "relationships": [],
+            },
+        )
+        # Direct write path: no cursor is created in dual-write mode.
+        assert await events.storage.get_checkpoint("knowledge_graph", USER) is None
+        assert await graph.storage.get_entity(USER, "company", "Acme") is not None
+
+
+class TestArtifactMetadataProjector:
+    class FakeArtifactService:
+        def __init__(self, db_manager):
+            self.storage = ArtifactMemoryStorage(db_manager, FORMATION_ID)
+
+        @staticmethod
+        def _build_summary(name, content_type, size_bytes, agent_id):
+            producer = agent_id or "overlord"
+            return f"{name} ({content_type}, {size_bytes} bytes) produced by {producer}."
+
+        def _compute_expiry(self):
+            return None
+
+    async def seed(self, events, service):
+        """Two versions of one artifact, captured through save + v2 events."""
+        for version, checksum in ((1, "a" * 64), (2, "b" * 64)):
+            row = await service.storage.save_artifact(
+                user_id=USER,
+                public_id=f"art_v{version}",
+                name="report.pdf",
+                content_type="application/pdf",
+                summary=f"v{version} summary",
+                storage_ref=f"u1/ab/blob{version}.bin",
+                size_bytes=1000 + version,
+                compressed_bytes=500 + version,
+                checksum_sha256=checksum,
+            )
+            event = await events.record(
+                user_id=USER,
+                event_type="artifact.saved",
+                event_version=2,
+                payload={
+                    "artifact_id": row["public_id"],
+                    "name": row["name"],
+                    "version": row["version"],
+                    "content_type": row["content_type"],
+                    "category": row["category"],
+                    "size_bytes": row["size_bytes"],
+                    "checksum_sha256": row["checksum_sha256"],
+                    "storage_ref": row["storage_ref"],
+                    "tags": row["tags"],
+                    "summary": row["summary"],
+                    "compressed_bytes": row["compressed_bytes"],
+                },
+                source="artifact_memory",
+                source_id=f"artifact/{row['public_id']}",
+            )
+            await service.storage.set_derived_event(row["id"], event["id"])
+
+    @staticmethod
+    def snapshot(rows):
+        return sorted(
+            (
+                r["public_id"],
+                r["name"],
+                r["version"],
+                r["is_latest"],
+                r["content_type"],
+                r["storage_ref"],
+                r["size_bytes"],
+                r["compressed_bytes"],
+                r["checksum_sha256"],
+                r["summary"],
+            )
+            for r in rows
+        )
+
+    async def test_wipe_and_replay_reproduces_metadata(self, db_manager, events):
+        service = self.FakeArtifactService(db_manager)
+        projector = ArtifactMetadataProjector(service)
+        events.register_projector(projector)
+        await self.seed(events, service)
+
+        before = self.snapshot(await service.storage.list_artifacts(USER, latest_only=False))
+        assert len(before) == 2
+
+        report = await events.rebuild(USER, projection="artifact_metadata")
+        assert report["artifact_metadata"] == {"events": 2, "applied": 2, "failed": 0}
+
+        after = self.snapshot(await service.storage.list_artifacts(USER, latest_only=False))
+        assert after == before
+        # Version chain reconstructed: exactly one latest head.
+        latest = await service.storage.list_artifacts(USER, latest_only=True)
+        assert len(latest) == 1 and latest[0]["version"] == 2
+
+    async def test_reset_spares_pre_substrate_rows(self, db_manager, events):
+        service = self.FakeArtifactService(db_manager)
+        projector = ArtifactMetadataProjector(service)
+        events.register_projector(projector)
+        # A pre-substrate row: no derived_from_event_id.
+        await service.storage.save_artifact(
+            user_id=USER,
+            public_id="art_legacy",
+            name="legacy.txt",
+            content_type="text/plain",
+            summary="legacy",
+            storage_ref="u1/aa/legacy.bin",
+            size_bytes=10,
+            compressed_bytes=5,
+            checksum_sha256="c" * 64,
+        )
+        assert await projector.reset(USER) == 0
+        rows = await service.storage.list_artifacts(USER, latest_only=False)
+        assert len(rows) == 1  # the legacy row survived
+
+    async def test_v1_event_reconstructs_deterministically(self, db_manager, events):
+        service = self.FakeArtifactService(db_manager)
+        projector = ArtifactMetadataProjector(service)
+        events.register_projector(projector)
+        # A v1 event (no summary / compressed_bytes) with no matching row:
+        # builders must handle every historical version.
+        event = await events.record(
+            user_id=USER,
+            event_type="artifact.saved",
+            payload={
+                "artifact_id": "art_old",
+                "name": "old.csv",
+                "version": 1,
+                "content_type": "text/csv",
+                "size_bytes": 64,
+                "storage_ref": "u1/cc/old.bin",
+            },
+            source="artifact_memory",
+            source_id="artifact/art_old",
+        )
+        await projector.apply(event)
+        row = await service.storage.get_by_public_id(USER, "art_old")
+        assert row is not None
+        assert row["compressed_bytes"] == 64  # size fallback
+        assert "old.csv" in row["summary"]  # deterministic reconstruction
+        assert row["derived_from_event_id"] == event["id"]

--- a/tests/unit/test_memory_events_provenance.py
+++ b/tests/unit/test_memory_events_provenance.py
@@ -1,0 +1,168 @@
+"""Provenance tests for the Memory Event Substrate (Phase 2c).
+
+"Why do you think X?": a knowledge graph fact must resolve, through its
+``derived_from_event_ids``, to the extraction event that wrote it and --
+via ``caused_by`` -- to the interaction turn that produced the extraction.
+Covers the causation-chain walk (root-first, cycle-cut, user-scoped) and
+the entity-level assembly used by GET /v1/memories/provenance.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.events import KnowledgeGraphProjector, MemoryEventService
+from muxi.runtime.services.memory.events.provenance import entity_provenance, event_provenance
+from muxi.runtime.services.memory.graph.service import KnowledgeGraphService
+
+FORMATION_ID = "provenance-test-formation"
+USER = "u1"
+
+
+@pytest.fixture
+def db_manager(tmp_path):
+    manager = DatabaseManager(f"sqlite:///{tmp_path}/provenance.db")
+    manager.create_tables(Base.metadata)
+    yield manager
+    manager.engine.dispose()
+
+
+@pytest.fixture
+def events(db_manager):
+    return MemoryEventService(db_manager, FORMATION_ID)
+
+
+@pytest.fixture
+def graph(db_manager, events):
+    service = KnowledgeGraphService(db_manager, FORMATION_ID, event_log=events)
+    events.register_projector(KnowledgeGraphProjector(service))
+    return service
+
+
+async def seed_conversation(events, graph):
+    """One turn -> one graph extraction, linked via caused_by."""
+    turn = await events.record(
+        user_id=USER,
+        event_type="interaction.turn",
+        payload={"user_message": "I live in London and work at Acme."},
+        source="interaction",
+    )
+    await graph.store_extraction(
+        USER,
+        {
+            "entities": [
+                {"name": "User", "type": "person", "confidence": 0.95},
+                {"name": "London", "type": "location", "confidence": 0.9},
+                {"name": "Acme", "type": "company", "confidence": 0.9},
+            ],
+            "relationships": [
+                {
+                    "from": "User",
+                    "from_type": "person",
+                    "to": "London",
+                    "to_type": "location",
+                    "type": "lives_in",
+                    "confidence": 0.9,
+                },
+                {
+                    "from": "User",
+                    "from_type": "person",
+                    "to": "Acme",
+                    "to_type": "company",
+                    "type": "works_at",
+                    "confidence": 0.85,
+                },
+            ],
+        },
+        caused_by=turn["id"],
+    )
+    return turn
+
+
+class TestProvenanceChain:
+    async def test_chain_walks_causation_root_first(self, events, graph):
+        turn = await seed_conversation(events, graph)
+        graph_events = await events.list_events(USER, event_types=["graph.extracted"])
+        chain = await events.provenance_chain(USER, graph_events[0]["id"])
+        assert [e["event_type"] for e in chain] == ["interaction.turn", "graph.extracted"]
+        assert chain[0]["id"] == turn["id"]
+
+    async def test_chain_for_root_event_is_itself(self, events, graph):
+        turn = await seed_conversation(events, graph)
+        chain = await events.provenance_chain(USER, turn["id"])
+        assert len(chain) == 1
+        assert chain[0]["id"] == turn["id"]
+
+    async def test_chain_is_user_scoped(self, events, graph):
+        await seed_conversation(events, graph)
+        graph_events = await events.list_events(USER, event_types=["graph.extracted"])
+        assert await events.provenance_chain("someone_else", graph_events[0]["id"]) == []
+
+    async def test_unknown_event_returns_empty_chain(self, events):
+        assert await events.provenance_chain(USER, 424242) == []
+
+
+class TestEntityProvenance:
+    async def test_why_do_you_think_i_live_in_london(self, events, graph):
+        await seed_conversation(events, graph)
+        result = await entity_provenance(events, graph, USER, "London", decay=events.decay)
+        assert result is not None
+        assert result["entity"]["name"] == "London"
+        assert result["entity"]["events"]  # the entity itself has a chain
+
+        lives_in = next(fact for fact in result["facts"] if fact["relationship_type"] == "lives_in")
+        assert lives_in["statement"] == "User -[lives_in]-> London"
+        assert lives_in["effective_confidence"] == pytest.approx(0.9, abs=0.01)
+        # The full chain: interaction.turn -> graph.extracted.
+        (chain,) = lives_in["events"]
+        assert [e["event_type"] for e in chain] == ["interaction.turn", "graph.extracted"]
+        assert chain[0]["source"] == "interaction"
+
+    async def test_entity_name_matching_is_case_insensitive(self, events, graph):
+        await seed_conversation(events, graph)
+        assert await entity_provenance(events, graph, USER, "london") is not None
+
+    async def test_unknown_entity_returns_none(self, events, graph):
+        await seed_conversation(events, graph)
+        assert await entity_provenance(events, graph, USER, "Atlantis") is None
+
+    async def test_contradicted_facts_stay_explainable(self, events, graph):
+        await seed_conversation(events, graph)
+        # A conflicting residence claim (below the supersede delta).
+        await graph.store_extraction(
+            USER,
+            {
+                "entities": [{"name": "Berlin", "type": "location", "confidence": 0.9}],
+                "relationships": [
+                    {
+                        "from": "User",
+                        "from_type": "person",
+                        "to": "Berlin",
+                        "to_type": "location",
+                        "type": "lives_in",
+                        "confidence": 0.88,
+                    }
+                ],
+            },
+        )
+        result = await entity_provenance(events, graph, USER, "User")
+        statuses = {fact["statement"]: fact["status"] for fact in result["facts"]}
+        assert statuses["User -[lives_in]-> London"] == "conflicted"
+        assert statuses["User -[lives_in]-> Berlin"] == "conflicted"
+
+
+class TestEventProvenance:
+    async def test_lookup_by_public_id(self, events, graph):
+        await seed_conversation(events, graph)
+        graph_events = await events.list_events(USER, event_types=["graph.extracted"])
+        result = await event_provenance(events, USER, graph_events[0]["public_id"])
+        assert result is not None
+        assert result["event"]["event_type"] == "graph.extracted"
+        assert [e["event_type"] for e in result["chain"]] == [
+            "interaction.turn",
+            "graph.extracted",
+        ]
+
+    async def test_unknown_public_id_returns_none(self, events):
+        assert await event_provenance(events, USER, "nope") is None

--- a/tests/unit/test_memory_events_service.py
+++ b/tests/unit/test_memory_events_service.py
@@ -210,20 +210,31 @@ class TestForgetSource:
 
 
 class TestPurgeLifecycle:
-    async def test_start_and_stop_purge_loop(self, service):
+    async def test_start_and_stop_maintenance_loop(self, service):
         service.start()
-        assert service._purge_task is not None
-        first_task = service._purge_task
+        assert service._maintenance_task is not None
+        first_task = service._maintenance_task
         service.start()  # idempotent while running
-        assert service._purge_task is first_task
+        assert service._maintenance_task is first_task
+        assert service._applier_task is None  # dual-write mode: no applier
         await service.stop()
-        assert service._purge_task is None
+        assert service._maintenance_task is None
         await service.stop()  # idempotent when stopped
+
+    async def test_start_event_first_spawns_applier(self, tmp_path):
+        db_manager = DatabaseManager(f"sqlite:///{tmp_path}/ef.db")
+        db_manager.create_tables(Base.metadata)
+        ef_service = MemoryEventService(db_manager, FORMATION_ID, config={"event_first": True})
+        ef_service.start()
+        assert ef_service._applier_task is not None
+        await ef_service.stop()
+        assert ef_service._applier_task is None
+        db_manager.engine.dispose()
 
     async def test_start_disabled_is_noop(self, service):
         service.enabled = False
         service.start()
-        assert service._purge_task is None
+        assert service._maintenance_task is None
 
     async def test_run_hard_purge_empty_log(self, service):
         assert await service.run_hard_purge() == 0

--- a/tests/unit/test_memory_events_storage.py
+++ b/tests/unit/test_memory_events_storage.py
@@ -173,11 +173,16 @@ class TestImmutability:
         ]
         assert sorted(mutators) == [
             "append",
+            "count_events",  # read-only size-cap accounting
+            "expire_volatile",  # soft-delete of expired volatile events
             "find_by_source_id",  # read-only idempotency-key lookup
             "get_checkpoint",
             "get_event",
+            "get_event_by_public_id",  # read-only provenance lookup
             "hard_purge",
+            "list_event_user_ids",  # read-only maintenance enumeration
             "list_events",
+            "max_event_id",  # read-only cursor tail lookup
             "reset_checkpoint",
             "set_checkpoint",
             "soft_delete_events",


### PR DESCRIPTION
## Summary

Memory Event Substrate Phases 2b-2d (memory-event-substrate PRD), building on the shipped core event log + Phase A dual-write (#212). The write path is now fully event-sourced-capable: projections consume from events incrementally with per-user cursors, every fact is explainable back to its originating interaction, decay applies at query time, legacy data becomes replayable, and GDPR forgetting is a first-class, reversible-then-purged flow.

## Phase 2b - Projection builders (incremental + idempotent)

- Per-(projection, user) cursors in `projection_checkpoints` now drive incremental consumption: `apply_event` projects one just-appended event; `project_pending` catches a cursor up to the log tail (crash recovery / background applier). Cursor-gated, so re-projection is idempotent; poison events are skipped with observability and reconciled by rebuild.
- New **artifact-metadata projector**: `artifacts` rows rebuild from `artifact.saved` events. Payloads bumped to v2 (full metadata: summary, compressed_bytes, tags); v1 events are reconstructed deterministically - **builders handle all historical event versions** (PRD open question 3). Blobs are never touched; pre-substrate rows survive resets so a rebuild can never orphan a blob's metadata.
- **Event-first cutover groundwork (Phase C semantics, flag-gated, DEFAULT OFF):** `memory.events.event_first: true` makes the extractor, knowledge graph, captain's log, ingestion, and shared-scope write paths append-then-derive through the substrate (synchronous apply + background applier at `memory.projections.apply_interval_seconds`, lag alerts past `lag_alert_threshold_seconds`). On startup, cursors snapshot to the log tail so dual-written history is never replayed into projections. Dual-write remains the default until cutover.

## Phase 2c - Provenance & decay

- **`GET /v1/memories/provenance?entity=X`** answers "why do you think X?": the KG entity, every fact touching it (contradicted/superseded included so disagreements stay explainable), and per-fact causation chains from the event log back to the originating `interaction.turn` or ingestion item. `?event_id=` traces a single event.
- Additive migration: `artifacts.derived_from_event_id` (Postgres `ADD COLUMN IF NOT EXISTS` + SQLite PRAGMA guard, same posture as the existing provenance migrations).
- **Decay at query time** (`memory.decay`): true half-life math (`0.5 ** (age/half_life)`; the PRD sketched `exp(-age/half_life)` under a parameter named half_life - the honest form is used and documented), default half-life 180d, volatile TTL 24h, per-relationship-type `half_lives` map. Volatile events without an explicit expiry are stamped at write; an hourly maintenance sweep soft-deletes expired volatile events so rebuilds drop their projections. Context-block ranking re-weights facts only for configured types - the hot read path pays nothing by default.
- **Contradiction detection at write** now records `fact.contradicted` audit events (idempotent per fact pair, `caused_by`-linked to the extraction event) plus a `memory.fact.contradicted` observability event. Replay purity preserved: rebuilds re-mark rows but never re-record audit events.

## Phase 2d - Rebuild & migration

- **`POST /memory/rebuild`** (admin; the runtime endpoint behind `muxi memory rebuild --user <id>` - CLI wrapper is CLI-repo territory): background job by default per the PRD recommendation (202 + `job_id`, poll `GET /memory/rebuild/{job_id}` via the request tracker); `background: false` blocks and returns the report inline; `backfill: true` runs the legacy backfill first; `dry_run` reports counts only.
- **`POST /memory/backfill`**: synthesizes idempotent `source='legacy'` events (per-row source_ids, e.g. `legacy/kg_entity/<public_id>`) for pre-event-log rows across KG entities/relationships, captain's log entries/lessons, artifacts, and orphan flat facts. Graph/log/artifact rows are stamped in place; flat facts become provenance-complete on the next rebuild (their write path inserts, it does not upsert).
- **`POST /memory/forget`** (GDPR): soft-delete a source's live events (reversible for the retention grace period, then removed by the hard-purge worker), record the `user.deletion` audit event, and rebuild projections as if the source never existed.
- Per-user event-log **size-cap alert** (`memory.events.retention.max_events_per_user`, alert-only per the PRD's SQLite single-table recommendation - the substrate ships the mechanism, capacity policy stays with the operator).

## Conventions held

- Dual-write stays the default; event-first is flag-gated, default off, documented (CHANGELOG + mental-model.md).
- Failure isolation: appends never block a turn; projection apply failures log + defer to the applier/rebuild.
- Idempotency: the `(formation, user, source, source_id)` unique index untouched; new writes (legacy backfill, contradiction audit) ride it.
- Additive migrations only; read-path/retrieval code touched minimally (context-block decay re-rank is a no-op unless configured).
- Fail-fast config validation for all new keys; `validate_events.py` at 100% (1360/1360); black 100 / isort / ruff 120 clean (CI-equivalent gates run locally).

## Tests

- **Unit:** full suite 2711 passed, 10 skipped. 62 new tests across 6 files: cursor resume + idempotent re-projection + poison-event containment (`test_memory_events_projection.py`), decay math + settings validation + volatile lifecycle + context-block re-ranking (`test_memory_events_decay.py`), provenance chains + entity assembly (`test_memory_events_provenance.py`), contradiction flags + audit events + replay purity (`test_memory_events_contradiction.py`), legacy backfill synthesis + idempotency + rebuild-after-backfill (`test_memory_events_backfill.py`), GDPR soft-delete + rebuild + grace-period undo + hard purge (`test_memory_events_gdpr.py`).
- **E2E:** new `2_memory/test_2s2_provenance_and_rebuild.py` (10/10 checks) - provenance chains on a real conversation, rebuild-from-events reproducing prior projections, GDPR forget + rebuild, legacy backfill. Existing `test_2s1` updated for the fourth projector - passing (10/10 checks).
- **Regression:** `run_random_tests.py 5` - 5/5 passed (2_memory, 3_multimodal x2, 8_clarification, 13_triggers).

## Coordination notes

Concurrent memory-revamp Phases 3-5 work owns the read path; this PR is write-path only (events -> projections). Shared files (`graph/service.py`, `log/service.py`, `long_term.py`, `sqlite.py`, `memobase.py`) received additive methods/params only; no retrieval logic was refactored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
