### PR TITLE
feat: memory revamp phases 3-5 - context optimization, knowledge index, lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 ## [unreleased]
 
+### Memory revamp phases 3-5 - context optimization, knowledge index, lint
+
+The memory system's read-path and lifecycle layers on top of the Phase 1-2
+knowledge graph and captain's log (memory-revamp PRD; Phase 6 hybrid search
+stays deferred pending benchmark evidence):
+
+- Pre-compaction flush (Phase 3): working-memory FIFO eviction no longer
+  silently loses conversational context. A new eviction listener hook on
+  `WorkingMemory` hands at-risk buffer items to a silent LLM turn - at the
+  `memory.compaction.flush_threshold` (default 0.80) crossing and again as
+  an eviction-time safety net - which digests them through the captain's
+  log pipeline (entry + source lineage + lessons + graph facts) before the
+  buffer drops them. Best-effort and failure-isolated: a failed flush never
+  blocks eviction or a chat turn. `flush_enabled: false` is byte-identical
+  to the previous behavior (pinned by unit test).
+- Cache-TTL context pruning (Phase 3): when a session resumes after the
+  provider prompt-cache window (`memory.pruning.mode: cache-ttl`, default
+  TTL 300s), stale tool results and oversized turns are soft-trimmed
+  (first/last 1500 chars) or hard-cleared from the assembled history; the
+  newest `keep_last_n_tool_results` stay intact. Inert when unconfigured:
+  no `memory.pruning` block means no pruner is constructed.
+- Knowledge index (Phase 4): a <=300-token navigable catalog of what exists
+  in memory (entities, captain's log span, artifact manifest via the
+  artifact memory service - the seam artifact-memory Phase 2 rides - and
+  lint-flagged knowledge gaps), cached per user, persisted in
+  `system_config` (`memory_index:{user_id}`), and injected at retrieval
+  start in both context representations. Regenerates on log entries,
+  artifact saves, entity-count jumps past `entity_count_threshold`, lint
+  runs, and 24h staleness; truncates per section with `[+N more]` under the
+  `max_tokens` cap. Index failures never break a turn.
+- Memory lint (Phase 5): a background audit (weekly by default, on demand
+  via `run_lint` / admin `POST /memory/lint`) following the shared
+  background-loop lifecycle (started beside the scheduler, cancelled on
+  shutdown, failure-isolated per run and per user). Flags conflicted facts
+  unresolved past `conflict_resolution_days` and captain's log gaps > 7
+  days, hard-deletes superseded facts past the retention window, removes
+  orphaned relationships (`orphan_cleanup`), flags artifacts unaccessed for
+  `stale_artifact_days`, and force-regenerates a stale index. Findings feed
+  back into the knowledge index as knowledge gaps. Inert when unconfigured:
+  only constructed when the formation declares a `memory.lint` block.
+- All four new config sections (`memory.compaction`, `memory.pruning`,
+  `memory.index`, `memory.lint`) fail-fast validate at load time. New
+  observability events: `MEMORY_PRECOMPACTION_FLUSH_*`,
+  `MEMORY_CONTEXT_PRUNED`, `MEMORY_INDEX_*`, `MEMORY_LINT_*` (event
+  validation stays 100%). New e2e: `test_2x1_memory_revamp_phases_3_5.py`
+  (flush surviving real eviction, index injection observable in a real
+  turn, on-demand lint).
+
 ### Knowledge reasoning RAG - Method A tree retrieval (Phase 1)
 
 Large knowledge files are now indexed as hierarchical trees navigated by an

--- a/e2e/tests/2_memory/base_memory_test.py
+++ b/e2e/tests/2_memory/base_memory_test.py
@@ -36,6 +36,7 @@ class BaseMemoryTest(BaseE2ETest):
         "basic": "formation-basic.yaml",
         "local_384": "formation-local-384.yaml",
         "local_768": "formation-local-768.yaml",
+        "memory_revamp": "formation-memory-revamp.yaml",
     }
 
     def __init__(self):

--- a/e2e/tests/2_memory/formations/formation-memory/formation-memory-revamp.yaml
+++ b/e2e/tests/2_memory/formations/formation-memory/formation-memory-revamp.yaml
@@ -1,0 +1,83 @@
+schema: "1.0.0"
+id: "memory-revamp-test-formation"
+description: "Formation for testing memory revamp phases 3-5 (context optimization, knowledge index, lint)"
+auto_extract_user_info: true
+
+runtime:
+  built_in_mcps: false
+
+agents:
+  - memory_agent
+
+overlord:
+  clarification:
+    enabled: false
+
+llm:
+  settings:
+    temperature: 0.7
+    max_tokens: 2000
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+    - embedding: "openai/text-embedding-3-small"
+
+memory:
+  working:
+    max_memory_mb: 1
+    fifo_interval_min: 5
+    vector_dimension: 1536
+    mode: "local"
+    auto_extract:
+      enabled: true
+      extract_user_info: true
+
+  buffer:
+    size: 50
+    multiplier: 10
+    vector_search: false
+
+  persistent:
+    provider: "sqlite"
+    connection_string: "memory_revamp_test.db"
+    embedding_model: "openai/text-embedding-3-small"
+
+  # Memory Revamp Phase 3: pre-compaction flush + cache-TTL pruning
+  compaction:
+    flush_enabled: true
+    flush_threshold: 0.80
+
+  pruning:
+    mode: "cache-ttl"
+    cache_ttl_seconds: 300
+    keep_last_n_tool_results: 3
+    soft_trim_max_chars: 4000
+
+  # Memory Revamp Phase 4: knowledge index
+  index:
+    enabled: true
+    max_tokens: 300
+    regenerate_on: ["lint", "log_entry", "artifact_save", "entity_count_threshold"]
+    entity_count_threshold: 10
+
+  # Memory Revamp Phase 5: lint
+  lint:
+    enabled: true
+    schedule: "weekly"
+    conflict_resolution_days: 7
+    orphan_cleanup: true
+    stale_artifact_days: 90
+
+logging:
+  system:
+    level: "debug"
+    destination: "stdout"
+  conversation:
+    enabled: true
+    streams:
+      - transport: "stdout"
+        level: "debug"
+        format: "jsonl"
+
+# Agent will be auto-discovered from agents/ directory

--- a/e2e/tests/2_memory/test_2x1_memory_revamp_phases_3_5.py
+++ b/e2e/tests/2_memory/test_2x1_memory_revamp_phases_3_5.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Test 2X1: Memory Revamp Phases 3-5 (Context Optimization, Knowledge Index, Lint)
+
+This test validates:
+1. The phase 3-5 services wire into the overlord from formation config:
+   pre-compaction flush (attached to the buffer's eviction path), cache-TTL
+   context pruner, knowledge index, and the memory lint background loop
+2. Pre-compaction flush SURVIVES EVICTION: buffer items evicted by the
+   working memory's FIFO cleanup are digested into the captain's log (and
+   knowledge graph) via the silent turn BEFORE they are dropped, so the
+   facts remain queryable after the buffer no longer holds them
+3. Knowledge index injection is observable in a real turn: the agent's
+   assembled system message for a subsequent chat turn carries the
+   "[Memory Index" blob (entities / captain's log catalog), within the
+   configured token cap
+4. Lint runs on demand: the report covers the audit checks and its
+   findings feed back into the knowledge index
+"""
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+from base_memory_test import BaseMemoryTest
+
+
+class TestMemoryRevampPhases35(BaseMemoryTest):
+    """Test context optimization, knowledge index, and lint end to end."""
+
+    async def test_memory_revamp(self):
+        test_name = "2x1_memory_revamp_phases_3_5"
+        self.print_test_header(
+            test_name, "Test pre-compaction flush, knowledge index injection, and lint"
+        )
+
+        start_time = time.time()
+        checks_passed = []
+        transcript = []
+        all_passed = True
+        user_id = "revamp_test_user"
+
+        try:
+            # Fresh database for deterministic schema/row assertions.
+            for suffix in ("", "-wal", "-shm"):
+                stale = Path.cwd() / f"memory_revamp_test.db{suffix}"
+                if stale.exists():
+                    stale.unlink()
+
+            print("\nPhase 1: Loading formation with phases 3-5 configured...")
+            await self.setup_memory_formation("memory_revamp")
+            effective_user_id = user_id if self.overlord.is_multi_user else "0"
+
+            # Check 1: all phase 3-5 services wired into the overlord
+            flush = getattr(self.overlord, "precompaction_flush", None)
+            pruner = getattr(self.overlord, "context_pruner", None)
+            memory_index = getattr(self.overlord, "memory_index", None)
+            memory_lint = getattr(self.overlord, "memory_lint", None)
+            wired = (
+                flush is not None
+                and pruner is not None
+                and memory_index is not None
+                and memory_lint is not None
+            )
+            if wired:
+                print("  ✓ Flush, pruner, knowledge index, and lint services wired")
+                checks_passed.append("Phase 3-5 services wired")
+            else:
+                print(
+                    f"  ✗ Missing services: flush={flush} pruner={pruner} "
+                    f"index={memory_index} lint={memory_lint}"
+                )
+                all_passed = False
+
+            # Check 2: the flush listener is attached to the buffer and the
+            # lint background loop is running (shared lifecycle pattern)
+            buffer_memory = self.overlord.buffer_memory
+            listener_attached = (
+                buffer_memory is not None and buffer_memory._eviction_listener is not None
+            )
+            lint_running = (
+                memory_lint is not None
+                and memory_lint._task is not None
+                and not memory_lint._task.done()
+            )
+            if listener_attached and lint_running:
+                print("  ✓ Eviction listener attached; lint loop running beside scheduler")
+                checks_passed.append("Lifecycle wiring correct")
+            else:
+                print(
+                    f"  ✗ listener_attached={listener_attached} lint_running={lint_running}"
+                )
+                all_passed = False
+
+            # Conversation turn with distinctive facts destined for eviction.
+            user_msg1 = (
+                "My name is Jordan. I founded a company called Automaze and today "
+                "we decided to launch the MUXI project next month."
+            )
+            response1 = await self.overlord.chat(
+                user_msg1, user_id=user_id, use_async=False, stream=False
+            )
+            response1_text = response1.content if hasattr(response1, "content") else str(response1)
+            transcript.append((user_msg1, response1_text))
+            print(f"\nUser: {user_msg1}")
+            print(f"Assistant: {response1_text[:200]}...")
+
+            # Give the fire-and-forget buffer writes time to land.
+            await asyncio.sleep(5)
+
+            print("\nPhase 2: Forcing FIFO eviction (pre-compaction flush)...")
+            # Shrink the budget so the stored turns exceed it, then run the
+            # REAL eviction path. The flush must capture the items first.
+            buffer_before = [
+                item["text"]
+                for item in buffer_memory.buffer
+                if item.get("namespace", "buffer") == "buffer"
+            ]
+            print(f"  Buffer items before eviction: {len(buffer_before)}")
+            buffer_memory.max_memory_mb = 0.000001
+            buffer_memory.check_memory_usage_and_cleanup()
+
+            buffer_after = [
+                item["text"]
+                for item in buffer_memory.buffer
+                if item.get("namespace", "buffer") == "buffer"
+            ]
+            evicted = len(buffer_before) - len(buffer_after)
+
+            # Check 3: eviction actually removed buffer items
+            if buffer_before and evicted > 0:
+                print(f"  ✓ FIFO eviction removed {evicted} buffer item(s)")
+                checks_passed.append("FIFO eviction removed items")
+            else:
+                print(f"  ✗ Eviction removed nothing (before={len(buffer_before)})")
+                all_passed = False
+
+            # Check 4: the silent flush turn persisted the evicted content
+            # to the captain's log BEFORE it was dropped (poll: the flush
+            # runs a real LLM digest in the background).
+            entries = []
+            captains_log = self.overlord.captains_log
+            for _ in range(24):
+                await asyncio.sleep(5)
+                entries = await captains_log.get_history(effective_user_id, include_sources=True)
+                if entries:
+                    break
+            if entries:
+                summary = (entries[0]["summary"] or "").lower()
+                fact_survived = any(
+                    marker in summary for marker in ("muxi", "automaze", "launch", "jordan")
+                )
+                if fact_survived:
+                    print(f"  ✓ Flush survived eviction - log entry: {entries[0]['summary']}")
+                    checks_passed.append("Pre-compaction flush survived eviction")
+                else:
+                    print(f"  ✗ Log entry exists but lost the facts: {entries[0]['summary']}")
+                    all_passed = False
+                if entries[0].get("sources"):
+                    print(f"  ✓ Flushed entry carries {len(entries[0]['sources'])} source rows")
+                    checks_passed.append("Flushed entry has source lineage")
+            else:
+                print("  ✗ No captain's log entry produced by the pre-compaction flush")
+                all_passed = False
+
+            print("\nPhase 3: Knowledge index injection in a real turn...")
+            # Check 5: the index blob renders the flushed knowledge
+            index_block = await memory_index.get_index_block(effective_user_id)
+            print(f"  Index block:\n    {index_block.replace(chr(10), chr(10) + '    ')}")
+            if index_block.startswith("[Memory Index") and len(index_block) <= (
+                memory_index.max_chars
+            ):
+                print(f"  ✓ Index blob rendered within cap ({len(index_block)} chars)")
+                checks_passed.append("Index blob rendered within size cap")
+            else:
+                print("  ✗ Index blob missing or over the size cap")
+                all_passed = False
+
+            # Check 6: a real chat turn carries the index at retrieval
+            # start. Both context representations are inspected via a
+            # pass-through spy on the orchestrator's enhancement step: the
+            # marker-formatted analyzer blob (=== MEMORY INDEX ===) and the
+            # clean bundle's profile text ([Memory Index blob).
+            orchestrator = self.overlord.chat_orchestrator
+            captured = {}
+            original_enhance = orchestrator._enhance_message_with_context
+            original_clean = orchestrator._build_clean_chat_context
+
+            async def spy_enhance(*args, **kwargs):
+                result = await original_enhance(*args, **kwargs)
+                captured["enhanced"] = result.enhanced
+                return result
+
+            async def spy_clean(*args, **kwargs):
+                bundle = await original_clean(*args, **kwargs)
+                captured["clean_profile"] = bundle.get("user_profile_text", "")
+                return bundle
+
+            orchestrator._enhance_message_with_context = spy_enhance
+            orchestrator._build_clean_chat_context = spy_clean
+            try:
+                recall_msg = "What do you know about my projects?"
+                recall_response = await self.overlord.chat(
+                    recall_msg, user_id=user_id, use_async=False, stream=False
+                )
+            finally:
+                orchestrator._enhance_message_with_context = original_enhance
+                orchestrator._build_clean_chat_context = original_clean
+            recall_text = (
+                recall_response.content
+                if hasattr(recall_response, "content")
+                else str(recall_response)
+            )
+            transcript.append((recall_msg, recall_text))
+            print(f"\nUser: {recall_msg}")
+            print(f"Assistant: {recall_text[:200]}...")
+
+            in_enhanced = "=== MEMORY INDEX ===" in captured.get(
+                "enhanced", ""
+            ) and "[Memory Index" in captured.get("enhanced", "")
+            in_clean = "[Memory Index" in captured.get("clean_profile", "")
+            if in_enhanced and in_clean:
+                print("  ✓ Memory index injected into the real turn's context")
+                print("    (analyzer blob AND clean chat bundle)")
+                checks_passed.append("Index injection observable in a real turn")
+            else:
+                print(f"  ✗ Index missing: enhanced={in_enhanced} clean={in_clean}")
+                all_passed = False
+
+            print("\nPhase 4: On-demand lint run...")
+            report = await memory_lint.run_lint(user_id=effective_user_id)
+            print(f"  Lint report: {report}")
+            expected_keys = {
+                "users",
+                "unresolved_conflicts",
+                "superseded_deleted",
+                "orphans_removed",
+                "log_gaps",
+                "stale_artifacts",
+                "index_regenerated",
+                "findings",
+            }
+            if expected_keys.issubset(report.keys()) and report["users"] == 1:
+                print("  ✓ Lint audited the user and returned the full health report")
+                checks_passed.append("Lint on-demand run works")
+            else:
+                print("  ✗ Lint report incomplete")
+                all_passed = False
+
+            # Check 8: lint findings feed the knowledge index store
+            findings = await memory_index.get_lint_findings(effective_user_id)
+            stored_findings = report["findings"].get(effective_user_id, [])
+            if findings == stored_findings:
+                print(f"  ✓ Lint findings fed back into the index ({len(findings)} finding(s))")
+                checks_passed.append("Lint findings feed the index")
+            else:
+                print(f"  ✗ Index findings {findings} != report findings {stored_findings}")
+                all_passed = False
+
+        except Exception as e:
+            import traceback
+
+            print(f"  ✗ Test failed with error: {e}")
+            traceback.print_exc()
+            all_passed = False
+
+        finally:
+            await self.cleanup()
+
+        duration = time.time() - start_time
+        self.print_test_result(test_name, all_passed, checks_passed, transcript, duration)
+
+        return all_passed
+
+    async def run_test(self):
+        """Run all test cases."""
+        print("\n" + "=" * 60)
+        print("AREA 2X1: MEMORY REVAMP PHASES 3-5")
+        print("=" * 60)
+
+        all_passed = await self.test_memory_revamp()
+
+        print("\n" + "=" * 60)
+        print(
+            f"OVERALL RESULT: {'✅ ALL TESTS PASSED' if all_passed else '❌ SOME TESTS FAILED'}"
+        )
+        print("=" * 60)
+
+        print("\nKEY INSIGHTS:")
+        print("- Buffer items run a silent digest turn before FIFO eviction drops them")
+        print("- The knowledge index catalogs memory and injects at retrieval start")
+        print("- Lint audits the store on demand and feeds findings into the index")
+
+        if all_passed:
+            print("SUCCESS", flush=True)
+        return all_passed
+
+
+def main():
+    """Main entry point."""
+    test = TestMemoryRevampPhases35()
+    result = asyncio.run(test.run_test())
+    os._exit(0 if result else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/mental-model.md
+++ b/mental-model.md
@@ -1489,6 +1489,108 @@ per-source `retrieval:` accepts `vector`/`tree`, rejects the reserved
 both on `formations/formation-tree-reasoning/` (the 6f slot went to the
 remote-knowledge-sources tests that merged concurrently).
 
+### Memory Revamp Phases 3-5 (2026-07-09): Context Optimization, Knowledge Index, Lint
+
+**PRD:** `engineering/prds/memory-revamp.md` (Phases 1-2 shipped as KG +
+Captain's Log; Phase 6 Hybrid Search is deferred pending benchmark evidence)
+
+Four read-path/lifecycle services on top of the Phase 1-2 write pipeline:
+
+**Pre-compaction flush** (`services/memory/flush.py`,
+`PreCompactionFlushService`): the working-memory buffer is bounded; FIFO
+cleanup silently dropped the oldest items when it filled before the periodic
+Captain's Log digest ran. `WorkingMemory.set_eviction_listener(listener,
+flush_threshold)` is the additive hook: `check_memory_usage_and_cleanup`
+notifies the listener (a) when estimated usage crosses
+`flush_threshold * max_memory_mb` (default 0.80) with the oldest ~25% of
+buffer-namespace items, and (b) at eviction time with any not-yet-flushed
+items (snapshotted BEFORE the deque drops them). Items are marked
+`_memory_flushed` in metadata so nothing flushes twice. The listener runs on
+the FIFO daemon thread, so the flush service bridges to the formation loop
+via `run_coroutine_threadsafe` and runs the **silent turn**: an LLM digest
+outside the user-visible conversation, through
+`CaptainsLogService.digest_turns()` (new public wrapper over `_digest_user`)
+— one pass writes the log entry, buffer-item source lineage, lessons, and
+the digest's KG facts. Best-effort by design: a failed flush never re-queues
+(the items leave the buffer regardless) and never blocks eviction. Wired in
+`overlord._initialize_context_optimization()` (startup, after the other
+memory loops); config `memory.compaction.flush_enabled` (default true) /
+`flush_threshold`. `flush_enabled: false` leaves the listener unset —
+byte-identical to pre-feature behavior (pinned by unit test).
+
+**Cache-TTL pruning** (`services/memory/pruning.py`, `ContextPruner`):
+providers cache prompt prefixes ~5 minutes; resuming an idle session
+re-caches old bulky content at full cost. When a `(user, session)` has been
+idle past `cache_ttl_seconds`, the pruner trims prunable messages (role
+"tool", or content over `soft_trim_max_chars`) from the assembled buffer
+turns — soft trim keeps the first/last 1500 chars around a truncation
+marker; `strategy: hard_clear` replaces the body with "[Previous output
+cleared]". The newest `keep_last_n_tool_results` prunable messages are
+always preserved. Modes: `never` / `cache-ttl` / `always`. **Inert when
+unconfigured:** the Overlord only constructs a pruner when `memory.pruning`
+exists; applied in `_build_clean_chat_context` right after the buffer-turn
+fetch, failure-isolated (any error returns the original turns).
+
+**Knowledge index** (`services/memory/index.py`, `KnowledgeIndexService`,
+`overlord.memory_index`): a <=300-token navigable catalog of what exists in
+memory (active entities, captain's log count/span/most-recent, artifact
+manifest via `ArtifactMemoryService.list_artifacts` — the seam
+artifact-memory Phase 2 rides — and "knowledge gaps flagged by last lint").
+Injected at **retrieval start** in BOTH context representations: the clean
+chat bundle (leads `user_profile_text` as `[Memory Index - as of ...]`) and
+the analyzer blob (`=== MEMORY INDEX ===` section, right after CURRENT
+REQUEST — this is the one non-actionable/analyzer turns see). Cached per
+user + write-through persisted to `system_config` key
+`memory_index:{user_id}`; regeneration triggers (`regenerate_on`) are a
+cheap per-read fingerprint (log count/updated stamp, artifact count, entity
+count moving >= `entity_count_threshold`) plus explicit `invalidate()` from
+lint and a 24h staleness bound. Rendering truncates per section on item
+boundaries with `[+N more]` and hard-caps at `max_tokens * 4` chars. All
+read paths return "" on error — an index failure never breaks a turn.
+
+**Memory lint** (`services/memory/lint.py`, `MemoryLintService`,
+`overlord.memory_lint`): background audit (schedule `weekly`/`daily`/seconds;
+started beside the scheduler in overlord startup, cancelled in shutdown,
+failure-isolated per run AND per user). Checks per PRD: conflicted facts
+unresolved past `conflict_resolution_days` -> findings; superseded facts
+older than `superseded_retention_days` (default 30) -> hard-delete (edges
+first, then entities, then `algorithms.invalidate`); orphaned relationships
+-> auto-remove when `orphan_cleanup`; captain's log gaps > 7 days between
+consecutive entries -> flag; artifacts not accessed in `stale_artifact_days`
+-> flag; index not regenerated in 24h -> force regeneration. Findings feed
+`index.set_lint_findings()` (persisted, survive restart). On-demand:
+`run_lint(user_id=None)` and admin `POST /memory/lint`. **Inert when
+unconfigured:** the service is only constructed when the formation declares
+a `memory.lint` block (pinned by unit test).
+
+**Config validation:** all four sections fail-fast in
+`config/validation.py::_validate_memory_config` (mode/strategy enums,
+threshold in (0,1], positive ints, `regenerate_on` trigger names).
+
+**Observability:** `MEMORY_PRECOMPACTION_FLUSH_TRIGGERED/_COMPLETED/_FAILED`,
+`MEMORY_CONTEXT_PRUNED`, `MEMORY_INDEX_REGENERATED/_FAILED`,
+`MEMORY_LINT_STARTED/_COMPLETED/_FAILED` (ConversationEvents).
+
+**Tests:** `tests/unit/test_precompaction_flush.py`,
+`test_context_pruning.py`, `test_knowledge_index.py`, `test_memory_lint.py`,
+`test_memory_revamp_config_validation.py`; e2e
+`e2e/tests/2_memory/test_2x1_memory_revamp_phases_3_5.py` on
+`formations/formation-memory/formation-memory-revamp.yaml` (flush surviving
+real eviction, index injection observed in a real turn via pass-through
+spies on both context builders, on-demand lint).
+
+**Gotchas:**
+1. `select(func.count()).filter_by(...)` has no entity namespace — the
+   index/lint count queries must use `.select_from(Model).where(...)`.
+2. MagicMock overlords in orchestrator unit tests make `context_pruner` /
+   `memory_index` truthy; test fixtures must set them to None explicitly.
+3. Same-timestamp buffer items dedupe to one source-lineage row (unique
+   constraint on `(log_id, source_type, source_id)`) — flush snapshots keep
+   the buffer's per-item `time.time()` stamps.
+4. A simple recall turn can route through the analyzer/non-actionable path
+   (never reaching the agent's clean-context assembly) — which is why the
+   index injects into the enhanced blob too, not just the clean bundle.
+
 ---
 
 ## 4. LLM Layer

--- a/src/muxi/runtime/datatypes/observability.py
+++ b/src/muxi/runtime/datatypes/observability.py
@@ -811,6 +811,36 @@ class ConversationEvents(Enum):
     MEMORY_LESSON_ARCHIVED = "memory.lesson.archived"
     # When lessons are archived by confidence decay
 
+    # Context optimization operations (Memory Revamp Phase 3)
+    MEMORY_PRECOMPACTION_FLUSH_TRIGGERED = "memory.precompaction.flush.triggered"
+    # When at-risk buffer items are handed to the pre-compaction flush
+
+    MEMORY_PRECOMPACTION_FLUSH_COMPLETED = "memory.precompaction.flush.completed"
+    # When the silent flush turn persists at-risk buffer items
+
+    MEMORY_PRECOMPACTION_FLUSH_FAILED = "memory.precompaction.flush.failed"
+    # When the pre-compaction flush fails (eviction proceeds regardless)
+
+    MEMORY_CONTEXT_PRUNED = "memory.context.pruned"
+    # When stale tool results are pruned from a resumed session's context
+
+    # Knowledge index operations (Memory Revamp Phase 4)
+    MEMORY_INDEX_REGENERATED = "memory.index.regenerated"
+    # When the per-user knowledge index blob is regenerated
+
+    MEMORY_INDEX_FAILED = "memory.index.failed"
+    # When a knowledge index lookup or regeneration fails
+
+    # Lint operations (Memory Revamp Phase 5)
+    MEMORY_LINT_STARTED = "memory.lint.started"
+    # When a memory lint run starts (scheduled or on-demand)
+
+    MEMORY_LINT_COMPLETED = "memory.lint.completed"
+    # When a memory lint run completes (report attached)
+
+    MEMORY_LINT_FAILED = "memory.lint.failed"
+    # When a memory lint run or per-user pass fails
+
     # Memory event substrate operations (Memory Platform Phase 2)
     MEMORY_EVENT_APPENDED = "memory.event.appended"
     # When a memory event is appended to the immutable event log

--- a/src/muxi/runtime/formation/config/validation.py
+++ b/src/muxi/runtime/formation/config/validation.py
@@ -2264,6 +2264,127 @@ class FormationValidator:
             else:
                 self._validate_persistent_memory_config(persistent_config)
 
+        # Validate context optimization configuration (Memory Revamp Phase 3)
+        if "compaction" in memory_config:
+            self._validate_compaction_config(memory_config["compaction"])
+        if "pruning" in memory_config:
+            self._validate_pruning_config(memory_config["pruning"])
+
+        # Validate knowledge index configuration (Memory Revamp Phase 4)
+        if "index" in memory_config:
+            self._validate_memory_index_config(memory_config["index"])
+
+        # Validate lint configuration (Memory Revamp Phase 5)
+        if "lint" in memory_config:
+            self._validate_memory_lint_config(memory_config["lint"])
+
+    def _validate_compaction_config(self, compaction_config: Any) -> None:
+        """Validate memory.compaction (pre-compaction flush) configuration."""
+        if not isinstance(compaction_config, dict):
+            self.result.add_error("memory.compaction must be a dictionary")
+            return
+        flush_enabled = compaction_config.get("flush_enabled", True)
+        if not isinstance(flush_enabled, bool):
+            self.result.add_error("memory.compaction.flush_enabled must be a boolean")
+        threshold = compaction_config.get("flush_threshold", 0.80)
+        if not isinstance(threshold, (int, float)) or isinstance(threshold, bool):
+            self.result.add_error("memory.compaction.flush_threshold must be a number")
+        elif not 0 < threshold <= 1:
+            self.result.add_error(
+                "memory.compaction.flush_threshold must be between 0 (exclusive) and 1"
+            )
+
+    def _validate_pruning_config(self, pruning_config: Any) -> None:
+        """Validate memory.pruning (cache-TTL pruning) configuration."""
+        if not isinstance(pruning_config, dict):
+            self.result.add_error("memory.pruning must be a dictionary")
+            return
+        from ...services.memory.pruning import PRUNING_MODES, PRUNING_STRATEGIES
+
+        mode = pruning_config.get("mode", "cache-ttl")
+        if not isinstance(mode, str) or mode.strip().lower() not in PRUNING_MODES:
+            self.result.add_error(f"memory.pruning.mode must be one of {sorted(PRUNING_MODES)}")
+        strategy = pruning_config.get("strategy", "soft_trim")
+        if not isinstance(strategy, str) or strategy.strip().lower() not in PRUNING_STRATEGIES:
+            self.result.add_error(
+                f"memory.pruning.strategy must be one of {sorted(PRUNING_STRATEGIES)}"
+            )
+        for key in ("cache_ttl_seconds", "soft_trim_max_chars"):
+            if key in pruning_config:
+                value = pruning_config[key]
+                if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0:
+                    self.result.add_error(f"memory.pruning.{key} must be a positive number")
+        if "keep_last_n_tool_results" in pruning_config:
+            value = pruning_config["keep_last_n_tool_results"]
+            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                self.result.add_error(
+                    "memory.pruning.keep_last_n_tool_results must be a non-negative integer"
+                )
+
+    def _validate_memory_index_config(self, index_config: Any) -> None:
+        """Validate memory.index (knowledge index) configuration."""
+        if not isinstance(index_config, dict):
+            self.result.add_error("memory.index must be a dictionary")
+            return
+        if "enabled" in index_config and not isinstance(index_config["enabled"], bool):
+            self.result.add_error("memory.index.enabled must be a boolean")
+        for key in ("max_tokens", "entity_count_threshold"):
+            if key in index_config:
+                value = index_config[key]
+                if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+                    self.result.add_error(f"memory.index.{key} must be a positive integer")
+        if "regenerate_on" in index_config:
+            from ...services.memory.index import REGENERATE_TRIGGERS
+
+            triggers = index_config["regenerate_on"]
+            if not isinstance(triggers, list):
+                self.result.add_error("memory.index.regenerate_on must be a list")
+            else:
+                for trigger in triggers:
+                    if (
+                        not isinstance(trigger, str)
+                        or trigger.strip().lower() not in REGENERATE_TRIGGERS
+                    ):
+                        self.result.add_error(
+                            f"memory.index.regenerate_on entries must be one of "
+                            f"{sorted(REGENERATE_TRIGGERS)} (got {trigger!r})"
+                        )
+
+    def _validate_memory_lint_config(self, lint_config: Any) -> None:
+        """Validate memory.lint configuration."""
+        if not isinstance(lint_config, dict):
+            self.result.add_error("memory.lint must be a dictionary")
+            return
+        if "enabled" in lint_config and not isinstance(lint_config["enabled"], bool):
+            self.result.add_error("memory.lint.enabled must be a boolean")
+        if "schedule" in lint_config:
+            schedule = lint_config["schedule"]
+            valid_string = isinstance(schedule, str) and schedule.strip().lower() in (
+                "daily",
+                "weekly",
+            )
+            valid_number = (
+                isinstance(schedule, (int, float))
+                and not isinstance(schedule, bool)
+                and schedule > 0
+            )
+            if not valid_string and not valid_number:
+                self.result.add_error(
+                    "memory.lint.schedule must be 'daily', 'weekly', or a positive "
+                    "number of seconds"
+                )
+        if "orphan_cleanup" in lint_config and not isinstance(lint_config["orphan_cleanup"], bool):
+            self.result.add_error("memory.lint.orphan_cleanup must be a boolean")
+        for key in (
+            "conflict_resolution_days",
+            "stale_artifact_days",
+            "superseded_retention_days",
+        ):
+            if key in lint_config:
+                value = lint_config[key]
+                if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+                    self.result.add_error(f"memory.lint.{key} must be a positive integer")
+
     def _get_default_working_memory_config(self) -> Dict[str, Any]:
         """Get default working memory configuration."""
         return {

--- a/src/muxi/runtime/formation/formation.py
+++ b/src/muxi/runtime/formation/formation.py
@@ -1345,6 +1345,8 @@ class Formation:
                 "captains_log": getattr(self, "_captains_log", None),
                 "memory_events": getattr(self, "_memory_events", None),
                 "artifact_memory": getattr(self, "_artifact_memory", None),
+                "memory_index": getattr(self, "_memory_index", None),
+                "memory_lint": getattr(self, "_memory_lint", None),
                 "working_memory_config": getattr(self, "_working_memory_config", None),
                 "document_chunk_manager": getattr(self, "_document_chunk_manager", None),
                 "request_tracker": getattr(self, "_request_tracker", None),

--- a/src/muxi/runtime/formation/initialization.py
+++ b/src/muxi/runtime/formation/initialization.py
@@ -788,6 +788,16 @@ def initialize_memory_systems(formation) -> None:
                 # formations without it get no artifact capture.
                 _initialize_artifact_memory(formation)
 
+                # Initialize the knowledge index (Memory Revamp Phase 4).
+                # Placed last among the memory services because the index
+                # catalogs all of them (graph, log, artifacts).
+                _initialize_memory_index(formation, memory_config.get("index", {}) or {})
+
+                # Initialize memory lint (Memory Revamp Phase 5). Inert
+                # when unconfigured: only constructed when the formation
+                # declares a memory.lint block. Findings feed the index.
+                _initialize_memory_lint(formation, memory_config.get("lint"))
+
 
 def _initialize_memory_events(formation, events_config: Dict[str, Any]) -> None:
     """Initialize the memory event substrate on top of persistent memory."""
@@ -863,6 +873,86 @@ def _initialize_artifact_memory(formation) -> None:
             description=f"Failed to initialize artifact memory: {str(e)}",
         )
         # Don't raise - artifact memory is additive to persistent memory
+
+
+def _initialize_memory_index(formation, index_config: Dict[str, Any]) -> None:
+    """Initialize the knowledge index service (Memory Revamp Phase 4)."""
+    if index_config.get("enabled", True) is False:
+        formation._memory_index = None
+        return
+
+    # The index catalogs the other memory services; without at least one
+    # source there is nothing to index.
+    sources = [
+        getattr(formation, "_knowledge_graph", None),
+        getattr(formation, "_captains_log", None),
+        getattr(formation, "_artifact_memory", None),
+    ]
+    if all(source is None for source in sources):
+        formation._memory_index = None
+        return
+
+    try:
+        from ..services.memory.index import KnowledgeIndexService
+
+        formation._memory_index = KnowledgeIndexService(
+            db_manager=formation._db_manager,
+            formation_id=getattr(formation, "formation_id", "default-formation"),
+            config=index_config,
+            knowledge_graph=getattr(formation, "_knowledge_graph", None),
+            captains_log=getattr(formation, "_captains_log", None),
+            artifact_memory=getattr(formation, "_artifact_memory", None),
+        )
+        print(
+            InitEventFormatter.format_ok(
+                "Initializing knowledge index",
+                f"max {formation._memory_index.max_tokens} tokens",
+            )
+        )
+    except Exception as e:
+        formation._memory_index = None
+        observability.observe(
+            event_type=observability.ErrorEvents.MEMORY_INITIALIZATION_FAILED,
+            level=observability.EventLevel.WARNING,
+            data={"error": str(e), "service": "memory_index"},
+            description=f"Failed to initialize knowledge index service: {str(e)}",
+        )
+        # Don't raise - the knowledge index is additive to persistent memory
+
+
+def _initialize_memory_lint(formation, lint_config) -> None:
+    """Initialize the memory lint service (Memory Revamp Phase 5).
+
+    Inert when unconfigured: formations without a ``memory.lint`` block get
+    no lint service at all (pinned by unit test).
+    """
+    if not isinstance(lint_config, dict) or lint_config.get("enabled", True) is False:
+        formation._memory_lint = None
+        return
+
+    try:
+        from ..services.memory.lint import MemoryLintService
+
+        formation._memory_lint = MemoryLintService(
+            db_manager=formation._db_manager,
+            formation_id=getattr(formation, "formation_id", "default-formation"),
+            config=lint_config,
+            knowledge_graph=getattr(formation, "_knowledge_graph", None),
+            captains_log=getattr(formation, "_captains_log", None),
+            artifact_memory=getattr(formation, "_artifact_memory", None),
+            index=getattr(formation, "_memory_index", None),
+        )
+        schedule = lint_config.get("schedule", "weekly")
+        print(InitEventFormatter.format_ok("Initializing memory lint", f"schedule {schedule}"))
+    except Exception as e:
+        formation._memory_lint = None
+        observability.observe(
+            event_type=observability.ErrorEvents.MEMORY_INITIALIZATION_FAILED,
+            level=observability.EventLevel.WARNING,
+            data={"error": str(e), "service": "memory_lint"},
+            description=f"Failed to initialize memory lint service: {str(e)}",
+        )
+        # Don't raise - lint is additive to persistent memory
 
 
 def _register_memory_projectors(formation) -> None:

--- a/src/muxi/runtime/formation/overlord/chat_orchestrator.py
+++ b/src/muxi/runtime/formation/overlord/chat_orchestrator.py
@@ -1389,20 +1389,45 @@ class ChatOrchestrator:
                     pass
             return None
 
+        async def _fetch_memory_index_block():
+            # Knowledge index injection (Memory Revamp Phase 4): the
+            # navigable catalog of what exists in memory, read at the start
+            # of the retrieval pass. Failure-safe by contract (returns ""
+            # on any error or when there is nothing to index).
+            memory_index = getattr(self.overlord, "memory_index", None)
+            if memory_index and user_id is not None:
+                try:
+                    return await memory_index.get_index_block(user_id)
+                except Exception:
+                    pass
+            return ""
+
         if is_profile_recall_request:
-            user_profile_text, profile_memory_facts, context_messages_list = await asyncio.gather(
+            (
+                user_profile_text,
+                profile_memory_facts,
+                context_messages_list,
+                memory_index_block,
+            ) = await asyncio.gather(
                 _fetch_user_synopsis(),
                 _fetch_profile_memory_facts(),
                 _fetch_buffer_context(),
+                _fetch_memory_index_block(),
             )
             long_term_memories = profile_memory_facts
             if not user_profile_text and not long_term_memories:
                 long_term_memories = await _fetch_long_term_memories()
         else:
-            user_profile_text, long_term_memories, context_messages_list = await asyncio.gather(
+            (
+                user_profile_text,
+                long_term_memories,
+                context_messages_list,
+                memory_index_block,
+            ) = await asyncio.gather(
                 _fetch_user_synopsis(),
                 _fetch_long_term_memories(),
                 _fetch_buffer_context(),
+                _fetch_memory_index_block(),
             )
 
         # Format buffer context results
@@ -1422,6 +1447,7 @@ class ChatOrchestrator:
                         "=== USER PROFILE ===",
                         "=== FILE PROCESSING RESULTS ===",
                         "=== RELEVANT MEMORIES ===",
+                        "=== MEMORY INDEX ===",
                     ]
                 ):
                     if "=== CURRENT REQUEST ===" in content and "User:" in content:
@@ -1459,13 +1485,21 @@ class ChatOrchestrator:
         enhanced_parts.append(f"User: {display_message}")
         enhanced_parts.append("")
 
-        # 2. User profile (high priority - provides context about the user)
+        # 2. Memory index (Memory Revamp Phase 4) - the retrieval pass
+        # starts by orienting on what exists in memory before any of the
+        # semantic sections below.
+        if memory_index_block:
+            enhanced_parts.append("=== MEMORY INDEX ===")
+            enhanced_parts.append(memory_index_block)
+            enhanced_parts.append("")
+
+        # 3. User profile (high priority - provides context about the user)
         if user_profile_text:
             enhanced_parts.append("=== USER PROFILE ===")
             enhanced_parts.append(user_profile_text)
             enhanced_parts.append("")
 
-        # 3. File processing results (high priority)
+        # 4. File processing results (high priority)
         # Include a unique request marker to prevent semantic cache matching
         # with previous requests that had similar text but no files
         if file_results:
@@ -1476,7 +1510,7 @@ class ChatOrchestrator:
             enhanced_parts.append(file_results)
             enhanced_parts.append("")
 
-        # 4. Relevant long-term memories (medium priority)
+        # 5. Relevant long-term memories (medium priority)
         # IMPORTANT: Put memories BEFORE the protocol so LLM sees the data first
         if long_term_memories:
             # Add memories section FIRST - before instructions
@@ -1500,7 +1534,7 @@ class ChatOrchestrator:
                 )
                 enhanced_parts.append("")
 
-        # 5. Conversation context (lowest priority - truncated first if needed)
+        # 6. Conversation context (lowest priority - truncated first if needed)
         if context_text:
             # Load conversation awareness protocol from prompts
             from ..prompts.loader import PromptLoader
@@ -1710,19 +1744,44 @@ class ChatOrchestrator:
                     pass
             return ""
 
+        async def _fetch_memory_index() -> str:
+            # Knowledge index injection (Memory Revamp Phase 4): the
+            # navigable catalog of what exists in memory, injected at the
+            # start of the retrieval pass so agents can orient before any
+            # semantic search. Failure-safe by contract (returns "" on any
+            # error or when there is nothing to index).
+            memory_index = getattr(self.overlord, "memory_index", None)
+            if memory_index and user_id is not None:
+                try:
+                    return await memory_index.get_index_block(user_id)
+                except Exception:
+                    pass
+            return ""
+
         (
             user_profile_text,
             long_term_memories,
             buffer_turns,
             graph_context,
             captains_log_context,
+            memory_index_block,
         ) = await asyncio.gather(
             _fetch_user_synopsis(),
             _fetch_long_term_memories(),
             _fetch_buffer_role_turns(),
             _fetch_graph_context(),
             _fetch_captains_log_context(),
+            _fetch_memory_index(),
         )
+
+        # Cache-TTL pruning (Memory Revamp Phase 3): trim stale tool
+        # results / oversized turns from the history when the session
+        # resumes after the provider's prompt-cache window. Inert when
+        # memory.pruning is not configured; failure-isolated inside the
+        # pruner (returns the original turns on any error).
+        context_pruner = getattr(self.overlord, "context_pruner", None)
+        if context_pruner is not None:
+            buffer_turns = context_pruner.prune_turns(user_id, session_id, buffer_turns)
 
         if graph_context:
             graph_block = f"Known entity relationships:\n{graph_context}"
@@ -1734,6 +1793,15 @@ class ChatOrchestrator:
             log_block = f"Recent activity log:\n{captains_log_context}"
             user_profile_text = (
                 f"{user_profile_text}\n\n{log_block}" if user_profile_text else log_block
+            )
+
+        # The knowledge index leads the memory addendum (PRD retrieval
+        # flow: "1. Read memory index <- orient: what exists?").
+        if memory_index_block:
+            user_profile_text = (
+                f"{memory_index_block}\n\n{user_profile_text}"
+                if user_profile_text
+                else memory_index_block
             )
 
         # Apply the scheduled-execution marker only at the agent's

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -588,6 +588,22 @@ class Overlord:
             configured_services.get("artifact_memory") if configured_services else None
         )
 
+        # Knowledge index (Memory Revamp Phase 4) - the navigable memory
+        # catalog injected at retrieval start; None when disabled or when
+        # there is nothing to index.
+        self.memory_index = configured_services.get("memory_index") if configured_services else None
+
+        # Memory lint (Memory Revamp Phase 5) - background knowledge-store
+        # audit; None unless the formation declares a memory.lint block.
+        self.memory_lint = configured_services.get("memory_lint") if configured_services else None
+
+        # Context optimization (Memory Revamp Phase 3) - created during
+        # startup: the pre-compaction flush bridges the buffer's FIFO
+        # eviction to the captain's log, and the pruner trims stale tool
+        # results on idle session resume. Both stay None when unconfigured.
+        self.precompaction_flush = None
+        self.context_pruner = None
+
         # Configure extraction settings (intelligence concerns)
         self.auto_extract_user_info = auto_extract_user_info
 
@@ -1574,10 +1590,72 @@ class Overlord:
         if getattr(self, "artifact_memory", None):
             self.artifact_memory.start()
 
+        # Start the memory lint background loop (Memory Revamp Phase 5).
+        # Only present when the formation declares a memory.lint block.
+        if getattr(self, "memory_lint", None):
+            self.memory_lint.start()
+
+        # Context optimization (Memory Revamp Phase 3): attach the
+        # pre-compaction flush to the buffer's eviction path (silent turn
+        # through the captain's log digest before FIFO drops items), and
+        # create the cache-TTL context pruner when memory.pruning is
+        # configured. Both are failure-isolated and inert when off.
+        self._initialize_context_optimization()
+
         # Populate formation capabilities after all services are loaded
         self._populate_formation_capabilities()
 
         #  SystemEvents.STARTED (overlord)
+
+    def _initialize_context_optimization(self) -> None:
+        """
+        Create the Phase 3 context-optimization services (Memory Revamp).
+
+        Pre-compaction flush: attached when the captain's log and buffer
+        memory both exist and ``memory.compaction.flush_enabled`` is not
+        false -- at-risk buffer items run a silent digest turn before FIFO
+        eviction can drop them. Cache-TTL pruner: created only when the
+        formation declares a ``memory.pruning`` block (inert otherwise).
+        Failure-isolated: an initialization error leaves both off.
+        """
+        memory_config = (
+            self.formation_config.get("memory", {}) if self.formation_config else {}
+        ) or {}
+
+        try:
+            compaction_config = memory_config.get("compaction", {}) or {}
+            if getattr(self, "captains_log", None) and self.buffer_memory is not None:
+                from ...services.memory.flush import PreCompactionFlushService
+
+                flush = PreCompactionFlushService(self.captains_log, compaction_config)
+                if flush.enabled:
+                    flush.attach(
+                        self.buffer_memory,
+                        lambda: getattr(self, "extraction_model", None)
+                        or getattr(self, "default_model", None),
+                    )
+                    self.precompaction_flush = flush
+        except Exception as e:
+            observability.observe(
+                event_type=observability.ErrorEvents.MEMORY_INITIALIZATION_FAILED,
+                level=observability.EventLevel.WARNING,
+                data={"error": str(e), "service": "precompaction_flush"},
+                description=f"Failed to initialize pre-compaction flush: {e}",
+            )
+
+        try:
+            pruning_config = memory_config.get("pruning")
+            if isinstance(pruning_config, dict) and pruning_config:
+                from ...services.memory.pruning import ContextPruner
+
+                self.context_pruner = ContextPruner(pruning_config)
+        except Exception as e:
+            observability.observe(
+                event_type=observability.ErrorEvents.MEMORY_INITIALIZATION_FAILED,
+                level=observability.EventLevel.WARNING,
+                data={"error": str(e), "service": "context_pruner"},
+                description=f"Failed to initialize context pruner: {e}",
+            )
 
     def _initialize_proactive_services(self) -> None:
         """
@@ -4570,6 +4648,18 @@ Agent response: {raw_response}"""
                     level=observability.EventLevel.WARNING,
                     data={"error": str(e), "service": "artifact_memory"},
                     description=f"Error stopping artifact memory service: {e}",
+                )
+
+        # Stop the memory lint background loop (Memory Revamp Phase 5)
+        if getattr(self, "memory_lint", None):
+            try:
+                await self.memory_lint.stop()
+            except Exception as e:
+                observability.observe(
+                    event_type=observability.ErrorEvents.INTERNAL_ERROR,
+                    level=observability.EventLevel.WARNING,
+                    data={"error": str(e), "service": "memory_lint"},
+                    description=f"Error stopping memory lint service: {e}",
                 )
 
         observability.observe(

--- a/src/muxi/runtime/formation/server/routes/admin/memory.py
+++ b/src/muxi/runtime/formation/server/routes/admin/memory.py
@@ -192,6 +192,52 @@ async def rebuild_memory_projections(
     return JSONResponse(content=response.model_dump(), status_code=200)
 
 
+class MemoryLintRequest(BaseModel):
+    """Model for an on-demand memory lint request."""
+
+    user_id: Optional[str] = None  # None audits every user
+
+
+@router.post("/memory/lint", response_model=APIResponse, operation_id="lint_memory")
+async def lint_memory(request: Request, lint: MemoryLintRequest) -> JSONResponse:
+    """
+    Run the memory lint audit on demand (Memory Revamp Phase 5).
+
+    Walks the knowledge store (one user, or every user when ``user_id`` is
+    omitted) and returns the health report: unresolved conflicts, superseded
+    facts hard-deleted, orphaned relationships removed, captain's log gaps,
+    stale artifacts, and knowledge index regenerations. Findings are written
+    back into the knowledge index as knowledge gaps.
+    """
+    formation = request.app.state.formation
+    request_id = getattr(request.state, "request_id", None)
+
+    overlord = getattr(formation, "_overlord", None)
+    memory_lint = getattr(overlord, "memory_lint", None) if overlord else None
+    if memory_lint is None:
+        response = create_error_response(
+            "SERVICE_UNAVAILABLE",
+            "Memory lint is not configured (declare a 'memory.lint' block)",
+            None,
+            request_id,
+        )
+        return JSONResponse(content=response.model_dump(), status_code=503)
+
+    try:
+        report = await memory_lint.run_lint(user_id=lint.user_id)
+    except Exception as e:
+        response = create_error_response(
+            "INTERNAL_ERROR", f"Memory lint failed: {str(e)}", None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=500)
+
+    data = {"user_id": lint.user_id, "report": report}
+    response = create_success_response(
+        APIObjectType.MEMORY, APIEventType.MEMORY_RETRIEVED, data, request_id
+    )
+    return JSONResponse(content=response.model_dump(), status_code=200)
+
+
 # ---------------------------------------------------------------------------
 # Distillery registration (Memory Distillery Phase 3b)
 # ---------------------------------------------------------------------------

--- a/src/muxi/runtime/services/memory/flush.py
+++ b/src/muxi/runtime/services/memory/flush.py
@@ -167,15 +167,23 @@ def _group_items_by_user(items: List[Dict[str, Any]]) -> Dict[str, List[tuple]]:
 
     Each turn is ``(timestamp_key, rendered_text)`` -- the exact shape the
     Captain's Log digest consumes, with the buffer timestamp as the
-    ``buffer_item`` source-lineage key.
+    ``buffer_item`` source-lineage key. Items without a ``user_id`` in
+    their metadata are skipped (with a debug event): attributing them to a
+    fallback scope would pollute a real user's persistent memory --
+    single-user mode stores ``user_id`` explicitly, so legitimate chat
+    items always carry the key.
     """
     grouped: Dict[str, List[tuple]] = {}
+    skipped_missing_user = 0
     for item in items:
         metadata = item.get("metadata") or {}
         text = (item.get("text") or "").strip()
         if not text:
             continue
-        user_id = str(metadata.get("user_id", "0"))
+        raw_user_id = metadata.get("user_id")
+        if raw_user_id is None:
+            skipped_missing_user += 1
+            continue
         role = metadata.get("role")
         if role == "user":
             rendered = f"User: {text}"
@@ -184,5 +192,15 @@ def _group_items_by_user(items: List[Dict[str, Any]]) -> Dict[str, List[tuple]]:
         else:
             rendered = text
         timestamp = item.get("timestamp") or 0.0
-        grouped.setdefault(user_id, []).append((f"{float(timestamp):.6f}", rendered))
+        grouped.setdefault(str(raw_user_id), []).append((f"{float(timestamp):.6f}", rendered))
+    if skipped_missing_user:
+        observability.observe(
+            event_type=observability.ConversationEvents.MEMORY_PRECOMPACTION_FLUSH_FAILED,
+            level=observability.EventLevel.DEBUG,
+            data={"reason": "missing_user_id", "skipped_items": skipped_missing_user},
+            description=(
+                f"Pre-compaction flush skipped {skipped_missing_user} buffer item(s) "
+                "without user_id metadata"
+            ),
+        )
     return grouped

--- a/src/muxi/runtime/services/memory/flush.py
+++ b/src/muxi/runtime/services/memory/flush.py
@@ -1,0 +1,188 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Pre-Compaction Flush - Silent Turn Before Buffer Eviction
+# Description:  Persists at-risk buffer context to the log + graph pre-eviction
+# Role:         Formation-level service bridging WorkingMemory FIFO cleanup
+#               and the Captain's Log / Knowledge Graph write pipeline
+# Usage:        Created and attached by the Overlord during startup
+# Author:       Muxi Framework Team
+#
+# Memory Revamp Phase 3 (Context Optimization - Pre-Compaction Flush).
+#
+# The working memory buffer is bounded: when its estimated usage exceeds
+# max_memory_mb, FIFO cleanup evicts the oldest items -- silently losing
+# conversational context in long-running sessions where the buffer fills
+# before the periodic Captain's Log digest runs. This service hooks the
+# eviction path so nothing is lost without first being captured:
+#
+# 1. Threshold trigger: when buffer usage crosses flush_threshold (default
+#    0.80) of the limit, the oldest ~25% of buffer items (the next eviction
+#    candidates) are handed to this service BEFORE any eviction happens.
+# 2. Eviction safety net: any item that reaches eviction without having
+#    been flushed is handed over at eviction time (the item dicts are
+#    snapshotted first, so persistence proceeds after the buffer drops them).
+#
+# Each hand-off runs a SILENT TURN: an LLM pass outside the user-visible
+# conversation that digests the at-risk items through the Captain's Log
+# pipeline -- which writes the narrative entry, source lineage, lessons,
+# and the digest's knowledge graph facts in one pass. No reply is surfaced.
+#
+# Failure isolation: the WorkingMemory listener callback never raises into
+# FIFO cleanup, and a failed silent turn only loses that best-effort flush
+# (eviction proceeds regardless -- exactly what happens today without it).
+# =============================================================================
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+from .. import observability
+
+# PRD defaults (Configuration Reference -> memory.compaction).
+DEFAULT_FLUSH_ENABLED = True
+DEFAULT_FLUSH_THRESHOLD = 0.80
+
+
+class PreCompactionFlushService:
+    """Runs the silent memory flush before working-memory eviction."""
+
+    def __init__(self, captains_log, config: Optional[Dict[str, Any]] = None):
+        """
+        Initialize the flush service.
+
+        Args:
+            captains_log: Phase 2 CaptainsLogService. The silent turn rides
+                its digest pipeline (log entry + lessons + graph facts).
+            config: The ``memory.compaction`` formation config section.
+        """
+        config = config or {}
+        self.enabled = bool(config.get("flush_enabled", DEFAULT_FLUSH_ENABLED))
+        self.flush_threshold = float(config.get("flush_threshold", DEFAULT_FLUSH_THRESHOLD))
+        self.captains_log = captains_log
+        self._model_getter = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+
+    def attach(self, working_memory, model_getter) -> None:
+        """
+        Register the eviction listener on the working memory buffer.
+
+        Must be called from the event loop the flush should run on (the
+        Overlord's startup path). No-op when disabled or when either side
+        of the bridge is missing.
+
+        Args:
+            working_memory: The WorkingMemory buffer instance to guard.
+            model_getter: Zero-argument callable returning the digest LLM
+                (or None while unavailable), resolved per flush.
+        """
+        if not self.enabled or working_memory is None or self.captains_log is None:
+            return
+        self._model_getter = model_getter
+        self._loop = asyncio.get_running_loop()
+        working_memory.set_eviction_listener(self._on_items_at_risk, self.flush_threshold)
+
+    # ------------------------------------------------------------------
+    # WorkingMemory bridge (sync, called from the FIFO cleanup thread)
+    # ------------------------------------------------------------------
+
+    def _on_items_at_risk(self, items: List[Dict[str, Any]]) -> None:
+        """
+        Receive at-risk buffer item snapshots and schedule the silent turn.
+
+        Called synchronously by WorkingMemory's cleanup path (which runs on
+        a daemon thread); the flush itself is scheduled onto the formation
+        event loop. Never raises.
+        """
+        if not items or self._loop is None or self._loop.is_closed():
+            return
+        try:
+            observability.observe(
+                event_type=(observability.ConversationEvents.MEMORY_PRECOMPACTION_FLUSH_TRIGGERED),
+                level=observability.EventLevel.DEBUG,
+                data={"items": len(items), "threshold": self.flush_threshold},
+                description=(
+                    f"Pre-compaction flush triggered for {len(items)} at-risk buffer item(s)"
+                ),
+            )
+            asyncio.run_coroutine_threadsafe(self.flush_items(list(items)), self._loop)
+        except Exception as e:
+            self._observe_failure(e, user_id=None)
+
+    # ------------------------------------------------------------------
+    # The silent turn
+    # ------------------------------------------------------------------
+
+    async def flush_items(self, items: List[Dict[str, Any]]) -> Dict[str, int]:
+        """
+        Run the silent memory flush for a batch of buffer item snapshots.
+
+        Groups items per user, renders them as conversation turns, and
+        digests each user's batch through the Captain's Log pipeline
+        (narrative entry + source lineage + lessons + graph facts).
+        Failure-isolated per user; returns aggregate stored counts.
+        """
+        totals = {"entries": 0, "sources": 0, "lessons": 0}
+        model = self._model_getter() if self._model_getter else None
+        if model is None or self.captains_log is None:
+            return totals
+
+        for user_id, turns in _group_items_by_user(items).items():
+            try:
+                stored = await self.captains_log.digest_turns(user_id, turns, model)
+                totals["entries"] += stored["entries"]
+                totals["sources"] += stored["sources"]
+                totals["lessons"] += stored["lessons"]
+                observability.observe(
+                    event_type=(
+                        observability.ConversationEvents.MEMORY_PRECOMPACTION_FLUSH_COMPLETED
+                    ),
+                    level=observability.EventLevel.DEBUG,
+                    data={"user_id": user_id, "turns": len(turns), **stored},
+                    description=(
+                        f"Pre-compaction flush persisted {len(turns)} buffer item(s) "
+                        "before eviction"
+                    ),
+                )
+            except Exception as e:
+                self._observe_failure(e, user_id=user_id)
+        return totals
+
+    def _observe_failure(self, error: Exception, user_id: Optional[str]) -> None:
+        """Emit the flush-failed event (shared by both failure sites)."""
+        observability.observe(
+            event_type=observability.ConversationEvents.MEMORY_PRECOMPACTION_FLUSH_FAILED,
+            level=observability.EventLevel.WARNING,
+            data={
+                "user_id": user_id,
+                "error": str(error),
+                "error_type": type(error).__name__,
+            },
+            description=f"Pre-compaction flush failed: {error}",
+        )
+
+
+def _group_items_by_user(items: List[Dict[str, Any]]) -> Dict[str, List[tuple]]:
+    """
+    Group buffer item snapshots into per-user digest turns.
+
+    Each turn is ``(timestamp_key, rendered_text)`` -- the exact shape the
+    Captain's Log digest consumes, with the buffer timestamp as the
+    ``buffer_item`` source-lineage key.
+    """
+    grouped: Dict[str, List[tuple]] = {}
+    for item in items:
+        metadata = item.get("metadata") or {}
+        text = (item.get("text") or "").strip()
+        if not text:
+            continue
+        user_id = str(metadata.get("user_id", "0"))
+        role = metadata.get("role")
+        if role == "user":
+            rendered = f"User: {text}"
+        elif role == "assistant":
+            rendered = f"Assistant: {text}"
+        else:
+            rendered = text
+        timestamp = item.get("timestamp") or 0.0
+        grouped.setdefault(user_id, []).append((f"{float(timestamp):.6f}", rendered))
+    return grouped

--- a/src/muxi/runtime/services/memory/index.py
+++ b/src/muxi/runtime/services/memory/index.py
@@ -440,11 +440,6 @@ class KnowledgeIndexService:
         self._lint_findings[user_id] = findings
         return findings
 
-    def last_generated_at(self, user_id: Any) -> Optional[float]:
-        """Epoch seconds of the user's last regeneration (None if never)."""
-        cached = self._cache.get(str(user_id))
-        return cached["generated_at"] if cached else None
-
     # ------------------------------------------------------------------
     # system_config persistence
     # ------------------------------------------------------------------

--- a/src/muxi/runtime/services/memory/index.py
+++ b/src/muxi/runtime/services/memory/index.py
@@ -1,0 +1,528 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Knowledge Index - Navigable Memory Catalog
+# Description:  Generates and caches the per-user memory index blob
+# Role:         Formation-level service injected at retrieval start
+# Usage:        Created in formation initialization, read by the Overlord
+# Author:       Muxi Framework Team
+#
+# Memory Revamp Phase 4 (Knowledge Index).
+#
+# Vector search answers "what's similar to X?" -- the index answers "what do
+# I actually know about this user?". A lightweight text blob cataloging the
+# memory store (entities, captain's log span, artifacts, knowledge gaps
+# flagged by the last lint) is injected at the start of every retrieval
+# pass, before any semantic search, so agents can navigate by intent.
+#
+# Generation and caching:
+# - The blob is cached in memory per user and write-through persisted to the
+#   system_config table (key ``memory_index:{user_id}``, PRD format).
+# - Regeneration triggers (config ``regenerate_on``) are implemented as a
+#   cheap fingerprint check on read -- log entry count/updated stamp
+#   ("log_entry"), artifact count ("artifact_save"), entity count moving by
+#   entity_count_threshold ("entity_count_threshold") -- plus an explicit
+#   ``invalidate()`` hook the lint job calls after each run ("lint"). The
+#   fingerprint costs three indexed COUNT-class queries, no LLM work.
+# - A blob older than STALE_AFTER_SECONDS (24h) always regenerates, which is
+#   also the staleness bound the lint job enforces.
+#
+# Size cap: the rendered blob never exceeds max_tokens (default 300,
+# estimated at CHARS_PER_TOKEN chars/token); each section truncates with an
+# explicit count of omitted items.
+#
+# Failure isolation: get_index_block returns "" on any error; regeneration
+# and persistence failures never affect the chat turn.
+#
+# Cross-PRD seam (artifact-memory Phase 2): the artifacts section reads from
+# the artifact memory service's ``list_artifacts`` -- the artifact manifest
+# rides this index without further wiring.
+# =============================================================================
+
+import json
+import time
+from datetime import date as date_type
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import func, select
+
+from ...utils.datetime_utils import utc_now_naive
+from .. import observability
+from .artifacts.models import SystemConfig
+from .graph.models import STATUS_ACTIVE, KGEntity
+from .log.models import CaptainsLogEntry
+
+# PRD defaults (Configuration Reference -> memory.index).
+DEFAULT_MAX_TOKENS = 300
+DEFAULT_ENTITY_COUNT_THRESHOLD = 10
+REGENERATE_ON_LINT = "lint"
+REGENERATE_ON_LOG_ENTRY = "log_entry"
+REGENERATE_ON_ARTIFACT_SAVE = "artifact_save"
+REGENERATE_ON_ENTITY_THRESHOLD = "entity_count_threshold"
+REGENERATE_TRIGGERS = {
+    REGENERATE_ON_LINT,
+    REGENERATE_ON_LOG_ENTRY,
+    REGENERATE_ON_ARTIFACT_SAVE,
+    REGENERATE_ON_ENTITY_THRESHOLD,
+}
+DEFAULT_REGENERATE_ON = sorted(REGENERATE_TRIGGERS)
+
+# Rough chars-per-token estimate used for the size cap.
+CHARS_PER_TOKEN = 4
+
+# A cached blob older than this always regenerates (PRD lint check:
+# "Knowledge index stale (not regenerated in > 24h) -> force regeneration").
+STALE_AFTER_SECONDS = 86400
+
+# system_config key formats (PRD "stored as a single row in system_config").
+INDEX_KEY_FORMAT = "memory_index:{user_id}"
+LINT_FINDINGS_KEY_FORMAT = "memory_lint:{user_id}"
+
+# How many rows each section may fetch before rendering/truncation.
+MAX_ENTITIES_FETCHED = 50
+MAX_GAPS_RENDERED = 5
+
+
+class KnowledgeIndexService:
+    """Generates, caches, and serves the per-user memory index blob."""
+
+    def __init__(
+        self,
+        db_manager,
+        formation_id: str,
+        config: Optional[Dict[str, Any]] = None,
+        knowledge_graph=None,
+        captains_log=None,
+        artifact_memory=None,
+    ):
+        """
+        Initialize the knowledge index service.
+
+        Args:
+            db_manager: Shared DatabaseManager (PostgreSQL or SQLite).
+            formation_id: Formation identifier scoping all rows.
+            config: The ``memory.index`` formation config section.
+            knowledge_graph: Phase 1 KnowledgeGraphService (or None).
+            captains_log: Phase 2 CaptainsLogService (or None).
+            artifact_memory: ArtifactMemoryService (or None) -- the clean
+                seam the artifact manifest rides.
+        """
+        config = config or {}
+        self.enabled = config.get("enabled", True)
+        self.max_tokens = int(config.get("max_tokens", DEFAULT_MAX_TOKENS))
+        self.entity_count_threshold = int(
+            config.get("entity_count_threshold", DEFAULT_ENTITY_COUNT_THRESHOLD)
+        )
+        regenerate_on = config.get("regenerate_on", DEFAULT_REGENERATE_ON)
+        self.regenerate_on = {str(trigger).strip().lower() for trigger in regenerate_on}
+
+        self.db_manager = db_manager
+        self.formation_id = formation_id
+        self.knowledge_graph = knowledge_graph
+        self.captains_log = captains_log
+        self.artifact_memory = artifact_memory
+
+        # user_id -> {"block", "fingerprint", "generated_at"}
+        self._cache: Dict[str, Dict[str, Any]] = {}
+        # user_id -> cached lint findings (backed by system_config).
+        self._lint_findings: Dict[str, List[str]] = {}
+        # Bumped by set_lint_findings/invalidate so the fingerprint check
+        # picks up lint runs without a database read.
+        self._lint_version: Dict[str, int] = {}
+
+    @property
+    def max_chars(self) -> int:
+        """The rendered blob's hard character budget."""
+        return self.max_tokens * CHARS_PER_TOKEN
+
+    # ------------------------------------------------------------------
+    # Read path (retrieval start)
+    # ------------------------------------------------------------------
+
+    async def get_index_block(self, user_id: Any) -> str:
+        """
+        Return the user's memory index blob for prompt injection.
+
+        Serves the cached blob when the fingerprint says nothing indexed
+        has changed; regenerates otherwise. Returns "" when disabled, when
+        there is nothing to index, or on any error (failure-isolated).
+        """
+        if not self.enabled:
+            return ""
+        try:
+            user_id = str(user_id)
+            fingerprint = await self._fingerprint(user_id)
+            cached = self._cache.get(user_id)
+            if cached is not None and not self._needs_regeneration(cached, fingerprint):
+                return cached["block"]
+            return await self.regenerate(user_id, fingerprint=fingerprint)
+        except Exception as e:
+            observability.observe(
+                event_type=observability.ConversationEvents.MEMORY_INDEX_FAILED,
+                level=observability.EventLevel.WARNING,
+                data={"user_id": str(user_id), "error": str(e), "error_type": type(e).__name__},
+                description=f"Knowledge index lookup failed: {e}",
+            )
+            return ""
+
+    def invalidate(self, user_id: Any, reason: str = "manual") -> None:
+        """Drop the cached blob so the next read regenerates."""
+        user_id = str(user_id)
+        self._cache.pop(user_id, None)
+        self._lint_version[user_id] = self._lint_version.get(user_id, 0) + 1
+        _ = reason  # recorded by callers' own events
+
+    # ------------------------------------------------------------------
+    # Regeneration
+    # ------------------------------------------------------------------
+
+    async def regenerate(self, user_id: Any, fingerprint: Optional[Dict[str, Any]] = None) -> str:
+        """
+        Rebuild the user's index blob, cache it, and persist it.
+
+        Returns the rendered blob ("" when there is nothing to index).
+        """
+        user_id = str(user_id)
+        if fingerprint is None:
+            fingerprint = await self._fingerprint(user_id)
+
+        entities: List[Dict[str, Any]] = []
+        if self.knowledge_graph is not None and getattr(self.knowledge_graph, "enabled", False):
+            entities = await self.knowledge_graph.storage.list_entities(
+                user_id, limit=MAX_ENTITIES_FETCHED
+            )
+
+        log_stats = await self._log_stats(user_id)
+
+        artifacts: List[Dict[str, Any]] = []
+        if self.artifact_memory is not None and getattr(self.artifact_memory, "enabled", False):
+            artifacts = await self.artifact_memory.list_artifacts(user_id)
+
+        gaps = await self.get_lint_findings(user_id)
+
+        block = self._render(
+            entity_count=fingerprint["entities"],
+            entities=entities,
+            log_stats=log_stats,
+            artifacts=artifacts,
+            gaps=gaps,
+        )
+
+        self._cache[user_id] = {
+            "block": block,
+            "fingerprint": fingerprint,
+            "generated_at": time.time(),
+        }
+        await self._persist_block(user_id, block)
+
+        observability.observe(
+            event_type=observability.ConversationEvents.MEMORY_INDEX_REGENERATED,
+            level=observability.EventLevel.DEBUG,
+            data={
+                "user_id": user_id,
+                "entities": fingerprint["entities"],
+                "log_entries": fingerprint["log_entries"],
+                "artifacts": fingerprint["artifacts"],
+                "gaps": len(gaps),
+                "chars": len(block),
+            },
+            description=f"Knowledge index regenerated ({len(block)} chars)",
+        )
+        return block
+
+    def _needs_regeneration(self, cached: Dict[str, Any], fingerprint: Dict[str, Any]) -> bool:
+        """Apply the configured regeneration triggers to the fingerprint."""
+        if time.time() - cached["generated_at"] > STALE_AFTER_SECONDS:
+            return True
+        old = cached["fingerprint"]
+        if REGENERATE_ON_LOG_ENTRY in self.regenerate_on and (
+            old["log_entries"] != fingerprint["log_entries"]
+            or old["log_updated"] != fingerprint["log_updated"]
+        ):
+            return True
+        if (
+            REGENERATE_ON_ARTIFACT_SAVE in self.regenerate_on
+            and old["artifacts"] != fingerprint["artifacts"]
+        ):
+            return True
+        if (
+            REGENERATE_ON_ENTITY_THRESHOLD in self.regenerate_on
+            and abs(old["entities"] - fingerprint["entities"]) >= self.entity_count_threshold
+        ):
+            return True
+        if (
+            REGENERATE_ON_LINT in self.regenerate_on
+            and old["lint_version"] != fingerprint["lint_version"]
+        ):
+            return True
+        return False
+
+    async def _fingerprint(self, user_id: str) -> Dict[str, Any]:
+        """Cheap change detector over everything the index catalogs."""
+        entity_count = 0
+        if self.knowledge_graph is not None and getattr(self.knowledge_graph, "enabled", False):
+            async with self.db_manager.get_async_session() as session:
+                stmt = (
+                    select(func.count())
+                    .select_from(KGEntity)
+                    .filter_by(
+                        user_id=user_id,
+                        formation_id=self.formation_id,
+                        status=STATUS_ACTIVE,
+                    )
+                )
+                entity_count = int((await session.execute(stmt)).scalar() or 0)
+
+        log_count = 0
+        log_updated = None
+        if self.captains_log is not None and getattr(self.captains_log, "enabled", False):
+            async with self.db_manager.get_async_session() as session:
+                stmt = (
+                    select(func.count(), func.max(CaptainsLogEntry.updated_at))
+                    .select_from(CaptainsLogEntry)
+                    .where(
+                        CaptainsLogEntry.user_id == user_id,
+                        CaptainsLogEntry.formation_id == self.formation_id,
+                    )
+                )
+                row = (await session.execute(stmt)).one()
+                log_count = int(row[0] or 0)
+                log_updated = row[1].isoformat() if row[1] else None
+
+        artifact_count = 0
+        if self.artifact_memory is not None and getattr(self.artifact_memory, "enabled", False):
+            artifact_count = await self._artifact_count(user_id)
+
+        return {
+            "entities": entity_count,
+            "log_entries": log_count,
+            "log_updated": log_updated,
+            "artifacts": artifact_count,
+            "lint_version": self._lint_version.get(user_id, 0),
+        }
+
+    async def _artifact_count(self, user_id: str) -> int:
+        """Count the user's live artifacts through the artifact service."""
+        try:
+            return len(await self.artifact_memory.list_artifacts(user_id))
+        except Exception:
+            return 0
+
+    async def _log_stats(self, user_id: str) -> Dict[str, Any]:
+        """Entry count, date span, and most recent summary for the log."""
+        stats = {"count": 0, "first": None, "last": None, "recent_summary": None}
+        if self.captains_log is None or not getattr(self.captains_log, "enabled", False):
+            return stats
+        async with self.db_manager.get_async_session() as session:
+            stmt = (
+                select(
+                    func.count(),
+                    func.min(CaptainsLogEntry.date),
+                    func.max(CaptainsLogEntry.date),
+                )
+                .select_from(CaptainsLogEntry)
+                .where(
+                    CaptainsLogEntry.user_id == user_id,
+                    CaptainsLogEntry.formation_id == self.formation_id,
+                )
+            )
+            row = (await session.execute(stmt)).one()
+            stats["count"] = int(row[0] or 0)
+            stats["first"] = _iso_date(row[1])
+            stats["last"] = _iso_date(row[2])
+        if stats["count"]:
+            entries = await self.captains_log.storage.list_entries(user_id, limit=1)
+            if entries and entries[0].get("summary"):
+                stats["recent_summary"] = entries[0]["summary"]
+        return stats
+
+    # ------------------------------------------------------------------
+    # Rendering (size-capped)
+    # ------------------------------------------------------------------
+
+    def _render(
+        self,
+        entity_count: int,
+        entities: List[Dict[str, Any]],
+        log_stats: Dict[str, Any],
+        artifacts: List[Dict[str, Any]],
+        gaps: List[str],
+    ) -> str:
+        """Render the index blob within the max_tokens character budget."""
+        if not entity_count and not log_stats["count"] and not artifacts and not gaps:
+            return ""
+
+        header = f"[Memory Index - as of {utc_now_naive().date().isoformat()}]"
+        sections: List[str] = []
+
+        if entity_count:
+            names = [_entity_label(entity) for entity in entities]
+            sections.append(
+                _fit_listing(f"Entities ({entity_count}): ", names, entity_count, budget=None)
+            )
+
+        if log_stats["count"]:
+            line = f"Captain's Log: {log_stats['count']} entries"
+            if log_stats["first"] and log_stats["last"]:
+                if log_stats["first"] == log_stats["last"]:
+                    line += f" on {log_stats['last']}"
+                else:
+                    line += f" spanning {log_stats['first']} - {log_stats['last']}"
+            if log_stats["recent_summary"]:
+                line += f". Most recent: {_clip(log_stats['recent_summary'], 120)}"
+            sections.append(line)
+
+        if artifacts:
+            labels = [_artifact_label(artifact) for artifact in artifacts]
+            sections.append(
+                _fit_listing(f"Artifacts ({len(artifacts)}): ", labels, len(artifacts), budget=None)
+            )
+
+        if gaps:
+            shown = gaps[:MAX_GAPS_RENDERED]
+            line = "Knowledge gaps flagged by last lint: " + "; ".join(
+                _clip(gap, 100) for gap in shown
+            )
+            if len(gaps) > len(shown):
+                line += f" [+{len(gaps) - len(shown)} more]"
+            sections.append(line)
+
+        # Assemble under the hard budget: sections that overflow get their
+        # listings re-fit into the remaining space, never silently dropped
+        # mid-item.
+        budget = self.max_chars - len(header)
+        rendered: List[str] = [header]
+        for section in sections:
+            available = budget - 2  # the joining blank costs "\n\n"
+            if available <= 0:
+                break
+            if len(section) > available:
+                section = _clip(section, available)
+            rendered.append(section)
+            budget -= len(section) + 2
+        return "\n\n".join(rendered)
+
+    # ------------------------------------------------------------------
+    # Lint findings (Phase 5 write-back)
+    # ------------------------------------------------------------------
+
+    async def set_lint_findings(self, user_id: Any, findings: List[str]) -> None:
+        """
+        Store the latest lint findings and invalidate the cached index.
+
+        Called by the Phase 5 lint job after each run so agents see the
+        memory store's known weaknesses. Persisted in system_config
+        (key ``memory_lint:{user_id}``) to survive restarts.
+        """
+        user_id = str(user_id)
+        findings = [str(finding) for finding in findings]
+        self._lint_findings[user_id] = findings
+        await self._system_set(
+            LINT_FINDINGS_KEY_FORMAT.format(user_id=user_id), json.dumps(findings)
+        )
+        self.invalidate(user_id, reason="lint")
+
+    async def get_lint_findings(self, user_id: Any) -> List[str]:
+        """Return the last lint run's findings for the user (may be [])."""
+        user_id = str(user_id)
+        cached = self._lint_findings.get(user_id)
+        if cached is not None:
+            return cached
+        raw = await self._system_get(LINT_FINDINGS_KEY_FORMAT.format(user_id=user_id))
+        findings: List[str] = []
+        if raw:
+            try:
+                loaded = json.loads(raw)
+                if isinstance(loaded, list):
+                    findings = [str(finding) for finding in loaded]
+            except (ValueError, TypeError):
+                findings = []
+        self._lint_findings[user_id] = findings
+        return findings
+
+    def last_generated_at(self, user_id: Any) -> Optional[float]:
+        """Epoch seconds of the user's last regeneration (None if never)."""
+        cached = self._cache.get(str(user_id))
+        return cached["generated_at"] if cached else None
+
+    # ------------------------------------------------------------------
+    # system_config persistence
+    # ------------------------------------------------------------------
+
+    async def _persist_block(self, user_id: str, block: str) -> None:
+        """Write-through the rendered blob (best-effort, never raises)."""
+        try:
+            await self._system_set(INDEX_KEY_FORMAT.format(user_id=user_id), block)
+        except Exception:
+            pass
+
+    async def _system_get(self, key: str) -> Optional[str]:
+        async with self.db_manager.get_async_session() as session:
+            row = await session.get(SystemConfig, key)
+            return row.value if row else None
+
+    async def _system_set(self, key: str, value: str) -> None:
+        async with self.db_manager.get_async_session() as session:
+            await session.merge(SystemConfig(key=key, value=value))
+            await session.flush()
+
+
+def _entity_label(entity: Dict[str, Any]) -> str:
+    """Render one entity as ``Name (Type)`` for the index listing."""
+    entity_type = (entity.get("type") or "").capitalize()
+    return f"{entity['name']} ({entity_type})" if entity_type else entity["name"]
+
+
+def _artifact_label(artifact: Dict[str, Any]) -> str:
+    """Render one artifact as ``Name (type, date)`` for the index listing."""
+    parts = []
+    content_type = artifact.get("content_type")
+    if content_type:
+        parts.append(str(content_type).rsplit("/", 1)[-1])
+    created = artifact.get("created_at")
+    if created:
+        parts.append(str(created)[:10])
+    suffix = f" ({', '.join(parts)})" if parts else ""
+    return f"{artifact.get('name', '?')}{suffix}"
+
+
+def _fit_listing(prefix: str, labels: List[str], total: int, budget: Optional[int]) -> str:
+    """
+    Render ``prefix + comma-joined labels`` with an omitted-items count.
+
+    ``budget`` limits the rendered length (None applies a generous default
+    that final assembly may clip further). Truncates on item boundaries
+    with ``[+N more]``, per the PRD's truncation rule.
+    """
+    if budget is None:
+        budget = 400
+    shown: List[str] = []
+    used = len(prefix)
+    for label in labels:
+        cost = len(label) + (2 if shown else 0)
+        if used + cost > budget:
+            break
+        shown.append(label)
+        used += cost
+    omitted = total - len(shown)
+    line = prefix + ", ".join(shown)
+    if omitted > 0:
+        line += f" [+{omitted} more]"
+    return line
+
+
+def _clip(text: str, limit: int) -> str:
+    """Hard-clip text to ``limit`` chars with an ellipsis marker."""
+    text = str(text)
+    if len(text) <= limit:
+        return text
+    return text[: max(limit - 3, 0)] + "..."
+
+
+def _iso_date(value) -> Optional[str]:
+    """Normalize a DATE column value (date or ISO string) to ISO text."""
+    if value is None:
+        return None
+    if isinstance(value, date_type):
+        return value.isoformat()
+    return str(value)[:10]

--- a/src/muxi/runtime/services/memory/lint.py
+++ b/src/muxi/runtime/services/memory/lint.py
@@ -1,0 +1,418 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Memory Lint - Background Knowledge Store Audit
+# Description:  Detects conflicts/gaps/staleness and cleans up graph debris
+# Role:         Formation-level background job (weekly + on-demand)
+# Usage:        Created in formation initialization, started by the Overlord
+# Author:       Muxi Framework Team
+#
+# Memory Revamp Phase 5 (Lint Operation). A background audit job (weekly by
+# default, or on demand via ``run_lint``, surfaced at
+# ``POST /memory/lint``) that walks every user's memory store and produces
+# a health report:
+#
+# | Check                                             | Action              |
+# |---------------------------------------------------|---------------------|
+# | Conflicted facts unresolved after N days          | Surface as finding  |
+# | Superseded facts older than the retention window  | Hard-delete         |
+# | Orphaned relationships (endpoint entity deleted)  | Auto-remove         |
+# | Captain's log gaps (> 7 days between entries)     | Flag as gap         |
+# | Artifacts not accessed in > stale_artifact_days   | Flag for review     |
+# | Knowledge index stale (> 24h since regeneration)  | Force regeneration  |
+#
+# Findings are written back into the Phase 4 knowledge index
+# (``set_lint_findings``) as "knowledge gaps flagged by last lint" so agents
+# are aware of the memory store's known weaknesses.
+#
+# Lifecycle follows the shared background-loop pattern (Phase 1 convention):
+# started by the Overlord beside the scheduler, cancelled on shutdown, and
+# failure-isolated -- a lint failure is logged and the loop keeps running.
+#
+# Inert when unconfigured: the formation only constructs this service when
+# the ``memory.lint`` block is present (pinned by unit test).
+# =============================================================================
+
+import asyncio
+import time
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Set
+
+from sqlalchemy import delete, select
+
+from ...utils.datetime_utils import utc_now_naive
+from .. import observability
+from .graph.models import STATUS_CONFLICTED, STATUS_SUPERSEDED, KGEntity, KGRelationship
+from .log.models import CaptainsLogEntry
+
+# PRD defaults (Configuration Reference -> memory.lint).
+DEFAULT_SCHEDULE = "weekly"
+DEFAULT_CONFLICT_RESOLUTION_DAYS = 7
+DEFAULT_ORPHAN_CLEANUP = True
+DEFAULT_STALE_ARTIFACT_DAYS = 90
+
+# Retention window for superseded facts before hard deletion. Superseded
+# rows are kept (not deleted) at write time so the graph retains what was
+# believed and when it changed; lint reclaims them once they age out.
+DEFAULT_SUPERSEDED_RETENTION_DAYS = 30
+
+# PRD: "Captain's log gaps (> 7 days with no entry despite activity)".
+LOG_GAP_DAYS = 7
+
+# PRD: "Knowledge index stale (not regenerated in > 24h)".
+INDEX_STALE_SECONDS = 86400
+
+_SCHEDULE_SECONDS = {"daily": 86400, "weekly": 604800}
+
+
+def _schedule_to_seconds(schedule: Any) -> float:
+    """Convert a lint schedule config value to seconds."""
+    if isinstance(schedule, (int, float)) and not isinstance(schedule, bool) and schedule > 0:
+        return float(schedule)
+    if isinstance(schedule, str):
+        seconds = _SCHEDULE_SECONDS.get(schedule.strip().lower())
+        if seconds is not None:
+            return float(seconds)
+    return float(_SCHEDULE_SECONDS[DEFAULT_SCHEDULE])
+
+
+class MemoryLintService:
+    """Audits the knowledge store and feeds findings to the knowledge index."""
+
+    def __init__(
+        self,
+        db_manager,
+        formation_id: str,
+        config: Optional[Dict[str, Any]] = None,
+        knowledge_graph=None,
+        captains_log=None,
+        artifact_memory=None,
+        index=None,
+    ):
+        """
+        Initialize the lint service.
+
+        Args:
+            db_manager: Shared DatabaseManager (PostgreSQL or SQLite).
+            formation_id: Formation identifier scoping all rows.
+            config: The ``memory.lint`` formation config section.
+            knowledge_graph: Phase 1 KnowledgeGraphService (or None).
+            captains_log: Phase 2 CaptainsLogService (or None).
+            artifact_memory: ArtifactMemoryService (or None).
+            index: Phase 4 KnowledgeIndexService (or None) receiving the
+                findings write-back and forced regeneration.
+        """
+        config = config or {}
+        self.enabled = config.get("enabled", True)
+        self.interval_seconds = _schedule_to_seconds(config.get("schedule", DEFAULT_SCHEDULE))
+        self.conflict_resolution_days = int(
+            config.get("conflict_resolution_days", DEFAULT_CONFLICT_RESOLUTION_DAYS)
+        )
+        self.orphan_cleanup = bool(config.get("orphan_cleanup", DEFAULT_ORPHAN_CLEANUP))
+        self.stale_artifact_days = int(
+            config.get("stale_artifact_days", DEFAULT_STALE_ARTIFACT_DAYS)
+        )
+        self.superseded_retention_days = int(
+            config.get("superseded_retention_days", DEFAULT_SUPERSEDED_RETENTION_DAYS)
+        )
+
+        self.db_manager = db_manager
+        self.formation_id = formation_id
+        self.knowledge_graph = knowledge_graph
+        self.captains_log = captains_log
+        self.artifact_memory = artifact_memory
+        self.index = index
+
+        self._task: Optional[asyncio.Task] = None
+
+    # ------------------------------------------------------------------
+    # Background loop (shared lifecycle pattern)
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the periodic lint background loop."""
+        if not self.enabled:
+            return
+        if self._task is not None and not self._task.done():
+            return
+        self._task = asyncio.create_task(self._loop())
+
+    async def stop(self) -> None:
+        """Cancel the background loop, if running."""
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def _loop(self) -> None:
+        """Sleep-run loop for the periodic audit."""
+        while True:
+            await asyncio.sleep(self.interval_seconds)
+            try:
+                await self.run_lint()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                observability.observe(
+                    event_type=observability.ConversationEvents.MEMORY_LINT_FAILED,
+                    level=observability.EventLevel.WARNING,
+                    data={"error": str(e), "error_type": type(e).__name__, "pass": "loop"},
+                    description=f"Memory lint run failed: {e}",
+                )
+
+    # ------------------------------------------------------------------
+    # The audit (weekly loop + on-demand entry point)
+    # ------------------------------------------------------------------
+
+    async def run_lint(self, user_id: Optional[str] = None) -> Dict[str, Any]:
+        """
+        Audit the knowledge store; returns the aggregate health report.
+
+        Args:
+            user_id: Limit the audit to one user (the on-demand path);
+                None audits every user with memory rows.
+        """
+        observability.observe(
+            event_type=observability.ConversationEvents.MEMORY_LINT_STARTED,
+            level=observability.EventLevel.DEBUG,
+            data={"user_id": user_id, "scope": "user" if user_id else "all"},
+            description="Memory lint run started",
+        )
+        report: Dict[str, Any] = {
+            "users": 0,
+            "unresolved_conflicts": 0,
+            "superseded_deleted": 0,
+            "orphans_removed": 0,
+            "log_gaps": 0,
+            "stale_artifacts": 0,
+            "index_regenerated": 0,
+            "findings": {},
+        }
+        users = [str(user_id)] if user_id else sorted(await self._list_user_ids())
+        for uid in users:
+            try:
+                user_report = await self._lint_user(uid)
+            except Exception as e:
+                observability.observe(
+                    event_type=observability.ConversationEvents.MEMORY_LINT_FAILED,
+                    level=observability.EventLevel.WARNING,
+                    data={"user_id": uid, "error": str(e), "error_type": type(e).__name__},
+                    description=f"Memory lint failed for user {uid}: {e}",
+                )
+                continue
+            report["users"] += 1
+            for key in (
+                "unresolved_conflicts",
+                "superseded_deleted",
+                "orphans_removed",
+                "log_gaps",
+                "stale_artifacts",
+                "index_regenerated",
+            ):
+                report[key] += user_report[key]
+            if user_report["findings"]:
+                report["findings"][uid] = user_report["findings"]
+
+        observability.observe(
+            event_type=observability.ConversationEvents.MEMORY_LINT_COMPLETED,
+            level=observability.EventLevel.DEBUG,
+            data={key: value for key, value in report.items() if key != "findings"},
+            description=(
+                f"Memory lint completed for {report['users']} user(s): "
+                f"{report['unresolved_conflicts']} unresolved conflict(s), "
+                f"{report['orphans_removed']} orphan(s) removed"
+            ),
+        )
+        return report
+
+    async def _lint_user(self, user_id: str) -> Dict[str, Any]:
+        """Run every check for one user and write findings to the index."""
+        findings: List[str] = []
+        report = {
+            "unresolved_conflicts": 0,
+            "superseded_deleted": 0,
+            "orphans_removed": 0,
+            "log_gaps": 0,
+            "stale_artifacts": 0,
+            "index_regenerated": 0,
+            "findings": findings,
+        }
+
+        graph_active = self.knowledge_graph is not None and getattr(
+            self.knowledge_graph, "enabled", False
+        )
+        if graph_active:
+            conflicts = await self._unresolved_conflicts(user_id)
+            report["unresolved_conflicts"] = len(conflicts)
+            findings.extend(conflicts)
+
+            report["superseded_deleted"] = await self._purge_superseded(user_id)
+
+            if self.orphan_cleanup:
+                report["orphans_removed"] = await self._remove_orphan_relationships(user_id)
+
+            if report["superseded_deleted"] or report["orphans_removed"]:
+                self.knowledge_graph.algorithms.invalidate(user_id)
+
+        gaps = await self._log_gaps(user_id)
+        report["log_gaps"] = len(gaps)
+        findings.extend(gaps)
+
+        stale = await self._stale_artifacts(user_id)
+        report["stale_artifacts"] = len(stale)
+        findings.extend(stale)
+
+        if self.index is not None and getattr(self.index, "enabled", False):
+            await self.index.set_lint_findings(user_id, findings)
+            generated_at = self.index.last_generated_at(user_id)
+            if generated_at is None or time.time() - generated_at > INDEX_STALE_SECONDS:
+                await self.index.regenerate(user_id)
+                report["index_regenerated"] = 1
+
+        return report
+
+    # ------------------------------------------------------------------
+    # Checks
+    # ------------------------------------------------------------------
+
+    async def _list_user_ids(self) -> Set[str]:
+        """Every user with knowledge graph or captain's log rows."""
+        users: Set[str] = set()
+        async with self.db_manager.get_async_session() as session:
+            stmt = select(KGEntity.user_id).filter_by(formation_id=self.formation_id).distinct()
+            users.update(str(row[0]) for row in (await session.execute(stmt)).all())
+            stmt = (
+                select(CaptainsLogEntry.user_id)
+                .filter_by(formation_id=self.formation_id)
+                .distinct()
+            )
+            users.update(str(row[0]) for row in (await session.execute(stmt)).all())
+        return users
+
+    async def _unresolved_conflicts(self, user_id: str) -> List[str]:
+        """Conflicted facts that have sat unresolved past the threshold."""
+        cutoff = utc_now_naive() - timedelta(days=self.conflict_resolution_days)
+        findings: List[str] = []
+        async with self.db_manager.get_async_session() as session:
+            stmt = select(KGEntity).filter_by(
+                user_id=user_id, formation_id=self.formation_id, status=STATUS_CONFLICTED
+            )
+            for entity in (await session.execute(stmt)).scalars().all():
+                if (entity.updated_at or entity.created_at) <= cutoff:
+                    findings.append(
+                        f"unresolved conflict on entity '{entity.name}' "
+                        f"(since {(entity.updated_at or entity.created_at).date().isoformat()})"
+                    )
+            stmt = select(KGRelationship).filter_by(
+                user_id=user_id, formation_id=self.formation_id, status=STATUS_CONFLICTED
+            )
+            relationships = (await session.execute(stmt)).scalars().all()
+            entity_ids = {r.from_entity_id for r in relationships} | {
+                r.to_entity_id for r in relationships
+            }
+            names: Dict[int, str] = {}
+            if entity_ids:
+                stmt = select(KGEntity.id, KGEntity.name).filter(KGEntity.id.in_(entity_ids))
+                names = {row[0]: row[1] for row in (await session.execute(stmt)).all()}
+            for relationship in relationships:
+                if (relationship.updated_at or relationship.created_at) <= cutoff:
+                    findings.append(
+                        "unresolved conflict: "
+                        f"{names.get(relationship.from_entity_id, '?')} "
+                        f"-[{relationship.type}]-> "
+                        f"{names.get(relationship.to_entity_id, '?')}"
+                    )
+        return findings
+
+    async def _purge_superseded(self, user_id: str) -> int:
+        """Hard-delete superseded facts older than the retention window."""
+        cutoff = utc_now_naive() - timedelta(days=self.superseded_retention_days)
+        deleted = 0
+        async with self.db_manager.get_async_session() as session:
+            # Relationships first (they reference entities by FK).
+            stmt = select(KGRelationship).filter_by(
+                user_id=user_id, formation_id=self.formation_id, status=STATUS_SUPERSEDED
+            )
+            for relationship in (await session.execute(stmt)).scalars().all():
+                if (relationship.updated_at or relationship.created_at) <= cutoff:
+                    await session.delete(relationship)
+                    deleted += 1
+            stmt = select(KGEntity).filter_by(
+                user_id=user_id, formation_id=self.formation_id, status=STATUS_SUPERSEDED
+            )
+            for entity in (await session.execute(stmt)).scalars().all():
+                if (entity.updated_at or entity.created_at) <= cutoff:
+                    # Remove edges referencing the entity before the row
+                    # itself so the FK never dangles mid-transaction.
+                    await session.execute(
+                        delete(KGRelationship).where(
+                            (KGRelationship.from_entity_id == entity.id)
+                            | (KGRelationship.to_entity_id == entity.id)
+                        )
+                    )
+                    await session.delete(entity)
+                    deleted += 1
+            await session.flush()
+        return deleted
+
+    async def _remove_orphan_relationships(self, user_id: str) -> int:
+        """Delete relationships whose endpoints no longer exist."""
+        removed = 0
+        async with self.db_manager.get_async_session() as session:
+            stmt = select(KGEntity.id).filter_by(user_id=user_id, formation_id=self.formation_id)
+            entity_ids = {int(row[0]) for row in (await session.execute(stmt)).all()}
+            stmt = select(KGRelationship).filter_by(user_id=user_id, formation_id=self.formation_id)
+            for relationship in (await session.execute(stmt)).scalars().all():
+                if (
+                    relationship.from_entity_id not in entity_ids
+                    or relationship.to_entity_id not in entity_ids
+                ):
+                    await session.delete(relationship)
+                    removed += 1
+            await session.flush()
+        return removed
+
+    async def _log_gaps(self, user_id: str) -> List[str]:
+        """Gaps of more than LOG_GAP_DAYS between consecutive log entries."""
+        if self.captains_log is None or not getattr(self.captains_log, "enabled", False):
+            return []
+        async with self.db_manager.get_async_session() as session:
+            stmt = (
+                select(CaptainsLogEntry.date)
+                .filter_by(user_id=user_id, formation_id=self.formation_id)
+                .order_by(CaptainsLogEntry.date.asc())
+            )
+            dates = [row[0] for row in (await session.execute(stmt)).all()]
+        findings = []
+        for previous, current in zip(dates, dates[1:]):
+            gap_days = (current - previous).days
+            if gap_days > LOG_GAP_DAYS:
+                findings.append(
+                    f"captain's log gap: {gap_days} days between "
+                    f"{previous.isoformat()} and {current.isoformat()}"
+                )
+        return findings
+
+    async def _stale_artifacts(self, user_id: str) -> List[str]:
+        """Artifacts not accessed within stale_artifact_days."""
+        if self.artifact_memory is None or not getattr(self.artifact_memory, "enabled", False):
+            return []
+        cutoff = utc_now_naive() - timedelta(days=self.stale_artifact_days)
+        findings = []
+        for artifact in await self.artifact_memory.list_artifacts(user_id):
+            last_accessed = artifact.get("last_accessed_at")
+            if not last_accessed:
+                continue
+            try:
+                accessed_at = datetime.fromisoformat(str(last_accessed))
+            except ValueError:
+                continue
+            if accessed_at <= cutoff:
+                findings.append(
+                    f"stale artifact '{artifact.get('name', '?')}' "
+                    f"(last accessed {str(last_accessed)[:10]})"
+                )
+        return findings

--- a/src/muxi/runtime/services/memory/lint.py
+++ b/src/muxi/runtime/services/memory/lint.py
@@ -19,7 +19,7 @@
 # | Orphaned relationships (endpoint entity deleted)  | Auto-remove         |
 # | Captain's log gaps (> 7 days between entries)     | Flag as gap         |
 # | Artifacts not accessed in > stale_artifact_days   | Flag for review     |
-# | Knowledge index stale (> 24h since regeneration)  | Force regeneration  |
+# | Knowledge index staleness                          | Regenerate per run  |
 #
 # Findings are written back into the Phase 4 knowledge index
 # (``set_lint_findings``) as "knowledge gaps flagged by last lint" so agents
@@ -34,7 +34,6 @@
 # =============================================================================
 
 import asyncio
-import time
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Set
 
@@ -58,9 +57,6 @@ DEFAULT_SUPERSEDED_RETENTION_DAYS = 30
 
 # PRD: "Captain's log gaps (> 7 days with no entry despite activity)".
 LOG_GAP_DAYS = 7
-
-# PRD: "Knowledge index stale (not regenerated in > 24h)".
-INDEX_STALE_SECONDS = 86400
 
 _SCHEDULE_SECONDS = {"daily": 86400, "weekly": 604800}
 
@@ -267,10 +263,13 @@ class MemoryLintService:
 
         if self.index is not None and getattr(self.index, "enabled", False):
             await self.index.set_lint_findings(user_id, findings)
-            generated_at = self.index.last_generated_at(user_id)
-            if generated_at is None or time.time() - generated_at > INDEX_STALE_SECONDS:
-                await self.index.regenerate(user_id)
-                report["index_regenerated"] = 1
+            # set_lint_findings just invalidated the cached blob, so
+            # regenerate unconditionally: lint runs weekly, regeneration is
+            # a handful of indexed queries (no LLM work), and rebuilding on
+            # every run satisfies the PRD's "index stale > 24h -> force
+            # regeneration" check by construction.
+            await self.index.regenerate(user_id)
+            report["index_regenerated"] = 1
 
         return report
 
@@ -328,33 +327,53 @@ class MemoryLintService:
         return findings
 
     async def _purge_superseded(self, user_id: str) -> int:
-        """Hard-delete superseded facts older than the retention window."""
+        """Hard-delete superseded facts older than the retention window.
+
+        Uses column-only selects plus bulk DELETEs (never ORM instance
+        deletes): a superseded relationship whose endpoint entity is also
+        superseded would otherwise be deleted twice -- once by the edge
+        cleanup for the purged entity and once by the ORM unit of work --
+        making the flush raise StaleDataError.
+        """
         cutoff = utc_now_naive() - timedelta(days=self.superseded_retention_days)
         deleted = 0
         async with self.db_manager.get_async_session() as session:
-            # Relationships first (they reference entities by FK).
-            stmt = select(KGRelationship).filter_by(
+            # Superseded relationships past retention (ids only).
+            stmt = select(
+                KGRelationship.id, KGRelationship.updated_at, KGRelationship.created_at
+            ).filter_by(user_id=user_id, formation_id=self.formation_id, status=STATUS_SUPERSEDED)
+            old_rel_ids = [
+                row[0]
+                for row in (await session.execute(stmt)).all()
+                if (row[1] or row[2]) <= cutoff
+            ]
+            if old_rel_ids:
+                await session.execute(
+                    delete(KGRelationship).where(KGRelationship.id.in_(old_rel_ids))
+                )
+                deleted += len(old_rel_ids)
+
+            # Superseded entities past retention (ids only).
+            stmt = select(KGEntity.id, KGEntity.updated_at, KGEntity.created_at).filter_by(
                 user_id=user_id, formation_id=self.formation_id, status=STATUS_SUPERSEDED
             )
-            for relationship in (await session.execute(stmt)).scalars().all():
-                if (relationship.updated_at or relationship.created_at) <= cutoff:
-                    await session.delete(relationship)
-                    deleted += 1
-            stmt = select(KGEntity).filter_by(
-                user_id=user_id, formation_id=self.formation_id, status=STATUS_SUPERSEDED
-            )
-            for entity in (await session.execute(stmt)).scalars().all():
-                if (entity.updated_at or entity.created_at) <= cutoff:
-                    # Remove edges referencing the entity before the row
-                    # itself so the FK never dangles mid-transaction.
-                    await session.execute(
-                        delete(KGRelationship).where(
-                            (KGRelationship.from_entity_id == entity.id)
-                            | (KGRelationship.to_entity_id == entity.id)
-                        )
+            old_entity_ids = [
+                row[0]
+                for row in (await session.execute(stmt)).all()
+                if (row[1] or row[2]) <= cutoff
+            ]
+            if old_entity_ids:
+                # Remove every edge referencing a purged entity before the
+                # entity rows so the FK never dangles mid-transaction
+                # (cascade cleanup, not counted as superseded deletions).
+                await session.execute(
+                    delete(KGRelationship).where(
+                        KGRelationship.from_entity_id.in_(old_entity_ids)
+                        | KGRelationship.to_entity_id.in_(old_entity_ids)
                     )
-                    await session.delete(entity)
-                    deleted += 1
+                )
+                await session.execute(delete(KGEntity).where(KGEntity.id.in_(old_entity_ids)))
+                deleted += len(old_entity_ids)
             await session.flush()
         return deleted
 
@@ -407,8 +426,13 @@ class MemoryLintService:
             if not last_accessed:
                 continue
             try:
-                accessed_at = datetime.fromisoformat(str(last_accessed))
-            except ValueError:
+                # Normalize tz-aware stamps to naive: the runtime stores
+                # naive UTC, but external artifact rows may carry offsets;
+                # comparing aware vs naive raises TypeError, and an
+                # unparseable stamp raises ValueError -- either would
+                # otherwise abort the whole user's lint pass.
+                accessed_at = datetime.fromisoformat(str(last_accessed)).replace(tzinfo=None)
+            except (ValueError, TypeError):
                 continue
             if accessed_at <= cutoff:
                 findings.append(

--- a/src/muxi/runtime/services/memory/log/service.py
+++ b/src/muxi/runtime/services/memory/log/service.py
@@ -257,6 +257,38 @@ class CaptainsLogService:
                 )
         return totals
 
+    async def digest_turns(
+        self, user_id: Any, turns: List[Tuple[str, str]], model
+    ) -> Dict[str, int]:
+        """
+        Digest an explicit batch of turns immediately (silent-turn path).
+
+        Public entry point for the Phase 3 pre-compaction flush: the items
+        leaving the working memory buffer are digested through the same
+        pipeline the periodic pass uses (entry + lineage + lessons + graph
+        facts). Failure-isolated and best-effort -- unlike the periodic
+        pass there is no re-queue on failure, because the source items are
+        leaving the buffer regardless. Returns stored counts.
+        """
+        totals = {"entries": 0, "sources": 0, "lessons": 0}
+        if not self.enabled or model is None or not turns:
+            return totals
+        try:
+            return await self._digest_user(str(user_id), list(turns), model)
+        except Exception as e:
+            observability.observe(
+                event_type=observability.ConversationEvents.MEMORY_CAPTAINS_LOG_FAILED,
+                level=observability.EventLevel.WARNING,
+                data={
+                    "user_id": str(user_id),
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                    "pass": "precompaction_flush",
+                },
+                description=f"Pre-compaction flush digest failed: {e}",
+            )
+            return totals
+
     def _requeue_turns(self, user_id: str, turns: List[Tuple[str, str]]) -> None:
         """Restore a failed digest's turn snapshot for the next run.
 

--- a/src/muxi/runtime/services/memory/pruning.py
+++ b/src/muxi/runtime/services/memory/pruning.py
@@ -1,0 +1,224 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Context Pruner - Cache-TTL Tool-Result Pruning
+# Description:  Prunes old tool results / oversized turns on idle resume
+# Role:         Formation-level utility applied when assembling chat context
+# Usage:        Created by the Overlord when memory.pruning is configured
+# Author:       Muxi Framework Team
+#
+# Memory Revamp Phase 3 (Context Optimization - Cache-TTL Pruning).
+#
+# Providers cache prompt prefixes for a short window (Anthropic: 5 minutes).
+# When a session resumes after that window, the whole prefix is re-cached at
+# full cost -- and old bulky content (tool results, large pasted outputs)
+# is the expensive part. This pruner trims that content from the assembled
+# context before the next request:
+#
+# - mode "never":     pruner is inert (the default when memory.pruning is
+#                     not configured -- the formation behaves byte-identically
+#                     to a build without this module).
+# - mode "cache-ttl": prune only when the (user, session) has been idle for
+#                     longer than cache_ttl_seconds.
+# - mode "always":    prune on every context assembly.
+#
+# Two strategies (PRD "Pruning Strategies"):
+# - soft_trim (default): keep the first/last SOFT_TRIM_KEEP_CHARS characters
+#   of any prunable message longer than soft_trim_max_chars, replacing the
+#   middle with a truncation marker.
+# - hard_clear: replace the prunable message body with CLEARED_PLACEHOLDER.
+#
+# "Keep recent" is always applied: the newest keep_last_n_tool_results
+# prunable messages are never touched.
+#
+# A message is prunable when its role is "tool" (explicit tool results, for
+# callers that assemble raw chat-API message lists) or when its content
+# exceeds soft_trim_max_chars (tool output surfaced inside stored buffer
+# turns -- the shape the orchestrator's clean-context path produces).
+#
+# Failure-isolated: pruning errors return the original messages unchanged.
+# =============================================================================
+
+import time
+from collections import OrderedDict
+from typing import Any, Dict, List, Optional, Tuple
+
+from .. import observability
+
+MODE_ALWAYS = "always"
+MODE_CACHE_TTL = "cache-ttl"
+MODE_NEVER = "never"
+PRUNING_MODES = {MODE_ALWAYS, MODE_CACHE_TTL, MODE_NEVER}
+
+STRATEGY_SOFT_TRIM = "soft_trim"
+STRATEGY_HARD_CLEAR = "hard_clear"
+PRUNING_STRATEGIES = {STRATEGY_SOFT_TRIM, STRATEGY_HARD_CLEAR}
+
+# PRD defaults (Configuration Reference -> memory.pruning).
+DEFAULT_MODE = MODE_CACHE_TTL
+DEFAULT_CACHE_TTL_SECONDS = 300
+DEFAULT_KEEP_LAST_N_TOOL_RESULTS = 3
+DEFAULT_SOFT_TRIM_MAX_CHARS = 4000
+
+# PRD "Soft trim": keep first 1500 + last 1500 chars, truncate the middle.
+SOFT_TRIM_KEEP_CHARS = 1500
+
+CLEARED_PLACEHOLDER = "[Previous output cleared]"
+
+# Bound on tracked (user, session) activity timestamps.
+ACTIVITY_CACHE_SIZE = 1024
+
+
+class ContextPruner:
+    """Prunes old tool results from assembled context after idle periods."""
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None):
+        """
+        Initialize the pruner from the ``memory.pruning`` config section.
+
+        Args:
+            config: The ``memory.pruning`` formation config section. When
+                the section is absent the formation never constructs a
+                pruner at all (inert when unconfigured); a present-but-
+                partial section fills in the PRD defaults.
+        """
+        config = config or {}
+        self.mode = str(config.get("mode", DEFAULT_MODE)).strip().lower()
+        if self.mode not in PRUNING_MODES:
+            raise ValueError(
+                f"memory.pruning.mode must be one of {sorted(PRUNING_MODES)}, got {self.mode!r}"
+            )
+        self.strategy = str(config.get("strategy", STRATEGY_SOFT_TRIM)).strip().lower()
+        if self.strategy not in PRUNING_STRATEGIES:
+            raise ValueError(
+                f"memory.pruning.strategy must be one of {sorted(PRUNING_STRATEGIES)}, "
+                f"got {self.strategy!r}"
+            )
+        self.cache_ttl_seconds = float(config.get("cache_ttl_seconds", DEFAULT_CACHE_TTL_SECONDS))
+        self.keep_last_n_tool_results = int(
+            config.get("keep_last_n_tool_results", DEFAULT_KEEP_LAST_N_TOOL_RESULTS)
+        )
+        self.soft_trim_max_chars = int(
+            config.get("soft_trim_max_chars", DEFAULT_SOFT_TRIM_MAX_CHARS)
+        )
+
+        # Last request timestamp per (user, session), LRU-capped.
+        self._last_activity: "OrderedDict[Tuple[str, str], float]" = OrderedDict()
+
+    # ------------------------------------------------------------------
+    # Activity tracking (the cache-ttl trigger)
+    # ------------------------------------------------------------------
+
+    def _activity_key(self, user_id: Any, session_id: Any) -> Tuple[str, str]:
+        return (str(user_id), str(session_id or "default"))
+
+    def record_activity(self, user_id: Any, session_id: Any, now: Optional[float] = None) -> None:
+        """Record a request for (user, session); starts the idle clock."""
+        key = self._activity_key(user_id, session_id)
+        self._last_activity[key] = time.time() if now is None else now
+        self._last_activity.move_to_end(key)
+        while len(self._last_activity) > ACTIVITY_CACHE_SIZE:
+            self._last_activity.popitem(last=False)
+
+    def should_prune(self, user_id: Any, session_id: Any, now: Optional[float] = None) -> bool:
+        """Return True when this request's context should be pruned."""
+        if self.mode == MODE_NEVER:
+            return False
+        if self.mode == MODE_ALWAYS:
+            return True
+        last = self._last_activity.get(self._activity_key(user_id, session_id))
+        if last is None:
+            # First request of the session in this process: nothing was
+            # provider-cached for it, so there is nothing worth pruning.
+            return False
+        now = time.time() if now is None else now
+        return (now - last) > self.cache_ttl_seconds
+
+    # ------------------------------------------------------------------
+    # Pruning
+    # ------------------------------------------------------------------
+
+    def prune_turns(
+        self, user_id: Any, session_id: Any, turns: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """
+        Prune one request's history turns and record the request's activity.
+
+        The orchestrator entry point: checks the idle trigger, applies the
+        strategy, and stamps the activity clock for the next request.
+        Failure-isolated -- any error returns the original turns unchanged.
+        """
+        try:
+            pruned_turns = turns
+            pruned_count = 0
+            if turns and self.should_prune(user_id, session_id):
+                pruned_turns, pruned_count = self.prune_messages(turns)
+                if pruned_count:
+                    observability.observe(
+                        event_type=observability.ConversationEvents.MEMORY_CONTEXT_PRUNED,
+                        level=observability.EventLevel.DEBUG,
+                        data={
+                            "user_id": str(user_id),
+                            "session_id": str(session_id or "default"),
+                            "mode": self.mode,
+                            "strategy": self.strategy,
+                            "pruned_messages": pruned_count,
+                        },
+                        description=(
+                            f"Pruned {pruned_count} stale tool-result message(s) "
+                            "from resumed session context"
+                        ),
+                    )
+            self.record_activity(user_id, session_id)
+            return pruned_turns
+        except Exception:
+            return turns
+
+    def prune_messages(self, messages: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], int]:
+        """
+        Apply the pruning strategy to one message list.
+
+        Returns (new message list, number of messages pruned). The newest
+        ``keep_last_n_tool_results`` prunable messages are preserved intact
+        (the PRD's "keep recent" rule); older ones are soft-trimmed or
+        hard-cleared per the configured strategy. Input dicts are never
+        mutated -- pruned messages are shallow copies.
+        """
+        prunable = [index for index, message in enumerate(messages) if self._is_prunable(message)]
+        if self.keep_last_n_tool_results > 0:
+            prunable = prunable[: -self.keep_last_n_tool_results]
+        if not prunable:
+            return messages, 0
+
+        result = list(messages)
+        pruned = 0
+        for index in prunable:
+            content = str(result[index].get("content") or "")
+            replacement = self._apply_strategy(content)
+            if replacement == content:
+                continue
+            updated = dict(result[index])
+            updated["content"] = replacement
+            result[index] = updated
+            pruned += 1
+        return result, pruned
+
+    def _is_prunable(self, message: Dict[str, Any]) -> bool:
+        """A message is prunable as a tool result or an oversized turn."""
+        if message.get("role") == "tool":
+            return True
+        content = message.get("content")
+        return isinstance(content, str) and len(content) > self.soft_trim_max_chars
+
+    def _apply_strategy(self, content: str) -> str:
+        """Return the pruned body for one message's content."""
+        if self.strategy == STRATEGY_HARD_CLEAR:
+            return CLEARED_PLACEHOLDER
+        if len(content) <= self.soft_trim_max_chars:
+            return content
+        trimmed = len(content) - 2 * SOFT_TRIM_KEEP_CHARS
+        return (
+            content[:SOFT_TRIM_KEEP_CHARS]
+            + f"\n[... {trimmed} chars trimmed ...]\n"
+            + content[-SOFT_TRIM_KEEP_CHARS:]
+        )

--- a/src/muxi/runtime/services/memory/working.py
+++ b/src/muxi/runtime/services/memory/working.py
@@ -270,6 +270,11 @@ class WorkingMemory:
         self.kv_store = {}
         self.kv_expiry = {}
 
+        # Pre-compaction flush hook (Memory Revamp Phase 3): registered via
+        # set_eviction_listener by the flush service; None means inert.
+        self._eviction_listener = None
+        self._eviction_flush_threshold: Optional[float] = None
+
         # Start the background FIFO cleanup task
         fifo_cleanup_task(self)
 
@@ -510,6 +515,59 @@ class WorkingMemory:
         self.partitions = new_partitions
         self.needs_rebuild = False
 
+    def set_eviction_listener(self, listener, flush_threshold: Optional[float] = None) -> None:
+        """
+        Register the pre-compaction flush hook (Memory Revamp Phase 3).
+
+        Args:
+            listener: Synchronous callable receiving a list of buffer item
+                snapshots ``{"text", "metadata", "timestamp"}``. Invoked
+                (a) when estimated buffer usage crosses
+                ``flush_threshold * max_memory_mb`` -- with the oldest ~25%
+                of buffer-namespace items (the next eviction candidates)
+                that have not been flushed yet -- and (b) at eviction time
+                with any not-yet-flushed items about to be dropped. The
+                callable must not block; listener errors are swallowed so
+                FIFO cleanup is never affected.
+            flush_threshold: Fraction of ``max_memory_mb`` (0-1] at which
+                the early flush fires; None disables the early trigger
+                (the eviction-time safety net still fires).
+        """
+        self._eviction_listener = listener
+        self._eviction_flush_threshold = flush_threshold
+
+    def _notify_eviction_listener(self, indices) -> None:
+        """Snapshot unflushed buffer items at ``indices`` and hand them off.
+
+        Items already handed to the listener are marked with the
+        ``_memory_flushed`` metadata key so threshold-triggered flushes and
+        the eviction-time safety net never double-flush the same item.
+        Never raises into the cleanup path.
+        """
+        if self._eviction_listener is None:
+            return
+        try:
+            buffer_items = list(self.buffer)
+            snapshots = []
+            for index in indices:
+                item = buffer_items[index]
+                metadata = item.get("metadata") or {}
+                if metadata.get("_memory_flushed"):
+                    continue
+                metadata["_memory_flushed"] = True
+                item["metadata"] = metadata
+                snapshots.append(
+                    {
+                        "text": item.get("text", ""),
+                        "metadata": dict(metadata),
+                        "timestamp": item.get("timestamp"),
+                    }
+                )
+            if snapshots:
+                self._eviction_listener(snapshots)
+        except Exception:
+            pass  # the flush is best-effort; cleanup must proceed
+
     def check_memory_usage_and_cleanup(self) -> None:
         """
         Check memory usage and perform FIFO cleanup if needed.
@@ -559,6 +617,21 @@ class WorkingMemory:
             #     f"configured limit: {self.max_memory_mb}MB"
             # )
 
+            # Pre-compaction flush trigger (Memory Revamp Phase 3): when
+            # usage crosses the flush threshold, hand the oldest ~25% of
+            # buffer items (the next eviction candidates) to the flush
+            # listener so their content is persisted BEFORE eviction can
+            # drop it.
+            if (
+                self._eviction_listener is not None
+                and self._eviction_flush_threshold
+                and buffer_namespace_indices
+                and estimated_usage_mb >= self._eviction_flush_threshold * self.max_memory_mb
+            ):
+                buffer_namespace_indices.sort()
+                flush_candidates = max(1, len(buffer_namespace_indices) // 4)
+                self._notify_eviction_listener(buffer_namespace_indices[:flush_candidates])
+
             # If we exceed the configured limit, remove oldest items from buffer namespace only
             if estimated_usage_mb > self.max_memory_mb and buffer_namespace_indices:
                 # Calculate how many buffer items to remove (25% of buffer items)
@@ -571,6 +644,11 @@ class WorkingMemory:
                 # Sort indices to remove oldest items first
                 buffer_namespace_indices.sort()
                 indices_to_remove = set(buffer_namespace_indices[:items_to_remove])
+
+                # Eviction-time safety net (Memory Revamp Phase 3): any item
+                # about to be evicted that was never flushed is snapshotted
+                # and handed to the flush listener before it is dropped.
+                self._notify_eviction_listener(sorted(indices_to_remove))
 
                 # Create new deque with same maxlen, keeping only non-removed items
                 new_buffer = collections.deque(maxlen=self.buffer.maxlen)

--- a/tests/unit/test_chat_orchestrator_clean_context.py
+++ b/tests/unit/test_chat_orchestrator_clean_context.py
@@ -67,6 +67,9 @@ def _make_orchestrator(
     }
     overlord.is_multi_user = False
     overlord.auto_extract_user_info = False
+    # Memory Revamp Phases 3-4: absent unless the formation configures them.
+    overlord.context_pruner = None
+    overlord.memory_index = None
 
     async def _search_buffer(
         query: str,
@@ -269,6 +272,9 @@ async def test_no_buffer_returns_empty_turns_not_error() -> None:
     overlord.long_term_memory = None
     overlord.buffer_memory_manager = None
     overlord.get_user_synopsis = AsyncMock(return_value="")
+    # Memory Revamp Phases 3-4: absent unless configured.
+    overlord.context_pruner = None
+    overlord.memory_index = None
     orch.overlord = overlord
 
     bundle = await orch._build_clean_chat_context(

--- a/tests/unit/test_context_pruning.py
+++ b/tests/unit/test_context_pruning.py
@@ -1,0 +1,160 @@
+"""Unit tests for Memory Revamp Phase 3: cache-TTL context pruning.
+
+Covers mode gating (never/always/cache-ttl), the idle-clock trigger, the
+keep-recent protection window, both strategies (soft trim shape with the
+PRD's first/last 1500 chars, hard clear placeholder), tool-role vs
+oversized-turn prunability, input immutability, config validation, and the
+inertness pins ("never" mode and first-request-of-session behave
+byte-identically to no pruner).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from muxi.runtime.services.memory.pruning import (
+    CLEARED_PLACEHOLDER,
+    DEFAULT_CACHE_TTL_SECONDS,
+    DEFAULT_KEEP_LAST_N_TOOL_RESULTS,
+    DEFAULT_SOFT_TRIM_MAX_CHARS,
+    SOFT_TRIM_KEEP_CHARS,
+    ContextPruner,
+)
+
+
+def _turn(content: str, role: str = "assistant"):
+    return {"role": role, "content": content}
+
+
+class TestConfig:
+    def test_defaults_match_prd(self):
+        pruner = ContextPruner()
+        assert pruner.mode == "cache-ttl"
+        assert pruner.strategy == "soft_trim"
+        assert pruner.cache_ttl_seconds == DEFAULT_CACHE_TTL_SECONDS
+        assert pruner.keep_last_n_tool_results == DEFAULT_KEEP_LAST_N_TOOL_RESULTS
+        assert pruner.soft_trim_max_chars == DEFAULT_SOFT_TRIM_MAX_CHARS
+
+    def test_invalid_mode_fails_fast(self):
+        with pytest.raises(ValueError, match="memory.pruning.mode"):
+            ContextPruner({"mode": "sometimes"})
+
+    def test_invalid_strategy_fails_fast(self):
+        with pytest.raises(ValueError, match="memory.pruning.strategy"):
+            ContextPruner({"strategy": "medium_clear"})
+
+
+class TestShouldPrune:
+    def test_never_mode_is_inert(self):
+        pruner = ContextPruner({"mode": "never"})
+        pruner.record_activity("u1", "s1", now=0.0)
+        assert pruner.should_prune("u1", "s1", now=10_000.0) is False
+
+    def test_always_mode_prunes_every_request(self):
+        pruner = ContextPruner({"mode": "always"})
+        assert pruner.should_prune("u1", "s1") is True
+
+    def test_cache_ttl_waits_for_idle_window(self):
+        pruner = ContextPruner({"mode": "cache-ttl", "cache_ttl_seconds": 300})
+        pruner.record_activity("u1", "s1", now=1000.0)
+        assert pruner.should_prune("u1", "s1", now=1200.0) is False  # still cached
+        assert pruner.should_prune("u1", "s1", now=1301.0) is True  # cache expired
+
+    def test_first_request_of_session_never_prunes(self):
+        # Nothing was provider-cached for a session this process has not
+        # seen; pruning would only degrade context (inertness pin).
+        pruner = ContextPruner({"mode": "cache-ttl"})
+        assert pruner.should_prune("u1", "brand-new") is False
+
+    def test_sessions_are_tracked_independently(self):
+        pruner = ContextPruner({"mode": "cache-ttl", "cache_ttl_seconds": 300})
+        pruner.record_activity("u1", "s1", now=1000.0)
+        pruner.record_activity("u1", "s2", now=1290.0)
+        assert pruner.should_prune("u1", "s1", now=1400.0) is True
+        assert pruner.should_prune("u1", "s2", now=1400.0) is False
+
+
+class TestPruneMessages:
+    def test_soft_trim_keeps_head_and_tail(self):
+        pruner = ContextPruner({"mode": "always", "keep_last_n_tool_results": 0})
+        content = "A" * 2000 + "B" * 2000 + "C" * 2000
+        pruned, count = pruner.prune_messages([_turn(content)])
+
+        assert count == 1
+        result = pruned[0]["content"]
+        assert result.startswith("A" * SOFT_TRIM_KEEP_CHARS)
+        assert result.endswith("C" * SOFT_TRIM_KEEP_CHARS)
+        assert "chars trimmed" in result
+        assert len(result) < len(content)
+
+    def test_hard_clear_replaces_body(self):
+        pruner = ContextPruner(
+            {"mode": "always", "strategy": "hard_clear", "keep_last_n_tool_results": 0}
+        )
+        pruned, count = pruner.prune_messages([_turn("X" * 5000)])
+        assert count == 1
+        assert pruned[0]["content"] == CLEARED_PLACEHOLDER
+
+    def test_tool_role_messages_are_prunable_regardless_of_size(self):
+        pruner = ContextPruner(
+            {"mode": "always", "strategy": "hard_clear", "keep_last_n_tool_results": 0}
+        )
+        pruned, count = pruner.prune_messages([_turn("small output", role="tool")])
+        assert count == 1
+        assert pruned[0]["content"] == CLEARED_PLACEHOLDER
+
+    def test_small_non_tool_messages_are_untouched(self):
+        pruner = ContextPruner({"mode": "always", "keep_last_n_tool_results": 0})
+        messages = [_turn("short user turn", role="user"), _turn("short reply")]
+        pruned, count = pruner.prune_messages(messages)
+        assert count == 0
+        assert pruned == messages
+
+    def test_keep_recent_protects_last_n_results(self):
+        pruner = ContextPruner(
+            {"mode": "always", "strategy": "hard_clear", "keep_last_n_tool_results": 2}
+        )
+        messages = [_turn(f"result {index}", role="tool") for index in range(5)]
+        pruned, count = pruner.prune_messages(messages)
+
+        assert count == 3
+        assert [m["content"] for m in pruned[:3]] == [CLEARED_PLACEHOLDER] * 3
+        assert pruned[3]["content"] == "result 3"
+        assert pruned[4]["content"] == "result 4"
+
+    def test_input_messages_are_never_mutated(self):
+        pruner = ContextPruner(
+            {"mode": "always", "strategy": "hard_clear", "keep_last_n_tool_results": 0}
+        )
+        original = _turn("Y" * 5000)
+        pruner.prune_messages([original])
+        assert original["content"] == "Y" * 5000
+
+
+class TestPruneTurns:
+    def test_prune_turns_applies_after_idle_and_records_activity(self):
+        pruner = ContextPruner(
+            {"mode": "cache-ttl", "cache_ttl_seconds": 300, "keep_last_n_tool_results": 0}
+        )
+        big = _turn("Z" * 10_000)
+
+        # First request: no idle history -> untouched, clock starts.
+        first = pruner.prune_turns("u1", "s1", [big])
+        assert first == [big]
+
+        # Simulate an idle window past the TTL, then request again.
+        key = ("u1", "s1")
+        pruner._last_activity[key] = pruner._last_activity[key] - 301
+        second = pruner.prune_turns("u1", "s1", [big])
+        assert "chars trimmed" in second[0]["content"]
+
+    def test_prune_turns_is_failure_isolated(self, monkeypatch):
+        pruner = ContextPruner({"mode": "always", "keep_last_n_tool_results": 0})
+        turns = [_turn("Z" * 10_000)]
+
+        def explode(messages):
+            raise RuntimeError("pruner boom")
+
+        monkeypatch.setattr(pruner, "prune_messages", explode)
+        result = pruner.prune_turns("u1", "s1", turns)  # must not raise
+        assert result == turns

--- a/tests/unit/test_knowledge_index.py
+++ b/tests/unit/test_knowledge_index.py
@@ -1,0 +1,350 @@
+"""Unit tests for Memory Revamp Phase 4: KnowledgeIndexService.
+
+Covers the empty/disabled read paths (failure-isolated ""), rendering of
+every section (entities, captain's log span, artifacts via the artifact
+service seam, lint-findings gaps), the size cap with count-of-omitted
+truncation, caching plus each regeneration trigger (log entry, artifact
+save, entity count threshold, lint invalidation, 24h staleness),
+system_config persistence of both the blob and the lint findings, and the
+enabled: false inertness pin at the initialization seam.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.graph.service import KnowledgeGraphService
+from muxi.runtime.services.memory.index import (
+    DEFAULT_ENTITY_COUNT_THRESHOLD,
+    DEFAULT_MAX_TOKENS,
+    INDEX_KEY_FORMAT,
+    KnowledgeIndexService,
+)
+from muxi.runtime.services.memory.log.service import CaptainsLogService
+
+FORMATION_ID = "index-test-formation"
+USER = "u1"
+
+
+class FakeArtifactMemory:
+    """Artifact-service seam double: the manifest the index rides."""
+
+    def __init__(self, artifacts=None):
+        self.enabled = True
+        self.artifacts = artifacts if artifacts is not None else []
+
+    async def list_artifacts(self, user_id, **kwargs):
+        return list(self.artifacts)
+
+
+@pytest.fixture
+def db_manager(tmp_path):
+    manager = DatabaseManager(f"sqlite:///{tmp_path}/index.db")
+    manager.create_tables(Base.metadata)
+    yield manager
+    manager.engine.dispose()
+
+
+@pytest.fixture
+def graph(db_manager):
+    return KnowledgeGraphService(db_manager, FORMATION_ID)
+
+
+@pytest.fixture
+def captains_log(db_manager, graph):
+    return CaptainsLogService(db_manager, FORMATION_ID, knowledge_graph=graph)
+
+
+@pytest.fixture
+def artifact_memory():
+    return FakeArtifactMemory(
+        [
+            {
+                "name": "Q1 Strategy Report",
+                "content_type": "application/pdf",
+                "created_at": "2026-03-28T10:00:00",
+                "last_accessed_at": "2026-03-28T10:00:00",
+            }
+        ]
+    )
+
+
+@pytest.fixture
+def index(db_manager, graph, captains_log, artifact_memory):
+    return KnowledgeIndexService(
+        db_manager,
+        FORMATION_ID,
+        knowledge_graph=graph,
+        captains_log=captains_log,
+        artifact_memory=artifact_memory,
+    )
+
+
+async def _seed_entity(graph, name="Automaze", entity_type="company"):
+    await graph.storage.upsert_entity(
+        user_id=USER, entity_type=entity_type, name=name, confidence=0.9
+    )
+
+
+async def _seed_log_entry(captains_log, entry_date, summary="Finalized the memory PRD"):
+    await captains_log.storage.upsert_entry(USER, entry_date, summary=summary)
+
+
+class TestConfig:
+    def test_defaults_match_prd(self, index):
+        assert index.enabled is True
+        assert index.max_tokens == DEFAULT_MAX_TOKENS
+        assert index.max_chars == DEFAULT_MAX_TOKENS * 4
+        assert index.entity_count_threshold == DEFAULT_ENTITY_COUNT_THRESHOLD
+        assert index.regenerate_on == {
+            "artifact_save",
+            "entity_count_threshold",
+            "lint",
+            "log_entry",
+        }
+
+    def test_disabled_index_returns_empty(self, db_manager, graph):
+        disabled = KnowledgeIndexService(
+            db_manager, FORMATION_ID, config={"enabled": False}, knowledge_graph=graph
+        )
+        assert disabled.enabled is False
+
+
+class TestReadPath:
+    async def test_empty_store_renders_nothing(self, db_manager, graph, captains_log):
+        index = KnowledgeIndexService(
+            db_manager,
+            FORMATION_ID,
+            knowledge_graph=graph,
+            captains_log=captains_log,
+            artifact_memory=FakeArtifactMemory([]),
+        )
+        assert await index.get_index_block(USER) == ""
+
+    async def test_disabled_returns_empty_even_with_data(
+        self, db_manager, graph, captains_log, artifact_memory
+    ):
+        await _seed_entity(graph)
+        disabled = KnowledgeIndexService(
+            db_manager,
+            FORMATION_ID,
+            config={"enabled": False},
+            knowledge_graph=graph,
+            captains_log=captains_log,
+            artifact_memory=artifact_memory,
+        )
+        assert await disabled.get_index_block(USER) == ""
+
+    async def test_blob_renders_all_sections(self, index, graph, captains_log):
+        await _seed_entity(graph, "Automaze", "company")
+        await _seed_entity(graph, "London", "location")
+        await _seed_log_entry(captains_log, date(2026, 1, 15))
+        await _seed_log_entry(captains_log, date(2026, 4, 3), summary="Memory PRD finalised")
+        await index.set_lint_findings(USER, ["stale entity 'Berlin office'"])
+
+        block = await index.get_index_block(USER)
+
+        assert block.startswith("[Memory Index - as of ")
+        assert "Entities (2):" in block
+        assert "Automaze (Company)" in block
+        assert "Captain's Log: 2 entries spanning 2026-01-15 - 2026-04-03" in block
+        assert "Most recent: Memory PRD finalised" in block
+        assert "Artifacts (1): Q1 Strategy Report (pdf, 2026-03-28)" in block
+        assert "Knowledge gaps flagged by last lint: stale entity 'Berlin office'" in block
+
+    async def test_read_failure_returns_empty(self, index, monkeypatch):
+        async def explode(user_id):
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(index, "_fingerprint", explode)
+        assert await index.get_index_block(USER) == ""
+
+
+class TestSizeCap:
+    async def test_blob_never_exceeds_max_tokens(
+        self, db_manager, graph, captains_log, artifact_memory
+    ):
+        small = KnowledgeIndexService(
+            db_manager,
+            FORMATION_ID,
+            config={"max_tokens": 100},
+            knowledge_graph=graph,
+            captains_log=captains_log,
+            artifact_memory=artifact_memory,
+        )
+        for i in range(30):
+            await _seed_entity(graph, f"Very Long Entity Name Number {i:02d}", "project")
+        await _seed_log_entry(captains_log, date(2026, 4, 3), summary="S" * 300)
+        await small.set_lint_findings(USER, [f"finding number {i}" for i in range(10)])
+
+        block = await small.get_index_block(USER)
+
+        assert block
+        assert len(block) <= small.max_chars
+
+    async def test_truncation_reports_omitted_count(self, index, graph):
+        for i in range(30):
+            await _seed_entity(graph, f"Entity With A Reasonably Long Name {i:02d}", "topic")
+
+        block = await index.get_index_block(USER)
+
+        assert "Entities (30):" in block
+        assert "more]" in block  # "[+N more]" marker with the omitted count
+
+
+class TestCachingAndRegeneration:
+    async def test_unchanged_store_serves_cached_blob(self, index, graph):
+        await _seed_entity(graph)
+        first = await index.get_index_block(USER)
+        second = await index.get_index_block(USER)
+        assert second is first  # identity: cache hit, no re-render
+
+    async def test_new_log_entry_triggers_regeneration(self, index, graph, captains_log):
+        await _seed_entity(graph)
+        first = await index.get_index_block(USER)
+        await _seed_log_entry(captains_log, date(2026, 4, 3))
+        second = await index.get_index_block(USER)
+        assert second is not first
+        assert "Captain's Log: 1 entries" in second
+
+    async def test_artifact_save_triggers_regeneration(self, index, graph, artifact_memory):
+        await _seed_entity(graph)
+        first = await index.get_index_block(USER)
+        artifact_memory.artifacts.append(
+            {"name": "New Diagram", "content_type": "image/png", "created_at": "2026-04-05"}
+        )
+        second = await index.get_index_block(USER)
+        assert second is not first
+        assert "New Diagram" in second
+
+    async def test_entity_growth_below_threshold_keeps_cache(self, index, graph):
+        await _seed_entity(graph)
+        first = await index.get_index_block(USER)
+        await _seed_entity(graph, "One More", "topic")  # +1 < threshold (10)
+        second = await index.get_index_block(USER)
+        assert second is first
+
+    async def test_entity_count_threshold_triggers_regeneration(
+        self, db_manager, graph, captains_log, artifact_memory
+    ):
+        index = KnowledgeIndexService(
+            db_manager,
+            FORMATION_ID,
+            config={"entity_count_threshold": 2},
+            knowledge_graph=graph,
+            captains_log=captains_log,
+            artifact_memory=artifact_memory,
+        )
+        await _seed_entity(graph)
+        first = await index.get_index_block(USER)
+        await _seed_entity(graph, "Second", "topic")
+        await _seed_entity(graph, "Third", "topic")
+        second = await index.get_index_block(USER)
+        assert second is not first
+        assert "Entities (3):" in second
+
+    async def test_lint_invalidation_triggers_regeneration(self, index, graph):
+        await _seed_entity(graph)
+        first = await index.get_index_block(USER)
+        await index.set_lint_findings(USER, ["missing relationship for 'Sarah Chen'"])
+        second = await index.get_index_block(USER)
+        assert second is not first
+        assert "missing relationship for 'Sarah Chen'" in second
+
+    async def test_stale_blob_regenerates_after_24h(self, index, graph):
+        await _seed_entity(graph)
+        first = await index.get_index_block(USER)
+        index._cache[USER]["generated_at"] = time.time() - 90_000  # > 24h ago
+        second = await index.get_index_block(USER)
+        assert second is not first
+
+    async def test_disabled_triggers_are_respected(
+        self, db_manager, graph, captains_log, artifact_memory
+    ):
+        index = KnowledgeIndexService(
+            db_manager,
+            FORMATION_ID,
+            config={"regenerate_on": ["lint"]},  # log_entry trigger off
+            knowledge_graph=graph,
+            captains_log=captains_log,
+            artifact_memory=artifact_memory,
+        )
+        await _seed_entity(graph)
+        first = await index.get_index_block(USER)
+        await _seed_log_entry(captains_log, date(2026, 4, 3))
+        second = await index.get_index_block(USER)
+        assert second is first  # log change ignored by config
+
+
+class TestPersistence:
+    async def test_blob_persisted_in_system_config(self, index, graph, db_manager):
+        await _seed_entity(graph)
+        block = await index.get_index_block(USER)
+
+        from muxi.runtime.services.memory.artifacts.models import SystemConfig
+
+        async with db_manager.get_async_session() as session:
+            row = await session.get(SystemConfig, INDEX_KEY_FORMAT.format(user_id=USER))
+        assert row is not None
+        assert row.value == block
+
+    async def test_lint_findings_survive_service_restart(
+        self, index, db_manager, graph, captains_log, artifact_memory
+    ):
+        await index.set_lint_findings(USER, ["captain's log gap: 12 days"])
+
+        reborn = KnowledgeIndexService(
+            db_manager,
+            FORMATION_ID,
+            knowledge_graph=graph,
+            captains_log=captains_log,
+            artifact_memory=artifact_memory,
+        )
+        assert await reborn.get_lint_findings(USER) == ["captain's log gap: 12 days"]
+
+
+class TestInitializationSeam:
+    def test_initialize_skips_without_sources(self, db_manager):
+        from muxi.runtime.formation.initialization import _initialize_memory_index
+
+        formation = SimpleNamespace(
+            _db_manager=db_manager,
+            _knowledge_graph=None,
+            _captains_log=None,
+            _artifact_memory=None,
+            formation_id=FORMATION_ID,
+        )
+        _initialize_memory_index(formation, {})
+        assert formation._memory_index is None
+
+    def test_initialize_disabled_pin(self, db_manager, graph):
+        from muxi.runtime.formation.initialization import _initialize_memory_index
+
+        formation = SimpleNamespace(
+            _db_manager=db_manager,
+            _knowledge_graph=graph,
+            _captains_log=None,
+            _artifact_memory=None,
+            formation_id=FORMATION_ID,
+        )
+        _initialize_memory_index(formation, {"enabled": False})
+        assert formation._memory_index is None
+
+    def test_initialize_with_sources(self, db_manager, graph):
+        from muxi.runtime.formation.initialization import _initialize_memory_index
+
+        formation = SimpleNamespace(
+            _db_manager=db_manager,
+            _knowledge_graph=graph,
+            _captains_log=None,
+            _artifact_memory=None,
+            formation_id=FORMATION_ID,
+        )
+        _initialize_memory_index(formation, {"max_tokens": 200})
+        assert formation._memory_index is not None
+        assert formation._memory_index.max_tokens == 200

--- a/tests/unit/test_memory_lint.py
+++ b/tests/unit/test_memory_lint.py
@@ -271,6 +271,49 @@ class TestSupersededPurge:
         entities = await graph.storage.list_entities(USER, status=None)
         assert any(e["name"] == "Recent Move" for e in entities)
 
+    async def test_superseded_relationship_with_superseded_endpoint(self, db_manager, graph):
+        """The overlap case: a superseded edge whose endpoint entity is also
+        superseded must purge cleanly (the old ORM-delete loop double-deleted
+        the edge and made the session flush raise StaleDataError)."""
+        old_home = await graph.storage.upsert_entity(
+            user_id=USER, entity_type="location", name="Old Home", confidence=0.5
+        )
+        person = await graph.storage.upsert_entity(
+            user_id=USER, entity_type="person", name="Ran", confidence=0.9
+        )
+        relationship = await graph.storage.upsert_relationship(
+            user_id=USER,
+            from_entity_id=person["id"],
+            to_entity_id=old_home["id"],
+            rel_type="lives_in",
+            confidence=0.5,
+        )
+        stamp = utc_now_naive() - timedelta(days=60)
+        async with db_manager.get_async_session() as session:
+            await session.execute(
+                update(KGEntity)
+                .where(KGEntity.id == old_home["id"])
+                .values(status=STATUS_SUPERSEDED, updated_at=stamp)
+            )
+            await session.execute(
+                update(KGRelationship)
+                .where(KGRelationship.id == relationship["id"])
+                .values(status=STATUS_SUPERSEDED, updated_at=stamp)
+            )
+
+        service = _lint(db_manager, knowledge_graph=graph)
+        report = await service.run_lint(user_id=USER)  # must not raise
+
+        # One superseded relationship + one superseded entity purged.
+        assert report["superseded_deleted"] == 2
+        entities = await graph.storage.list_entities(USER, status=None)
+        assert all(e["name"] != "Old Home" for e in entities)
+        assert await graph.storage.list_relationships(USER) == []
+        # The failure previously surfaced as a silently skipped user: the
+        # per-user catch swallowed the StaleDataError. A counted user pins
+        # that the pass really ran.
+        assert report["users"] == 1
+
 
 class TestOrphanCleanup:
     async def _seed_orphan(self, db_manager, graph) -> None:
@@ -343,6 +386,26 @@ class TestLogGapsAndArtifacts:
         assert "Old Report" in report["findings"][USER][0]
         assert all("Fresh Diagram" not in f for f in report["findings"][USER])
 
+    async def test_tz_aware_timestamps_never_abort_the_lint_pass(self, db_manager, captains_log):
+        """tz-aware ISO stamps must normalize instead of raising TypeError
+        (which the per-user catch would turn into a silently skipped user)."""
+        stale_aware = (utc_now_naive() - timedelta(days=120)).isoformat() + "+00:00"
+        fresh_aware = utc_now_naive().isoformat() + "+00:00"
+        artifact_memory = FakeArtifactMemory(
+            [
+                {"name": "Aware Old Report", "last_accessed_at": stale_aware},
+                {"name": "Aware Fresh Diagram", "last_accessed_at": fresh_aware},
+                {"name": "Broken Stamp", "last_accessed_at": "not-a-date"},
+            ]
+        )
+
+        service = _lint(db_manager, captains_log=captains_log, artifact_memory=artifact_memory)
+        report = await service.run_lint(user_id=USER)  # must not raise
+
+        assert report["users"] == 1  # the user's pass completed
+        assert report["stale_artifacts"] == 1
+        assert "Aware Old Report" in report["findings"][USER][0]
+
 
 class TestIndexIntegration:
     async def test_findings_feed_the_knowledge_index(self, db_manager, graph, captains_log):
@@ -355,7 +418,8 @@ class TestIndexIntegration:
         service = _lint(db_manager, knowledge_graph=graph, captains_log=captains_log, index=index)
         report = await service.run_lint(user_id=USER)
 
-        # Never regenerated before -> the staleness check forces one.
+        # Lint regenerates the index unconditionally after the findings
+        # write-back (set_lint_findings invalidates the cached blob).
         assert report["index_regenerated"] == 1
         findings = await index.get_lint_findings(USER)
         assert findings == report["findings"][USER]
@@ -363,6 +427,22 @@ class TestIndexIntegration:
         block = await index.get_index_block(USER)
         assert "Knowledge gaps flagged by last lint:" in block
         assert "lives_in" in block
+
+    async def test_lint_regenerates_even_a_fresh_index(self, db_manager, graph, captains_log):
+        """Pins the always-regenerate-after-lint decision: lint is weekly
+        and regeneration is cheap, so no staleness gate applies."""
+        index = KnowledgeIndexService(
+            db_manager, FORMATION_ID, knowledge_graph=graph, captains_log=captains_log
+        )
+        await graph.storage.upsert_entity(
+            user_id=USER, entity_type="person", name="Ran", confidence=0.9
+        )
+        assert await index.get_index_block(USER)  # cache is warm and fresh
+
+        service = _lint(db_manager, knowledge_graph=graph, captains_log=captains_log, index=index)
+        report = await service.run_lint(user_id=USER)
+
+        assert report["index_regenerated"] == 1
 
     async def test_all_users_sweep_discovers_users_from_rows(self, db_manager, graph, captains_log):
         await graph.storage.upsert_entity(

--- a/tests/unit/test_memory_lint.py
+++ b/tests/unit/test_memory_lint.py
@@ -1,0 +1,397 @@
+"""Unit tests for Memory Revamp Phase 5: MemoryLintService.
+
+Covers config/cadence resolution, the background-loop lifecycle, every
+audit check -- unresolved-conflict detection (entities and relationships,
+produced through the real contradiction-detection write path), superseded
+hard-deletion past the retention window, orphaned-relationship cleanup
+(gated by orphan_cleanup), captain's log gap flagging, stale artifact
+flagging, forced index regeneration -- the findings write-back into the
+Phase 4 index, per-user failure isolation, and the inertness pin: no
+``memory.lint`` block means no service is constructed at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date, timedelta
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import update
+
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.graph.models import (
+    STATUS_CONFLICTED,
+    STATUS_SUPERSEDED,
+    KGEntity,
+    KGRelationship,
+)
+from muxi.runtime.services.memory.graph.service import KnowledgeGraphService
+from muxi.runtime.services.memory.index import KnowledgeIndexService
+from muxi.runtime.services.memory.lint import (
+    DEFAULT_CONFLICT_RESOLUTION_DAYS,
+    DEFAULT_STALE_ARTIFACT_DAYS,
+    MemoryLintService,
+    _schedule_to_seconds,
+)
+from muxi.runtime.services.memory.log.service import CaptainsLogService
+from muxi.runtime.utils.datetime_utils import utc_now_naive
+
+FORMATION_ID = "lint-test-formation"
+USER = "u1"
+
+
+class FakeArtifactMemory:
+    def __init__(self, artifacts=None):
+        self.enabled = True
+        self.artifacts = artifacts if artifacts is not None else []
+
+    async def list_artifacts(self, user_id, **kwargs):
+        return list(self.artifacts)
+
+
+@pytest.fixture
+def db_manager(tmp_path):
+    manager = DatabaseManager(f"sqlite:///{tmp_path}/lint.db")
+    manager.create_tables(Base.metadata)
+    yield manager
+    manager.engine.dispose()
+
+
+@pytest.fixture
+def graph(db_manager):
+    return KnowledgeGraphService(db_manager, FORMATION_ID)
+
+
+@pytest.fixture
+def captains_log(db_manager, graph):
+    return CaptainsLogService(db_manager, FORMATION_ID, knowledge_graph=graph)
+
+
+def _lint(db_manager, config=None, **services) -> MemoryLintService:
+    return MemoryLintService(db_manager, FORMATION_ID, config=config or {}, **services)
+
+
+async def _backdate_graph_rows(db_manager, days: int) -> None:
+    """Push every graph row's updated_at into the past."""
+    stamp = utc_now_naive() - timedelta(days=days)
+    async with db_manager.get_async_session() as session:
+        await session.execute(update(KGEntity).values(updated_at=stamp))
+        await session.execute(update(KGRelationship).values(updated_at=stamp))
+
+
+async def _seed_conflicted_relationship(graph) -> None:
+    """Create a real conflict through the contradiction-detection path."""
+    person = await graph.storage.upsert_entity(
+        user_id=USER, entity_type="person", name="Ran", confidence=0.9
+    )
+    london = await graph.storage.upsert_entity(
+        user_id=USER, entity_type="location", name="London", confidence=0.9
+    )
+    berlin = await graph.storage.upsert_entity(
+        user_id=USER, entity_type="location", name="Berlin", confidence=0.9
+    )
+    # lives_in is exclusive: a second object at similar confidence marks
+    # both edges conflicted instead of silently overriding.
+    await graph.storage.upsert_relationship(
+        user_id=USER,
+        from_entity_id=person["id"],
+        to_entity_id=london["id"],
+        rel_type="lives_in",
+        confidence=0.9,
+    )
+    await graph.storage.upsert_relationship(
+        user_id=USER,
+        from_entity_id=person["id"],
+        to_entity_id=berlin["id"],
+        rel_type="lives_in",
+        confidence=0.9,
+    )
+
+
+class TestConfig:
+    def test_defaults_match_prd(self, db_manager):
+        service = _lint(db_manager)
+        assert service.enabled is True
+        assert service.interval_seconds == 604800  # "weekly"
+        assert service.conflict_resolution_days == DEFAULT_CONFLICT_RESOLUTION_DAYS
+        assert service.orphan_cleanup is True
+        assert service.stale_artifact_days == DEFAULT_STALE_ARTIFACT_DAYS
+
+    def test_schedule_resolution(self):
+        assert _schedule_to_seconds("daily") == 86400
+        assert _schedule_to_seconds("weekly") == 604800
+        assert _schedule_to_seconds(2) == 2.0
+        assert _schedule_to_seconds("bogus") == 604800  # falls back to weekly
+
+    def test_unconfigured_formation_gets_no_lint_service(self, db_manager):
+        """Inertness pin: no memory.lint block -> no service constructed."""
+        from muxi.runtime.formation.initialization import _initialize_memory_lint
+
+        formation = SimpleNamespace(
+            _db_manager=db_manager,
+            _knowledge_graph=None,
+            _captains_log=None,
+            _artifact_memory=None,
+            _memory_index=None,
+            formation_id=FORMATION_ID,
+        )
+        _initialize_memory_lint(formation, None)  # memory.lint absent
+        assert formation._memory_lint is None
+
+        _initialize_memory_lint(formation, {"enabled": False})
+        assert formation._memory_lint is None
+
+        _initialize_memory_lint(formation, {"schedule": "daily"})
+        assert formation._memory_lint is not None
+        assert formation._memory_lint.interval_seconds == 86400
+
+
+class TestLifecycle:
+    async def test_loop_starts_and_stops(self, db_manager):
+        service = _lint(db_manager, config={"schedule": 3600})
+        service.start()
+        assert service._task is not None and not service._task.done()
+        service.start()  # idempotent
+        await service.stop()
+        assert service._task is None
+
+    async def test_disabled_service_never_starts(self, db_manager):
+        service = _lint(db_manager, config={"enabled": False})
+        service.start()
+        assert service._task is None
+
+    async def test_loop_survives_run_failures(self, db_manager, monkeypatch):
+        service = _lint(db_manager, config={"schedule": 0.01})
+
+        calls = []
+
+        async def failing_run(user_id=None):
+            calls.append(1)
+            raise RuntimeError("audit boom")
+
+        monkeypatch.setattr(service, "run_lint", failing_run)
+        service.start()
+        await asyncio.sleep(0.08)
+        await service.stop()
+        assert len(calls) >= 2  # kept running after the failure
+
+
+class TestConflictDetection:
+    async def test_unresolved_conflicts_are_flagged_after_threshold(self, db_manager, graph):
+        await _seed_conflicted_relationship(graph)
+        await _backdate_graph_rows(db_manager, days=10)
+
+        service = _lint(db_manager, knowledge_graph=graph)
+        report = await service.run_lint(user_id=USER)
+
+        assert report["unresolved_conflicts"] == 2  # both lives_in edges
+        findings = report["findings"][USER]
+        assert any("Ran -[lives_in]-> London" in finding for finding in findings)
+        assert any("Ran -[lives_in]-> Berlin" in finding for finding in findings)
+
+    async def test_fresh_conflicts_are_not_flagged_yet(self, db_manager, graph):
+        await _seed_conflicted_relationship(graph)  # updated_at = now
+
+        service = _lint(db_manager, knowledge_graph=graph)
+        report = await service.run_lint(user_id=USER)
+
+        assert report["unresolved_conflicts"] == 0
+
+    async def test_conflicted_entities_are_flagged(self, db_manager, graph):
+        await graph.storage.upsert_entity(
+            user_id=USER, entity_type="location", name="Berlin office", confidence=0.9
+        )
+        async with db_manager.get_async_session() as session:
+            await session.execute(
+                update(KGEntity)
+                .where(KGEntity.name == "Berlin office")
+                .values(
+                    status=STATUS_CONFLICTED,
+                    updated_at=utc_now_naive() - timedelta(days=30),
+                )
+            )
+
+        service = _lint(db_manager, knowledge_graph=graph)
+        report = await service.run_lint(user_id=USER)
+
+        assert report["unresolved_conflicts"] == 1
+        assert "Berlin office" in report["findings"][USER][0]
+
+
+class TestSupersededPurge:
+    async def test_old_superseded_facts_are_hard_deleted(self, db_manager, graph):
+        entity = await graph.storage.upsert_entity(
+            user_id=USER, entity_type="location", name="Old Home", confidence=0.5
+        )
+        keeper = await graph.storage.upsert_entity(
+            user_id=USER, entity_type="person", name="Ran", confidence=0.9
+        )
+        await graph.storage.upsert_relationship(
+            user_id=USER,
+            from_entity_id=keeper["id"],
+            to_entity_id=entity["id"],
+            rel_type="lives_in",
+            confidence=0.5,
+        )
+        async with db_manager.get_async_session() as session:
+            await session.execute(
+                update(KGEntity)
+                .where(KGEntity.id == entity["id"])
+                .values(
+                    status=STATUS_SUPERSEDED,
+                    updated_at=utc_now_naive() - timedelta(days=60),
+                )
+            )
+
+        service = _lint(db_manager, knowledge_graph=graph)
+        report = await service.run_lint(user_id=USER)
+
+        assert report["superseded_deleted"] == 1
+        entities = await graph.storage.list_entities(USER, status=None)
+        assert all(e["name"] != "Old Home" for e in entities)
+        # The edge referencing the purged entity went with it.
+        assert await graph.storage.list_relationships(USER) == []
+
+    async def test_recent_superseded_facts_are_retained(self, db_manager, graph):
+        entity = await graph.storage.upsert_entity(
+            user_id=USER, entity_type="location", name="Recent Move", confidence=0.5
+        )
+        async with db_manager.get_async_session() as session:
+            await session.execute(
+                update(KGEntity)
+                .where(KGEntity.id == entity["id"])
+                .values(status=STATUS_SUPERSEDED)  # updated now
+            )
+
+        service = _lint(db_manager, knowledge_graph=graph)
+        report = await service.run_lint(user_id=USER)
+
+        assert report["superseded_deleted"] == 0
+        entities = await graph.storage.list_entities(USER, status=None)
+        assert any(e["name"] == "Recent Move" for e in entities)
+
+
+class TestOrphanCleanup:
+    async def _seed_orphan(self, db_manager, graph) -> None:
+        left = await graph.storage.upsert_entity(
+            user_id=USER, entity_type="person", name="Left", confidence=0.9
+        )
+        right = await graph.storage.upsert_entity(
+            user_id=USER, entity_type="company", name="Right", confidence=0.9
+        )
+        await graph.storage.upsert_relationship(
+            user_id=USER,
+            from_entity_id=left["id"],
+            to_entity_id=right["id"],
+            rel_type="works_at",
+            confidence=0.9,
+        )
+        # Delete one endpoint out from under the edge.
+        from sqlalchemy import delete
+
+        async with db_manager.get_async_session() as session:
+            await session.execute(delete(KGEntity).where(KGEntity.id == right["id"]))
+
+    async def test_orphaned_relationships_are_removed(self, db_manager, graph):
+        await self._seed_orphan(db_manager, graph)
+
+        service = _lint(db_manager, knowledge_graph=graph)
+        report = await service.run_lint(user_id=USER)
+
+        assert report["orphans_removed"] == 1
+        assert await graph.storage.list_relationships(USER) == []
+
+    async def test_orphan_cleanup_can_be_disabled(self, db_manager, graph):
+        await self._seed_orphan(db_manager, graph)
+
+        service = _lint(db_manager, config={"orphan_cleanup": False}, knowledge_graph=graph)
+        report = await service.run_lint(user_id=USER)
+
+        assert report["orphans_removed"] == 0
+        assert len(await graph.storage.list_relationships(USER)) == 1
+
+
+class TestLogGapsAndArtifacts:
+    async def test_log_gaps_are_flagged(self, db_manager, captains_log):
+        await captains_log.storage.upsert_entry(USER, date(2026, 1, 1), summary="a")
+        await captains_log.storage.upsert_entry(USER, date(2026, 1, 20), summary="b")
+        await captains_log.storage.upsert_entry(USER, date(2026, 1, 24), summary="c")
+
+        service = _lint(db_manager, captains_log=captains_log)
+        report = await service.run_lint(user_id=USER)
+
+        assert report["log_gaps"] == 1
+        assert "19 days between 2026-01-01 and 2026-01-20" in report["findings"][USER][0]
+
+    async def test_stale_artifacts_are_flagged(self, db_manager, captains_log):
+        stale_stamp = (utc_now_naive() - timedelta(days=120)).isoformat()
+        fresh_stamp = utc_now_naive().isoformat()
+        artifact_memory = FakeArtifactMemory(
+            [
+                {"name": "Old Report", "last_accessed_at": stale_stamp},
+                {"name": "Fresh Diagram", "last_accessed_at": fresh_stamp},
+            ]
+        )
+
+        service = _lint(db_manager, captains_log=captains_log, artifact_memory=artifact_memory)
+        # The user has to exist somewhere for the all-users sweep; scope
+        # directly instead.
+        report = await service.run_lint(user_id=USER)
+
+        assert report["stale_artifacts"] == 1
+        assert "Old Report" in report["findings"][USER][0]
+        assert all("Fresh Diagram" not in f for f in report["findings"][USER])
+
+
+class TestIndexIntegration:
+    async def test_findings_feed_the_knowledge_index(self, db_manager, graph, captains_log):
+        index = KnowledgeIndexService(
+            db_manager, FORMATION_ID, knowledge_graph=graph, captains_log=captains_log
+        )
+        await _seed_conflicted_relationship(graph)
+        await _backdate_graph_rows(db_manager, days=10)
+
+        service = _lint(db_manager, knowledge_graph=graph, captains_log=captains_log, index=index)
+        report = await service.run_lint(user_id=USER)
+
+        # Never regenerated before -> the staleness check forces one.
+        assert report["index_regenerated"] == 1
+        findings = await index.get_lint_findings(USER)
+        assert findings == report["findings"][USER]
+
+        block = await index.get_index_block(USER)
+        assert "Knowledge gaps flagged by last lint:" in block
+        assert "lives_in" in block
+
+    async def test_all_users_sweep_discovers_users_from_rows(self, db_manager, graph, captains_log):
+        await graph.storage.upsert_entity(
+            user_id="alpha", entity_type="person", name="A", confidence=0.9
+        )
+        await captains_log.storage.upsert_entry("beta", date(2026, 1, 1), summary="b")
+
+        service = _lint(db_manager, knowledge_graph=graph, captains_log=captains_log)
+        report = await service.run_lint()
+
+        assert report["users"] == 2
+
+    async def test_per_user_failure_is_isolated(self, db_manager, graph, monkeypatch):
+        await graph.storage.upsert_entity(
+            user_id="alpha", entity_type="person", name="A", confidence=0.9
+        )
+        await graph.storage.upsert_entity(
+            user_id="beta", entity_type="person", name="B", confidence=0.9
+        )
+
+        service = _lint(db_manager, knowledge_graph=graph)
+        original = service._lint_user
+
+        async def flaky(user_id):
+            if user_id == "alpha":
+                raise RuntimeError("user boom")
+            return await original(user_id)
+
+        monkeypatch.setattr(service, "_lint_user", flaky)
+        report = await service.run_lint()  # must not raise
+
+        assert report["users"] == 1  # beta audited despite alpha's failure

--- a/tests/unit/test_memory_revamp_config_validation.py
+++ b/tests/unit/test_memory_revamp_config_validation.py
@@ -1,0 +1,124 @@
+"""Unit tests for Memory Revamp Phases 3-5 config validation.
+
+Fail-fast validation of the new formation config sections:
+``memory.compaction`` (pre-compaction flush), ``memory.pruning``
+(cache-TTL pruning), ``memory.index`` (knowledge index), and
+``memory.lint``. Uses the section-level validator methods directly, the
+same pattern the slug validation tests use.
+"""
+
+from __future__ import annotations
+
+from muxi.runtime.formation.config.validation import FormationValidator
+
+
+def _validate_memory(memory_config: dict) -> list[str]:
+    validator = FormationValidator()
+    validator._validate_memory_config(memory_config)
+    return validator.result.errors
+
+
+class TestCompactionValidation:
+    def test_valid_config_passes(self):
+        assert not _validate_memory({"compaction": {"flush_enabled": True, "flush_threshold": 0.8}})
+
+    def test_absent_section_passes(self):
+        assert not _validate_memory({})
+
+    def test_non_dict_fails(self):
+        errors = _validate_memory({"compaction": "yes"})
+        assert any("memory.compaction must be a dictionary" in e for e in errors)
+
+    def test_flush_enabled_type_checked(self):
+        errors = _validate_memory({"compaction": {"flush_enabled": "yes"}})
+        assert any("flush_enabled must be a boolean" in e for e in errors)
+
+    def test_flush_threshold_range_checked(self):
+        for bad in (0, -0.5, 1.5):
+            errors = _validate_memory({"compaction": {"flush_threshold": bad}})
+            assert any("flush_threshold" in e for e in errors), bad
+
+
+class TestPruningValidation:
+    def test_valid_config_passes(self):
+        assert not _validate_memory(
+            {
+                "pruning": {
+                    "mode": "cache-ttl",
+                    "cache_ttl_seconds": 300,
+                    "keep_last_n_tool_results": 3,
+                    "soft_trim_max_chars": 4000,
+                }
+            }
+        )
+
+    def test_invalid_mode_fails(self):
+        errors = _validate_memory({"pruning": {"mode": "sometimes"}})
+        assert any("memory.pruning.mode" in e for e in errors)
+
+    def test_invalid_strategy_fails(self):
+        errors = _validate_memory({"pruning": {"strategy": "medium"}})
+        assert any("memory.pruning.strategy" in e for e in errors)
+
+    def test_negative_numbers_fail(self):
+        errors = _validate_memory({"pruning": {"cache_ttl_seconds": -1}})
+        assert any("cache_ttl_seconds" in e for e in errors)
+        errors = _validate_memory({"pruning": {"keep_last_n_tool_results": -1}})
+        assert any("keep_last_n_tool_results" in e for e in errors)
+
+
+class TestIndexValidation:
+    def test_valid_config_passes(self):
+        assert not _validate_memory(
+            {
+                "index": {
+                    "enabled": True,
+                    "max_tokens": 300,
+                    "regenerate_on": ["lint", "log_entry"],
+                    "entity_count_threshold": 10,
+                }
+            }
+        )
+
+    def test_invalid_max_tokens_fails(self):
+        errors = _validate_memory({"index": {"max_tokens": 0}})
+        assert any("memory.index.max_tokens" in e for e in errors)
+
+    def test_unknown_regenerate_trigger_fails(self):
+        errors = _validate_memory({"index": {"regenerate_on": ["full_moon"]}})
+        assert any("regenerate_on" in e for e in errors)
+
+    def test_regenerate_on_must_be_list(self):
+        errors = _validate_memory({"index": {"regenerate_on": "lint"}})
+        assert any("must be a list" in e for e in errors)
+
+
+class TestLintValidation:
+    def test_valid_config_passes(self):
+        assert not _validate_memory(
+            {
+                "lint": {
+                    "enabled": True,
+                    "schedule": "weekly",
+                    "conflict_resolution_days": 7,
+                    "orphan_cleanup": True,
+                    "stale_artifact_days": 90,
+                }
+            }
+        )
+
+    def test_numeric_schedule_passes(self):
+        assert not _validate_memory({"lint": {"schedule": 3600}})
+
+    def test_invalid_schedule_fails(self):
+        errors = _validate_memory({"lint": {"schedule": "fortnightly"}})
+        assert any("memory.lint.schedule" in e for e in errors)
+
+    def test_day_counts_must_be_positive_integers(self):
+        for key in ("conflict_resolution_days", "stale_artifact_days"):
+            errors = _validate_memory({"lint": {key: 0}})
+            assert any(key in e for e in errors), key
+
+    def test_orphan_cleanup_type_checked(self):
+        errors = _validate_memory({"lint": {"orphan_cleanup": "yes"}})
+        assert any("orphan_cleanup must be a boolean" in e for e in errors)

--- a/tests/unit/test_precompaction_flush.py
+++ b/tests/unit/test_precompaction_flush.py
@@ -1,0 +1,290 @@
+"""Unit tests for Memory Revamp Phase 3: pre-compaction flush.
+
+Covers the WorkingMemory eviction listener hook (threshold trigger,
+eviction-time safety net, no-double-flush marking, listener failure
+isolation), the PreCompactionFlushService silent turn (grouping per user,
+digest through the captain's log, model-less no-op), configuration gating
+(flush_enabled: false stays fully inert -- the standing inertness pin), and
+the end-to-end path: items evicted from the buffer survive in the captain's
+log and knowledge graph.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.flush import (
+    DEFAULT_FLUSH_THRESHOLD,
+    PreCompactionFlushService,
+    _group_items_by_user,
+)
+from muxi.runtime.services.memory.graph.service import KnowledgeGraphService
+from muxi.runtime.services.memory.log.service import CaptainsLogService
+from muxi.runtime.services.memory.working import WorkingMemory
+
+FORMATION_ID = "flush-test-formation"
+
+DIGEST_RESPONSE = (
+    "{"
+    '"summary": "The user shared launch details for the MUXI project.",'
+    '"decisions": ["Launch next month"],'
+    '"projects": ["MUXI"],'
+    '"context": "Buffer flush test.",'
+    '"lessons": [],'
+    '"entities": [{"name": "MUXI", "type": "project", "confidence": 0.95}],'
+    '"relationships": []'
+    "}"
+)
+
+
+class FakeModel:
+    def __init__(self, response=DIGEST_RESPONSE):
+        self.response = response
+        self.calls = 0
+
+    async def generate_text(self, prompt, caching=True):
+        self.calls += 1
+        if isinstance(self.response, Exception):
+            raise self.response
+        return self.response
+
+
+@pytest.fixture
+def db_manager(tmp_path):
+    manager = DatabaseManager(f"sqlite:///{tmp_path}/flush.db")
+    manager.create_tables(Base.metadata)
+    yield manager
+    manager.engine.dispose()
+
+
+@pytest.fixture
+def captains_log(db_manager):
+    graph = KnowledgeGraphService(db_manager, FORMATION_ID)
+    return CaptainsLogService(db_manager, FORMATION_ID, knowledge_graph=graph)
+
+
+_ITEM_COUNTER = iter(range(1, 10_000))
+
+
+def _buffer_item(text: str, role: str = "user", user_id: str = "u1", flushed: bool = False):
+    metadata = {"role": role, "user_id": user_id, "formation_id": FORMATION_ID}
+    if flushed:
+        metadata["_memory_flushed"] = True
+    return {
+        "text": text,
+        # Distinct timestamps: the buffer stamps each add() individually,
+        # and the digest's source lineage is keyed by them.
+        "timestamp": time.time() + next(_ITEM_COUNTER) * 1e-3,
+        "metadata": metadata,
+        "namespace": "buffer",
+        "embedding": None,
+    }
+
+
+def _make_working_memory(max_memory_mb) -> WorkingMemory:
+    return WorkingMemory(formation_id=FORMATION_ID, max_size=10, max_memory_mb=max_memory_mb)
+
+
+class TestWorkingMemoryEvictionListener:
+    def test_listener_unset_by_default(self):
+        wm = _make_working_memory(max_memory_mb=1000)
+        assert wm._eviction_listener is None
+        # Cleanup with no listener behaves exactly as before (inert pin).
+        wm.buffer.append(_buffer_item("hello"))
+        wm.check_memory_usage_and_cleanup()
+        assert len(wm.buffer) == 1
+
+    def test_threshold_trigger_fires_before_eviction(self):
+        # ~2000 bytes of buffer text; limit 0.004 MB, threshold 0.25
+        # -> usage is above the flush threshold but below the eviction limit.
+        wm = _make_working_memory(max_memory_mb=0.004)
+        received = []
+        wm.set_eviction_listener(received.extend, flush_threshold=0.25)
+        for index in range(4):
+            wm.buffer.append(_buffer_item("x" * 500 + f" {index}"))
+
+        wm.check_memory_usage_and_cleanup()
+
+        # Oldest ~25% handed over; nothing evicted.
+        assert len(received) == 1
+        assert received[0]["text"].endswith(" 0")
+        assert len(wm.buffer) == 4
+
+    def test_eviction_safety_net_hands_off_unflushed_items(self):
+        wm = _make_working_memory(max_memory_mb=0.0001)  # force eviction
+        received = []
+        wm.set_eviction_listener(received.extend)  # no threshold: safety net only
+        for index in range(4):
+            wm.buffer.append(_buffer_item("y" * 500 + f" {index}"))
+
+        wm.check_memory_usage_and_cleanup()
+
+        # 25% of 4 items = the oldest one, snapshotted then evicted.
+        assert len(received) == 1
+        assert received[0]["text"].endswith(" 0")
+        assert len(wm.buffer) == 3
+        assert all(not item["text"].endswith(" 0") for item in wm.buffer)
+
+    def test_items_never_flush_twice(self):
+        wm = _make_working_memory(max_memory_mb=0.004)
+        received = []
+        wm.set_eviction_listener(received.extend, flush_threshold=0.25)
+        for index in range(4):
+            wm.buffer.append(_buffer_item("z" * 500 + f" {index}"))
+
+        wm.check_memory_usage_and_cleanup()
+        wm.check_memory_usage_and_cleanup()  # same threshold crossing again
+
+        assert len(received) == 1  # marked _memory_flushed after the first pass
+
+    def test_listener_failure_never_breaks_cleanup(self):
+        wm = _make_working_memory(max_memory_mb=0.0001)
+
+        def exploding_listener(items):
+            raise RuntimeError("listener boom")
+
+        wm.set_eviction_listener(exploding_listener, flush_threshold=0.5)
+        for index in range(4):
+            wm.buffer.append(_buffer_item("w" * 500 + f" {index}"))
+
+        wm.check_memory_usage_and_cleanup()  # must not raise
+        assert len(wm.buffer) == 3  # eviction still proceeded
+
+    def test_non_buffer_namespaces_are_never_handed_over(self):
+        wm = _make_working_memory(max_memory_mb=0.0001)
+        received = []
+        wm.set_eviction_listener(received.extend, flush_threshold=0.1)
+        knowledge = _buffer_item("k" * 500)
+        knowledge["namespace"] = "knowledge"
+        wm.buffer.append(knowledge)
+        wm.buffer.append(_buffer_item("b" * 2000))
+
+        wm.check_memory_usage_and_cleanup()
+
+        assert received
+        assert all(item["text"].startswith("b") for item in received)
+
+
+class TestGrouping:
+    def test_groups_items_per_user_with_roles(self):
+        items = [
+            _buffer_item("hello", role="user", user_id="u1"),
+            _buffer_item("hi there", role="assistant", user_id="u1"),
+            _buffer_item("other user", role="user", user_id="u2"),
+            _buffer_item("raw note", role=None, user_id="u2"),
+            _buffer_item("   ", role="user", user_id="u3"),  # empty text skipped
+        ]
+        grouped = _group_items_by_user(items)
+
+        assert set(grouped) == {"u1", "u2"}
+        assert [text for _, text in grouped["u1"]] == ["User: hello", "Assistant: hi there"]
+        assert [text for _, text in grouped["u2"]] == ["User: other user", "raw note"]
+        # Timestamp keys are parseable epoch seconds (buffer_item lineage keys).
+        for timestamp_key, _ in grouped["u1"]:
+            float(timestamp_key)
+
+    def test_missing_user_id_defaults_to_single_user_scope(self):
+        item = _buffer_item("anonymous")
+        del item["metadata"]["user_id"]
+        grouped = _group_items_by_user([item])
+        assert set(grouped) == {"0"}
+
+
+class TestFlushService:
+    def test_defaults_match_prd(self, captains_log):
+        service = PreCompactionFlushService(captains_log)
+        assert service.enabled is True
+        assert service.flush_threshold == DEFAULT_FLUSH_THRESHOLD
+
+    async def test_disabled_flush_stays_inert(self, captains_log):
+        wm = _make_working_memory(max_memory_mb=1000)
+        service = PreCompactionFlushService(captains_log, {"flush_enabled": False})
+        service.attach(wm, lambda: FakeModel())
+        assert service.enabled is False
+        assert wm._eviction_listener is None
+
+    async def test_attach_requires_both_sides(self, captains_log):
+        wm = _make_working_memory(max_memory_mb=1000)
+        service = PreCompactionFlushService(None)
+        service.attach(wm, lambda: FakeModel())
+        assert wm._eviction_listener is None
+
+        attached = PreCompactionFlushService(captains_log)
+        attached.attach(wm, lambda: FakeModel())
+        assert wm._eviction_listener is not None
+
+    async def test_flush_items_digests_through_captains_log(self, captains_log):
+        service = PreCompactionFlushService(captains_log)
+        model = FakeModel()
+        service._model_getter = lambda: model
+
+        totals = await service.flush_items(
+            [
+                _buffer_item("We are launching MUXI next month", role="user"),
+                _buffer_item("Noted - exciting launch!", role="assistant"),
+            ]
+        )
+
+        assert totals["entries"] == 1
+        assert model.calls == 1
+        entries = await captains_log.get_history("u1", include_sources=True)
+        assert len(entries) == 1
+        assert "MUXI" in entries[0]["summary"]
+        # Source lineage carries the buffer timestamp keys.
+        assert len(entries[0]["sources"]) == 2
+        # The digest's graph facts landed in the knowledge graph too.
+        entities = await captains_log.knowledge_graph.storage.list_entities("u1")
+        assert any(entity["name"] == "MUXI" for entity in entities)
+
+    async def test_flush_without_model_is_a_noop(self, captains_log):
+        service = PreCompactionFlushService(captains_log)
+        service._model_getter = lambda: None
+        totals = await service.flush_items([_buffer_item("hello")])
+        assert totals == {"entries": 0, "sources": 0, "lessons": 0}
+        assert await captains_log.get_history("u1") == []
+
+    async def test_digest_failure_is_isolated_per_user(self, captains_log):
+        service = PreCompactionFlushService(captains_log)
+        model = FakeModel(response=RuntimeError("llm down"))
+        service._model_getter = lambda: model
+
+        totals = await service.flush_items([_buffer_item("hello")])  # must not raise
+        assert totals["entries"] == 0
+
+    async def test_end_to_end_flush_survives_eviction(self, captains_log):
+        """Items evicted from the buffer live on in the captain's log."""
+        wm = _make_working_memory(max_memory_mb=0.0001)  # force eviction
+        model = FakeModel()
+        service = PreCompactionFlushService(captains_log)
+        service.attach(wm, lambda: model)
+
+        fact = "We are launching MUXI next month. " + "pad " * 200
+        wm.buffer.append(_buffer_item(fact, role="user"))
+        wm.buffer.append(_buffer_item("Got it!", role="assistant"))
+
+        wm.check_memory_usage_and_cleanup()  # evicts the oldest item
+        await asyncio.sleep(0.2)  # let the scheduled silent turn run
+
+        assert model.calls == 1
+        entries = await captains_log.get_history("u1")
+        assert len(entries) == 1
+        assert "MUXI" in entries[0]["summary"]
+        # And the evicted item really left the buffer.
+        assert all(not item["text"].startswith("We are launching") for item in wm.buffer)
+
+
+class TestCaptainsLogDigestTurns:
+    async def test_digest_turns_requires_enabled_service_and_model(self, db_manager):
+        service = CaptainsLogService(db_manager, FORMATION_ID, config={"enabled": False})
+        totals = await service.digest_turns("u1", [("1.0", "User: hi")], FakeModel())
+        assert totals == {"entries": 0, "sources": 0, "lessons": 0}
+
+    async def test_digest_turns_failure_returns_zero_counts(self, captains_log):
+        totals = await captains_log.digest_turns(
+            "u1", [("1.0", "User: hi")], FakeModel(response=RuntimeError("boom"))
+        )
+        assert totals == {"entries": 0, "sources": 0, "lessons": 0}

--- a/tests/unit/test_precompaction_flush.py
+++ b/tests/unit/test_precompaction_flush.py
@@ -187,11 +187,18 @@ class TestGrouping:
         for timestamp_key, _ in grouped["u1"]:
             float(timestamp_key)
 
-    def test_missing_user_id_defaults_to_single_user_scope(self):
+    def test_missing_user_id_items_are_skipped(self):
+        # Items without user_id metadata are dropped rather than attributed
+        # to a fallback scope (which would pollute a real user's log or
+        # create orphan entries).
         item = _buffer_item("anonymous")
         del item["metadata"]["user_id"]
-        grouped = _group_items_by_user([item])
-        assert set(grouped) == {"0"}
+        keeper = _buffer_item("attributed", user_id="u9")
+
+        grouped = _group_items_by_user([item, keeper])
+
+        assert set(grouped) == {"u9"}
+        assert [text for _, text in grouped["u9"]] == ["User: attributed"]
 
 
 class TestFlushService:


### PR DESCRIPTION
## Summary

Implements Memory Revamp **Phases 3, 4, and 5** per `engineering/prds/memory-revamp.md` (Phases 1-2 shipped as KG + Captain's Log; Phase 6 Hybrid Search stays deferred pending Tier 2 benchmark evidence).

### Phase 3 - Context Optimization
- **Pre-compaction flush** (`services/memory/flush.py`): `WorkingMemory` gains an additive `set_eviction_listener` hook. At `memory.compaction.flush_threshold` (default 0.80) of the buffer budget — and again as an eviction-time safety net — at-risk buffer items are snapshotted and run through a **silent turn**: an LLM digest via the Captain's Log pipeline (entry + `buffer_item` source lineage + lessons + KG facts) *before* FIFO eviction drops them. Items are marked so nothing flushes twice. Best-effort and failure-isolated: a failed flush never blocks eviction or a chat turn. `flush_enabled: false` leaves the listener unset — byte-identical to previous behavior (pinned by test).
- **Cache-TTL pruning** (`services/memory/pruning.py`): when a `(user, session)` resumes after the provider prompt-cache window (`mode: cache-ttl`, TTL 300s; also `always`/`never`), stale tool results and oversized turns are soft-trimmed (first/last 1500 chars) or hard-cleared (`strategy: hard_clear`), always preserving the newest `keep_last_n_tool_results`. **Inert when unconfigured** — no `memory.pruning` block, no pruner constructed (pinned by test).

### Phase 4 - Knowledge Index
- `KnowledgeIndexService` (`services/memory/index.py`): a <=300-token navigable catalog — entities, Captain's Log count/span/most-recent, **artifact manifest via `ArtifactMemoryService.list_artifacts`** (the clean seam artifact-memory Phase 2 rides), and "knowledge gaps flagged by last lint".
- Injected at **retrieval start** in both context representations (clean chat bundle and the `=== MEMORY INDEX ===` analyzer-blob section, so non-actionable/analyzer turns see it too).
- Cached per user + write-through persisted to `system_config` (`memory_index:{user_id}`). Regeneration triggers (`regenerate_on`): log entries, artifact saves, entity count moving >= `entity_count_threshold`, lint runs (explicit invalidation), and a 24h staleness bound — implemented as a cheap per-read fingerprint, no LLM work.
- Size cap: per-section truncation on item boundaries with `[+N more]`, hard cap at `max_tokens * 4` chars. All read paths return `""` on error — an index failure never breaks a turn.

### Phase 5 - Lint
- `MemoryLintService` (`services/memory/lint.py`): background audit (weekly default; `daily`/seconds; on-demand via `run_lint()` and admin `POST /memory/lint`), following the shared background-loop lifecycle (started beside the scheduler, cancelled on shutdown, failure-isolated per run and per user).
- Checks per PRD: conflicted facts unresolved past `conflict_resolution_days` -> findings; superseded facts older than the retention window -> hard-delete (edges first, algorithms cache invalidated); orphaned relationships -> auto-remove (`orphan_cleanup`); Captain's Log gaps > 7 days -> flag; artifacts unaccessed past `stale_artifact_days` -> flag; index stale > 24h -> force regeneration.
- Findings feed back into the Phase 4 index via `set_lint_findings` (persisted, survive restart).
- **Inert when unconfigured**: only constructed when the formation declares a `memory.lint` block (pinned by test).

### Cross-cutting
- Fail-fast config validation for all four new sections (`memory.compaction` / `pruning` / `index` / `lint`).
- 9 new observability events (`MEMORY_PRECOMPACTION_FLUSH_*`, `MEMORY_CONTEXT_PRUNED`, `MEMORY_INDEX_*`, `MEMORY_LINT_*`); `scripts/validate_events.py` stays 100% (1364/1364).
- Coordination note: write-path plumbing (KG/log/vector, event projectors) untouched — Phase 3-5 ride additive hooks (`set_eviction_listener`, public `digest_turns` wrapper, read-only index/lint queries) to stay merge-friendly with the concurrent event-substrate work.
- `mental-model.md` memory-system section + CHANGELOG `[unreleased]` entry.

## Testing

- **90 new unit tests** across 5 files: `test_precompaction_flush.py` (17: threshold trigger, eviction safety net, no-double-flush, failure isolation, end-to-end flush-survives-eviction, inertness pins), `test_context_pruning.py` (16: modes, TTL clock, keep-recent, soft-trim shape, hard clear, immutability), `test_knowledge_index.py` (21: rendering, size cap/truncation, every regeneration trigger, persistence, seam/inertness), `test_memory_lint.py` (18: conflict/orphan/superseded/gap/stale checks via real contradiction-detection writes, lifecycle, findings write-back, inertness pin), `test_memory_revamp_config_validation.py` (18: fail-fast validation).
- **Full unit suite**: 2738 passed, 10 skipped.
- **New e2e** `e2e/tests/2_memory/test_2x1_memory_revamp_phases_3_5.py` (own formation yaml): all 9 checks SUCCESS — pre-compaction flush surviving real FIFO eviction, index injection observable in a real turn (spied on both context builders), on-demand lint feeding the index.
- **Regression**: `run_random_tests.py 5` — 23a7 heartbeat, 3i2 multimodal, 4e1 MCP user isolation, 6c1 knowledge routing, 8d1 safety-critical clarification.
- black 100 / isort profile=black / ruff 120 clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
