### PR TITLE
feat: remote knowledge sources - archives, scheduling, extra protocols (p2-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,66 @@
 
 ## [unreleased]
 
+### Remote knowledge sources - archives, scheduling, extra protocols (Phases 2-4)
+
+Completes the remote-knowledge-sources PRD on top of the Phase 1 core
+sync: archive extraction, scheduled re-sync with incremental
+re-embedding, a manual sync trigger endpoint, and four more protocols.
+
+- **Archive extraction (Phase 2)**: ``extract: true`` sources download a
+  single archive (``.zip``, ``.tar``, ``.tar.gz``/``.tgz``,
+  ``.tar.bz2``, ``.tar.xz``) and extract it into the local mirror;
+  ``extract_pattern`` keeps only matching members. Extraction is
+  security-hardened: member names are path-traversal-safe (same guards
+  as the manifest), symlink/hardlink/device members are rejected, and
+  decompression bombs are bounded by ``max_extracted_files`` (default
+  1000) and ``max_extracted_size`` (default 500MB) counted on the
+  DECOMPRESSED stream, never trusted from headers. Extraction happens in
+  a temp dir next to the mirror (always cleaned up); the mirror is only
+  updated after the whole archive extracted successfully, so a corrupt
+  or malicious archive degrades to the previously synced content.
+  Unchanged archives (hash + size) skip both download and extraction.
+- **Scheduled re-sync (Phase 3)**: sources with a cron ``schedule``
+  (or ``@hourly``/``@daily``/``@weekly``) now actually re-sync
+  periodically. The new ``KnowledgeSyncService`` registers with the
+  existing SchedulerService worker loop (the heartbeat's periodic-task
+  extension point -- no second scheduler). Per-source locks skip
+  overlapping syncs (``knowledge.sync.skipped``); total failures retry
+  with exponential backoff (per-source ``retry:`` block --
+  ``max_attempts``/``initial_delay``/``max_delay``/``exponential_base``,
+  defaults 3/5s/300s/2) and then fall back to the next cron fire, always
+  serving stale content in the meantime. After a sync that changed the
+  mirror, only the changed/deleted files are re-embedded
+  (``KnowledgeHandler.refresh_remote_source``), not the whole source.
+  Schedules without a running scheduler degrade to startup-only sync
+  with a loud init warning. ``@startup`` / no schedule keep the Phase 1
+  startup-only behavior.
+- **Manual sync trigger**: ``POST /v1/agents/{agent_id}/knowledge/sync``
+  (AdminKey; optional ``{"source_id": ...}`` body) re-syncs an agent's
+  remote sources on demand through the same locks and incremental
+  re-embed path, returning per-source results.
+- **Additional protocols (Phase 4)**: ``gs://`` (Google Cloud Storage,
+  Content-MD5 change detection, optional ``auth: {type: gcp,
+  credentials_json}`` else ADC), ``az://`` (Azure Blob Storage,
+  Content-MD5/ETag; requires ``auth: {type: azure}`` with
+  ``connection_string`` or ``account_name``+``account_key``),
+  ``ftp://`` (stdlib, size+mtime, ``basic`` auth or URL userinfo), and
+  ``sftp://`` (paramiko, size+mtime, ``ssh_key`` or ``basic`` auth;
+  strict host-key checking by default with the same
+  ``accept_new_host_keys`` opt-in as rsync+ssh). All use the shared
+  atomic-download path. Optional SDKs ship as extras --
+  ``muxi-runtime[gcs]``, ``[azure]``, ``[sftp]`` -- with clear
+  config-time errors naming the extra when missing; ftp needs nothing.
+- Fixed a latent WorkingMemory bug surfaced by incremental re-embedding:
+  FAISS partitions for pre-computed embeddings (knowledge chunks) were
+  created/rebuilt at the buffer's own embedding dimension, silently
+  dropping vectors on write and crashing every vector search after the
+  first index rebuild. Partition dimensionality now follows the vectors
+  it stores.
+- All new config keys are fail-fast validated at load time; formations
+  without remote sources remain untouched (the remote machinery is never
+  imported).
+
 ### Knowledge reasoning RAG - Method A tree retrieval (Phase 1)
 
 Large knowledge files are now indexed as hierarchical trees navigated by an

--- a/e2e/tests/6_knowledge/formations/formation-manual-sync/agents/chronicler.yaml
+++ b/e2e/tests/6_knowledge/formations/formation-manual-sync/agents/chronicler.yaml
@@ -1,0 +1,19 @@
+schema: "1.0.0"
+id: "chronicler"
+name: "Chronicler Agent"
+description: "AI assistant specialized in the Emberfall Chronicle"
+
+system_message: |
+  You are an AI assistant with knowledge about the Emberfall Chronicle.
+  Answer questions using your knowledge base.
+
+role: "assistant"
+specialties:
+  - "emberfall_chronicle"
+
+knowledge:
+  enabled: true
+  sources:
+    - url: "http://127.0.0.1:18933/kb/emberfall-chronicle.md"
+      id: emberfall-chronicle
+      description: "Emberfall Chronicle reference document (remote HTTP source)"

--- a/e2e/tests/6_knowledge/formations/formation-manual-sync/formation.yaml
+++ b/e2e/tests/6_knowledge/formations/formation-manual-sync/formation.yaml
@@ -1,0 +1,38 @@
+schema: "1.0.0"
+id: "remote-knowledge-manual-sync-test"
+description: "Formation exercising the manual remote-knowledge sync trigger endpoint"
+
+llm:
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+    anthropic: "${{ secrets.ANTHROPIC_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+    - embedding: "openai/text-embedding-3-small"
+
+agents:
+  - chronicler
+
+memory:
+  buffer:
+    size: 50
+    multiplier: 10
+    vector_search: false
+
+server:
+  enabled: true
+  port: 8273
+  api_keys:
+    admin_key: test-admin-key-6f4
+    client_key: test-client-key-6f4
+
+logging:
+  system:
+    level: "debug"
+    destination: "stdout"
+  conversation:
+    enabled: true
+    streams:
+      - transport: "stdout"
+        level: "info"
+        format: "jsonl"

--- a/e2e/tests/6_knowledge/formations/formation-manual-sync/remote-content/kb/emberfall-chronicle.md
+++ b/e2e/tests/6_knowledge/formations/formation-manual-sync/remote-content/kb/emberfall-chronicle.md
@@ -1,0 +1,11 @@
+# The Emberfall Chronicle
+
+The Emberfall Chronicle is the fictional record of the volcanic
+city-state of Cindervale. It has been maintained since the year 55 of
+the Ashen Calendar.
+
+Key facts:
+
+- The Chronicle is kept by an order of scribes called the Ashbound.
+- The Chronicle is stored in the Basalt Library beneath Mount Cinder.
+- Entries are written with obsidian styluses on slate tablets.

--- a/e2e/tests/6_knowledge/formations/formation-manual-sync/secrets.enc
+++ b/e2e/tests/6_knowledge/formations/formation-manual-sync/secrets.enc
@@ -1,0 +1,1 @@
+../../../../assets/secrets.enc

--- a/e2e/tests/6_knowledge/formations/formation-remote-archive/agents/archivist.yaml
+++ b/e2e/tests/6_knowledge/formations/formation-remote-archive/agents/archivist.yaml
@@ -1,0 +1,22 @@
+schema: "1.0.0"
+id: "archivist"
+name: "Archivist Agent"
+description: "AI assistant specialized in the Lumen Concordat archive"
+
+system_message: |
+  You are an AI assistant with knowledge about the Lumen Concordat.
+  Answer questions using your knowledge base.
+
+role: "assistant"
+specialties:
+  - "lumen_concordat"
+  - "archives"
+
+knowledge:
+  enabled: true
+  sources:
+    - url: "http://127.0.0.1:18932/kb/lumen-archive.zip"
+      id: lumen-archive
+      description: "Lumen Concordat reference archive (remote zip source)"
+      extract: true
+      extract_pattern: "*.md"

--- a/e2e/tests/6_knowledge/formations/formation-remote-archive/archive-src/guides/lamplighter-roster.md
+++ b/e2e/tests/6_knowledge/formations/formation-remote-archive/archive-src/guides/lamplighter-roster.md
@@ -1,0 +1,11 @@
+# Lamplighter Roster
+
+The current head lamplighter of Brightharbor is Superintendent Vela
+Orin, who has held the post since year 447 of the Ember Calendar.
+
+Roster notes:
+
+- Superintendent Vela Orin oversees the nine-member council.
+- Each lantern district elects one lamplighter for a seven-year term.
+- The oldest serving lamplighter is Keeper Damaris of the Wickward
+  district.

--- a/e2e/tests/6_knowledge/formations/formation-remote-archive/archive-src/ignored-notes.txt
+++ b/e2e/tests/6_knowledge/formations/formation-remote-archive/archive-src/ignored-notes.txt
@@ -1,0 +1,3 @@
+These plain-text notes must NOT be ingested: the source declares
+extract_pattern "*.md", so .txt members are filtered out during
+extraction.

--- a/e2e/tests/6_knowledge/formations/formation-remote-archive/archive-src/lumen-facts.md
+++ b/e2e/tests/6_knowledge/formations/formation-remote-archive/archive-src/lumen-facts.md
@@ -1,0 +1,18 @@
+# The Lumen Concordat
+
+The Lumen Concordat is the fictional treaty that governs the floating
+lantern-city of Brightharbor. It was signed in the year 312 of the Ember
+Calendar.
+
+Key facts:
+
+- The Concordat is administered by a council of nine lamplighters.
+- The seat of the Lumen Concordat is the Prismhall, a glass tower in the
+  center of Brightharbor.
+- The treaty's master copy is written in phosphorescent ink and kept in
+  the Radiant Archive.
+- Disputes between lantern districts are settled at the Festival of
+  First Light, held every spring.
+
+The Lumen Concordat has been amended only once, after the Dimming of
+year 401, when the city's lights failed for three nights.

--- a/e2e/tests/6_knowledge/formations/formation-remote-archive/formation.yaml
+++ b/e2e/tests/6_knowledge/formations/formation-remote-archive/formation.yaml
@@ -1,0 +1,31 @@
+schema: "1.0.0"
+id: "remote-knowledge-archive-test"
+description: "Formation with an agent whose knowledge extracts from a remote zip archive"
+
+llm:
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+    anthropic: "${{ secrets.ANTHROPIC_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+    - embedding: "openai/text-embedding-3-small"
+
+agents:
+  - archivist
+
+memory:
+  buffer:
+    size: 50
+    multiplier: 10
+    vector_search: false
+
+logging:
+  system:
+    level: "debug"
+    destination: "stdout"
+  conversation:
+    enabled: true
+    streams:
+      - transport: "stdout"
+        level: "info"
+        format: "jsonl"

--- a/e2e/tests/6_knowledge/formations/formation-remote-archive/secrets.enc
+++ b/e2e/tests/6_knowledge/formations/formation-remote-archive/secrets.enc
@@ -1,0 +1,1 @@
+../../../../assets/secrets.enc

--- a/e2e/tests/6_knowledge/test_6f3_remote_archive_source.py
+++ b/e2e/tests/6_knowledge/test_6f3_remote_archive_source.py
@@ -1,0 +1,168 @@
+"""
+Test 6F3: Remote Archive Knowledge Source (Chat Flow)
+Verify a formation can declare an http:// knowledge source with
+`extract: true`, download the zip at load time, extract it (with
+extract_pattern filtering) into the local mirror, and answer questions
+from the extracted content.
+
+Fixture: a local stdlib HTTP server (no external infrastructure) serving
+a zip built on the fly from formations/formation-remote-archive/archive-src/.
+"""
+
+import asyncio
+import functools
+import shutil
+import sys
+import tempfile
+import threading
+import zipfile
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+from muxi.runtime.formation import Formation  # noqa: E402
+
+FORMATION_DIR = Path(__file__).parent / "formations" / "formation-remote-archive"
+FORMATION_ID = "remote-knowledge-archive-test"
+HTTP_PORT = 18932
+
+
+def ensure_secret_links():
+    """Create .key / secrets.enc symlinks if missing (they are gitignored)."""
+    assets = Path(__file__).parent.parent.parent / "assets"
+    for name in (".key", "secrets.enc"):
+        link = FORMATION_DIR / name
+        if not link.exists():
+            if link.is_symlink():
+                link.unlink()
+            link.symlink_to(Path("..") / ".." / ".." / ".." / "assets" / name)
+        assert (assets / name).exists(), f"e2e/assets/{name} missing"
+
+
+def wipe_remote_mirror():
+    """Remove cached knowledge state so the sync is exercised cold."""
+    knowledge_cache = Path.home() / ".muxi" / FORMATION_ID / "cache" / "knowledge"
+    if knowledge_cache.exists():
+        shutil.rmtree(knowledge_cache, ignore_errors=True)
+
+
+def build_archive(webroot: Path) -> Path:
+    """Zip archive-src/ into <webroot>/kb/lumen-archive.zip."""
+    src_dir = FORMATION_DIR / "archive-src"
+    kb_dir = webroot / "kb"
+    kb_dir.mkdir(parents=True, exist_ok=True)
+    archive_path = kb_dir / "lumen-archive.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        for path in sorted(src_dir.rglob("*")):
+            if path.is_file():
+                archive.write(path, path.relative_to(src_dir).as_posix())
+    return archive_path
+
+
+def start_http_server(webroot: Path):
+    handler = functools.partial(SimpleHTTPRequestHandler, directory=str(webroot))
+    server = ThreadingHTTPServer(("127.0.0.1", HTTP_PORT), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def test_remote_archive_knowledge_source():
+    async def run_test():
+        server = None
+        webroot = Path(tempfile.mkdtemp(prefix="muxi-6f3-webroot-"))
+        try:
+            print("\n=== Test 6F3: Remote Archive Knowledge Source (Chat Flow) ===")
+
+            ensure_secret_links()
+            wipe_remote_mirror()
+
+            print("\nBuilding zip fixture and starting local HTTP server...")
+            build_archive(webroot)
+            server = start_http_server(webroot)
+
+            print("Loading formation with remote archive knowledge source...")
+            formation = Formation()
+            await formation.load(str(FORMATION_DIR / "formation.yaml"))
+
+            print("Starting overlord (downloads + extracts the archive at startup)...")
+            overlord = await formation.start_overlord()
+
+            # The extracted members must be mirrored locally...
+            mirror_root = Path.home() / ".muxi" / FORMATION_ID / "cache" / "knowledge" / "remote"
+            facts = list(mirror_root.rglob("lumen-facts.md"))
+            roster = list(mirror_root.rglob("lamplighter-roster.md"))
+            assert facts, f"Extracted file not found under {mirror_root}"
+            assert roster, "Nested archive member was not extracted"
+            print(f"Archive members extracted into the mirror: {facts[0].parent}")
+
+            # ...the raw archive and pattern-filtered members must not be
+            assert not list(mirror_root.rglob("*.zip")), "Raw archive leaked into the mirror"
+            assert not list(
+                mirror_root.rglob("ignored-notes.txt")
+            ), "extract_pattern did not filter .txt member"
+            print("Raw archive and non-matching members kept out of the mirror")
+
+            manifests = list(mirror_root.rglob("manifest.json"))
+            assert manifests, "Sync manifest was not written"
+            manifest_text = manifests[0].read_text(encoding="utf-8")
+            assert '"success"' in manifest_text, f"Manifest not successful: {manifest_text}"
+            assert '"archive_hash"' in manifest_text, "Manifest missing archive change token"
+            print("Sync manifest recorded a successful archive sync")
+
+            question = (
+                "According to your knowledge, what is the Lumen Concordat, where is its "
+                "seat, and who is the current head lamplighter?"
+            )
+            response = await overlord.chat(
+                question,
+                agent_name="archivist",
+                user_id="test_user",
+                session_id="test_session_remote_archive",
+                stream=False,
+            )
+
+            print(f"\nUser: {question}")
+            if isinstance(response, dict):
+                response_text = response.get("response", str(response))
+            else:
+                response_text = str(response)
+            print(f"Archivist: {response_text}")
+
+            assert response is not None, "No response from archivist agent"
+            assert len(response_text) > 50, "Response too short, likely no knowledge used"
+            response_lower = response_text.lower()
+            keywords = ["brightharbor", "prismhall", "lamplighter", "vela orin"]
+            assert any(k in response_lower for k in keywords), (
+                "Response does not contain facts from the extracted archive: " f"{response_text}"
+            )
+            print("Agent answered using content extracted from the remote archive")
+
+            await formation.stop_overlord()
+
+            print("\nTest 6F3 passed: remote zip source extracted at load and used in chat")
+            return True
+
+        except Exception as e:
+            print(f"\nTest 6F3 failed: {str(e)}")
+            import traceback
+
+            traceback.print_exc()
+            return False
+        finally:
+            if server is not None:
+                server.shutdown()
+                server.server_close()
+            shutil.rmtree(webroot, ignore_errors=True)
+
+    success = asyncio.run(run_test())
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    import os
+
+    exit_code = test_remote_archive_knowledge_source()
+    if exit_code == 0:
+        print("SUCCESS", flush=True)
+    os._exit(exit_code)

--- a/e2e/tests/6_knowledge/test_6f4_manual_sync_trigger.py
+++ b/e2e/tests/6_knowledge/test_6f4_manual_sync_trigger.py
@@ -1,0 +1,214 @@
+"""
+Test 6F4: Manual Remote Knowledge Sync Trigger (Admin API)
+Verify the POST /v1/agents/{agent_id}/knowledge/sync endpoint:
+
+1. Triggering a sync when the remote is unchanged reports zero changes.
+2. After the remote file changes, the trigger re-syncs the mirror and
+   incrementally re-embeds the changed file - the agent can answer from
+   the NEW content without a restart.
+3. Unknown agents / source ids return 404.
+
+Fixture: a local stdlib HTTP server serving a mutable temp webroot seeded
+from formations/formation-manual-sync/remote-content/.
+"""
+
+import asyncio
+import functools
+import shutil
+import sys
+import tempfile
+import threading
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+from muxi.runtime.formation import Formation  # noqa: E402
+
+FORMATION_DIR = Path(__file__).parent / "formations" / "formation-manual-sync"
+FORMATION_ID = "remote-knowledge-manual-sync-test"
+HTTP_PORT = 18933
+API_BASE = "http://127.0.0.1:8273/v1"
+ADMIN_HEADERS = {"X-Muxi-Admin-Key": "test-admin-key-6f4", "Content-Type": "application/json"}
+
+# v2 of the served document. The updated fact sits at the TOP because the
+# knowledge search pipeline previews chunk content (~200 chars) into the
+# agent context; the point of this test is change detection + re-embed,
+# not long-document retrieval.
+UPDATED_CONTENT = """# The Emberfall Chronicle
+
+The current head scribe of the Ashbound is Archivist Pyra Senn,
+appointed in year 512 of the Ashen Calendar.
+
+The Emberfall Chronicle is the fictional record of the volcanic
+city-state of Cindervale, stored in the Basalt Library beneath Mount
+Cinder.
+"""
+
+
+class QuietHTTPRequestHandler(SimpleHTTPRequestHandler):
+    def log_message(self, format, *args):  # noqa: A002 - stdlib signature
+        pass
+
+
+def ensure_secret_links():
+    """Create .key / secrets.enc symlinks if missing (they are gitignored)."""
+    assets = Path(__file__).parent.parent.parent / "assets"
+    for name in (".key", "secrets.enc"):
+        link = FORMATION_DIR / name
+        if not link.exists():
+            if link.is_symlink():
+                link.unlink()
+            link.symlink_to(Path("..") / ".." / ".." / ".." / "assets" / name)
+        assert (assets / name).exists(), f"e2e/assets/{name} missing"
+
+
+def wipe_remote_mirror():
+    """Remove cached knowledge state so the startup sync is exercised cold."""
+    knowledge_cache = Path.home() / ".muxi" / FORMATION_ID / "cache" / "knowledge"
+    if knowledge_cache.exists():
+        shutil.rmtree(knowledge_cache, ignore_errors=True)
+
+
+def start_http_server(webroot: Path):
+    handler = functools.partial(QuietHTTPRequestHandler, directory=str(webroot))
+    server = ThreadingHTTPServer(("127.0.0.1", HTTP_PORT), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+async def trigger_sync(client, agent_id, payload=None):
+    return await client.post(
+        f"{API_BASE}/agents/{agent_id}/knowledge/sync",
+        headers=ADMIN_HEADERS,
+        json=payload or {},
+    )
+
+
+def test_manual_sync_trigger():
+    async def run_test():
+        server = None
+        formation = None
+        webroot = Path(tempfile.mkdtemp(prefix="muxi-6f4-webroot-"))
+        try:
+            print("\n=== Test 6F4: Manual Remote Knowledge Sync Trigger (Admin API) ===")
+
+            ensure_secret_links()
+            wipe_remote_mirror()
+
+            print("\nSeeding webroot and starting local HTTP fixture server...")
+            shutil.copytree(FORMATION_DIR / "remote-content", webroot, dirs_exist_ok=True)
+            served_file = webroot / "kb" / "emberfall-chronicle.md"
+            server = start_http_server(webroot)
+
+            print("Loading formation and starting overlord + API server...")
+            formation = Formation()
+            await formation.load(str(FORMATION_DIR / "formation.yaml"))
+            await formation.start_overlord()
+            await formation.start_server(block=False)
+            await asyncio.sleep(2)
+
+            async with httpx.AsyncClient(timeout=60.0) as client:
+                # 1. Unchanged remote: sync succeeds with zero changes
+                print("\n1. Triggering sync with an unchanged remote...")
+                response = await trigger_sync(client, "chronicler")
+                assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+                data = response.json()["data"]
+                assert data["agent_id"] == "chronicler"
+                result = data["results"][0]
+                assert result["status"] == "success", f"Unexpected result: {result}"
+                assert (
+                    result["files_added"] == 0 and result["files_modified"] == 0
+                ), f"Unchanged remote must not re-download: {result}"
+                print("   Unchanged remote reported zero changes")
+
+                # 2. Remote changes -> manual sync updates mirror + embeddings
+                print("\n2. Updating the remote file and re-triggering the sync...")
+                served_file.write_text(UPDATED_CONTENT, encoding="utf-8")
+                response = await trigger_sync(
+                    client, "chronicler", {"source_id": "emberfall-chronicle"}
+                )
+                assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+                result = response.json()["data"]["results"][0]
+                assert result["status"] == "success", f"Unexpected result: {result}"
+                assert result["files_modified"] == 1, f"Change not detected: {result}"
+                print("   Changed remote re-synced (1 file modified)")
+
+                mirror_root = (
+                    Path.home() / ".muxi" / FORMATION_ID / "cache" / "knowledge" / "remote"
+                )
+                mirrored = list(mirror_root.rglob("emberfall-chronicle.md"))
+                assert mirrored, f"Synced file not found under {mirror_root}"
+                assert "Pyra Senn" in mirrored[0].read_text(
+                    encoding="utf-8"
+                ), "Mirror does not contain the updated content"
+                print("   Mirror updated with the new content")
+
+                # 3. The changed file was re-embedded: the agent must know
+                # the fact that only exists in the post-startup version.
+                print("\n3. Asking the agent about the newly synced fact...")
+                overlord = formation._overlord
+                question = (
+                    "According to your knowledge, who is the current head scribe of "
+                    "the Ashbound and when were they appointed?"
+                )
+                chat_response = await overlord.chat(
+                    question,
+                    agent_name="chronicler",
+                    user_id="test_user",
+                    session_id="test_session_manual_sync",
+                    stream=False,
+                )
+                if isinstance(chat_response, dict):
+                    response_text = chat_response.get("response", str(chat_response))
+                else:
+                    response_text = str(chat_response)
+                print(f"\nUser: {question}")
+                print(f"Chronicler: {response_text}")
+                assert "pyra" in response_text.lower() or "senn" in response_text.lower(), (
+                    "Agent does not know the re-synced fact (re-embedding failed?): "
+                    f"{response_text}"
+                )
+                print("   Agent answered from the re-synced + re-embedded content")
+
+                # 4. Unknown agent / source id -> 404
+                print("\n4. Verifying 404s for unknown agent and source id...")
+                response = await trigger_sync(client, "no-such-agent")
+                assert response.status_code == 404, f"Expected 404, got {response.status_code}"
+                response = await trigger_sync(client, "chronicler", {"source_id": "nope"})
+                assert response.status_code == 404, f"Expected 404, got {response.status_code}"
+                print("   Unknown agent and source id both return 404")
+
+            print("\nTest 6F4 passed: manual sync trigger re-syncs and re-embeds on demand")
+            return True
+
+        except Exception as e:
+            print(f"\nTest 6F4 failed: {str(e)}")
+            import traceback
+
+            traceback.print_exc()
+            return False
+        finally:
+            if formation is not None:
+                try:
+                    await formation.stop_overlord()
+                except Exception:
+                    pass
+            if server is not None:
+                server.shutdown()
+                server.server_close()
+            shutil.rmtree(webroot, ignore_errors=True)
+
+    success = asyncio.run(run_test())
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    import os
+
+    exit_code = test_manual_sync_trigger()
+    if exit_code == 0:
+        print("SUCCESS", flush=True)
+    os._exit(exit_code)

--- a/mental-model.md
+++ b/mental-model.md
@@ -595,13 +595,16 @@ different plan instead of returning the failure. Off by default; enable via
   the for-loop to `asyncio.gather`. There's a `TODO(perf-round-2)`
   comment in `load_sources_from_config` flagging this.
 
-**Remote Knowledge Sources (Phase 1 core sync, 2026-07-09):**
+**Remote Knowledge Sources (Phases 1-4 complete, 2026-07-09):**
 - Agents can declare url-based knowledge sources alongside local paths:
-  `knowledge.sources[*].url` with schemes `http(s)://`, `s3://`,
-  `rsync://`, `rsync+ssh://`, `file://` (bind mounts). Everything lives in
+  `knowledge.sources[*].url` with schemes `http(s)://`, `s3://`, `gs://`,
+  `az://`, `rsync://`, `rsync+ssh://`, `ftp://`, `sftp://`, `file://`
+  (bind mounts). Everything lives in
   `formation/agents/knowledge/remote/`: `handler.py` (ProtocolHandler ABC
-  + `SourceConfig`), `protocols/{http,s3,rsync,file}.py`, `manifest.py`
-  (per-source sync state), `sync.py` (SyncManager orchestration).
+  + `SourceConfig`), `protocols/{http,s3,gcs,azure,rsync,ftp,sftp,file}.py`,
+  `manifest.py` (per-source sync state), `sync.py` (SyncManager
+  orchestration), `extractor.py` (Phase 2 archive extraction),
+  `scheduler.py` (Phase 3 KnowledgeSyncService).
 - **Architecture: mirror-then-ingest.** `KnowledgeHandler.from_agent_config`
   partitions sources; remote ones sync into a local mirror at
   `<get_knowledge_dir()>/remote/<agent_id>/<source_id>/content/` (i.e.
@@ -626,9 +629,74 @@ different plan instead of returning the failure. Off by default; enable via
   `KNOWLEDGE_SYNC_FAILED` event (WARNING-level when stale content
   exists). E2E: `6_knowledge/test_6f2_remote_source_failure_isolation.py`.
 - **Change detection** is protocol-native: HTTP ETag/Last-Modified, S3
-  ETag, file:// size+mtime composite, rsync native delta (`sync_tree`
-  incremental path; the manifest is rebuilt from the local tree after).
-  A missing remote hash forces a re-download (correctness > bandwidth).
+  ETag, GCS Content-MD5, Azure Content-MD5/ETag, ftp/sftp/file://
+  size+mtime composites, rsync native delta (`sync_tree` incremental
+  path; the manifest is rebuilt from the local tree after). A missing
+  remote hash forces a re-download (correctness > bandwidth).
+- **Optional protocol SDKs** ship as pip extras — `muxi-runtime[gcs]`
+  (google-cloud-storage, usually already present via the core
+  google-cloud-aiplatform dependency), `[azure]` (azure-storage-blob),
+  `[sftp]` (paramiko); ftp uses the stdlib. Missing SDKs raise a clear
+  `RemoteSyncError` naming the extra at handler creation (config time),
+  mirroring the boto3/kafka optional-dep pattern. All SDK calls run in
+  `asyncio.to_thread` (they are sync clients).
+- **Archive extraction (Phase 2, `extract: true`).** The source URL must
+  be a single archive (`.zip`, `.tar`, `.tar.gz`/`.tgz`, `.tar.bz2`,
+  `.tar.xz`); `SyncManager._sync_archive` downloads it into a hidden
+  temp dir NEXT TO the mirror (same fs, never ingested, always cleaned
+  up), extracts via `extractor.py::ArchiveExtractor`, then updates the
+  mirror file-by-file (`os.replace`) and diffs against the manifest for
+  per-file change detection (manifest also stores `archive_hash`/`size`
+  so an unchanged archive skips download AND extraction). Security:
+  member names go through the same `safe_relative_path`/`resolve_within`
+  guards as the manifest, symlink/hardlink/device members are rejected,
+  and decompression bombs are bounded by `max_extracted_files` (1000)
+  and `max_extracted_size` (500MB) counted on the DECOMPRESSED stream —
+  a violation aborts the whole extraction, leaving the previous mirror
+  intact (stale-wins). `extract_pattern` filters members; skipped
+  members are never decompressed (don't count against bounds).
+- **Scheduling (Phase 3, `scheduler.py::KnowledgeSyncService`).** NOT a
+  second loop: the overlord (`_initialize_knowledge_sync_service`, right
+  after proactive services) registers the service with
+  `SchedulerService.register_periodic_task` — the same extension point
+  as the proactive heartbeat — when any source has a periodic schedule
+  (cron or `@hourly`/`@daily`/`@weekly`; `@startup`/no schedule =
+  startup-only). `tick()` never raises; croniter computes per-source
+  `next_fire`. Per-source `asyncio.Lock`s skip overlapping syncs
+  (`knowledge.sync.skipped` SystemEvent), shared by scheduled AND manual
+  triggers. Total sync failure retries with exponential backoff (source
+  `retry:` block — max_attempts/initial_delay/max_delay/exponential_base,
+  defaults 3/5s/300s/2), then falls back to the next cron fire; partial
+  syncs don't retry (stale-wins already applied). Schedules declared
+  without a running scheduler degrade to startup-only + init warning
+  (never a startup failure — backward compatible with Phase 1
+  formations).
+- **Incremental re-embedding.** `SyncResult` carries
+  `changed_paths`/`deleted_paths`; after a sync with changes the service
+  calls `KnowledgeHandler.refresh_remote_source`, which removes stale
+  chunks by per-chunk `file_path` metadata (directory-ingested chunks
+  carry it) and re-ingests ONLY the changed files through `add_file`
+  (transient per-file FileKnowledge, popped from `handler.sources`
+  after). The whole mirror is never re-embedded on a one-file change.
+  Re-embed failure is isolated (event + stale embeddings served).
+- **Manual sync trigger**: `POST /v1/agents/{agent_id}/knowledge/sync`
+  (admin routes, `routes/admin/agents.py`; optional `{"source_id": ...}`
+  body) calls `KnowledgeSyncService.sync_now` — same locks, same
+  re-embed path; a source with a sync in flight reports status
+  `skipped`. Works even without the scheduler (the service is created
+  whenever remote sources exist). E2E:
+  `6_knowledge/test_6f4_manual_sync_trigger.py` (also proves the
+  re-embed end-to-end: the agent answers from post-startup content).
+- **WorkingMemory partition-dim fix (found by Phase 3).** FAISS
+  partitions used to be created/rebuilt at the memory-wide `dimension`;
+  knowledge chunks arrive via `add_with_embedding` with PRE-COMPUTED
+  vectors whose dim can differ (e.g. 1536 openai doc embeddings in the
+  768 nomic buffer memory) — writes were silently dropped
+  (`index_count == 0` recency fallback masked it) and the first
+  `_rebuild_index` after a `remove_by_metadata` shape-crashed every
+  vector search. Partitions are now created at the dim of the vectors
+  they store (`_get_partition(dimension=...)`, `_rebuild_index` groups
+  by actual embedding length).
 - **Downloads are atomic** (`atomic_download` in `remote/handler.py`):
   HTTP/S3/file handlers stream into a `.part` temp file in the SAME
   directory as the destination, fsync, then `os.replace`. A mid-stream
@@ -639,31 +707,35 @@ different plan instead of returning the failure. Off by default; enable via
   untrusted: `safe_relative_path` rejects absolute/traversal/backslash
   paths and `resolve_within` re-verifies the resolved (symlink-aware)
   target stays inside the content dir. rsync runs with `--safe-links`.
-- **SSH host keys are strict by default** (rsync+ssh):
-  `StrictHostKeyChecking=yes` — the host must already be in known_hosts
-  or the sync fails, so a MITM on first contact cannot inject knowledge
-  content. `accept_new_host_keys: true` on the source is the explicit
-  opt-in for SSH's trust-on-first-use (`accept-new` still rejects
-  CHANGED keys). Mechanism not policy: safe default, loud escape hatch.
-  The temp file holding `ssh_key` material is 0600 and removed even
-  when setup fails mid-way (write/chmod) — never left behind.
+- **SSH host keys are strict by default** (rsync+ssh AND sftp):
+  `StrictHostKeyChecking=yes` / paramiko `RejectPolicy` — the host must
+  already be in known_hosts or the sync fails, so a MITM on first
+  contact cannot inject knowledge content. `accept_new_host_keys: true`
+  on the source is the explicit opt-in for SSH's trust-on-first-use.
+  Mechanism not policy: safe default, loud escape hatch. The temp file
+  holding rsync `ssh_key` material is 0600 and removed even when setup
+  fails mid-way (write/chmod) — never left behind.
 - **Validation is fail-fast** (`config/validation.py::
-  _validate_remote_knowledge_source`): unsupported/planned schemes
-  (`gs`, `az`, `ftp`, `sftp` are "planned"), glob on http(s)/rsync URLs,
-  malformed auth blocks (`basic`/`bearer` for http, `aws` for s3,
-  `ssh_key` for rsync+ssh), `accept_new_host_keys` outside rsync+ssh,
-  and Phase 2 `extract`/`extract_pattern` keys are load-time errors.
-  For `aws` auth, `access_key`/`secret_key` are both-or-neither —
-  neither means boto3's default credential chain (env vars, instance
-  profile). Credentials flow through the standard `${{ secrets.* }}`
+  _validate_remote_knowledge_source`): unknown schemes, glob on
+  http(s)/rsync URLs (and with `extract`), malformed auth blocks
+  (`basic`/`bearer` for http, `aws` for s3, `gcp` for gs, `azure` for
+  az — REQUIRED for az since the account is not in the URL, `basic` for
+  ftp, `ssh_key`/`basic` for sftp, `ssh_key` for rsync+ssh),
+  `accept_new_host_keys` outside rsync+ssh/sftp, extract options
+  (`extract` boolean, not for rsync; `extract_pattern`/bounds require
+  `extract: true`), and the `retry:` block (allowed keys + ranges) are
+  load-time errors. For `aws` auth, `access_key`/`secret_key` are
+  both-or-neither; `gcp` `credentials_json` is optional (ADC chain).
+  Credentials flow through the standard `${{ secrets.* }}`
   interpolation (resolved before handlers see config).
-- **Phase 1 scope note:** `schedule` is accepted and syntax-validated
-  (cron or `@startup`/`@hourly`/`@daily`/`@weekly`) but periodic re-sync
-  is Phase 3 — every remote source syncs exactly once at formation
-  startup. Archive extraction is Phase 2. HTTP sources are single-file
-  only (no directory listing protocol).
-- Events: `knowledge.sync.started` / `knowledge.sync.completed`
-  (SystemEvents) and `error.knowledge.sync.failed` (ErrorEvents).
+- HTTP sources are single-file only (no directory listing protocol) —
+  which is exactly what archive sources want (`extract: true` over one
+  zip export URL).
+- Events: `knowledge.sync.started` / `knowledge.sync.completed` /
+  `knowledge.sync.skipped` (SystemEvents) and
+  `error.knowledge.sync.failed` (ErrorEvents; also used with
+  `phase: retry_scheduled|retries_exhausted|reingest|tick` data by the
+  Phase 3 scheduler).
 
 **Pre-routing gate ordering (current state, 2026-04-26):**
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,20 @@ kafka = [
     "kafka-python>=2.0.0",  # Kafka streaming support for observability
 ]
 
+# Remote knowledge source protocols (PRD: remote-knowledge-sources).
+# Each extra unlocks one optional protocol handler; the handlers raise a
+# clear config-time error naming the extra when the library is missing.
+# s3:// uses boto3 (already core), ftp:// uses the stdlib.
+gcs = [
+    "google-cloud-storage>=2.14.0",  # gs:// knowledge sources
+]
+azure = [
+    "azure-storage-blob>=12.19.0",  # az:// knowledge sources
+]
+sftp = [
+    "paramiko>=3.4.0",  # sftp:// knowledge sources
+]
+
 # ---------------------------------------------------------------------------
 # Runtime variants
 # ---------------------------------------------------------------------------
@@ -240,6 +254,11 @@ cuda = [
 ]
 
 dev = [
+    # Optional protocol SDKs so the mocked remote-knowledge handler tests
+    # (azure/sftp) execute instead of skipping (gcs ships transitively via
+    # google-cloud-aiplatform in core)
+    "azure-storage-blob>=12.19.0",
+    "paramiko>=3.4.0",
     "pytest>=9.0.3",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0.0",

--- a/src/muxi/runtime/datatypes/api.py
+++ b/src/muxi/runtime/datatypes/api.py
@@ -28,6 +28,7 @@ class APIEventType(str, Enum):
     AGENT_UPDATED = "agent.updated"
     AGENT_DELETED = "agent.deleted"
     AGENT_LIST = "agent.list"
+    AGENT_KNOWLEDGE_SYNCED = "agent.knowledge.synced"
 
     SECRET_CREATED = "secret.created"
     SECRET_RETRIEVED = "secret.retrieved"

--- a/src/muxi/runtime/datatypes/observability.py
+++ b/src/muxi/runtime/datatypes/observability.py
@@ -414,6 +414,10 @@ class SystemEvents(Enum):
     KNOWLEDGE_SYNC_COMPLETED = "knowledge.sync.completed"
     # When a remote knowledge source sync completes (includes partial syncs)
 
+    KNOWLEDGE_SYNC_SKIPPED = "knowledge.sync.skipped"
+    # When a scheduled/manual sync is skipped because a sync for the same
+    # source is still in flight (per-source lock, no overlapping syncs)
+
     # ===================================================================
     # INFRASTRUCTURE MONITORING (MOVED FROM CONVERSATIONEVENTs)
     # ===================================================================

--- a/src/muxi/runtime/formation/agents/knowledge/handler.py
+++ b/src/muxi/runtime/formation/agents/knowledge/handler.py
@@ -1841,6 +1841,93 @@ class KnowledgeHandler:
                 f"{len(knowledge_sources)} sources configured but failed"
             )
 
+    async def refresh_remote_source(
+        self,
+        source_config: Dict[str, Any],
+        changed_files: List[str],
+        deleted_files: List[str],
+    ) -> int:
+        """Re-embed only the files a remote re-sync changed (Phase 3).
+
+        The startup ingestion treats each synced mirror as one directory
+        source; scheduled re-syncs must not re-embed the whole mirror when
+        a single file changes. This removes the stale chunks for the
+        changed/deleted files (matched via per-chunk ``file_path``
+        metadata, which both directory and single-file ingestion record)
+        and re-ingests just the changed files through the standard
+        ``add_file`` pipeline (chunking, tree gate, MD5 dedupe, events).
+
+        Args:
+            source_config: The synthetic local source config of the mirror
+                (``SyncManager.synthetic_local_source``)
+            changed_files: Absolute paths of added/modified mirror files
+            deleted_files: Absolute paths of files removed from the mirror
+
+        Returns:
+            Number of chunks (or tree nodes) added for the changed files
+        """
+        if self.working_memory is None:
+            return 0
+
+        for file_path in {*changed_files, *deleted_files}:
+            abs_path = os.path.abspath(file_path)
+            # Directory-ingested chunks carry source=<mirror dir> but
+            # always record the per-file path; single-file re-ingests
+            # carry source=<file>. Clear both shapes.
+            self.working_memory.remove_by_metadata(
+                metadata_filter={"file_path": abs_path}, namespace=DOCUMENT_NAMESPACE
+            )
+            self.working_memory.remove_by_metadata(
+                metadata_filter={"source": abs_path}, namespace=DOCUMENT_NAMESPACE
+            )
+            self._remove_tree_for(abs_path)
+            cache_file = self._get_cache_file_path(abs_path)
+            if os.path.exists(cache_file):
+                try:
+                    os.remove(cache_file)
+                except OSError:
+                    pass
+
+        generate_embeddings_fn = self._generate_embeddings_fn
+        if generate_embeddings_fn is None:
+            observability.observe(
+                event_type=observability.SystemEvents.KNOWLEDGE_SOURCE_LOADED,
+                level=observability.EventLevel.WARNING,
+                description="Remote refresh has no embedding function - skipping re-embed",
+                data={"source_name": source_config.get("name", "")},
+            )
+            return 0
+
+        chunks_added = 0
+        for file_path in changed_files:
+            if not os.path.isfile(file_path):
+                continue
+            knowledge_source = FileKnowledge(
+                path=file_path,
+                description=source_config.get("description"),
+                name=source_config.get("name"),
+                max_file_size=source_config.get("max_file_size", 10 * 1024 * 1024),
+                recursive=False,
+            )
+            chunks_added += await self.add_file(knowledge_source, generate_embeddings_fn)
+            # Transient per-file source: keep the registered sources list
+            # stable across re-syncs (the mirror's directory source stays).
+            if knowledge_source in self.sources:
+                self.sources.remove(knowledge_source)
+
+        observability.observe(
+            event_type=observability.SystemEvents.KNOWLEDGE_SOURCE_LOADED,
+            level=observability.EventLevel.INFO,
+            description="Remote knowledge changes re-embedded",
+            data={
+                "source_name": source_config.get("name", ""),
+                "files_changed": len(changed_files),
+                "files_deleted": len(deleted_files),
+                "chunks_added": chunks_added,
+            },
+        )
+        return chunks_added
+
     async def _inject_knowledge_into_memory(
         self,
         knowledge_results: List[Dict[str, Any]],

--- a/src/muxi/runtime/formation/agents/knowledge/remote/__init__.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/__init__.py
@@ -2,32 +2,38 @@
 # FRONTMATTER
 # =============================================================================
 # Title:        Remote Knowledge Sources
-# Description:  Sync remote knowledge sources (HTTP, S3, rsync, file) to a
-#               local mirror that feeds the existing knowledge pipeline
-# Role:         Phase 1 core sync infrastructure (PRD: Remote Knowledge Sources)
+# Description:  Sync remote knowledge sources (HTTP, S3, GCS, Azure, rsync,
+#               FTP, SFTP, file) to a local mirror that feeds the existing
+#               knowledge pipeline
+# Role:         Remote knowledge PRD Phases 1-4 (core sync, archive
+#               extraction, scheduling, additional protocols)
 # Usage:        Used by KnowledgeHandler.from_agent_config when an agent
-#               declares url-based knowledge sources
+#               declares url-based knowledge sources; the overlord registers
+#               KnowledgeSyncService for scheduled re-sync + manual triggers
 # Author:       Muxi Framework Team
-#
-# Phase 1 scope: protocol handlers (HTTP, S3, rsync, file), manifest-based
-# change detection, and startup-time sync orchestration. Archive extraction
-# (Phase 2), cron scheduling (Phase 3), and additional protocols (Phase 4)
-# are intentionally out of scope; the module layout leaves seams for them.
 # =============================================================================
 
+from .extractor import ArchiveExtractor, ExtractionResult, is_archive_filename
 from .handler import DownloadResult, ProtocolHandler, RemoteFile, RemoteSyncError
 from .manifest import Manifest, safe_relative_path
+from .scheduler import KnowledgeSyncService, RetryPolicy, resolve_cron_expression
 from .sync import SyncManager, SyncResult, is_remote_source, partition_sources
 
 __all__ = [
+    "ArchiveExtractor",
     "DownloadResult",
+    "ExtractionResult",
+    "KnowledgeSyncService",
     "Manifest",
     "ProtocolHandler",
     "RemoteFile",
     "RemoteSyncError",
+    "RetryPolicy",
     "SyncManager",
     "SyncResult",
+    "is_archive_filename",
     "is_remote_source",
     "partition_sources",
+    "resolve_cron_expression",
     "safe_relative_path",
 ]

--- a/src/muxi/runtime/formation/agents/knowledge/remote/extractor.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/extractor.py
@@ -1,0 +1,227 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Archive Extractor - Remote Knowledge Sources
+# Description:  Safely extracts knowledge archives (zip/tar) into a directory
+# Role:         Phase 2 of the remote knowledge PRD (archive extraction)
+# Usage:        SyncManager extracts downloaded archives when `extract: true`
+# Author:       Muxi Framework Team
+#
+# Security posture (all enforced per member, streaming):
+# - Path traversal: member names are untrusted. safe_relative_path +
+#   resolve_within (the same guards the manifest uses) reject absolute
+#   paths, drive letters, backslashes, and any `..` component, and
+#   re-verify the resolved target stays inside the extraction root.
+# - Symlinks/hardlinks/devices: rejected (skipped and reported). A symlink
+#   member could otherwise alias content outside the extraction root.
+# - Decompression bombs: cumulative extracted bytes and file count are
+#   bounded (`max_extracted_size`, `max_extracted_files`). Bytes are
+#   counted as they are decompressed - header-declared sizes are treated
+#   as hints, never trusted. Exceeding a bound aborts the whole
+#   extraction (RemoteSyncError), so a malicious archive can never
+#   partially ingest.
+# =============================================================================
+
+import os
+import posixpath
+import shutil
+import stat
+import tarfile
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import IO, List, Optional
+
+from .handler import RemoteSyncError, matches_pattern
+from .manifest import resolve_within
+
+# Decompression-bomb bounds. Conservative but roomy: the per-source
+# ingestion limits (max_files / max_total_size) still apply downstream,
+# so these only need to stop pathological archives before they fill the
+# disk. Overridable per source via max_extracted_files / max_extracted_size.
+DEFAULT_MAX_EXTRACTED_FILES = 1000
+DEFAULT_MAX_EXTRACTED_SIZE = 500 * 1024 * 1024  # 500MB
+
+_COPY_CHUNK = 65536
+
+# Recognized archive filename suffixes (PRD section 5). Ordered longest
+# first so `.tar.gz` wins over `.gz`-style suffix probing.
+ARCHIVE_SUFFIXES = (
+    ".tar.gz",
+    ".tar.bz2",
+    ".tar.xz",
+    ".tgz",
+    ".tar",
+    ".zip",
+)
+
+
+def is_archive_filename(name: str) -> bool:
+    """Whether ``name`` looks like a supported archive."""
+    lowered = name.lower()
+    return any(lowered.endswith(suffix) for suffix in ARCHIVE_SUFFIXES)
+
+
+@dataclass
+class ExtractionResult:
+    """Outcome of extracting one archive."""
+
+    files: List[str] = field(default_factory=list)  # rel paths extracted
+    skipped: List[str] = field(default_factory=list)  # unsafe/symlink/filtered members
+    total_size: int = 0  # cumulative extracted bytes
+
+
+class ArchiveExtractor:
+    """Path-traversal-safe, bomb-bounded archive extraction.
+
+    Supports ZIP and TAR (plain, gz, bz2, xz). ``pattern`` is the source's
+    ``extract_pattern`` glob; members not matching it are skipped (not
+    counted against the bomb bounds - they are never decompressed).
+    """
+
+    def __init__(
+        self,
+        pattern: Optional[str] = None,
+        max_files: int = DEFAULT_MAX_EXTRACTED_FILES,
+        max_total_size: int = DEFAULT_MAX_EXTRACTED_SIZE,
+    ):
+        self.pattern = pattern
+        self.max_files = max_files
+        self.max_total_size = max_total_size
+
+    def extract(self, archive_path: Path, dest_dir: Path) -> ExtractionResult:
+        """Extract ``archive_path`` into ``dest_dir`` (created if missing).
+
+        Returns the list of extracted rel paths; raises RemoteSyncError on
+        unsupported formats, corrupt archives, or bomb-bound violations.
+        """
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        name = archive_path.name.lower()
+        try:
+            if name.endswith(".zip"):
+                return self._extract_zip(archive_path, dest_dir)
+            if name.endswith((".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tar.xz")):
+                return self._extract_tar(archive_path, dest_dir)
+        except (zipfile.BadZipFile, tarfile.TarError, EOFError, OSError) as e:
+            raise RemoteSyncError(f"Failed to extract archive {archive_path.name}: {e}") from e
+        raise RemoteSyncError(
+            f"Unsupported archive format: {archive_path.name} "
+            f"(supported: {', '.join(ARCHIVE_SUFFIXES)})"
+        )
+
+    # ------------------------------------------------------------------
+    # Format-specific extraction
+    # ------------------------------------------------------------------
+
+    def _extract_zip(self, archive_path: Path, dest_dir: Path) -> ExtractionResult:
+        result = ExtractionResult()
+        with zipfile.ZipFile(archive_path) as archive:
+            for info in archive.infolist():
+                if info.is_dir():
+                    continue
+                # Unix mode lives in the high 16 bits of external_attr.
+                # Reject any member whose file-type bits declare a
+                # non-regular file (symlink members are the classic escape
+                # vector). Members without type bits (Windows-produced
+                # zips) are treated as regular files.
+                file_type = stat.S_IFMT(info.external_attr >> 16)
+                if file_type and file_type != stat.S_IFREG:
+                    result.skipped.append(info.filename)
+                    continue
+                target = self._member_target(info.filename, dest_dir, result)
+                if target is None:
+                    continue
+                with archive.open(info) as src:
+                    self._copy_bounded(src, target, result, info.filename)
+        return result
+
+    def _extract_tar(self, archive_path: Path, dest_dir: Path) -> ExtractionResult:
+        result = ExtractionResult()
+        with tarfile.open(archive_path, mode="r:*") as archive:
+            for member in archive:
+                if member.isdir():
+                    continue
+                # Symlinks, hardlinks, devices, FIFOs: rejected. Only
+                # regular file members are ever written to disk.
+                if not member.isreg():
+                    result.skipped.append(member.name)
+                    continue
+                target = self._member_target(member.name, dest_dir, result)
+                if target is None:
+                    continue
+                src = archive.extractfile(member)
+                if src is None:
+                    result.skipped.append(member.name)
+                    continue
+                with src:
+                    self._copy_bounded(src, target, result, member.name)
+        return result
+
+    # ------------------------------------------------------------------
+    # Shared member handling
+    # ------------------------------------------------------------------
+
+    def _member_target(
+        self, member_name: str, dest_dir: Path, result: ExtractionResult
+    ) -> Optional[str]:
+        """Resolve a member's safe target path; None to skip the member.
+
+        Normalization keeps benign internal ``a/./b`` shapes working while
+        absolute names and any net-``..`` traversal are rejected by the
+        resolve_within/safe_relative_path guards.
+        """
+        rel_path = posixpath.normpath(member_name)
+        if self.pattern and not matches_pattern(rel_path, self.pattern):
+            result.skipped.append(member_name)
+            return None
+        # Untrusted member name: must resolve inside the extraction root
+        # (rejects traversal, absolute paths, backslashes, drive letters).
+        target = resolve_within(str(dest_dir), rel_path)
+        if target is None:
+            result.skipped.append(member_name)
+            return None
+        if len(result.files) + 1 > self.max_files:
+            raise RemoteSyncError(
+                f"Archive exceeds max_extracted_files ({self.max_files}); "
+                "aborting extraction (possible decompression bomb)"
+            )
+        result.files.append(rel_path)
+        return target
+
+    def _copy_bounded(
+        self, src: IO[bytes], target: str, result: ExtractionResult, member_name: str
+    ) -> None:
+        """Stream-copy a member, enforcing the cumulative size bound.
+
+        Bytes are counted as decompressed - never trusted from headers. On
+        violation the partially written tree is removed by the caller's
+        temp-dir cleanup; here we just abort loudly.
+        """
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, "wb") as out:
+            while True:
+                chunk = src.read(_COPY_CHUNK)
+                if not chunk:
+                    break
+                result.total_size += len(chunk)
+                if result.total_size > self.max_total_size:
+                    out.close()
+                    self._remove_quietly(target)
+                    raise RemoteSyncError(
+                        f"Archive exceeds max_extracted_size ({self.max_total_size} bytes) "
+                        f"while extracting '{member_name}'; aborting extraction "
+                        "(possible decompression bomb)"
+                    )
+                out.write(chunk)
+
+    @staticmethod
+    def _remove_quietly(path: str) -> None:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
+def cleanup_dir(path: str) -> None:
+    """Best-effort recursive removal of a temp extraction directory."""
+    shutil.rmtree(path, ignore_errors=True)

--- a/src/muxi/runtime/formation/agents/knowledge/remote/handler.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/handler.py
@@ -36,6 +36,12 @@ DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
 DEFAULT_MAX_TOTAL_SIZE = 100 * 1024 * 1024  # 100MB
 DEFAULT_SYNC_TIMEOUT = 300  # seconds
 
+# Default retry policy for scheduled re-syncs (PRD section 9).
+DEFAULT_RETRY_MAX_ATTEMPTS = 3
+DEFAULT_RETRY_INITIAL_DELAY = 5.0  # seconds
+DEFAULT_RETRY_MAX_DELAY = 300.0  # seconds
+DEFAULT_RETRY_EXPONENTIAL_BASE = 2.0
+
 
 class RemoteSyncError(Exception):
     """Raised when a remote knowledge source operation fails."""
@@ -92,10 +98,20 @@ class SourceConfig:
     max_file_size: int = DEFAULT_MAX_FILE_SIZE
     max_total_size: int = DEFAULT_MAX_TOTAL_SIZE
     timeout: int = DEFAULT_SYNC_TIMEOUT
-    # rsync+ssh only: opt into SSH's trust-on-first-use for unknown host
-    # keys (StrictHostKeyChecking=accept-new). Default is strict: the
+    # rsync+ssh / sftp only: opt into SSH's trust-on-first-use for unknown
+    # host keys (StrictHostKeyChecking=accept-new). Default is strict: the
     # host must already be in known_hosts or the sync fails.
     accept_new_host_keys: bool = False
+    # Archive extraction (Phase 2). When True the source URL points at a
+    # single archive; its extracted contents (optionally filtered by
+    # extract_pattern) become the source's files. Extraction is bounded
+    # by max_extracted_files / max_extracted_size (decompression bombs).
+    extract: bool = False
+    extract_pattern: Optional[str] = None
+    max_extracted_files: int = 0  # 0 -> extractor default
+    max_extracted_size: int = 0  # 0 -> extractor default
+    # Scheduled re-sync retry policy (Phase 3, PRD section 9).
+    retry: Dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, config: Dict[str, Any]) -> "SourceConfig":
@@ -114,6 +130,11 @@ class SourceConfig:
             max_total_size=int(config.get("max_total_size", DEFAULT_MAX_TOTAL_SIZE)),
             timeout=int(config.get("timeout", DEFAULT_SYNC_TIMEOUT)),
             accept_new_host_keys=bool(config.get("accept_new_host_keys", False)),
+            extract=bool(config.get("extract", False)),
+            extract_pattern=config.get("extract_pattern") or None,
+            max_extracted_files=int(config.get("max_extracted_files", 0) or 0),
+            max_extracted_size=int(config.get("max_extracted_size", 0) or 0),
+            retry=config.get("retry") or {},
         )
 
 

--- a/src/muxi/runtime/formation/agents/knowledge/remote/manifest.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/manifest.py
@@ -90,6 +90,11 @@ class Manifest:
     last_sync_duration_ms: int = 0
     last_sync_status: str = "never"  # never | success | partial | failed
     last_sync_error: str = ""
+    # Archive sources (Phase 2): change token + size of the last archive
+    # successfully downloaded AND extracted. An unchanged archive skips
+    # both the download and the re-extraction.
+    archive_hash: str = ""
+    archive_size: int = 0
     files: Dict[str, FileRecord] = field(default_factory=dict)
 
     @property
@@ -154,6 +159,8 @@ class Manifest:
         manifest.last_sync_duration_ms = int(data.get("last_sync_duration_ms", 0) or 0)
         manifest.last_sync_status = str(data.get("last_sync_status", "never"))
         manifest.last_sync_error = str(data.get("last_sync_error", ""))
+        manifest.archive_hash = str(data.get("archive_hash", ""))
+        manifest.archive_size = int(data.get("archive_size", 0) or 0)
 
         raw_files = data.get("files", {})
         if isinstance(raw_files, dict):
@@ -177,6 +184,8 @@ class Manifest:
             "last_sync_duration_ms": self.last_sync_duration_ms,
             "last_sync_status": self.last_sync_status,
             "last_sync_error": self.last_sync_error,
+            "archive_hash": self.archive_hash,
+            "archive_size": self.archive_size,
             "files": {rel: asdict(record) for rel, record in self.files.items()},
             "stats": self.stats,
         }

--- a/src/muxi/runtime/formation/agents/knowledge/remote/protocols/__init__.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/protocols/__init__.py
@@ -7,21 +7,21 @@
 # Usage:        SyncManager calls create_handler(source_config)
 # Author:       Muxi Framework Team
 #
-# Phase 1 protocols: http(s), s3, rsync(+ssh), file. Phase 4 protocols
-# (gs, az, ftp, sftp) are declared in PLANNED_SCHEMES so config validation
-# can distinguish "not yet supported" from "unknown scheme".
+# Protocol auto-detection: the URL scheme picks the handler. Handler
+# imports are local so optional/heavy protocol dependencies (boto3,
+# google-cloud-storage, azure-storage-blob, paramiko) are only touched
+# when a formation actually declares that protocol; missing optional
+# dependencies raise a clear RemoteSyncError naming the install extra.
 # =============================================================================
 
 from urllib.parse import urlparse
 
 from ..handler import ProtocolHandler, RemoteSyncError, SourceConfig
 
-# Schemes implemented in Phase 1
-SUPPORTED_SCHEMES = frozenset({"http", "https", "s3", "rsync", "rsync+ssh", "file"})
-
-# Schemes on the roadmap (PRD Phase 4) - rejected at validation time with
-# a "planned" message rather than "unknown scheme"
-PLANNED_SCHEMES = frozenset({"gs", "az", "ftp", "sftp"})
+# Every scheme with a shipped handler (PRD Phases 1 + 4)
+SUPPORTED_SCHEMES = frozenset(
+    {"http", "https", "s3", "gs", "az", "rsync", "rsync+ssh", "ftp", "sftp", "file"}
+)
 
 
 def get_url_scheme(url: str) -> str:
@@ -45,10 +45,26 @@ def create_handler(config: SourceConfig) -> ProtocolHandler:
         from .s3 import S3Handler
 
         return S3Handler(config)
+    if scheme == "gs":
+        from .gcs import GCSHandler
+
+        return GCSHandler(config)
+    if scheme == "az":
+        from .azure import AzureHandler
+
+        return AzureHandler(config)
     if scheme in ("rsync", "rsync+ssh"):
         from .rsync import RsyncHandler
 
         return RsyncHandler(config)
+    if scheme == "ftp":
+        from .ftp import FTPHandler
+
+        return FTPHandler(config)
+    if scheme == "sftp":
+        from .sftp import SFTPHandler
+
+        return SFTPHandler(config)
     if scheme == "file":
         from .file import FileHandler
 
@@ -60,7 +76,6 @@ def create_handler(config: SourceConfig) -> ProtocolHandler:
 
 
 __all__ = [
-    "PLANNED_SCHEMES",
     "SUPPORTED_SCHEMES",
     "create_handler",
     "get_url_scheme",

--- a/src/muxi/runtime/formation/agents/knowledge/remote/protocols/azure.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/protocols/azure.py
@@ -1,0 +1,200 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Azure Handler - Remote Knowledge Sources
+# Description:  Syncs knowledge files from Azure Blob Storage containers
+# Role:         Protocol handler for az:// sources (PRD Phase 4)
+# Usage:        Created by the protocol registry for az:// source URLs
+# Author:       Muxi Framework Team
+#
+# Uses azure-storage-blob (optional dependency, `muxi-runtime[azure]`
+# extra) dispatched to worker threads - the sync SDK must never block the
+# event loop. Change detection uses the blob's Content-MD5 (ETag
+# fallback).
+#
+# URL shape: az://<container>/<prefix-or-blob>. The storage ACCOUNT is
+# not part of the URL - it comes from the required ``auth`` block
+# (validated at config load time):
+#   auth: {type: azure, connection_string: $AZ_CONN}
+#   auth: {type: azure, account_name: acme, account_key: $AZ_KEY}
+# =============================================================================
+
+import asyncio
+import posixpath
+from pathlib import Path
+from typing import Any, List, Optional
+from urllib.parse import urlparse
+
+from ..handler import (
+    DownloadResult,
+    ProtocolHandler,
+    RemoteFile,
+    RemoteSyncError,
+    SourceConfig,
+    atomic_download,
+    hash_file_sha256,
+    matches_pattern,
+)
+
+try:  # pragma: no cover - import guard mirrors the boto3 optional-dep pattern
+    from azure.storage.blob import BlobServiceClient
+
+    AZURE_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    BlobServiceClient = None
+    AZURE_AVAILABLE = False
+
+_COPY_CHUNK = 65536
+
+
+class AzureHandler(ProtocolHandler):
+    """Protocol handler for az:// knowledge sources (Azure Blob Storage)."""
+
+    def __init__(self, config: SourceConfig):
+        super().__init__(config)
+        if not AZURE_AVAILABLE:
+            raise RemoteSyncError(
+                "az:// knowledge sources require the azure-storage-blob library. "
+                "Install it with: pip install 'muxi-runtime[azure]' "
+                "(or pip install azure-storage-blob)"
+            )
+        self._service_client: Optional[Any] = None
+
+    async def list_files(self, url: str, pattern: Optional[str] = None) -> List[RemoteFile]:
+        container, prefix = _parse_az_url(url)
+        return await asyncio.to_thread(self._list_files_sync, container, prefix, pattern)
+
+    async def download_file(self, url: str, dest: Path) -> DownloadResult:
+        container, blob_name = _parse_az_url(url)
+        return await asyncio.to_thread(self._download_sync, container, blob_name, dest)
+
+    async def get_file_hash(self, url: str) -> str:
+        container, blob_name = _parse_az_url(url)
+        return await asyncio.to_thread(self._head_hash_sync, container, blob_name)
+
+    async def close(self) -> None:
+        client, self._service_client = self._service_client, None
+        if client is not None:
+            try:
+                await asyncio.to_thread(client.close)
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
+    # Internals (run in a worker thread)
+    # ------------------------------------------------------------------
+
+    def _get_service_client(self) -> Any:
+        if self._service_client is None:
+            auth = self.config.auth or {}
+            connection_string = auth.get("connection_string")
+            if connection_string:
+                self._service_client = BlobServiceClient.from_connection_string(connection_string)
+            elif auth.get("account_name") and auth.get("account_key"):
+                account_url = f"https://{auth['account_name']}.blob.core.windows.net"
+                self._service_client = BlobServiceClient(
+                    account_url=account_url, credential=auth["account_key"]
+                )
+            else:
+                # Config validation requires the auth block, so this is a
+                # defensive guard for programmatic misuse only.
+                raise RemoteSyncError(
+                    "az:// knowledge sources require auth with a connection_string "
+                    "or account_name + account_key"
+                )
+        return self._service_client
+
+    def _list_files_sync(
+        self, container: str, prefix: str, pattern: Optional[str]
+    ) -> List[RemoteFile]:
+        client = self._get_service_client().get_container_client(container)
+        results: List[RemoteFile] = []
+        try:
+            for blob in client.list_blobs(name_starts_with=prefix or None):
+                name = blob.name
+                if name.endswith("/"):
+                    continue
+                rel_path = name.removeprefix(prefix).lstrip("/") if prefix else name
+                if not rel_path:
+                    rel_path = posixpath.basename(name)
+                if pattern and not matches_pattern(rel_path, pattern):
+                    continue
+                results.append(
+                    RemoteFile(
+                        path=rel_path,
+                        url=f"az://{container}/{name}",
+                        size=int(blob.size or 0),
+                        remote_hash=_change_token(blob),
+                    )
+                )
+        except Exception as e:
+            raise RemoteSyncError(f"Failed to list az://{container}/{prefix}: {e}") from e
+        return results
+
+    def _download_sync(self, container: str, blob_name: str, dest: Path) -> DownloadResult:
+        client = self._get_service_client().get_blob_client(container, blob_name)
+        max_size = self.config.max_file_size
+        # Stream into a temp file and atomically swap it in on success: a
+        # mid-transfer failure must never truncate a previously synced
+        # good copy (see atomic_download in handler.py).
+        with atomic_download(dest) as tmp_path:
+            try:
+                properties = client.get_blob_properties()
+                size = int(properties.size or 0)
+                if size > max_size:
+                    raise RemoteSyncError(
+                        f"Remote file exceeds max_file_size "
+                        f"({size} > {max_size}): az://{container}/{blob_name}"
+                    )
+                downloader = client.download_blob()
+                written = 0
+                with open(tmp_path, "wb") as f:
+                    for chunk in downloader.chunks():
+                        written += len(chunk)
+                        if written > max_size:
+                            raise RemoteSyncError(
+                                f"Remote file exceeds max_file_size "
+                                f"({written} > {max_size}): az://{container}/{blob_name}"
+                            )
+                        f.write(chunk)
+            except RemoteSyncError:
+                raise
+            except Exception as e:
+                raise RemoteSyncError(
+                    f"Failed to download az://{container}/{blob_name}: {e}"
+                ) from e
+        return DownloadResult(
+            path=dest.name,
+            local_path=dest,
+            size=written,
+            local_hash=hash_file_sha256(dest),
+        )
+
+    def _head_hash_sync(self, container: str, blob_name: str) -> str:
+        client = self._get_service_client().get_blob_client(container, blob_name)
+        try:
+            properties = client.get_blob_properties()
+        except Exception:
+            return ""
+        return _change_token(properties) or ""
+
+
+def _parse_az_url(url: str) -> tuple:
+    """Split az://container/blob-or-prefix into (container, blob)."""
+    parsed = urlparse(url)
+    container = parsed.netloc
+    if not container:
+        raise RemoteSyncError(f"az:// knowledge source URL is missing a container: {url}")
+    return container, parsed.path.lstrip("/")
+
+
+def _change_token(blob: Any) -> Optional[str]:
+    """Content-MD5 change token with ETag fallback."""
+    settings = getattr(blob, "content_settings", None)
+    content_md5 = getattr(settings, "content_md5", None) if settings else None
+    if content_md5:
+        return f"md5:{bytes(content_md5).hex()}"
+    etag = getattr(blob, "etag", None)
+    if etag:
+        return f"etag:{str(etag).strip(chr(34))}"
+    return None

--- a/src/muxi/runtime/formation/agents/knowledge/remote/protocols/ftp.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/protocols/ftp.py
@@ -1,0 +1,260 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        FTP Handler - Remote Knowledge Sources
+# Description:  Syncs knowledge files from FTP servers
+# Role:         Protocol handler for ftp:// sources (PRD Phase 4)
+# Usage:        Created by the protocol registry for ftp:// source URLs
+# Author:       Muxi Framework Team
+#
+# Uses the stdlib ftplib (no extra dependency) dispatched to worker
+# threads. Change detection is a size + mtime composite (MLSD facts, with
+# SIZE/MDTM fallback for servers without MLSD) - FTP exposes no content
+# hashes, so a missing token simply re-downloads (correctness over
+# bandwidth, same policy as the other handlers).
+#
+# Auth: ``auth: {type: basic, username, password}`` (already
+# secret-interpolated), URL userinfo (ftp://user:pass@host/), or
+# anonymous when neither is present.
+# =============================================================================
+
+import asyncio
+import ftplib
+import posixpath
+from pathlib import Path
+from typing import List, Optional, Tuple
+from urllib.parse import unquote, urlparse
+
+from ..handler import (
+    DownloadResult,
+    ProtocolHandler,
+    RemoteFile,
+    RemoteSyncError,
+    atomic_download,
+    hash_file_sha256,
+    matches_pattern,
+)
+
+# Hard cap on directory entries visited during a recursive listing so a
+# pathological/hostile server cannot spin the walk forever.
+MAX_LIST_ENTRIES = 10000
+
+
+class FTPHandler(ProtocolHandler):
+    """Protocol handler for ftp:// knowledge sources."""
+
+    async def list_files(self, url: str, pattern: Optional[str] = None) -> List[RemoteFile]:
+        return await asyncio.to_thread(self._list_files_sync, url, pattern)
+
+    async def download_file(self, url: str, dest: Path) -> DownloadResult:
+        return await asyncio.to_thread(self._download_sync, url, dest)
+
+    async def get_file_hash(self, url: str) -> str:
+        return await asyncio.to_thread(self._head_hash_sync, url)
+
+    # ------------------------------------------------------------------
+    # Internals (run in a worker thread)
+    # ------------------------------------------------------------------
+
+    def _connect(self, parsed) -> ftplib.FTP:
+        host = parsed.hostname or ""
+        if not host:
+            raise RemoteSyncError("ftp:// knowledge source URL is missing a host")
+        auth = self.config.auth or {}
+        username = auth.get("username") or (
+            unquote(parsed.username) if parsed.username else "anonymous"
+        )
+        password = auth.get("password") or (
+            unquote(parsed.password) if parsed.password else "anonymous@"
+        )
+        try:
+            ftp = ftplib.FTP(timeout=self.config.timeout)
+            ftp.connect(host, parsed.port or 21)
+            ftp.login(username, password)
+        except (ftplib.all_errors, OSError) as e:
+            raise RemoteSyncError(f"Failed to connect to ftp://{host}: {e}") from e
+        return ftp
+
+    def _list_files_sync(self, url: str, pattern: Optional[str]) -> List[RemoteFile]:
+        parsed = urlparse(url)
+        base_path = unquote(parsed.path) or "/"
+        ftp = self._connect(parsed)
+        try:
+            results: List[RemoteFile] = []
+            if self._is_file(ftp, base_path):
+                size, token = self._probe_file(ftp, base_path)
+                rel_path = posixpath.basename(base_path.rstrip("/"))
+                if not pattern or matches_pattern(rel_path, pattern):
+                    results.append(
+                        RemoteFile(
+                            path=rel_path,
+                            url=self._file_url(parsed, base_path),
+                            size=size if size >= 0 else None,
+                            remote_hash=token,
+                        )
+                    )
+                return results
+
+            entries: List[Tuple[str, int, Optional[str]]] = []
+            base_dir = base_path.rstrip("/") or "/"
+            self._walk(ftp, base_dir, "", entries)
+            for rel_path, size, token in entries:
+                if pattern and not matches_pattern(rel_path, pattern):
+                    continue
+                results.append(
+                    RemoteFile(
+                        path=rel_path,
+                        url=self._file_url(parsed, posixpath.join(base_dir, rel_path)),
+                        size=size if size >= 0 else None,
+                        remote_hash=token,
+                    )
+                )
+            return results
+        except ftplib.all_errors as e:
+            raise RemoteSyncError(f"Failed to list ftp source {url}: {e}") from e
+        finally:
+            self._quit(ftp)
+
+    def _walk(
+        self,
+        ftp: ftplib.FTP,
+        directory: str,
+        rel_prefix: str,
+        entries: List[Tuple[str, int, Optional[str]]],
+    ) -> None:
+        """Recursively collect (rel_path, size, token) under ``directory``."""
+        if len(entries) > MAX_LIST_ENTRIES:
+            raise RemoteSyncError(
+                f"ftp listing exceeded {MAX_LIST_ENTRIES} entries; refusing to continue"
+            )
+        try:
+            listing = list(ftp.mlsd(directory, facts=["type", "size", "modify"]))
+        except (ftplib.error_perm, AttributeError):
+            listing = None
+
+        if listing is not None:
+            for name, facts in listing:
+                if name in (".", ".."):
+                    continue
+                entry_type = (facts.get("type") or "").lower()
+                rel_path = posixpath.join(rel_prefix, name) if rel_prefix else name
+                if entry_type == "dir":
+                    self._walk(ftp, posixpath.join(directory, name), rel_path, entries)
+                elif entry_type == "file":
+                    size = int(facts.get("size", -1) or -1)
+                    modify = facts.get("modify", "")
+                    token = f"stat:{size}:{modify}" if size >= 0 and modify else None
+                    entries.append((rel_path, size, token))
+                # links and special entries are ignored
+            return
+
+        # MLSD unsupported: NLST + probe each entry (file via SIZE, dir
+        # via a recursive walk attempt).
+        try:
+            names = ftp.nlst(directory)
+        except ftplib.error_perm as e:
+            # Empty directory on some servers responds 550
+            if str(e).startswith("550"):
+                return
+            raise
+        for full_name in names:
+            name = posixpath.basename(full_name.rstrip("/"))
+            if not name or name in (".", ".."):
+                continue
+            full_path = posixpath.join(directory, name)
+            rel_path = posixpath.join(rel_prefix, name) if rel_prefix else name
+            if self._is_file(ftp, full_path):
+                size, token = self._probe_file(ftp, full_path)
+                entries.append((rel_path, size, token))
+            else:
+                self._walk(ftp, full_path, rel_path, entries)
+
+    @staticmethod
+    def _is_file(ftp: ftplib.FTP, path: str) -> bool:
+        """Whether ``path`` is a regular file (SIZE succeeds on files only)."""
+        try:
+            ftp.voidcmd("TYPE I")
+            return ftp.size(path) is not None
+        except ftplib.all_errors:
+            return False
+
+    @staticmethod
+    def _probe_file(ftp: ftplib.FTP, path: str) -> Tuple[int, Optional[str]]:
+        """(size, change token) for a single file via SIZE + MDTM."""
+        size = -1
+        modify = ""
+        try:
+            ftp.voidcmd("TYPE I")
+            size = ftp.size(path) or -1
+        except ftplib.all_errors:
+            pass
+        try:
+            response = ftp.voidcmd(f"MDTM {path}")
+            modify = response.split(maxsplit=1)[1] if " " in response else ""
+        except ftplib.all_errors:
+            pass
+        token = f"stat:{size}:{modify}" if size >= 0 and modify else None
+        return size, token
+
+    def _download_sync(self, url: str, dest: Path) -> DownloadResult:
+        parsed = urlparse(url)
+        path = unquote(parsed.path)
+        max_size = self.config.max_file_size
+        ftp = self._connect(parsed)
+        try:
+            # Stream into a temp file and atomically swap it in on
+            # success (see atomic_download in handler.py).
+            with atomic_download(dest) as tmp_path:
+                written = 0
+                with open(tmp_path, "wb") as f:
+
+                    def _write(chunk: bytes) -> None:
+                        nonlocal written
+                        written += len(chunk)
+                        if written > max_size:
+                            raise RemoteSyncError(
+                                f"Remote file exceeds max_file_size "
+                                f"({written} > {max_size}): {url}"
+                            )
+                        f.write(chunk)
+
+                    try:
+                        ftp.retrbinary(f"RETR {path}", _write)
+                    except RemoteSyncError:
+                        raise
+                    except ftplib.all_errors as e:
+                        raise RemoteSyncError(f"Failed to download {url}: {e}") from e
+        finally:
+            self._quit(ftp)
+        return DownloadResult(
+            path=dest.name,
+            local_path=dest,
+            size=written,
+            local_hash=hash_file_sha256(dest),
+        )
+
+    def _head_hash_sync(self, url: str) -> str:
+        parsed = urlparse(url)
+        ftp = self._connect(parsed)
+        try:
+            _, token = self._probe_file(ftp, unquote(parsed.path))
+            return token or ""
+        finally:
+            self._quit(ftp)
+
+    @staticmethod
+    def _file_url(parsed, file_path: str) -> str:
+        """Rebuild a per-file ftp:// URL (credentials stay in config)."""
+        host = parsed.hostname or ""
+        port = f":{parsed.port}" if parsed.port else ""
+        return f"ftp://{host}{port}{file_path}"
+
+    @staticmethod
+    def _quit(ftp: ftplib.FTP) -> None:
+        try:
+            ftp.quit()
+        except ftplib.all_errors:
+            try:
+                ftp.close()
+            except OSError:
+                pass

--- a/src/muxi/runtime/formation/agents/knowledge/remote/protocols/gcs.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/protocols/gcs.py
@@ -1,0 +1,174 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        GCS Handler - Remote Knowledge Sources
+# Description:  Syncs knowledge files from Google Cloud Storage buckets
+# Role:         Protocol handler for gs:// sources (PRD Phase 4)
+# Usage:        Created by the protocol registry for gs:// source URLs
+# Author:       Muxi Framework Team
+#
+# Uses google-cloud-storage (a transitive dependency of the core
+# google-cloud-aiplatform requirement, and available standalone via the
+# `muxi-runtime[gcs]` extra) dispatched to worker threads - the SDK is
+# synchronous and must never block the event loop. Change detection uses
+# the blob's Content-MD5.
+#
+# Auth: optional ``auth: {type: gcp, credentials_json: <service account
+# JSON>}`` block (already secret-interpolated). Without it, Google's
+# Application Default Credentials chain applies (env var, metadata
+# server, gcloud login).
+# =============================================================================
+
+import asyncio
+import posixpath
+from pathlib import Path
+from typing import Any, List, Optional
+from urllib.parse import urlparse
+
+from ..handler import (
+    DownloadResult,
+    ProtocolHandler,
+    RemoteFile,
+    RemoteSyncError,
+    SourceConfig,
+    atomic_download,
+    hash_file_sha256,
+    matches_pattern,
+)
+
+try:  # pragma: no cover - import guard mirrors the boto3 optional-dep pattern
+    from google.cloud import storage as gcs_storage
+
+    GCS_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    gcs_storage = None
+    GCS_AVAILABLE = False
+
+
+class GCSHandler(ProtocolHandler):
+    """Protocol handler for gs:// knowledge sources."""
+
+    def __init__(self, config: SourceConfig):
+        super().__init__(config)
+        if not GCS_AVAILABLE:
+            raise RemoteSyncError(
+                "gs:// knowledge sources require the google-cloud-storage library. "
+                "Install it with: pip install 'muxi-runtime[gcs]' "
+                "(or pip install google-cloud-storage)"
+            )
+        self._client: Optional[Any] = None
+
+    async def list_files(self, url: str, pattern: Optional[str] = None) -> List[RemoteFile]:
+        bucket, prefix = _parse_gs_url(url)
+        return await asyncio.to_thread(self._list_files_sync, bucket, prefix, pattern)
+
+    async def download_file(self, url: str, dest: Path) -> DownloadResult:
+        bucket, key = _parse_gs_url(url)
+        return await asyncio.to_thread(self._download_sync, bucket, key, dest)
+
+    async def get_file_hash(self, url: str) -> str:
+        bucket, key = _parse_gs_url(url)
+        return await asyncio.to_thread(self._head_hash_sync, bucket, key)
+
+    # ------------------------------------------------------------------
+    # Internals (run in a worker thread)
+    # ------------------------------------------------------------------
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            auth = self.config.auth or {}
+            credentials_json = auth.get("credentials_json")
+            if (auth.get("type") or "").lower() == "gcp" and credentials_json:
+                import json
+
+                from google.oauth2 import service_account
+
+                info = json.loads(credentials_json)
+                credentials = service_account.Credentials.from_service_account_info(info)
+                self._client = gcs_storage.Client(
+                    credentials=credentials, project=info.get("project_id")
+                )
+            else:
+                # Application Default Credentials chain
+                self._client = gcs_storage.Client()
+        return self._client
+
+    def _list_files_sync(
+        self, bucket: str, prefix: str, pattern: Optional[str]
+    ) -> List[RemoteFile]:
+        client = self._get_client()
+        results: List[RemoteFile] = []
+        try:
+            for blob in client.list_blobs(bucket, prefix=prefix or None):
+                name = blob.name
+                if name.endswith("/"):
+                    continue  # zero-byte "directory" marker
+                rel_path = name.removeprefix(prefix).lstrip("/") if prefix else name
+                if not rel_path:
+                    rel_path = posixpath.basename(name)
+                if pattern and not matches_pattern(rel_path, pattern):
+                    continue
+                results.append(
+                    RemoteFile(
+                        path=rel_path,
+                        url=f"gs://{bucket}/{name}",
+                        size=int(blob.size or 0),
+                        remote_hash=_md5_token(blob.md5_hash) or _etag_token(blob.etag),
+                    )
+                )
+        except Exception as e:
+            raise RemoteSyncError(f"Failed to list gs://{bucket}/{prefix}: {e}") from e
+        return results
+
+    def _download_sync(self, bucket: str, key: str, dest: Path) -> DownloadResult:
+        client = self._get_client()
+        # Download into a temp file and atomically swap it in on success:
+        # a mid-transfer failure must never truncate a previously synced
+        # good copy (see atomic_download in handler.py).
+        with atomic_download(dest) as tmp_path:
+            try:
+                blob = client.bucket(bucket).blob(key)
+                blob.reload()
+                size = int(blob.size or 0)
+                if size > self.config.max_file_size:
+                    raise RemoteSyncError(
+                        f"Remote file exceeds max_file_size "
+                        f"({size} > {self.config.max_file_size}): gs://{bucket}/{key}"
+                    )
+                blob.download_to_filename(str(tmp_path))
+            except RemoteSyncError:
+                raise
+            except Exception as e:
+                raise RemoteSyncError(f"Failed to download gs://{bucket}/{key}: {e}") from e
+        return DownloadResult(
+            path=dest.name,
+            local_path=dest,
+            size=size,
+            local_hash=hash_file_sha256(dest),
+        )
+
+    def _head_hash_sync(self, bucket: str, key: str) -> str:
+        client = self._get_client()
+        try:
+            blob = client.bucket(bucket).blob(key)
+            blob.reload()
+        except Exception:
+            return ""
+        return _md5_token(blob.md5_hash) or _etag_token(blob.etag) or ""
+
+
+def _parse_gs_url(url: str) -> tuple:
+    """Split gs://bucket/key-or-prefix into (bucket, key)."""
+    parsed = urlparse(url)
+    bucket = parsed.netloc
+    if not bucket:
+        raise RemoteSyncError(f"gs:// knowledge source URL is missing a bucket: {url}")
+    return bucket, parsed.path.lstrip("/")
+
+
+def _md5_token(md5_hash: Optional[str]) -> Optional[str]:
+    return f"md5:{md5_hash}" if md5_hash else None
+
+
+def _etag_token(etag: Optional[str]) -> Optional[str]:
+    return f"etag:{etag.strip(chr(34))}" if etag else None

--- a/src/muxi/runtime/formation/agents/knowledge/remote/protocols/sftp.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/protocols/sftp.py
@@ -1,0 +1,267 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        SFTP Handler - Remote Knowledge Sources
+# Description:  Syncs knowledge files from SFTP servers
+# Role:         Protocol handler for sftp:// sources (PRD Phase 4)
+# Usage:        Created by the protocol registry for sftp:// source URLs
+# Author:       Muxi Framework Team
+#
+# Uses paramiko (optional dependency, `muxi-runtime[sftp]` extra)
+# dispatched to worker threads. Change detection is a size + mtime
+# composite. Symlinks in the remote tree are skipped (same policy as the
+# file:// handler and the archive extractor).
+#
+# Host key policy mirrors rsync+ssh: STRICT by default - the host must
+# already be in known_hosts or the sync fails, so a MITM on first contact
+# cannot inject knowledge content. ``accept_new_host_keys: true`` on the
+# source is the explicit opt-in for trust-on-first-use.
+#
+# Auth: ``auth: {type: ssh_key, key: <private key material>}`` or
+# ``auth: {type: basic, username, password}`` (already
+# secret-interpolated). The username may also come from the URL.
+# =============================================================================
+
+import asyncio
+import io
+import os
+import posixpath
+import stat as stat_module
+from pathlib import Path
+from typing import Any, List, Optional, Tuple
+from urllib.parse import unquote, urlparse
+
+from ..handler import (
+    DownloadResult,
+    ProtocolHandler,
+    RemoteFile,
+    RemoteSyncError,
+    SourceConfig,
+    atomic_download,
+    hash_file_sha256,
+    matches_pattern,
+)
+
+try:  # pragma: no cover - import guard mirrors the boto3 optional-dep pattern
+    import paramiko
+
+    PARAMIKO_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    paramiko = None
+    PARAMIKO_AVAILABLE = False
+
+# Hard cap on entries visited during a recursive listing (hostile server guard)
+MAX_LIST_ENTRIES = 10000
+
+
+class SFTPHandler(ProtocolHandler):
+    """Protocol handler for sftp:// knowledge sources."""
+
+    def __init__(self, config: SourceConfig):
+        super().__init__(config)
+        if not PARAMIKO_AVAILABLE:
+            raise RemoteSyncError(
+                "sftp:// knowledge sources require the paramiko library. "
+                "Install it with: pip install 'muxi-runtime[sftp]' "
+                "(or pip install paramiko)"
+            )
+
+    async def list_files(self, url: str, pattern: Optional[str] = None) -> List[RemoteFile]:
+        return await asyncio.to_thread(self._list_files_sync, url, pattern)
+
+    async def download_file(self, url: str, dest: Path) -> DownloadResult:
+        return await asyncio.to_thread(self._download_sync, url, dest)
+
+    async def get_file_hash(self, url: str) -> str:
+        return await asyncio.to_thread(self._head_hash_sync, url)
+
+    # ------------------------------------------------------------------
+    # Internals (run in a worker thread)
+    # ------------------------------------------------------------------
+
+    def _connect(self, parsed) -> Tuple[Any, Any]:
+        """Open (ssh_client, sftp_client) for a parsed sftp:// URL."""
+        host = parsed.hostname or ""
+        if not host:
+            raise RemoteSyncError("sftp:// knowledge source URL is missing a host")
+
+        auth = self.config.auth or {}
+        auth_type = (auth.get("type") or "").lower()
+        username = auth.get("username") or (unquote(parsed.username) if parsed.username else None)
+        password = auth.get("password") if auth_type == "basic" else None
+        pkey = None
+        if auth_type == "ssh_key" and auth.get("key"):
+            pkey = self._load_private_key(auth["key"])
+
+        client = paramiko.SSHClient()
+        # Known-hosts policy: strict by default (host must already be
+        # known), trust-on-first-use only with the explicit source opt-in.
+        client.load_system_host_keys()
+        user_known_hosts = os.path.expanduser("~/.ssh/known_hosts")
+        if os.path.isfile(user_known_hosts):
+            try:
+                client.load_host_keys(user_known_hosts)
+            except (IOError, OSError):
+                pass
+        if self.config.accept_new_host_keys:
+            client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        else:
+            client.set_missing_host_key_policy(paramiko.RejectPolicy())
+
+        try:
+            client.connect(
+                hostname=host,
+                port=parsed.port or 22,
+                username=username,
+                password=password,
+                pkey=pkey,
+                timeout=self.config.timeout,
+                allow_agent=pkey is None and password is None,
+                look_for_keys=pkey is None and password is None,
+            )
+            sftp = client.open_sftp()
+        except Exception as e:
+            try:
+                client.close()
+            except Exception:
+                pass
+            raise RemoteSyncError(f"Failed to connect to sftp://{host}: {e}") from e
+        return client, sftp
+
+    @staticmethod
+    def _load_private_key(key_material: str) -> Any:
+        """Parse private key material (Ed25519 / ECDSA / RSA)."""
+        last_error: Optional[Exception] = None
+        for key_class in (paramiko.Ed25519Key, paramiko.ECDSAKey, paramiko.RSAKey):
+            try:
+                return key_class.from_private_key(io.StringIO(key_material))
+            except Exception as e:  # try the next key type
+                last_error = e
+        raise RemoteSyncError(
+            f"Could not parse sftp ssh_key material as Ed25519/ECDSA/RSA: {last_error}"
+        )
+
+    def _list_files_sync(self, url: str, pattern: Optional[str]) -> List[RemoteFile]:
+        parsed = urlparse(url)
+        base_path = unquote(parsed.path) or "/"
+        client, sftp = self._connect(parsed)
+        try:
+            base_stat = sftp.stat(base_path.rstrip("/") or "/")
+            results: List[RemoteFile] = []
+            if stat_module.S_ISREG(base_stat.st_mode):
+                rel_path = posixpath.basename(base_path.rstrip("/"))
+                if not pattern or matches_pattern(rel_path, pattern):
+                    results.append(
+                        RemoteFile(
+                            path=rel_path,
+                            url=self._file_url(parsed, base_path),
+                            size=base_stat.st_size,
+                            remote_hash=_stat_token(base_stat),
+                        )
+                    )
+                return results
+
+            entries: List[Tuple[str, Any]] = []
+            base_dir = base_path.rstrip("/") or "/"
+            self._walk(sftp, base_dir, "", entries)
+            for rel_path, attrs in entries:
+                if pattern and not matches_pattern(rel_path, pattern):
+                    continue
+                results.append(
+                    RemoteFile(
+                        path=rel_path,
+                        url=self._file_url(parsed, posixpath.join(base_dir, rel_path)),
+                        size=attrs.st_size,
+                        remote_hash=_stat_token(attrs),
+                    )
+                )
+            return results
+        except RemoteSyncError:
+            raise
+        except Exception as e:
+            raise RemoteSyncError(f"Failed to list sftp source {url}: {e}") from e
+        finally:
+            self._close(client, sftp)
+
+    def _walk(self, sftp: Any, directory: str, rel_prefix: str, entries: List) -> None:
+        """Recursively collect (rel_path, attrs) for regular files."""
+        if len(entries) > MAX_LIST_ENTRIES:
+            raise RemoteSyncError(
+                f"sftp listing exceeded {MAX_LIST_ENTRIES} entries; refusing to continue"
+            )
+        for attrs in sftp.listdir_attr(directory):
+            name = attrs.filename
+            if name in (".", ".."):
+                continue
+            rel_path = posixpath.join(rel_prefix, name) if rel_prefix else name
+            if stat_module.S_ISDIR(attrs.st_mode):
+                self._walk(sftp, posixpath.join(directory, name), rel_path, entries)
+            elif stat_module.S_ISREG(attrs.st_mode):
+                entries.append((rel_path, attrs))
+            # symlinks and special files are skipped (never followed)
+
+    def _download_sync(self, url: str, dest: Path) -> DownloadResult:
+        parsed = urlparse(url)
+        path = unquote(parsed.path)
+        client, sftp = self._connect(parsed)
+        try:
+            try:
+                remote_stat = sftp.stat(path)
+            except Exception as e:
+                raise RemoteSyncError(f"Failed to stat sftp file {url}: {e}") from e
+            size = remote_stat.st_size or 0
+            if size > self.config.max_file_size:
+                raise RemoteSyncError(
+                    f"Remote file exceeds max_file_size "
+                    f"({size} > {self.config.max_file_size}): {url}"
+                )
+            # Download into a temp file and atomically swap it in on
+            # success (see atomic_download in handler.py).
+            with atomic_download(dest) as tmp_path:
+                try:
+                    sftp.get(path, str(tmp_path))
+                except Exception as e:
+                    raise RemoteSyncError(f"Failed to download {url}: {e}") from e
+        finally:
+            self._close(client, sftp)
+        return DownloadResult(
+            path=dest.name,
+            local_path=dest,
+            size=size,
+            local_hash=hash_file_sha256(dest),
+        )
+
+    def _head_hash_sync(self, url: str) -> str:
+        parsed = urlparse(url)
+        client, sftp = self._connect(parsed)
+        try:
+            attrs = sftp.stat(unquote(parsed.path))
+        except Exception:
+            return ""
+        finally:
+            self._close(client, sftp)
+        return _stat_token(attrs) or ""
+
+    @staticmethod
+    def _file_url(parsed, file_path: str) -> str:
+        """Rebuild a per-file sftp:// URL (credentials stay in config)."""
+        host = parsed.hostname or ""
+        user = f"{parsed.username}@" if parsed.username else ""
+        port = f":{parsed.port}" if parsed.port else ""
+        return f"sftp://{user}{host}{port}{file_path}"
+
+    @staticmethod
+    def _close(client: Any, sftp: Any) -> None:
+        for closable in (sftp, client):
+            try:
+                closable.close()
+            except Exception:
+                pass
+
+
+def _stat_token(attrs: Any) -> Optional[str]:
+    size = getattr(attrs, "st_size", None)
+    mtime = getattr(attrs, "st_mtime", None)
+    if size is None or mtime is None:
+        return None
+    return f"stat:{size}:{int(mtime)}"

--- a/src/muxi/runtime/formation/agents/knowledge/remote/scheduler.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/scheduler.py
@@ -1,0 +1,370 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Knowledge Sync Scheduler - Remote Knowledge Sources
+# Description:  Periodic re-sync + manual sync triggers for remote sources
+# Role:         Phase 3 of the remote knowledge PRD (scheduling & automation)
+# Usage:        Overlord creates one KnowledgeSyncService per formation and
+#               registers it with the SchedulerService's periodic-task loop
+# Author:       Muxi Framework Team
+#
+# This is NOT a second scheduler loop. Like the proactive heartbeat, the
+# service registers with the existing SchedulerService via
+# ``register_periodic_task``; the scheduler's worker cycle dispatches
+# ``tick()`` onto the main event loop, and the service applies per-source
+# cron gating itself (croniter, the same parser the scheduler and config
+# validation already use).
+#
+# Guarantees:
+# - Per-source locking: overlapping syncs for the same source are skipped
+#   (KNOWLEDGE_SYNC_SKIPPED), whether triggered by schedule or manually.
+# - Retry with exponential backoff on total sync failure (PRD section 9):
+#   initial_delay * base^attempt, capped at max_delay, up to max_attempts;
+#   exhausted retries fall back to the next cron fire.
+# - Failure isolation: a scheduled sync failure emits events and degrades
+#   to stale content - it can never break chat, job processing, or the
+#   scheduler loop (tick() never raises).
+# - Incremental re-embedding: after a sync that changed the mirror, only
+#   the changed/deleted files are re-embedded via
+#   ``KnowledgeHandler.refresh_remote_source``.
+# =============================================================================
+
+import asyncio
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from .....services import observability
+from .handler import (
+    DEFAULT_RETRY_EXPONENTIAL_BASE,
+    DEFAULT_RETRY_INITIAL_DELAY,
+    DEFAULT_RETRY_MAX_ATTEMPTS,
+    DEFAULT_RETRY_MAX_DELAY,
+    SourceConfig,
+)
+from .sync import SyncManager, SyncResult
+
+# Cron aliases accepted for ``schedule`` (config validation mirrors this
+# set). ``@startup`` means "sync at formation startup only" - it is valid
+# config but never periodic.
+SCHEDULE_ALIASES = {
+    "@hourly": "0 * * * *",
+    "@daily": "0 0 * * *",
+    "@weekly": "0 0 * * 0",
+}
+STARTUP_ONLY_SCHEDULE = "@startup"
+
+
+def resolve_cron_expression(schedule: Optional[str]) -> Optional[str]:
+    """Map a source ``schedule`` to a cron expression (None -> not periodic).
+
+    Sources without a schedule, or with ``@startup``, sync only at
+    formation startup (Phase 1 behavior preserved).
+    """
+    if not schedule or not isinstance(schedule, str):
+        return None
+    schedule = schedule.strip()
+    if schedule == STARTUP_ONLY_SCHEDULE:
+        return None
+    return SCHEDULE_ALIASES.get(schedule, schedule)
+
+
+@dataclass
+class RetryPolicy:
+    """Exponential backoff policy for failed scheduled syncs (PRD sec. 9)."""
+
+    max_attempts: int = DEFAULT_RETRY_MAX_ATTEMPTS
+    initial_delay: float = DEFAULT_RETRY_INITIAL_DELAY
+    max_delay: float = DEFAULT_RETRY_MAX_DELAY
+    exponential_base: float = DEFAULT_RETRY_EXPONENTIAL_BASE
+
+    @classmethod
+    def from_dict(cls, config: Dict[str, Any]) -> "RetryPolicy":
+        return cls(
+            max_attempts=int(config.get("max_attempts", DEFAULT_RETRY_MAX_ATTEMPTS)),
+            initial_delay=float(config.get("initial_delay", DEFAULT_RETRY_INITIAL_DELAY)),
+            max_delay=float(config.get("max_delay", DEFAULT_RETRY_MAX_DELAY)),
+            exponential_base=float(config.get("exponential_base", DEFAULT_RETRY_EXPONENTIAL_BASE)),
+        )
+
+    def delay_for_attempt(self, attempt: int) -> float:
+        """Backoff delay in seconds after the ``attempt``-th failure (1-based)."""
+        delay = self.initial_delay * (self.exponential_base ** max(0, attempt - 1))
+        return min(delay, self.max_delay)
+
+
+@dataclass
+class ScheduledSource:
+    """Per-source scheduling state."""
+
+    agent_id: str
+    raw_source: Dict[str, Any]
+    source_id: str
+    cron: Optional[str]  # None -> manual-only (no periodic re-sync)
+    retry: RetryPolicy = field(default_factory=RetryPolicy)
+    next_fire: Optional[datetime] = None
+    failed_attempts: int = 0
+
+
+class KnowledgeSyncService:
+    """Scheduled + manual re-sync of remote knowledge sources.
+
+    Created by the overlord when any agent declares remote (url-based)
+    knowledge sources; registered as a SchedulerService periodic task only
+    when at least one source has a periodic schedule. Manual triggers
+    (admin API) work either way.
+    """
+
+    def __init__(
+        self,
+        overlord: Any,
+        agent_sources: Dict[str, List[Dict[str, Any]]],
+        formation_id: str = "default-formation",
+    ):
+        """
+        Args:
+            overlord: The overlord (used to resolve agents lazily at sync
+                time, so agent replacement never leaves a stale reference)
+            agent_sources: agent_id -> list of raw remote source dicts
+            formation_id: Formation id (mirror path resolution)
+        """
+        self.overlord = overlord
+        self.formation_id = formation_id
+        self._sources: List[ScheduledSource] = []
+        self._locks: Dict[Tuple[str, str], asyncio.Lock] = {}
+
+        now = datetime.now(timezone.utc)
+        for agent_id, sources in agent_sources.items():
+            for raw_source in sources:
+                config = SourceConfig.from_dict(raw_source)
+                cron = resolve_cron_expression(raw_source.get("schedule"))
+                entry = ScheduledSource(
+                    agent_id=agent_id,
+                    raw_source=raw_source,
+                    source_id=config.source_id,
+                    cron=cron,
+                    retry=RetryPolicy.from_dict(config.retry),
+                )
+                if cron is not None:
+                    # Startup already synced this source (prepare_sources),
+                    # so the first periodic fire is the next cron slot.
+                    entry.next_fire = self._next_cron_fire(cron, now)
+                self._sources.append(entry)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def has_scheduled_sources(self) -> bool:
+        """Whether any source re-syncs periodically."""
+        return any(entry.cron is not None for entry in self._sources)
+
+    @property
+    def scheduled_source_count(self) -> int:
+        return sum(1 for entry in self._sources if entry.cron is not None)
+
+    def sources_for_agent(self, agent_id: str) -> List[ScheduledSource]:
+        return [entry for entry in self._sources if entry.agent_id == agent_id]
+
+    async def tick(self, now: Optional[datetime] = None) -> None:
+        """Scheduler-cycle hook: re-sync every source whose schedule is due.
+
+        Never raises. Sources are processed sequentially; the per-source
+        locks make concurrent ticks (or manual triggers) skip rather than
+        overlap.
+        """
+        try:
+            now = now or datetime.now(timezone.utc)
+            for entry in self._sources:
+                if entry.next_fire is None or now < entry.next_fire:
+                    continue
+                await self._run_scheduled_sync(entry, now)
+        except Exception as e:
+            observability.observe(
+                event_type=observability.ErrorEvents.KNOWLEDGE_SYNC_FAILED,
+                level=observability.EventLevel.ERROR,
+                description=f"Knowledge sync tick failed (isolated): {e}",
+                data={"error": str(e), "error_type": type(e).__name__, "phase": "tick"},
+            )
+
+    async def sync_now(
+        self, agent_id: str, source_id: Optional[str] = None, trigger: str = "manual"
+    ) -> List[Dict[str, Any]]:
+        """Manually trigger a sync for an agent's remote sources.
+
+        Args:
+            agent_id: Agent whose sources to sync
+            source_id: Optional single source id; None syncs all of the
+                agent's remote sources
+            trigger: Trigger label for observability events
+
+        Returns:
+            One summary dict per source (status "skipped" when a sync for
+            that source was already in flight)
+
+        Raises:
+            KeyError: unknown agent_id/source_id combination
+        """
+        entries = self.sources_for_agent(agent_id)
+        if source_id is not None:
+            entries = [entry for entry in entries if entry.source_id == source_id]
+        if not entries:
+            if source_id is not None:
+                raise KeyError(
+                    f"No remote knowledge source '{source_id}' registered "
+                    f"for agent '{agent_id}'"
+                )
+            raise KeyError(f"No remote knowledge sources registered for agent '{agent_id}'")
+
+        results: List[Dict[str, Any]] = []
+        for entry in entries:
+            result = await self._sync_and_reingest(entry, trigger=trigger)
+            if result is None:
+                results.append(
+                    {
+                        "source_id": entry.source_id,
+                        "url": entry.raw_source.get("url", ""),
+                        "status": "skipped",
+                        "reason": "sync already in progress",
+                    }
+                )
+            else:
+                results.append(
+                    {
+                        "source_id": result.source_id,
+                        "url": result.url,
+                        "status": result.status,
+                        "files_added": result.files_added,
+                        "files_modified": result.files_modified,
+                        "files_deleted": result.files_deleted,
+                        "files_failed": result.files_failed,
+                        "bytes_downloaded": result.bytes_downloaded,
+                        "duration_ms": result.duration_ms,
+                        "error": result.error,
+                    }
+                )
+        return results
+
+    # ------------------------------------------------------------------
+    # Scheduling internals
+    # ------------------------------------------------------------------
+
+    async def _run_scheduled_sync(self, entry: ScheduledSource, now: datetime) -> None:
+        """Run one due scheduled sync and update the entry's schedule state."""
+        result = await self._sync_and_reingest(entry, trigger="scheduled")
+        if result is None:
+            # Lock contention: leave next_fire as-is; the in-flight sync
+            # owns this slot and the next tick re-evaluates.
+            return
+
+        if result.status == "failed":
+            entry.failed_attempts += 1
+            if entry.failed_attempts < entry.retry.max_attempts:
+                delay = entry.retry.delay_for_attempt(entry.failed_attempts)
+                entry.next_fire = now + timedelta(seconds=delay)
+                observability.observe(
+                    event_type=observability.ErrorEvents.KNOWLEDGE_SYNC_FAILED,
+                    level=observability.EventLevel.WARNING,
+                    description=(
+                        f"Scheduled knowledge sync failed - retrying in {delay:.0f}s "
+                        f"(attempt {entry.failed_attempts}/{entry.retry.max_attempts})"
+                    ),
+                    data={
+                        "source_id": entry.source_id,
+                        "agent_id": entry.agent_id,
+                        "attempt": entry.failed_attempts,
+                        "max_attempts": entry.retry.max_attempts,
+                        "retry_in_seconds": delay,
+                        "retry_at": entry.next_fire.isoformat(),
+                        "phase": "retry_scheduled",
+                    },
+                )
+                return
+            observability.observe(
+                event_type=observability.ErrorEvents.KNOWLEDGE_SYNC_FAILED,
+                level=observability.EventLevel.ERROR,
+                description=(
+                    "Scheduled knowledge sync retries exhausted - waiting for next "
+                    "scheduled run (stale content remains served)"
+                ),
+                data={
+                    "source_id": entry.source_id,
+                    "agent_id": entry.agent_id,
+                    "attempts": entry.failed_attempts,
+                    "phase": "retries_exhausted",
+                },
+            )
+
+        entry.failed_attempts = 0
+        entry.next_fire = self._next_cron_fire(entry.cron, now)
+
+    async def _sync_and_reingest(
+        self, entry: ScheduledSource, trigger: str
+    ) -> Optional[SyncResult]:
+        """Lock-guarded sync + incremental re-embed for one source.
+
+        Returns None when the source's lock is already held (overlapping
+        syncs are skipped, PRD section 7).
+        """
+        lock = self._locks.setdefault((entry.agent_id, entry.source_id), asyncio.Lock())
+        if lock.locked():
+            observability.observe(
+                event_type=observability.SystemEvents.KNOWLEDGE_SYNC_SKIPPED,
+                level=observability.EventLevel.INFO,
+                description="Knowledge sync skipped - previous sync still running",
+                data={
+                    "source_id": entry.source_id,
+                    "agent_id": entry.agent_id,
+                    "trigger": trigger,
+                },
+            )
+            return None
+
+        async with lock:
+            sync_manager = SyncManager(agent_id=entry.agent_id, formation_id=self.formation_id)
+            result = await sync_manager.sync_source(dict(entry.raw_source), trigger=trigger)
+            if result.status != "failed" and result.has_changes:
+                await self._reingest_changes(entry, sync_manager, result)
+            return result
+
+    async def _reingest_changes(
+        self, entry: ScheduledSource, sync_manager: SyncManager, result: SyncResult
+    ) -> None:
+        """Re-embed only the files this sync changed (failure isolated)."""
+        try:
+            agent = getattr(self.overlord, "agents", {}).get(entry.agent_id)
+            handler = getattr(agent, "knowledge_handler", None) if agent else None
+            if handler is None:
+                return
+            config = SourceConfig.from_dict(entry.raw_source)
+            source_config = sync_manager.synthetic_local_source(config, result)
+            changed = [os.path.join(result.content_dir, rel) for rel in result.changed_paths]
+            deleted = [os.path.join(result.content_dir, rel) for rel in result.deleted_paths]
+            await handler.refresh_remote_source(source_config, changed, deleted)
+        except Exception as e:
+            observability.observe(
+                event_type=observability.ErrorEvents.KNOWLEDGE_SYNC_FAILED,
+                level=observability.EventLevel.ERROR,
+                description=(
+                    "Re-embedding synced knowledge changes failed - previously "
+                    f"embedded content remains served: {e}"
+                ),
+                data={
+                    "source_id": entry.source_id,
+                    "agent_id": entry.agent_id,
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                    "phase": "reingest",
+                },
+            )
+
+    @staticmethod
+    def _next_cron_fire(cron: Optional[str], now: datetime) -> Optional[datetime]:
+        """Next fire time for a cron expression after ``now`` (UTC)."""
+        if not cron:
+            return None
+        from croniter import croniter
+
+        return croniter(cron, now).get_next(datetime)

--- a/src/muxi/runtime/formation/agents/knowledge/remote/sync.py
+++ b/src/muxi/runtime/formation/agents/knowledge/remote/sync.py
@@ -7,7 +7,7 @@
 # Usage:        KnowledgeHandler.from_agent_config calls prepare_sources()
 # Author:       Muxi Framework Team
 #
-# Design (Phase 1):
+# Design:
 # - Remote content is mirrored under the runtime knowledge cache dir
 #   (never inside the formation directory, which may be read-only):
 #   <knowledge_dir>/remote/<agent_id>/<source_id>/content/
@@ -20,22 +20,36 @@
 #   #2). On a cold start (nothing synced yet + source unreachable) the
 #   source contributes zero knowledge; a loud init warning plus an
 #   ERROR-level KNOWLEDGE_SYNC_FAILED event surface the gap.
-# - Scheduling is Phase 3: every remote source syncs once at formation
-#   startup regardless of its declared ``schedule``.
+# - Every remote source syncs once at formation startup; sources with a
+#   periodic ``schedule`` are then re-synced by the Phase 3 scheduler
+#   (see scheduler.py), which re-embeds only the changed files.
+# - Archive sources (``extract: true``, Phase 2) download a single
+#   archive and extract it (path-safe, bomb-bounded) into the mirror.
 #
 # Path safety: relative paths from handlers and manifests are validated
 # (safe_relative_path + resolve_within) so synced files can never land
 # outside the per-source content directory.
 # =============================================================================
 
+import asyncio
 import os
+import posixpath
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 from .....services import observability
 from .....utils.user_dirs import get_knowledge_dir
+from .extractor import (
+    DEFAULT_MAX_EXTRACTED_FILES,
+    DEFAULT_MAX_EXTRACTED_SIZE,
+    ArchiveExtractor,
+    cleanup_dir,
+    is_archive_filename,
+)
 from .handler import (
     ProtocolHandler,
     RemoteFile,
@@ -83,6 +97,15 @@ class SyncResult:
     duration_ms: int = 0
     error: str = ""
     skipped_files: List[str] = field(default_factory=list)
+    # Rel paths whose local content changed (added or modified) / vanished
+    # this sync. Phase 3 uses these to re-embed only what changed.
+    changed_paths: List[str] = field(default_factory=list)
+    deleted_paths: List[str] = field(default_factory=list)
+
+    @property
+    def has_changes(self) -> bool:
+        """Whether this sync changed any local content."""
+        return bool(self.changed_paths or self.deleted_paths)
 
     @property
     def has_local_content(self) -> bool:
@@ -134,7 +157,7 @@ class SyncManager:
             config = SourceConfig.from_dict(raw_source)
             result = await self.sync_source(raw_source)
             if result.has_local_content:
-                prepared.append(self._synthetic_local_source(config, result))
+                prepared.append(self.synthetic_local_source(config, result))
             else:
                 from .....datatypes.observability import InitEventFormatter
 
@@ -172,7 +195,9 @@ class SyncManager:
         handler: Optional[ProtocolHandler] = None
         try:
             handler = create_handler(config)
-            if handler.supports_incremental():
+            if config.extract:
+                result = await self._sync_archive(handler, config, content_dir, manifest)
+            elif handler.supports_incremental():
                 result = await self._sync_incremental(handler, config, content_dir, manifest)
             else:
                 result = await self._sync_enumerated(handler, config, content_dir, manifest)
@@ -327,6 +352,8 @@ class SyncManager:
                 result.files_added += 1
             else:
                 result.files_modified += 1
+            if existing is None or existing.local_hash != download.local_hash:
+                result.changed_paths.append(rel_path)
 
         # Remote deletions: drop local files whose manifest entry vanished
         for rel_path in list(manifest.files.keys()):
@@ -337,6 +364,7 @@ class SyncManager:
                 try:
                     os.remove(local_path)
                     result.files_deleted += 1
+                    result.deleted_paths.append(rel_path)
                 except OSError:
                     pass
 
@@ -379,9 +407,11 @@ class SyncManager:
             if previous is None:
                 result.files_added += 1
                 result.bytes_downloaded += size
+                result.changed_paths.append(rel_path)
             elif previous != (size, token):
                 result.files_modified += 1
                 result.bytes_downloaded += size
+                result.changed_paths.append(rel_path)
             manifest.record_file(
                 rel_path,
                 remote_hash=token,
@@ -389,8 +419,163 @@ class SyncManager:
                 size=size,
             )
 
-        result.files_deleted = len(set(before) - set(after))
+        result.deleted_paths = sorted(set(before) - set(after))
+        result.files_deleted = len(result.deleted_paths)
         return result
+
+    async def _sync_archive(
+        self,
+        handler: ProtocolHandler,
+        config: SourceConfig,
+        content_dir: str,
+        manifest: Manifest,
+    ) -> SyncResult:
+        """Download-and-extract sync for archive sources (``extract: true``).
+
+        The archive downloads and extracts into a hidden temp dir NEXT TO
+        the content mirror (same filesystem, never ingested); only after
+        extraction fully succeeds does the mirror get updated file-by-file
+        (``os.replace``). Any failure before that point leaves the previous
+        mirror untouched (stale-wins). Temp state is always cleaned up.
+        """
+        remote_files = await handler.list_files(config.url, None)
+        if len(remote_files) != 1:
+            raise RemoteSyncError(
+                f"Archive knowledge source must resolve to exactly one file, "
+                f"got {len(remote_files)}: {config.url}"
+            )
+        archive = remote_files[0]
+
+        result = SyncResult(
+            source_id=config.source_id, url=config.url, status="success", content_dir=content_dir
+        )
+
+        # Unchanged archive with an intact mirror: skip download + extraction.
+        if (
+            archive.remote_hash
+            and manifest.archive_hash == archive.remote_hash
+            and (archive.size is None or manifest.archive_size == archive.size)
+            and result.has_local_content
+        ):
+            return result
+
+        work_dir = tempfile.mkdtemp(prefix=".archive-", dir=os.path.dirname(content_dir))
+        try:
+            archive_path = Path(work_dir) / self._archive_filename(archive, config)
+            download = await handler.download_file(archive.url, archive_path)
+            result.bytes_downloaded = download.size
+
+            if not is_archive_filename(archive_path.name):
+                raise RemoteSyncError(
+                    f"'extract: true' source is not a supported archive: {archive_path.name}"
+                )
+
+            extractor = ArchiveExtractor(
+                pattern=config.extract_pattern,
+                max_files=config.max_extracted_files or DEFAULT_MAX_EXTRACTED_FILES,
+                max_total_size=config.max_extracted_size or DEFAULT_MAX_EXTRACTED_SIZE,
+            )
+            extract_dir = Path(work_dir) / "extracted"
+            extraction = await asyncio.to_thread(extractor.extract, archive_path, extract_dir)
+            result.skipped_files.extend(extraction.skipped)
+
+            # Apply the standard per-source selection limits to the
+            # extracted tree (include/exclude, per-file size, count, total).
+            selected: List[Tuple[str, str, int]] = []
+            total_size = 0
+            for rel_path in sorted(extraction.files):
+                if not self._passes_filters(rel_path, config):
+                    continue
+                src_path = os.path.join(str(extract_dir), rel_path)
+                try:
+                    size = os.path.getsize(src_path)
+                except OSError:
+                    result.skipped_files.append(rel_path)
+                    continue
+                if size > config.max_file_size:
+                    result.skipped_files.append(rel_path)
+                    continue
+                if len(selected) >= config.max_files:
+                    result.skipped_files.append(rel_path)
+                    continue
+                if total_size + size > config.max_total_size:
+                    result.skipped_files.append(rel_path)
+                    continue
+                total_size += size
+                selected.append((rel_path, src_path, size))
+
+            # Materialize into the content mirror (extraction is complete
+            # and bounded at this point). Same filesystem -> atomic swaps.
+            seen_paths = set()
+            new_files: Dict[str, Any] = {}
+            for rel_path, src_path, size in selected:
+                target = resolve_within(content_dir, rel_path)
+                if target is None:
+                    result.skipped_files.append(rel_path)
+                    result.files_failed += 1
+                    continue
+                seen_paths.add(rel_path)
+                local_hash = hash_file_sha256(Path(src_path))
+                existing = manifest.files.get(rel_path)
+                if (
+                    existing is not None
+                    and existing.local_hash == local_hash
+                    and os.path.isfile(target)
+                ):
+                    new_files[rel_path] = existing
+                    continue
+                os.makedirs(os.path.dirname(target), exist_ok=True)
+                os.replace(src_path, target)
+                manifest.record_file(
+                    rel_path,
+                    remote_hash=archive.remote_hash or "",
+                    local_hash=local_hash,
+                    size=size,
+                )
+                new_files[rel_path] = manifest.files[rel_path]
+                result.changed_paths.append(rel_path)
+                if existing is None:
+                    result.files_added += 1
+                else:
+                    result.files_modified += 1
+
+            # Files present in the previous archive but not this one
+            for rel_path in list(manifest.files.keys()):
+                if rel_path in seen_paths:
+                    continue
+                target = resolve_within(content_dir, rel_path)
+                if target and os.path.isfile(target):
+                    try:
+                        os.remove(target)
+                        result.files_deleted += 1
+                        result.deleted_paths.append(rel_path)
+                    except OSError:
+                        pass
+
+            manifest.files = new_files
+            manifest.archive_hash = archive.remote_hash or ""
+            manifest.archive_size = archive.size if archive.size is not None else download.size
+            _prune_empty_dirs(content_dir)
+        finally:
+            cleanup_dir(work_dir)
+
+        if result.files_failed:
+            result.status = "partial"
+            result.error = f"{result.files_failed} file(s) failed to sync"
+        return result
+
+    @staticmethod
+    def _archive_filename(archive: RemoteFile, config: SourceConfig) -> str:
+        """Pick a local filename that preserves the archive's format suffix."""
+        for candidate in (
+            posixpath.basename(urlparse(archive.url).path),
+            archive.path,
+            posixpath.basename(urlparse(config.url).path),
+        ):
+            candidate = posixpath.basename(candidate or "")
+            if candidate and is_archive_filename(candidate):
+                return candidate
+        return "archive"
 
     # ------------------------------------------------------------------
     # Internals
@@ -403,8 +588,12 @@ class SyncManager:
             return False
         return not any(matches_pattern(rel_path, pattern) for pattern in config.exclude)
 
-    def _synthetic_local_source(self, config: SourceConfig, result: SyncResult) -> Dict[str, Any]:
-        """Build the local ``path`` source config for a synced mirror."""
+    def synthetic_local_source(self, config: SourceConfig, result: SyncResult) -> Dict[str, Any]:
+        """Build the local ``path`` source config for a synced mirror.
+
+        Used at startup (prepare_sources) and by the Phase 3 re-sync
+        scheduler when re-embedding changed mirror files.
+        """
         return {
             "path": result.content_dir,
             "name": config.source_id,

--- a/src/muxi/runtime/formation/config/validation.py
+++ b/src/muxi/runtime/formation/config/validation.py
@@ -1246,11 +1246,31 @@ class FormationValidator:
         elif not description.strip():
             self.result.add_error(f"{subject} 'description' cannot be empty")
 
-    # URL schemes accepted for remote knowledge sources in Phase 1, and
-    # schemes from the PRD roadmap that are recognized but not built yet.
-    REMOTE_KNOWLEDGE_SUPPORTED_SCHEMES = {"http", "https", "s3", "rsync", "rsync+ssh", "file"}
-    REMOTE_KNOWLEDGE_PLANNED_SCHEMES = {"gs", "az", "ftp", "sftp"}
+    # URL schemes accepted for remote knowledge sources (PRD Phases 1 + 4).
+    # Mirror of formation/agents/knowledge/remote/protocols SUPPORTED_SCHEMES
+    # - kept literal here so config validation stays import-light.
+    REMOTE_KNOWLEDGE_SUPPORTED_SCHEMES = {
+        "http",
+        "https",
+        "s3",
+        "gs",
+        "az",
+        "rsync",
+        "rsync+ssh",
+        "ftp",
+        "sftp",
+        "file",
+    }
     REMOTE_KNOWLEDGE_SCHEDULE_ALIASES = {"@startup", "@hourly", "@daily", "@weekly"}
+    # Schemes whose sources can never be a downloadable single archive
+    # (rsync syncs whole trees natively), so 'extract' is a config error.
+    REMOTE_KNOWLEDGE_NO_EXTRACT_SCHEMES = {"rsync", "rsync+ssh"}
+    # Schemes where glob patterns in the URL are meaningless: HTTP has no
+    # directory listing; rsync uses include/exclude filters instead.
+    REMOTE_KNOWLEDGE_NO_GLOB_SCHEMES = {"http", "https", "rsync", "rsync+ssh"}
+    # Schemes supporting SSH's trust-on-first-use opt-in
+    REMOTE_KNOWLEDGE_SSH_SCHEMES = {"rsync+ssh", "sftp"}
+    REMOTE_KNOWLEDGE_RETRY_KEYS = ("max_attempts", "initial_delay", "max_delay", "exponential_base")
 
     def _validate_remote_knowledge_source(
         self, source: Dict[str, Any], subject: str, seen_source_ids: set
@@ -1258,8 +1278,8 @@ class FormationValidator:
         """Validate a remote (url-based) knowledge source declaration.
 
         Fail-fast at load time: unsupported schemes, malformed URLs,
-        incomplete auth blocks, and Phase 2+ options (archive extraction)
-        are configuration errors. Credentials should be referenced via
+        incomplete auth blocks, and malformed extraction/retry options are
+        configuration errors. Credentials should be referenced via
         ``${{ secrets.* }}`` interpolation, which resolves before the
         handlers ever see the config.
         """
@@ -1273,13 +1293,6 @@ class FormationValidator:
         parsed = urlparse(url)
         scheme = parsed.scheme.lower()
 
-        if scheme in self.REMOTE_KNOWLEDGE_PLANNED_SCHEMES:
-            self.result.add_error(
-                f"{subject} scheme '{scheme}://' is not yet supported (planned). "
-                f"Supported schemes: "
-                f"{', '.join(sorted(self.REMOTE_KNOWLEDGE_SUPPORTED_SCHEMES))}"
-            )
-            return
         if scheme not in self.REMOTE_KNOWLEDGE_SUPPORTED_SCHEMES:
             self.result.add_error(
                 f"{subject} has unsupported URL scheme '{scheme or '(none)'}'. "
@@ -1301,6 +1314,19 @@ class FormationValidator:
         elif scheme == "s3":
             if not parsed.netloc:
                 self.result.add_error(f"{subject} 's3://' URL is missing a bucket name")
+        elif scheme == "gs":
+            if not parsed.netloc:
+                self.result.add_error(f"{subject} 'gs://' URL is missing a bucket name")
+        elif scheme == "az":
+            if not parsed.netloc:
+                self.result.add_error(f"{subject} 'az://' URL is missing a container name")
+            if "auth" not in source:
+                self.result.add_error(
+                    f"{subject} 'az://' sources require an 'auth' block "
+                    "(the storage account is not part of the URL): use "
+                    "auth type 'azure' with connection_string or "
+                    "account_name + account_key"
+                )
         elif scheme in ("rsync", "rsync+ssh"):
             if not parsed.netloc:
                 self.result.add_error(f"{subject} '{scheme}://' URL is missing a host")
@@ -1309,6 +1335,9 @@ class FormationValidator:
                     f"{subject} glob patterns are not supported for {scheme}:// sources; "
                     "use 'include'/'exclude' filters instead"
                 )
+        elif scheme in ("ftp", "sftp"):
+            if not parsed.netloc:
+                self.result.add_error(f"{subject} '{scheme}://' URL is missing a host")
         elif scheme == "file":
             if parsed.netloc not in ("", "localhost"):
                 self.result.add_error(
@@ -1329,16 +1358,81 @@ class FormationValidator:
             else:
                 seen_source_ids.add(source_id)
 
-        # Phase 2 surface: archive extraction is not implemented yet.
-        # Fail fast rather than silently ingesting the raw archive.
-        for phase2_key in ("extract", "extract_pattern"):
-            if phase2_key in source:
-                self.result.add_error(
-                    f"{subject} '{phase2_key}' (archive extraction) is not yet supported"
-                )
-
+        self._validate_remote_knowledge_extract(source, subject, scheme, has_glob)
+        self._validate_remote_knowledge_retry(source, subject)
         self._validate_remote_knowledge_auth(source, subject, scheme)
         self._validate_remote_knowledge_options(source, subject, scheme)
+
+    def _validate_remote_knowledge_extract(
+        self, source: Dict[str, Any], subject: str, scheme: str, has_glob: bool
+    ) -> None:
+        """Validate the archive extraction options of a remote source."""
+        extract = source.get("extract", False)
+        if "extract" in source and not isinstance(extract, bool):
+            self.result.add_error(f"{subject} 'extract' must be a boolean")
+            return
+
+        if extract:
+            if scheme in self.REMOTE_KNOWLEDGE_NO_EXTRACT_SCHEMES:
+                self.result.add_error(
+                    f"{subject} 'extract' is not valid for {scheme}:// sources "
+                    "(rsync syncs whole trees natively)"
+                )
+            if has_glob:
+                self.result.add_error(
+                    f"{subject} 'extract' requires a single archive URL "
+                    "(glob patterns are not supported with extraction)"
+                )
+
+        for extract_key in ("extract_pattern", "max_extracted_files", "max_extracted_size"):
+            if extract_key in source and not extract:
+                self.result.add_error(f"{subject} '{extract_key}' requires 'extract: true'")
+
+        if "extract_pattern" in source:
+            extract_pattern = source["extract_pattern"]
+            if not isinstance(extract_pattern, str) or not extract_pattern.strip():
+                self.result.add_error(
+                    f"{subject} 'extract_pattern' must be a non-empty glob string"
+                )
+
+        for limit_key in ("max_extracted_files", "max_extracted_size"):
+            if limit_key in source:
+                value = source[limit_key]
+                if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+                    self.result.add_error(f"{subject} '{limit_key}' must be a positive integer")
+
+    def _validate_remote_knowledge_retry(self, source: Dict[str, Any], subject: str) -> None:
+        """Validate the scheduled re-sync 'retry' block (PRD section 9)."""
+        if "retry" not in source:
+            return
+        retry = source["retry"]
+        if not isinstance(retry, dict):
+            self.result.add_error(
+                f"{subject} 'retry' must be a mapping "
+                f"(allowed keys: {', '.join(self.REMOTE_KNOWLEDGE_RETRY_KEYS)})"
+            )
+            return
+        for key in retry:
+            if key not in self.REMOTE_KNOWLEDGE_RETRY_KEYS:
+                self.result.add_error(
+                    f"{subject} retry setting '{key}' is not recognized "
+                    f"(allowed: {', '.join(self.REMOTE_KNOWLEDGE_RETRY_KEYS)})"
+                )
+        if "max_attempts" in retry:
+            value = retry["max_attempts"]
+            if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+                self.result.add_error(f"{subject} retry 'max_attempts' must be a positive integer")
+        for delay_key in ("initial_delay", "max_delay"):
+            if delay_key in retry:
+                value = retry[delay_key]
+                if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+                    self.result.add_error(
+                        f"{subject} retry '{delay_key}' must be a positive number (seconds)"
+                    )
+        if "exponential_base" in retry:
+            value = retry["exponential_base"]
+            if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 1:
+                self.result.add_error(f"{subject} retry 'exponential_base' must be a number >= 1")
 
     def _validate_remote_knowledge_auth(
         self, source: Dict[str, Any], subject: str, scheme: str
@@ -1361,8 +1455,12 @@ class FormationValidator:
             "http": {"basic", "bearer"},
             "https": {"basic", "bearer"},
             "s3": {"aws"},
+            "gs": {"gcp"},
+            "az": {"azure"},
             "rsync": set(),
             "rsync+ssh": {"ssh_key"},
+            "ftp": {"basic"},
+            "sftp": {"ssh_key", "basic"},
             "file": set(),
         }
         valid_types = valid_types_by_scheme.get(scheme, set())
@@ -1390,6 +1488,23 @@ class FormationValidator:
                     "(neither uses boto3's default credential chain)"
                 )
             required_fields = ["access_key", "secret_key"] if has_access and has_secret else []
+        elif auth_type == "gcp":
+            # credentials_json is optional: without it Google's Application
+            # Default Credentials chain applies. When present it must be a
+            # non-empty string (the service account JSON, secret-resolved).
+            required_fields = ["credentials_json"] if "credentials_json" in auth else []
+        elif auth_type == "azure":
+            # Either a connection string, or account_name + account_key.
+            if "connection_string" in auth:
+                required_fields = ["connection_string"]
+            elif "account_name" in auth or "account_key" in auth:
+                required_fields = ["account_name", "account_key"]
+            else:
+                self.result.add_error(
+                    f"{subject} auth type 'azure' requires 'connection_string' "
+                    "or 'account_name' + 'account_key'"
+                )
+                required_fields = []
         else:
             required_fields = {
                 "basic": ["username", "password"],
@@ -1440,23 +1555,24 @@ class FormationValidator:
             if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
                 self.result.add_error(f"{subject} '{limit_key}' must be a positive integer")
 
-        # accept_new_host_keys: rsync+ssh only. Opts into SSH's
-        # trust-on-first-use (StrictHostKeyChecking=accept-new) instead of
-        # the strict default that requires the host in known_hosts. TOFU
-        # means a MITM on FIRST contact could inject knowledge content -
-        # hence explicit opt-in, never the default.
+        # accept_new_host_keys: SSH-based schemes only (rsync+ssh, sftp).
+        # Opts into SSH's trust-on-first-use instead of the strict default
+        # that requires the host in known_hosts. TOFU means a MITM on
+        # FIRST contact could inject knowledge content - hence explicit
+        # opt-in, never the default.
         if "accept_new_host_keys" in source:
             value = source["accept_new_host_keys"]
-            if scheme != "rsync+ssh":
+            if scheme not in self.REMOTE_KNOWLEDGE_SSH_SCHEMES:
                 self.result.add_error(
-                    f"{subject} 'accept_new_host_keys' is only valid for " "rsync+ssh:// sources"
+                    f"{subject} 'accept_new_host_keys' is only valid for "
+                    f"{' / '.join(sorted(self.REMOTE_KNOWLEDGE_SSH_SCHEMES))} sources"
                 )
             elif not isinstance(value, bool):
                 self.result.add_error(f"{subject} 'accept_new_host_keys' must be a boolean")
 
-        # schedule: accepted and syntax-checked in Phase 1, but periodic
-        # re-sync lands in a later phase — every remote source syncs at
-        # formation startup regardless of the declared schedule.
+        # schedule: cron expression or alias. Periodic re-sync (Phase 3)
+        # additionally requires the scheduler service; without it, sources
+        # sync at formation startup only (loud init warning).
         if "schedule" in source:
             schedule = source["schedule"]
             if not isinstance(schedule, str) or not schedule.strip():

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -831,6 +831,9 @@ class Overlord:
         # a2a_cache_manager will be initialized earlier in __init__ at line 385
         self.mcp_service = MCPService.get_instance()  # Get existing instance
         self.scheduler_service: Optional[SchedulerService] = None
+        # Remote knowledge re-sync service (Phase 3). Created only when an
+        # agent declares url-based knowledge sources; None otherwise.
+        self.knowledge_sync_service: Optional[Any] = None
 
         # Initialize TaskDecomposer now that MCP service is available
         self.task_decomposer = TaskDecomposer(
@@ -1548,6 +1551,11 @@ class Overlord:
         # No-op for formations without a 'proactive' block.
         self._initialize_proactive_services()
 
+        # Register periodic re-sync of remote knowledge sources (Phase 3)
+        # after the scheduler for the same reason. No-op for formations
+        # without url-based knowledge sources.
+        self._initialize_knowledge_sync_service()
+
         # Start the knowledge graph periodic extraction loop now that the
         # extraction/default model is resolved. The getter is evaluated per
         # run so the loop always uses the current capability model.
@@ -1660,6 +1668,65 @@ class Overlord:
                 f"heartbeat {'on' if self.heartbeat_service else 'off'}",
             )
         )
+
+    def _initialize_knowledge_sync_service(self) -> None:
+        """
+        Create the remote knowledge re-sync service (Remote Knowledge
+        Sources Phase 3).
+
+        Inert when unconfigured: formations without url-based knowledge
+        sources never import the remote knowledge package (the cheap dict
+        check below mirrors ``KnowledgeHandler.from_agent_config``). When
+        remote sources exist, the service always supports manual sync
+        triggers; periodic re-sync additionally requires the scheduler
+        (the service registers as a periodic task on its worker loop, the
+        same extension point the proactive heartbeat uses). Declared
+        schedules without a running scheduler degrade to startup-only
+        sync with a loud init warning - never a startup failure.
+        """
+        agent_sources: Dict[str, List[Dict[str, Any]]] = {}
+        for agent_id, agent in self.agents.items():
+            knowledge_config = getattr(agent, "_knowledge_config", None)
+            if not isinstance(knowledge_config, dict) or not knowledge_config.get("enabled"):
+                continue
+            remote_sources = [
+                source
+                for source in (knowledge_config.get("sources") or [])
+                if isinstance(source, dict) and source.get("url")
+            ]
+            if remote_sources:
+                agent_sources[agent_id] = remote_sources
+
+        if not agent_sources:
+            return
+
+        from ...datatypes.observability import InitEventFormatter
+        from ..agents.knowledge.remote.scheduler import KnowledgeSyncService
+
+        self.knowledge_sync_service = KnowledgeSyncService(
+            overlord=self,
+            agent_sources=agent_sources,
+            formation_id=self.formation_id,
+        )
+
+        if not self.knowledge_sync_service.has_scheduled_sources:
+            return
+        if self.scheduler_service:
+            self.scheduler_service.register_periodic_task(self.knowledge_sync_service)
+            print(
+                InitEventFormatter.format_ok(
+                    "Remote knowledge sync scheduler active",
+                    f"{self.knowledge_sync_service.scheduled_source_count} scheduled source(s)",
+                )
+            )
+        else:
+            print(
+                InitEventFormatter.format_warn(
+                    "Remote knowledge schedules require the scheduler",
+                    "sources synced at startup only - enable 'scheduler.enabled: true' "
+                    "(requires persistent memory) for periodic re-sync",
+                )
+            )
 
     async def record_inbound_channel(
         self,

--- a/src/muxi/runtime/formation/server/routes/admin/agents.py
+++ b/src/muxi/runtime/formation/server/routes/admin/agents.py
@@ -235,6 +235,15 @@ class AgentCreate(BaseModel):
     a2a: Optional[Dict[str, Any]] = Field(default=None, description="A2A settings")
 
 
+class KnowledgeSyncTrigger(BaseModel):
+    """Model for manually triggering a remote knowledge source sync."""
+
+    source_id: Optional[str] = Field(
+        default=None,
+        description="Remote knowledge source id to sync; omit to sync all of the agent's sources",
+    )
+
+
 class AgentUpdate(BaseModel):
     """Model for updating an agent."""
 
@@ -355,6 +364,68 @@ async def get_agent(request: Request, agent_id: str) -> JSONResponse:
 
     response = create_success_response(
         APIObjectType.AGENT, APIEventType.AGENT_RETRIEVED, agent, request_id
+    )
+    return JSONResponse(content=response.model_dump(), status_code=200)
+
+
+@router.post("/agents/{agent_id}/knowledge/sync", response_model=APIResponse)
+async def sync_agent_knowledge(
+    request: Request, agent_id: str, trigger: Optional[KnowledgeSyncTrigger] = None
+) -> JSONResponse:
+    """
+    Manually trigger a re-sync of an agent's remote knowledge sources.
+
+    Syncs run through the same per-source locks as scheduled re-syncs, so
+    a source with a sync already in flight reports status "skipped"
+    instead of overlapping. Changed files are re-embedded incrementally.
+
+    Args:
+        agent_id: ID of the agent whose remote sources to sync
+        trigger: Optional body with a single source_id to sync
+
+    Returns:
+        Per-source sync results (status, file counts, duration)
+    """
+    formation = request.app.state.formation
+    request_id: Optional[str] = getattr(request.state, "request_id", None)
+
+    overlord = getattr(formation, "_overlord", None)
+    if overlord is None or agent_id not in getattr(overlord, "agents", {}):
+        response = create_error_response(
+            AGENT_NOT_FOUND_ERROR, f"Agent '{agent_id}' not found", None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=404)
+
+    sync_service = getattr(overlord, "knowledge_sync_service", None)
+    if sync_service is None or not sync_service.sources_for_agent(agent_id):
+        response = create_error_response(
+            INVALID_REQUEST_ERROR,
+            f"Agent '{agent_id}' has no remote knowledge sources",
+            None,
+            request_id,
+        )
+        return JSONResponse(content=response.model_dump(), status_code=400)
+
+    source_id = trigger.source_id if trigger else None
+    try:
+        results = await sync_service.sync_now(agent_id, source_id=source_id, trigger="manual")
+    except KeyError as e:
+        response = create_error_response(
+            "RESOURCE_NOT_FOUND", str(e).strip("'\""), None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=404)
+    except Exception as e:
+        logger.error("Manual knowledge sync failed for '%s': %s", agent_id, e, exc_info=True)
+        response = create_error_response(
+            INTERNAL_ERROR, f"Knowledge sync failed: {str(e)}", None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=500)
+
+    response = create_success_response(
+        APIObjectType.AGENT,
+        APIEventType.AGENT_KNOWLEDGE_SYNCED,
+        {"agent_id": agent_id, "results": results},
+        request_id,
     )
     return JSONResponse(content=response.model_dump(), status_code=200)
 

--- a/src/muxi/runtime/services/memory/working.py
+++ b/src/muxi/runtime/services/memory/working.py
@@ -371,7 +371,10 @@ class WorkingMemory:
         """
         partition = self.partitions.get(key)
         if partition is None:
-            partition = _IndexPartition(dimension or self.dimension)
+            # Explicit None check (not truthiness): an explicit dimension
+            # must always win; only an absent override falls back to the
+            # memory-wide dim.
+            partition = _IndexPartition(dimension if dimension is not None else self.dimension)
             self.partitions[key] = partition
         return partition
 

--- a/src/muxi/runtime/services/memory/working.py
+++ b/src/muxi/runtime/services/memory/working.py
@@ -359,11 +359,19 @@ class WorkingMemory:
         keys.append(FORMATION_PARTITION)
         return keys
 
-    def _get_partition(self, key: str) -> _IndexPartition:
-        """Return the partition for ``key``, creating it lazily."""
+    def _get_partition(self, key: str, dimension: Optional[int] = None) -> _IndexPartition:
+        """Return the partition for ``key``, creating it lazily.
+
+        ``dimension`` overrides the memory-wide dim for the new partition.
+        Pre-computed embeddings (``add_with_embedding``, e.g. knowledge
+        chunks embedded with the formation's document model) may carry a
+        different dimensionality than this memory's own embedding model;
+        their partition must be created at the vectors' actual dim or
+        every ``index.add`` fails with a shape mismatch.
+        """
         partition = self.partitions.get(key)
         if partition is None:
-            partition = _IndexPartition(self.dimension)
+            partition = _IndexPartition(dimension or self.dimension)
             self.partitions[key] = partition
         return partition
 
@@ -490,13 +498,26 @@ class WorkingMemory:
 
         for i, item in enumerate(self.buffer):
             if "embedding" in item and item["embedding"] is not None:
+                embedding = item["embedding"]
+                dim = len(embedding)
                 key = self._partition_key(item.get("namespace", "buffer"), item.get("metadata"))
                 partition = new_partitions.get(key)
                 if partition is None:
-                    partition = _IndexPartition(self.dimension)
+                    # Partition dim follows the vectors it stores, NOT the
+                    # memory-wide dim: pre-computed embeddings (knowledge
+                    # chunks via add_with_embedding) may differ from this
+                    # memory's own embedding model. Rebuilding them at
+                    # self.dimension used to shape-crash the whole rebuild
+                    # (and with it every subsequent vector search).
+                    partition = _IndexPartition(dim)
                     new_partitions[key] = partition
                     embeddings_by_key[key] = []
-                embeddings_by_key[key].append(item["embedding"])
+                if dim != partition.index.d:
+                    # Defensive: never mix dims within one partition; the
+                    # mismatched item stays in the buffer (recency reach)
+                    # but out of this partition's index.
+                    continue
+                embeddings_by_key[key].append(embedding)
                 partition.index_mapping[i] = partition.index_count
                 partition.reverse_index_mapping[partition.index_count] = i
                 partition.index_count += 1
@@ -1307,8 +1328,15 @@ class WorkingMemory:
                     embedding_np = embedding_np / norm
 
                 # Route the vector to its partition (per-session for
-                # buffer items, shared otherwise) and update the mapping
-                partition = self._get_partition(self._partition_key(namespace, metadata))
+                # buffer items, shared otherwise) and update the mapping.
+                # The partition is created at THIS embedding's dim: pre-
+                # computed vectors routinely differ from the buffer's own
+                # embedding model dim (e.g. 1536-dim knowledge chunks in
+                # a 768-dim buffer memory).
+                partition = self._get_partition(
+                    self._partition_key(namespace, metadata),
+                    dimension=int(embedding_np.shape[1]),
+                )
                 partition.index.add(embedding_np)
 
                 buffer_idx = len(self.buffer) - 1

--- a/tests/unit/test_remote_knowledge_extractor.py
+++ b/tests/unit/test_remote_knowledge_extractor.py
@@ -1,0 +1,194 @@
+"""Unit tests for the remote knowledge ArchiveExtractor (Phase 2).
+
+Covers format support (zip/tar/tar.gz), extract_pattern filtering, and the
+security posture: path-traversal member names, symlink members, and
+decompression-bomb bounds (total size + file count).
+"""
+
+import io
+import os
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from muxi.runtime.formation.agents.knowledge.remote.extractor import (
+    ArchiveExtractor,
+    is_archive_filename,
+)
+from muxi.runtime.formation.agents.knowledge.remote.handler import RemoteSyncError
+
+
+def make_zip(path: Path, files: dict) -> Path:
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, content in files.items():
+            archive.writestr(name, content)
+    return path
+
+
+def make_tar(path: Path, files: dict, mode: str = "w") -> Path:
+    with tarfile.open(path, mode) as archive:
+        for name, content in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(content)
+            archive.addfile(info, io.BytesIO(content))
+    return path
+
+
+def tree(root: Path) -> dict:
+    found = {}
+    for dirpath, _, filenames in os.walk(root):
+        for filename in filenames:
+            full = Path(dirpath) / filename
+            found[str(full.relative_to(root))] = full.read_bytes()
+    return found
+
+
+class TestFormats:
+    def test_is_archive_filename(self):
+        for name in ("a.zip", "a.tar", "a.tar.gz", "a.tgz", "a.tar.bz2", "a.tar.xz", "A.ZIP"):
+            assert is_archive_filename(name), name
+        for name in ("a.md", "a.gz", "a.pdf", "archive", ".."):
+            assert not is_archive_filename(name), name
+
+    def test_extract_zip(self, tmp_path):
+        archive = make_zip(tmp_path / "kb.zip", {"a.md": b"alpha", "docs/b.md": b"beta"})
+        result = ArchiveExtractor().extract(archive, tmp_path / "out")
+        assert sorted(result.files) == ["a.md", "docs/b.md"]
+        assert tree(tmp_path / "out") == {"a.md": b"alpha", os.path.join("docs", "b.md"): b"beta"}
+        assert result.total_size == 9
+
+    def test_extract_tar(self, tmp_path):
+        archive = make_tar(tmp_path / "kb.tar", {"a.md": b"alpha", "docs/b.md": b"beta"})
+        result = ArchiveExtractor().extract(archive, tmp_path / "out")
+        assert sorted(result.files) == ["a.md", "docs/b.md"]
+
+    def test_extract_tar_gz(self, tmp_path):
+        archive = make_tar(tmp_path / "kb.tar.gz", {"nested/deep/c.md": b"gamma"}, mode="w:gz")
+        result = ArchiveExtractor().extract(archive, tmp_path / "out")
+        assert result.files == ["nested/deep/c.md"]
+        assert (tmp_path / "out" / "nested" / "deep" / "c.md").read_bytes() == b"gamma"
+
+    def test_unsupported_format_raises(self, tmp_path):
+        bogus = tmp_path / "kb.rar"
+        bogus.write_bytes(b"not an archive")
+        with pytest.raises(RemoteSyncError, match="Unsupported archive format"):
+            ArchiveExtractor().extract(bogus, tmp_path / "out")
+
+    def test_corrupt_zip_raises(self, tmp_path):
+        corrupt = tmp_path / "kb.zip"
+        corrupt.write_bytes(b"definitely not a zip")
+        with pytest.raises(RemoteSyncError, match="Failed to extract"):
+            ArchiveExtractor().extract(corrupt, tmp_path / "out")
+
+
+class TestPatternFiltering:
+    def test_extract_pattern_keeps_only_matches(self, tmp_path):
+        archive = make_zip(
+            tmp_path / "kb.zip",
+            {"a.md": b"alpha", "b.txt": b"skip", "docs/c.md": b"keep", "docs/d.log": b"skip"},
+        )
+        result = ArchiveExtractor(pattern="*.md").extract(archive, tmp_path / "out")
+        assert sorted(result.files) == ["a.md", "docs/c.md"]
+        assert sorted(result.skipped) == ["b.txt", "docs/d.log"]
+        assert not (tmp_path / "out" / "b.txt").exists()
+
+    def test_skipped_members_never_decompressed_into_bounds(self, tmp_path):
+        """Filtered-out members must not count against the size bound."""
+        archive = make_zip(tmp_path / "kb.zip", {"big.bin": b"x" * 1000, "small.md": b"keep"})
+        extractor = ArchiveExtractor(pattern="*.md", max_total_size=100)
+        result = extractor.extract(archive, tmp_path / "out")
+        assert result.files == ["small.md"]
+
+
+class TestPathSafety:
+    def test_traversal_member_names_rejected(self, tmp_path):
+        # Zip member names with traversal / absolute paths must never
+        # escape the extraction root.
+        archive = make_zip(
+            tmp_path / "evil.zip",
+            {
+                "../escape.md": b"evil",
+                "/abs/escape.md": b"evil",
+                "nested/../../escape2.md": b"evil",
+                "safe.md": b"ok",
+            },
+        )
+        out = tmp_path / "quarantine" / "out"
+        result = ArchiveExtractor().extract(archive, out)
+        assert result.files == ["safe.md"]
+        assert len(result.skipped) == 3
+        assert not (tmp_path / "escape.md").exists()
+        assert not (tmp_path / "escape2.md").exists()
+        assert not (tmp_path / "quarantine" / "escape.md").exists()
+        assert not Path("/abs/escape.md").exists()
+        assert tree(out) == {"safe.md": b"ok"}
+
+    def test_tar_symlink_members_rejected(self, tmp_path):
+        target = tmp_path / "outside.md"
+        target.write_text("outside", encoding="utf-8")
+        archive_path = tmp_path / "links.tar"
+        with tarfile.open(archive_path, "w") as archive:
+            link = tarfile.TarInfo("link.md")
+            link.type = tarfile.SYMTYPE
+            link.linkname = str(target)
+            archive.addfile(link)
+            hard = tarfile.TarInfo("hard.md")
+            hard.type = tarfile.LNKTYPE
+            hard.linkname = str(target)
+            archive.addfile(hard)
+            regular = tarfile.TarInfo("ok.md")
+            regular.size = 2
+            archive.addfile(regular, io.BytesIO(b"ok"))
+        result = ArchiveExtractor().extract(archive_path, tmp_path / "out")
+        assert result.files == ["ok.md"]
+        assert sorted(result.skipped) == ["hard.md", "link.md"]
+        assert not (tmp_path / "out" / "link.md").exists()
+
+    def test_zip_symlink_members_rejected(self, tmp_path):
+        archive_path = tmp_path / "links.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            info = zipfile.ZipInfo("link.md")
+            # S_IFLNK | 0755 in the high 16 bits marks a symlink member
+            info.external_attr = 0o120755 << 16
+            archive.writestr(info, "/etc/passwd")
+            archive.writestr("ok.md", "ok")
+        result = ArchiveExtractor().extract(archive_path, tmp_path / "out")
+        assert result.files == ["ok.md"]
+        assert result.skipped == ["link.md"]
+        assert not (tmp_path / "out" / "link.md").exists()
+
+
+class TestBombBounds:
+    def test_total_size_bound_aborts(self, tmp_path):
+        # Highly compressible payload: small archive, big decompressed size
+        archive = make_zip(tmp_path / "bomb.zip", {"bomb.md": b"0" * 100_000})
+        with pytest.raises(RemoteSyncError, match="max_extracted_size"):
+            ArchiveExtractor(max_total_size=1024).extract(archive, tmp_path / "out")
+        # Nothing partial left behind for the caller to ingest
+        assert not (tmp_path / "out" / "bomb.md").exists()
+
+    def test_total_size_bound_is_cumulative(self, tmp_path):
+        archive = make_zip(tmp_path / "bomb.zip", {f"f{i}.md": b"x" * 600 for i in range(4)})
+        with pytest.raises(RemoteSyncError, match="max_extracted_size"):
+            ArchiveExtractor(max_total_size=1500).extract(archive, tmp_path / "out")
+
+    def test_file_count_bound_aborts(self, tmp_path):
+        archive = make_zip(tmp_path / "many.zip", {f"f{i}.md": b"x" for i in range(20)})
+        with pytest.raises(RemoteSyncError, match="max_extracted_files"):
+            ArchiveExtractor(max_files=10).extract(archive, tmp_path / "out")
+
+    def test_tar_lying_header_still_bounded(self, tmp_path):
+        """Bytes are counted as decompressed - header sizes are not trusted."""
+        archive = make_tar(tmp_path / "big.tar.gz", {"big.md": b"y" * 50_000}, mode="w:gz")
+        with pytest.raises(RemoteSyncError, match="max_extracted_size"):
+            ArchiveExtractor(max_total_size=100).extract(archive, tmp_path / "out")
+
+    def test_within_bounds_succeeds(self, tmp_path):
+        archive = make_zip(tmp_path / "ok.zip", {"a.md": b"x" * 100, "b.md": b"y" * 100})
+        result = ArchiveExtractor(max_files=2, max_total_size=200).extract(
+            archive, tmp_path / "out"
+        )
+        assert sorted(result.files) == ["a.md", "b.md"]
+        assert result.total_size == 200

--- a/tests/unit/test_remote_knowledge_handlers.py
+++ b/tests/unit/test_remote_knowledge_handlers.py
@@ -24,7 +24,6 @@ from muxi.runtime.formation.agents.knowledge.remote.handler import (
     split_url_pattern,
 )
 from muxi.runtime.formation.agents.knowledge.remote.protocols import (
-    PLANNED_SCHEMES,
     SUPPORTED_SCHEMES,
     create_handler,
 )
@@ -59,15 +58,20 @@ class TestUrlHelpers:
         assert a != b
         assert "/" not in a and ":" not in a
 
-    def test_registry_scheme_sets_are_disjoint(self):
-        assert not (SUPPORTED_SCHEMES & PLANNED_SCHEMES)
+    def test_all_prd_schemes_supported(self):
+        assert SUPPORTED_SCHEMES == frozenset(
+            {"http", "https", "s3", "gs", "az", "rsync", "rsync+ssh", "ftp", "sftp", "file"}
+        )
 
     def test_create_handler_dispatch(self):
+        from muxi.runtime.formation.agents.knowledge.remote.protocols.ftp import FTPHandler
+
         assert isinstance(create_handler(make_config("https://h/x.md")), HTTPHandler)
         assert isinstance(create_handler(make_config("file:///tmp/x")), FileHandler)
         assert isinstance(create_handler(make_config("rsync://h/mod/x/")), RsyncHandler)
+        assert isinstance(create_handler(make_config("ftp://h/x")), FTPHandler)
         with pytest.raises(RemoteSyncError):
-            create_handler(make_config("ftp://h/x"))
+            create_handler(make_config("gopher://h/x"))
 
 
 class TestFileHandler:

--- a/tests/unit/test_remote_knowledge_phase4_handlers.py
+++ b/tests/unit/test_remote_knowledge_phase4_handlers.py
@@ -1,0 +1,425 @@
+"""Unit tests for the Phase 4 remote knowledge protocol handlers.
+
+GCS/Azure/FTP/SFTP handlers are exercised against mocked SDK clients (no
+cloud/FTP/SSH infrastructure required), plus scheme auto-detection and
+the clear config-time errors for missing optional dependencies.
+"""
+
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from muxi.runtime.formation.agents.knowledge.remote.handler import (
+    RemoteSyncError,
+    SourceConfig,
+)
+from muxi.runtime.formation.agents.knowledge.remote.protocols import (
+    SUPPORTED_SCHEMES,
+    azure as azure_module,
+    create_handler,
+    gcs as gcs_module,
+    sftp as sftp_module,
+)
+from muxi.runtime.formation.agents.knowledge.remote.protocols.azure import AzureHandler
+from muxi.runtime.formation.agents.knowledge.remote.protocols.ftp import FTPHandler
+from muxi.runtime.formation.agents.knowledge.remote.protocols.gcs import GCSHandler
+from muxi.runtime.formation.agents.knowledge.remote.protocols.sftp import SFTPHandler
+
+AZURE_AUTH = {"type": "azure", "connection_string": "UseDevelopmentStorage=true"}
+
+
+def make_config(url, **overrides):
+    return SourceConfig.from_dict({"url": url, **overrides})
+
+
+class TestAutoDetection:
+    def test_phase4_schemes_supported(self):
+        assert {"gs", "az", "ftp", "sftp"} <= SUPPORTED_SCHEMES
+
+    def test_ftp_dispatch(self):
+        assert isinstance(create_handler(make_config("ftp://host/docs/")), FTPHandler)
+
+    @pytest.mark.skipif(not gcs_module.GCS_AVAILABLE, reason="google-cloud-storage not installed")
+    def test_gs_dispatch(self):
+        assert isinstance(create_handler(make_config("gs://bucket/docs/*")), GCSHandler)
+
+    @pytest.mark.skipif(not azure_module.AZURE_AVAILABLE, reason="azure-storage-blob not installed")
+    def test_az_dispatch(self):
+        assert isinstance(
+            create_handler(make_config("az://container/docs/*", auth=AZURE_AUTH)), AzureHandler
+        )
+
+    @pytest.mark.skipif(not sftp_module.PARAMIKO_AVAILABLE, reason="paramiko not installed")
+    def test_sftp_dispatch(self):
+        assert isinstance(create_handler(make_config("sftp://user@host/docs/")), SFTPHandler)
+
+
+class TestOptionalDependencyErrors:
+    """Missing optional SDKs must fail with a clear, actionable error."""
+
+    def test_gcs_missing_dependency_error(self):
+        with mock.patch.object(gcs_module, "GCS_AVAILABLE", False):
+            with pytest.raises(RemoteSyncError, match=r"muxi-runtime\[gcs\]"):
+                GCSHandler(make_config("gs://bucket/x"))
+
+    def test_azure_missing_dependency_error(self):
+        with mock.patch.object(azure_module, "AZURE_AVAILABLE", False):
+            with pytest.raises(RemoteSyncError, match=r"muxi-runtime\[azure\]"):
+                AzureHandler(make_config("az://container/x", auth=AZURE_AUTH))
+
+    def test_sftp_missing_dependency_error(self):
+        with mock.patch.object(sftp_module, "PARAMIKO_AVAILABLE", False):
+            with pytest.raises(RemoteSyncError, match=r"muxi-runtime\[sftp\]"):
+                SFTPHandler(make_config("sftp://user@host/x"))
+
+
+@pytest.mark.skipif(not gcs_module.GCS_AVAILABLE, reason="google-cloud-storage not installed")
+class TestGCSHandler:
+    def _handler_with_client(self, url, client, **overrides):
+        handler = GCSHandler(make_config(url, **overrides))
+        handler._client = client
+        return handler
+
+    def _blob(self, name, size=0, md5="bWQ1", etag='"e"'):
+        return SimpleNamespace(name=name, size=size, md5_hash=md5, etag=etag)
+
+    async def test_list_files_with_pattern(self):
+        client = mock.Mock()
+        client.list_blobs.return_value = [
+            self._blob("docs/a.md", 10, md5="aaa"),
+            self._blob("docs/skip.txt", 5),
+            self._blob("docs/nested/b.md", 20, md5="bbb"),
+            self._blob("docs/dir/", 0),
+        ]
+        handler = self._handler_with_client("gs://bucket/docs/*.md", client)
+        files = await handler.list_files("gs://bucket/docs/", "*.md")
+        assert sorted(f.path for f in files) == ["a.md", "nested/b.md"]
+        by_path = {f.path: f for f in files}
+        assert by_path["a.md"].remote_hash == "md5:aaa"
+        assert by_path["a.md"].url == "gs://bucket/docs/a.md"
+        client.list_blobs.assert_called_once_with("bucket", prefix="docs/")
+
+    async def test_download_file(self, tmp_path):
+        blob = mock.Mock()
+        blob.size = 5
+
+        def fake_download(dest):
+            Path(dest).write_bytes(b"hello")
+
+        blob.download_to_filename.side_effect = fake_download
+        blob.reload.return_value = None
+        client = mock.Mock()
+        client.bucket.return_value.blob.return_value = blob
+
+        handler = self._handler_with_client("gs://bucket/docs/a.md", client)
+        result = await handler.download_file("gs://bucket/docs/a.md", tmp_path / "a.md")
+        assert result.size == 5
+        assert (tmp_path / "a.md").read_bytes() == b"hello"
+        assert result.local_hash == hashlib.sha256(b"hello").hexdigest()
+
+    async def test_download_size_limit(self, tmp_path):
+        blob = mock.Mock()
+        blob.size = 999999
+        blob.reload.return_value = None
+        client = mock.Mock()
+        client.bucket.return_value.blob.return_value = blob
+        handler = self._handler_with_client("gs://bucket/a.md", client, max_file_size=10)
+        with pytest.raises(RemoteSyncError, match="max_file_size"):
+            await handler.download_file("gs://bucket/a.md", tmp_path / "a.md")
+
+    async def test_mid_transfer_failure_leaves_previous_file_intact(self, tmp_path):
+        dest = tmp_path / "a.md"
+        dest.write_bytes(b"previous good content")
+
+        blob = mock.Mock()
+        blob.size = 5
+        blob.reload.return_value = None
+
+        def partial_then_fail(path):
+            Path(path).write_bytes(b"trunc")
+            raise IOError("connection reset")
+
+        blob.download_to_filename.side_effect = partial_then_fail
+        client = mock.Mock()
+        client.bucket.return_value.blob.return_value = blob
+        handler = self._handler_with_client("gs://bucket/a.md", client)
+        with pytest.raises(RemoteSyncError):
+            await handler.download_file("gs://bucket/a.md", dest)
+        assert dest.read_bytes() == b"previous good content"
+        assert not list(tmp_path.glob("*.part")), "temp download file leaked"
+
+    async def test_missing_bucket_raises(self):
+        handler = GCSHandler(make_config("gs://bucket/x"))
+        with pytest.raises(RemoteSyncError, match="bucket"):
+            await handler.list_files("gs:///prefix/")
+
+
+@pytest.mark.skipif(not azure_module.AZURE_AVAILABLE, reason="azure-storage-blob not installed")
+class TestAzureHandler:
+    def _handler_with_client(self, url, service_client, **overrides):
+        handler = AzureHandler(make_config(url, auth=AZURE_AUTH, **overrides))
+        handler._service_client = service_client
+        return handler
+
+    def _blob(self, name, size=0, content_md5=b"\x01\x02", etag='"e1"'):
+        return SimpleNamespace(
+            name=name,
+            size=size,
+            etag=etag,
+            content_settings=SimpleNamespace(content_md5=content_md5),
+        )
+
+    async def test_list_files_with_pattern(self):
+        container_client = mock.Mock()
+        container_client.list_blobs.return_value = [
+            self._blob("docs/a.md", 10),
+            self._blob("docs/skip.txt", 5),
+        ]
+        service_client = mock.Mock()
+        service_client.get_container_client.return_value = container_client
+        handler = self._handler_with_client("az://container/docs/*.md", service_client)
+        files = await handler.list_files("az://container/docs/", "*.md")
+        assert [f.path for f in files] == ["a.md"]
+        assert files[0].remote_hash == "md5:0102"
+        assert files[0].url == "az://container/docs/a.md"
+        container_client.list_blobs.assert_called_once_with(name_starts_with="docs/")
+
+    async def test_download_file_streams_chunks(self, tmp_path):
+        blob_client = mock.Mock()
+        blob_client.get_blob_properties.return_value = SimpleNamespace(
+            size=10, etag='"e"', content_settings=None
+        )
+        downloader = mock.Mock()
+        downloader.chunks.return_value = iter([b"hello", b"world"])
+        blob_client.download_blob.return_value = downloader
+        service_client = mock.Mock()
+        service_client.get_blob_client.return_value = blob_client
+
+        handler = self._handler_with_client("az://container/a.md", service_client)
+        result = await handler.download_file("az://container/a.md", tmp_path / "a.md")
+        assert result.size == 10
+        assert (tmp_path / "a.md").read_bytes() == b"helloworld"
+
+    async def test_download_size_limit_mid_stream(self, tmp_path):
+        blob_client = mock.Mock()
+        blob_client.get_blob_properties.return_value = SimpleNamespace(
+            size=5, etag='"e"', content_settings=None
+        )
+        downloader = mock.Mock()
+        downloader.chunks.return_value = iter([b"x" * 64, b"y" * 64])
+        blob_client.download_blob.return_value = downloader
+        service_client = mock.Mock()
+        service_client.get_blob_client.return_value = blob_client
+
+        dest = tmp_path / "a.md"
+        dest.write_bytes(b"previous good content")
+        handler = self._handler_with_client(
+            "az://container/a.md", service_client, max_file_size=100
+        )
+        with pytest.raises(RemoteSyncError, match="max_file_size"):
+            await handler.download_file("az://container/a.md", dest)
+        assert dest.read_bytes() == b"previous good content"
+        assert not list(tmp_path.glob("*.part")), "temp download file leaked"
+
+    async def test_missing_container_raises(self):
+        handler = AzureHandler(make_config("az://container/x", auth=AZURE_AUTH))
+        with pytest.raises(RemoteSyncError, match="container"):
+            await handler.list_files("az:///prefix/")
+
+
+class TestFTPHandler:
+    def _handler(self, url="ftp://files.corp/docs/", **overrides):
+        return FTPHandler(make_config(url, **overrides))
+
+    def _mock_ftp(self, mlsd_tree, files):
+        """mlsd_tree: dir -> [(name, facts)], files: path -> bytes."""
+        ftp = mock.Mock()
+
+        def mlsd(directory, facts=None):
+            if directory in mlsd_tree:
+                return list(mlsd_tree[directory])
+            import ftplib
+
+            raise ftplib.error_perm("550 not a directory")
+
+        def size(path):
+            if path in files:
+                return len(files[path])
+            import ftplib
+
+            raise ftplib.error_perm("550 not a file")
+
+        def retrbinary(cmd, callback):
+            path = cmd.removeprefix("RETR ")
+            callback(files[path])
+
+        ftp.mlsd.side_effect = mlsd
+        ftp.size.side_effect = size
+        ftp.retrbinary.side_effect = retrbinary
+        ftp.voidcmd.return_value = "213 20260709100000"
+        return ftp
+
+    async def test_list_directory_recursive_with_pattern(self):
+        tree = {
+            "/docs": [
+                ("a.md", {"type": "file", "size": "5", "modify": "20260709100000"}),
+                ("skip.txt", {"type": "file", "size": "4", "modify": "20260709100000"}),
+                ("nested", {"type": "dir"}),
+                (".", {"type": "cdir"}),
+            ],
+            "/docs/nested": [
+                ("b.md", {"type": "file", "size": "4", "modify": "20260709110000"}),
+            ],
+        }
+        ftp = self._mock_ftp(tree, {})
+        handler = self._handler()
+        with mock.patch.object(handler, "_connect", return_value=ftp):
+            files = await handler.list_files("ftp://files.corp/docs/", "*.md")
+        assert sorted(f.path for f in files) == ["a.md", "nested/b.md"]
+        by_path = {f.path: f for f in files}
+        assert by_path["a.md"].size == 5
+        assert by_path["a.md"].remote_hash == "stat:5:20260709100000"
+        assert by_path["nested/b.md"].url == "ftp://files.corp/docs/nested/b.md"
+
+    async def test_single_file_source(self):
+        ftp = self._mock_ftp({}, {"/docs/guide.md": b"hello"})
+        handler = self._handler("ftp://files.corp/docs/guide.md")
+        with mock.patch.object(handler, "_connect", return_value=ftp):
+            files = await handler.list_files("ftp://files.corp/docs/guide.md")
+        assert [f.path for f in files] == ["guide.md"]
+        assert files[0].size == 5
+
+    async def test_download_file(self, tmp_path):
+        ftp = self._mock_ftp({}, {"/docs/a.md": b"hello"})
+        handler = self._handler()
+        with mock.patch.object(handler, "_connect", return_value=ftp):
+            result = await handler.download_file("ftp://files.corp/docs/a.md", tmp_path / "a.md")
+        assert result.size == 5
+        assert (tmp_path / "a.md").read_bytes() == b"hello"
+        assert result.local_hash == hashlib.sha256(b"hello").hexdigest()
+
+    async def test_download_size_limit_mid_stream(self, tmp_path):
+        ftp = self._mock_ftp({}, {"/docs/big.md": b"x" * 4096})
+        handler = self._handler(max_file_size=64)
+        dest = tmp_path / "big.md"
+        dest.write_bytes(b"previous good content")
+        with mock.patch.object(handler, "_connect", return_value=ftp):
+            with pytest.raises(RemoteSyncError, match="max_file_size"):
+                await handler.download_file("ftp://files.corp/docs/big.md", dest)
+        assert dest.read_bytes() == b"previous good content"
+        assert not list(tmp_path.glob("*.part")), "temp download file leaked"
+
+    async def test_missing_host_raises(self):
+        handler = self._handler()
+        with pytest.raises(RemoteSyncError, match="host"):
+            await handler.list_files("ftp:///docs/")
+
+    async def test_auth_credentials_used_for_login(self):
+        handler = self._handler(auth={"type": "basic", "username": "u", "password": "p"})
+        with mock.patch(
+            "muxi.runtime.formation.agents.knowledge.remote.protocols.ftp.ftplib.FTP"
+        ) as ftp_class:
+            handler._connect(
+                __import__("urllib.parse", fromlist=["urlparse"]).urlparse("ftp://files.corp/docs/")
+            )
+            ftp_class.return_value.login.assert_called_once_with("u", "p")
+
+
+@pytest.mark.skipif(not sftp_module.PARAMIKO_AVAILABLE, reason="paramiko not installed")
+class TestSFTPHandler:
+    def _handler(self, url="sftp://user@host/docs/", **overrides):
+        return SFTPHandler(make_config(url, **overrides))
+
+    @staticmethod
+    def _attrs(filename, mode, size=0, mtime=1751970000):
+        return SimpleNamespace(filename=filename, st_mode=mode, st_size=size, st_mtime=mtime)
+
+    def _mock_sftp(self, listings, stats, files=None):
+        sftp = mock.Mock()
+        sftp.listdir_attr.side_effect = lambda d: listings[d]
+        sftp.stat.side_effect = lambda p: stats[p]
+
+        def get(path, dest):
+            Path(dest).write_bytes((files or {})[path])
+
+        sftp.get.side_effect = get
+        return sftp
+
+    async def test_list_directory_skips_symlinks(self):
+        import stat as stat_module
+
+        listings = {
+            "/docs": [
+                self._attrs("a.md", stat_module.S_IFREG | 0o644, size=5),
+                self._attrs("link.md", stat_module.S_IFLNK | 0o777, size=5),
+                self._attrs("nested", stat_module.S_IFDIR | 0o755),
+            ],
+            "/docs/nested": [
+                self._attrs("b.md", stat_module.S_IFREG | 0o644, size=4),
+            ],
+        }
+        stats = {"/docs": self._attrs("docs", stat_module.S_IFDIR | 0o755)}
+        sftp = self._mock_sftp(listings, stats)
+        handler = self._handler()
+        with mock.patch.object(handler, "_connect", return_value=(mock.Mock(), sftp)):
+            files = await handler.list_files("sftp://user@host/docs/")
+        assert sorted(f.path for f in files) == ["a.md", "nested/b.md"]
+        by_path = {f.path: f for f in files}
+        assert by_path["a.md"].remote_hash == "stat:5:1751970000"
+        assert by_path["nested/b.md"].url == "sftp://user@host/docs/nested/b.md"
+
+    async def test_download_file(self, tmp_path):
+        import stat as stat_module
+
+        stats = {"/docs/a.md": self._attrs("a.md", stat_module.S_IFREG | 0o644, size=5)}
+        sftp = self._mock_sftp({}, stats, files={"/docs/a.md": b"hello"})
+        handler = self._handler()
+        with mock.patch.object(handler, "_connect", return_value=(mock.Mock(), sftp)):
+            result = await handler.download_file("sftp://user@host/docs/a.md", tmp_path / "a.md")
+        assert result.size == 5
+        assert (tmp_path / "a.md").read_bytes() == b"hello"
+
+    async def test_download_size_limit(self, tmp_path):
+        import stat as stat_module
+
+        stats = {"/docs/big.md": self._attrs("big.md", stat_module.S_IFREG | 0o644, size=9999)}
+        sftp = self._mock_sftp({}, stats)
+        handler = self._handler(max_file_size=10)
+        with mock.patch.object(handler, "_connect", return_value=(mock.Mock(), sftp)):
+            with pytest.raises(RemoteSyncError, match="max_file_size"):
+                await handler.download_file("sftp://user@host/docs/big.md", tmp_path / "big.md")
+
+    def test_host_key_policy_strict_by_default(self):
+        import paramiko
+
+        handler = self._handler()
+        with mock.patch(
+            "muxi.runtime.formation.agents.knowledge.remote.protocols.sftp.paramiko.SSHClient"
+        ) as client_class:
+            client = client_class.return_value
+            client.connect.side_effect = paramiko.SSHException("stop here")
+            from urllib.parse import urlparse
+
+            with pytest.raises(RemoteSyncError):
+                handler._connect(urlparse("sftp://user@host/docs/"))
+            policy = client.set_missing_host_key_policy.call_args[0][0]
+            assert isinstance(policy, paramiko.RejectPolicy)
+
+    def test_host_key_tofu_requires_explicit_opt_in(self):
+        import paramiko
+
+        handler = self._handler(accept_new_host_keys=True)
+        with mock.patch(
+            "muxi.runtime.formation.agents.knowledge.remote.protocols.sftp.paramiko.SSHClient"
+        ) as client_class:
+            client = client_class.return_value
+            client.connect.side_effect = paramiko.SSHException("stop here")
+            from urllib.parse import urlparse
+
+            with pytest.raises(RemoteSyncError):
+                handler._connect(urlparse("sftp://user@host/docs/"))
+            policy = client.set_missing_host_key_policy.call_args[0][0]
+            assert isinstance(policy, paramiko.AutoAddPolicy)

--- a/tests/unit/test_remote_knowledge_scheduler.py
+++ b/tests/unit/test_remote_knowledge_scheduler.py
@@ -1,0 +1,356 @@
+"""Unit tests for the remote knowledge sync scheduler (Phase 3).
+
+Covers cron schedule resolution, due-time gating, per-source lock
+contention (no overlapping syncs), retry with exponential backoff, manual
+sync triggers, and the incremental re-embed hook. The SyncManager is
+stubbed so no network or filesystem sync happens.
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Dict, List
+from unittest import mock
+
+import pytest
+
+from muxi.runtime.formation.agents.knowledge.remote.scheduler import (
+    KnowledgeSyncService,
+    RetryPolicy,
+    resolve_cron_expression,
+)
+from muxi.runtime.formation.agents.knowledge.remote.sync import SyncResult
+
+NOW = datetime(2026, 7, 9, 10, 0, 0, tzinfo=timezone.utc)
+
+SCHEDULED_SOURCE = {
+    "url": "stub://source",
+    "id": "scheduled-source",
+    "description": "scheduled stub source",
+    "schedule": "*/15 * * * *",
+}
+
+MANUAL_SOURCE = {
+    "url": "stub://manual",
+    "id": "manual-source",
+    "description": "manual-only stub source",
+}
+
+
+class StubSyncManager:
+    """Records sync calls and returns scripted results."""
+
+    instances: List["StubSyncManager"] = []
+    script: Dict[str, SyncResult] = {}
+    delay: float = 0.0
+
+    def __init__(self, agent_id: str, formation_id: str = "default-formation", root_dir=None):
+        self.agent_id = agent_id
+        self.formation_id = formation_id
+        self.sync_calls: List[Dict] = []
+        StubSyncManager.instances.append(self)
+
+    async def sync_source(self, raw_source, trigger="startup"):
+        self.sync_calls.append({"source": raw_source, "trigger": trigger})
+        if StubSyncManager.delay:
+            await asyncio.sleep(StubSyncManager.delay)
+        source_id = raw_source.get("id", "")
+        result = StubSyncManager.script.get(source_id)
+        if result is None:
+            result = SyncResult(
+                source_id=source_id,
+                url=raw_source.get("url", ""),
+                status="success",
+                content_dir=f"/mirror/{source_id}/content",
+            )
+        return result
+
+    def synthetic_local_source(self, config, result):
+        return {
+            "path": result.content_dir,
+            "name": config.source_id,
+            "description": config.description,
+        }
+
+
+@pytest.fixture(autouse=True)
+def stub_sync_manager():
+    StubSyncManager.instances = []
+    StubSyncManager.script = {}
+    StubSyncManager.delay = 0.0
+    with mock.patch(
+        "muxi.runtime.formation.agents.knowledge.remote.scheduler.SyncManager",
+        StubSyncManager,
+    ):
+        yield
+
+
+def make_overlord(handler=None):
+    agent = SimpleNamespace(knowledge_handler=handler)
+    return SimpleNamespace(agents={"agent-x": agent})
+
+
+def make_service(sources=None, handler=None, agent_id="agent-x"):
+    return KnowledgeSyncService(
+        overlord=make_overlord(handler),
+        agent_sources={agent_id: sources or [dict(SCHEDULED_SOURCE)]},
+    )
+
+
+def scripted_result(source_id, status="success", changed=None, deleted=None):
+    result = SyncResult(
+        source_id=source_id,
+        url="stub://source",
+        status=status,
+        content_dir=f"/mirror/{source_id}/content",
+        error="boom" if status == "failed" else "",
+    )
+    result.changed_paths = list(changed or [])
+    result.deleted_paths = list(deleted or [])
+    return result
+
+
+class TestCronResolution:
+    def test_aliases_resolve_to_cron(self):
+        assert resolve_cron_expression("@hourly") == "0 * * * *"
+        assert resolve_cron_expression("@daily") == "0 0 * * *"
+        assert resolve_cron_expression("@weekly") == "0 0 * * 0"
+
+    def test_startup_and_missing_are_not_periodic(self):
+        assert resolve_cron_expression("@startup") is None
+        assert resolve_cron_expression(None) is None
+        assert resolve_cron_expression("") is None
+
+    def test_raw_cron_passes_through(self):
+        assert resolve_cron_expression("*/15 * * * *") == "*/15 * * * *"
+
+
+class TestRetryPolicy:
+    def test_defaults(self):
+        policy = RetryPolicy.from_dict({})
+        assert policy.max_attempts == 3
+        assert policy.initial_delay == 5.0
+        assert policy.max_delay == 300.0
+        assert policy.exponential_base == 2.0
+
+    def test_backoff_progression_and_cap(self):
+        policy = RetryPolicy(initial_delay=5, max_delay=30, exponential_base=2)
+        assert policy.delay_for_attempt(1) == 5
+        assert policy.delay_for_attempt(2) == 10
+        assert policy.delay_for_attempt(3) == 20
+        assert policy.delay_for_attempt(4) == 30  # capped
+        assert policy.delay_for_attempt(10) == 30
+
+
+class TestScheduling:
+    def test_scheduled_sources_get_next_fire(self):
+        service = make_service([dict(SCHEDULED_SOURCE), dict(MANUAL_SOURCE)])
+        entries = {e.source_id: e for e in service.sources_for_agent("agent-x")}
+        assert entries["scheduled-source"].next_fire is not None
+        assert entries["manual-source"].next_fire is None
+        assert service.has_scheduled_sources
+        assert service.scheduled_source_count == 1
+
+    def test_manual_only_service_has_no_scheduled_sources(self):
+        service = make_service([dict(MANUAL_SOURCE)])
+        assert not service.has_scheduled_sources
+
+    async def test_tick_before_due_does_not_sync(self):
+        service = make_service()
+        entry = service.sources_for_agent("agent-x")[0]
+        await service.tick(now=entry.next_fire - timedelta(seconds=1))
+        assert StubSyncManager.instances == []
+
+    async def test_tick_at_due_time_syncs_and_reschedules(self):
+        service = make_service()
+        entry = service.sources_for_agent("agent-x")[0]
+        due = entry.next_fire
+        await service.tick(now=due)
+        assert len(StubSyncManager.instances) == 1
+        assert StubSyncManager.instances[0].sync_calls[0]["trigger"] == "scheduled"
+        # Rescheduled to the next cron slot after the sync
+        assert entry.next_fire > due
+
+    async def test_tick_isolated_from_sync_crash(self):
+        service = make_service()
+        entry = service.sources_for_agent("agent-x")[0]
+        with mock.patch.object(StubSyncManager, "sync_source", side_effect=RuntimeError("explode")):
+            await service.tick(now=entry.next_fire)  # must not raise
+
+
+class TestRetryBackoff:
+    async def test_failure_schedules_exponential_retries_then_cron(self):
+        source = {**SCHEDULED_SOURCE, "retry": {"initial_delay": 5, "exponential_base": 2}}
+        service = make_service([source])
+        entry = service.sources_for_agent("agent-x")[0]
+        StubSyncManager.script["scheduled-source"] = scripted_result(
+            "scheduled-source", status="failed"
+        )
+
+        first_due = entry.next_fire
+        await service.tick(now=first_due)
+        assert entry.failed_attempts == 1
+        assert entry.next_fire == first_due + timedelta(seconds=5)
+
+        second_due = entry.next_fire
+        await service.tick(now=second_due)
+        assert entry.failed_attempts == 2
+        assert entry.next_fire == second_due + timedelta(seconds=10)
+
+        # Third failure exhausts max_attempts (default 3): back to cron
+        third_due = entry.next_fire
+        await service.tick(now=third_due)
+        assert entry.failed_attempts == 0
+        assert entry.next_fire.minute % 15 == 0
+        assert entry.next_fire > third_due
+
+    async def test_success_resets_failed_attempts(self):
+        service = make_service()
+        entry = service.sources_for_agent("agent-x")[0]
+        StubSyncManager.script["scheduled-source"] = scripted_result(
+            "scheduled-source", status="failed"
+        )
+        await service.tick(now=entry.next_fire)
+        assert entry.failed_attempts == 1
+
+        StubSyncManager.script["scheduled-source"] = scripted_result("scheduled-source")
+        await service.tick(now=entry.next_fire)
+        assert entry.failed_attempts == 0
+
+    async def test_backoff_delay_capped_at_max_delay(self):
+        source = {
+            **SCHEDULED_SOURCE,
+            "retry": {"initial_delay": 100, "max_delay": 120, "max_attempts": 5},
+        }
+        service = make_service([source])
+        entry = service.sources_for_agent("agent-x")[0]
+        StubSyncManager.script["scheduled-source"] = scripted_result(
+            "scheduled-source", status="failed"
+        )
+        due = entry.next_fire
+        await service.tick(now=due)
+        assert entry.next_fire == due + timedelta(seconds=100)
+        due = entry.next_fire
+        await service.tick(now=due)
+        assert entry.next_fire == due + timedelta(seconds=120)  # capped, not 200
+
+
+class TestLockContention:
+    async def test_concurrent_syncs_of_same_source_skip(self):
+        StubSyncManager.delay = 0.2
+        service = make_service([dict(MANUAL_SOURCE)])
+
+        first, second = await asyncio.gather(
+            service.sync_now("agent-x"),
+            service.sync_now("agent-x"),
+        )
+        statuses = sorted([first[0]["status"], second[0]["status"]])
+        assert statuses == ["skipped", "success"]
+        # Only one sync actually ran
+        total_calls = sum(len(i.sync_calls) for i in StubSyncManager.instances)
+        assert total_calls == 1
+
+    async def test_scheduled_tick_skips_while_manual_sync_running(self):
+        StubSyncManager.delay = 0.2
+        service = make_service()
+        entry = service.sources_for_agent("agent-x")[0]
+        due = entry.next_fire
+
+        manual = asyncio.create_task(service.sync_now("agent-x", "scheduled-source"))
+        await asyncio.sleep(0.05)
+        await service.tick(now=due)
+        results = await manual
+
+        assert results[0]["status"] == "success"
+        # The scheduled slot was skipped, next_fire untouched
+        assert entry.next_fire == due
+        total_calls = sum(len(i.sync_calls) for i in StubSyncManager.instances)
+        assert total_calls == 1
+
+    async def test_different_sources_do_not_contend(self):
+        StubSyncManager.delay = 0.1
+        service = make_service([dict(SCHEDULED_SOURCE), dict(MANUAL_SOURCE)])
+        results = await asyncio.gather(
+            service.sync_now("agent-x", "scheduled-source"),
+            service.sync_now("agent-x", "manual-source"),
+        )
+        assert [r[0]["status"] for r in results] == ["success", "success"]
+
+
+class TestManualTrigger:
+    async def test_sync_now_all_sources(self):
+        service = make_service([dict(SCHEDULED_SOURCE), dict(MANUAL_SOURCE)])
+        results = await service.sync_now("agent-x")
+        assert {r["source_id"] for r in results} == {"scheduled-source", "manual-source"}
+        assert all(r["status"] == "success" for r in results)
+        triggers = [call["trigger"] for i in StubSyncManager.instances for call in i.sync_calls]
+        assert triggers == ["manual", "manual"]
+
+    async def test_sync_now_single_source(self):
+        service = make_service([dict(SCHEDULED_SOURCE), dict(MANUAL_SOURCE)])
+        results = await service.sync_now("agent-x", source_id="manual-source")
+        assert len(results) == 1
+        assert results[0]["source_id"] == "manual-source"
+
+    async def test_sync_now_unknown_agent_raises(self):
+        service = make_service()
+        with pytest.raises(KeyError):
+            await service.sync_now("nope")
+
+    async def test_sync_now_unknown_source_raises(self):
+        service = make_service()
+        with pytest.raises(KeyError):
+            await service.sync_now("agent-x", source_id="nope")
+
+
+class TestReembedding:
+    def make_handler(self):
+        handler = mock.MagicMock()
+        handler.refresh_remote_source = mock.AsyncMock(return_value=3)
+        return handler
+
+    async def test_changed_files_trigger_incremental_reembed(self):
+        handler = self.make_handler()
+        service = make_service([dict(MANUAL_SOURCE)], handler=handler)
+        StubSyncManager.script["manual-source"] = scripted_result(
+            "manual-source", changed=["a.md", "docs/b.md"], deleted=["old.md"]
+        )
+        await service.sync_now("agent-x")
+
+        handler.refresh_remote_source.assert_awaited_once()
+        source_config, changed, deleted = handler.refresh_remote_source.await_args.args
+        assert source_config["path"] == "/mirror/manual-source/content"
+        assert changed == [
+            "/mirror/manual-source/content/a.md",
+            "/mirror/manual-source/content/docs/b.md",
+        ]
+        assert deleted == ["/mirror/manual-source/content/old.md"]
+
+    async def test_no_changes_skip_reembed(self):
+        handler = self.make_handler()
+        service = make_service([dict(MANUAL_SOURCE)], handler=handler)
+        await service.sync_now("agent-x")
+        handler.refresh_remote_source.assert_not_awaited()
+
+    async def test_failed_sync_skips_reembed(self):
+        handler = self.make_handler()
+        service = make_service([dict(MANUAL_SOURCE)], handler=handler)
+        StubSyncManager.script["manual-source"] = scripted_result(
+            "manual-source", status="failed", changed=["a.md"]
+        )
+        await service.sync_now("agent-x")
+        handler.refresh_remote_source.assert_not_awaited()
+
+    async def test_missing_knowledge_handler_tolerated(self):
+        service = make_service([dict(MANUAL_SOURCE)], handler=None)
+        StubSyncManager.script["manual-source"] = scripted_result("manual-source", changed=["a.md"])
+        results = await service.sync_now("agent-x")
+        assert results[0]["status"] == "success"
+
+    async def test_reembed_failure_is_isolated(self):
+        handler = self.make_handler()
+        handler.refresh_remote_source.side_effect = RuntimeError("embed exploded")
+        service = make_service([dict(MANUAL_SOURCE)], handler=handler)
+        StubSyncManager.script["manual-source"] = scripted_result("manual-source", changed=["a.md"])
+        results = await service.sync_now("agent-x")  # must not raise
+        assert results[0]["status"] == "success"

--- a/tests/unit/test_remote_knowledge_sync.py
+++ b/tests/unit/test_remote_knowledge_sync.py
@@ -1,13 +1,15 @@
 """Unit tests for the remote knowledge SyncManager orchestration.
 
 Uses a stub in-memory protocol handler so sync behavior (change
-detection, degrade paths, path safety, limits) is tested without any
-network dependency.
+detection, degrade paths, path safety, limits, archive extraction) is
+tested without any network dependency.
 """
 
 import hashlib
+import io
 import os
 import sys
+import zipfile
 from pathlib import Path
 from typing import Dict, List, Optional
 from unittest import mock
@@ -411,6 +413,188 @@ class TestEnumeratedSync:
         assert len(result.skipped_files) == 3
 
 
+class TestChangePaths:
+    async def test_enumerated_sync_reports_changed_and_deleted_paths(self, tmp_path):
+        state = {"files": {"a.md": b"alpha", "b.md": b"beta"}}
+
+        def factory(cfg):
+            return StubHandler(cfg, state["files"])
+
+        manager, patcher = make_manager(tmp_path, factory)
+        with patcher:
+            first = await manager.sync_source(dict(SOURCE))
+            state["files"] = {"a.md": b"ALPHA v2", "c.md": b"gamma"}
+            second = await manager.sync_source(dict(SOURCE))
+
+        assert sorted(first.changed_paths) == ["a.md", "b.md"]
+        assert first.deleted_paths == []
+        assert first.has_changes
+        assert sorted(second.changed_paths) == ["a.md", "c.md"]
+        assert second.deleted_paths == ["b.md"]
+
+    async def test_no_change_sync_reports_no_changes(self, tmp_path):
+        files = {"a.md": b"alpha"}
+        manager, patcher = make_manager(tmp_path, lambda cfg: StubHandler(cfg, files))
+        with patcher:
+            await manager.sync_source(dict(SOURCE))
+            second = await manager.sync_source(dict(SOURCE))
+        assert not second.has_changes
+
+
+def make_zip_bytes(files: Dict[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        for name, content in files.items():
+            archive.writestr(name, content)
+    return buffer.getvalue()
+
+
+ARCHIVE_SOURCE = {
+    "url": "stub://kb.zip",
+    "id": "archive-source",
+    "description": "stub archive source",
+    "extract": True,
+}
+
+
+class TestArchiveSync:
+    def archive_manager(self, tmp_path, state):
+        def factory(cfg):
+            handler = StubHandler(cfg, {"kb.zip": state["zip"]})
+            state["handlers"].append(handler)
+            return handler
+
+        return make_manager(tmp_path, factory)
+
+    async def test_cold_archive_sync_extracts_content(self, tmp_path):
+        state = {
+            "zip": make_zip_bytes({"a.md": b"alpha", "docs/b.md": b"beta"}),
+            "handlers": [],
+        }
+        manager, patcher = self.archive_manager(tmp_path, state)
+        with patcher:
+            result = await manager.sync_source(dict(ARCHIVE_SOURCE))
+
+        assert result.status == "success"
+        assert result.files_added == 2
+        assert sorted(result.changed_paths) == ["a.md", "docs/b.md"]
+        content_dir = Path(result.content_dir)
+        assert (content_dir / "a.md").read_bytes() == b"alpha"
+        assert (content_dir / "docs" / "b.md").read_bytes() == b"beta"
+        # The archive itself is never mirrored into the content dir
+        assert not list(content_dir.rglob("*.zip"))
+        # Temp extraction state is cleaned up
+        assert not list(content_dir.parent.glob(".archive-*"))
+
+        manifest = Manifest.load(
+            str(content_dir.parent / MANIFEST_FILENAME), "archive-source", ARCHIVE_SOURCE["url"]
+        )
+        assert manifest.archive_hash.startswith("hash:")
+        assert set(manifest.files) == {"a.md", "docs/b.md"}
+
+    async def test_unchanged_archive_not_redownloaded(self, tmp_path):
+        state = {"zip": make_zip_bytes({"a.md": b"alpha"}), "handlers": []}
+        manager, patcher = self.archive_manager(tmp_path, state)
+        with patcher:
+            await manager.sync_source(dict(ARCHIVE_SOURCE))
+            second = await manager.sync_source(dict(ARCHIVE_SOURCE))
+
+        assert second.status == "success"
+        assert not second.has_changes
+        assert state["handlers"][1].download_calls == []
+
+    async def test_changed_archive_reports_only_changed_files(self, tmp_path):
+        state = {
+            "zip": make_zip_bytes({"a.md": b"alpha", "b.md": b"beta"}),
+            "handlers": [],
+        }
+        manager, patcher = self.archive_manager(tmp_path, state)
+        with patcher:
+            await manager.sync_source(dict(ARCHIVE_SOURCE))
+            state["zip"] = make_zip_bytes({"a.md": b"alpha", "b.md": b"beta v2", "c.md": b"new"})
+            result = await manager.sync_source(dict(ARCHIVE_SOURCE))
+
+        assert result.files_added == 1
+        assert result.files_modified == 1
+        assert sorted(result.changed_paths) == ["b.md", "c.md"]
+        assert result.deleted_paths == []
+
+    async def test_removed_archive_member_deleted_locally(self, tmp_path):
+        state = {
+            "zip": make_zip_bytes({"a.md": b"alpha", "b.md": b"beta"}),
+            "handlers": [],
+        }
+        manager, patcher = self.archive_manager(tmp_path, state)
+        with patcher:
+            await manager.sync_source(dict(ARCHIVE_SOURCE))
+            state["zip"] = make_zip_bytes({"a.md": b"alpha"})
+            result = await manager.sync_source(dict(ARCHIVE_SOURCE))
+
+        assert result.deleted_paths == ["b.md"]
+        assert not (Path(result.content_dir) / "b.md").exists()
+
+    async def test_extract_pattern_filters_members(self, tmp_path):
+        state = {
+            "zip": make_zip_bytes({"a.md": b"keep", "b.txt": b"skip", "docs/c.md": b"keep"}),
+            "handlers": [],
+        }
+        source = {**ARCHIVE_SOURCE, "extract_pattern": "*.md"}
+        manager, patcher = self.archive_manager(tmp_path, state)
+        with patcher:
+            result = await manager.sync_source(source)
+
+        content_dir = Path(result.content_dir)
+        assert (content_dir / "a.md").exists()
+        assert (content_dir / "docs" / "c.md").exists()
+        assert not (content_dir / "b.txt").exists()
+        assert "b.txt" in result.skipped_files
+
+    async def test_corrupt_archive_degrades_to_stale_content(self, tmp_path):
+        state = {"zip": make_zip_bytes({"a.md": b"good v1"}), "handlers": []}
+        manager, patcher = self.archive_manager(tmp_path, state)
+        with patcher:
+            first = await manager.sync_source(dict(ARCHIVE_SOURCE))
+            state["zip"] = b"corrupt bytes, not a zip"
+            second = await manager.sync_source(dict(ARCHIVE_SOURCE))
+
+        assert first.status == "success"
+        assert second.status == "failed"
+        assert "extract" in second.error.lower() or "archive" in second.error.lower()
+        # Stale-wins: the previously extracted content survives untouched
+        assert (Path(second.content_dir) / "a.md").read_bytes() == b"good v1"
+        # And the failed attempt leaked no temp extraction dirs
+        assert not list(Path(second.content_dir).parent.glob(".archive-*"))
+
+    async def test_bomb_bound_fails_sync_without_partial_ingest(self, tmp_path):
+        state = {
+            "zip": make_zip_bytes({f"f{i}.md": b"x" * 4096 for i in range(10)}),
+            "handlers": [],
+        }
+        source = {**ARCHIVE_SOURCE, "max_extracted_size": 8192}
+        manager, patcher = self.archive_manager(tmp_path, state)
+        with patcher:
+            result = await manager.sync_source(source)
+
+        assert result.status == "failed"
+        assert "max_extracted_size" in result.error
+        assert not result.has_local_content
+
+    async def test_traversal_members_never_escape_mirror(self, tmp_path):
+        state = {
+            "zip": make_zip_bytes({"../evil.md": b"escape", "safe.md": b"ok"}),
+            "handlers": [],
+        }
+        manager, patcher = self.archive_manager(tmp_path, state)
+        with patcher:
+            result = await manager.sync_source(dict(ARCHIVE_SOURCE))
+
+        content_dir = Path(result.content_dir)
+        assert (content_dir / "safe.md").exists()
+        assert not (content_dir.parent / "evil.md").exists()
+        assert not (tmp_path / "evil.md").exists()
+        assert "../evil.md" in result.skipped_files
+
+
 class TestIncrementalSync:
     async def test_incremental_add_modify_delete(self, tmp_path):
         state = {"files": {"a.md": b"alpha", "b.md": b"beta"}}
@@ -434,6 +618,73 @@ class TestIncrementalSync:
             str(content_dir.parent / MANIFEST_FILENAME), "stub-source", SOURCE["url"]
         )
         assert set(manifest.files) == {"a.md", "c.md"}
+
+
+class TestRefreshRemoteSource:
+    """KnowledgeHandler.refresh_remote_source: incremental re-embed (Phase 3)."""
+
+    def make_handler(self, tmp_path):
+        from muxi.runtime.formation.agents.knowledge.handler import KnowledgeHandler
+
+        working_memory = mock.MagicMock()
+        working_memory.remove_by_metadata.return_value = 1
+        handler = KnowledgeHandler(
+            "agent-x",
+            working_memory=working_memory,
+            cache_dir=str(tmp_path / "cache"),
+            embedding_dimension=8,
+        )
+
+        async def fake_embeddings(texts):
+            return [[0.0] * 8 for _ in texts]
+
+        handler._generate_embeddings_fn = fake_embeddings
+        return handler, working_memory
+
+    async def test_removes_stale_chunks_and_reingests_changed_files(self, tmp_path):
+        from muxi.runtime.formation.agents.knowledge.handler import KnowledgeHandler
+
+        handler, working_memory = self.make_handler(tmp_path)
+        mirror = tmp_path / "mirror"
+        mirror.mkdir()
+        changed_file = mirror / "a.md"
+        changed_file.write_text("updated content", encoding="utf-8")
+        deleted_file = str(mirror / "gone.md")
+
+        source_config = {"path": str(mirror), "name": "src", "description": "remote mirror"}
+        with mock.patch.object(
+            KnowledgeHandler, "add_file", new_callable=mock.AsyncMock, return_value=2
+        ) as add_mock:
+            chunks = await handler.refresh_remote_source(
+                source_config, [str(changed_file)], [deleted_file]
+            )
+
+        assert chunks == 2
+        # Stale chunks for both files were removed via per-chunk file_path
+        removed_paths = {
+            call.kwargs["metadata_filter"].get("file_path")
+            for call in working_memory.remove_by_metadata.call_args_list
+            if "file_path" in call.kwargs.get("metadata_filter", {})
+        }
+        assert removed_paths == {str(changed_file), deleted_file}
+        # Only the changed file was re-ingested (deleted one is gone)
+        add_mock.assert_awaited_once()
+        ingested_source = add_mock.await_args.args[0]
+        assert ingested_source.path == str(changed_file)
+        assert ingested_source.name == "src"
+        # The transient per-file source never leaks into the sources list
+        assert handler.sources == []
+
+    async def test_no_embedding_fn_skips_reembed(self, tmp_path):
+        handler, _ = self.make_handler(tmp_path)
+        handler._generate_embeddings_fn = None
+        mirror = tmp_path / "mirror"
+        mirror.mkdir()
+        (mirror / "a.md").write_text("x", encoding="utf-8")
+        chunks = await handler.refresh_remote_source(
+            {"path": str(mirror), "name": "src"}, [str(mirror / "a.md")], []
+        )
+        assert chunks == 0
 
 
 class TestPrepareSources:

--- a/tests/unit/test_remote_knowledge_validation.py
+++ b/tests/unit/test_remote_knowledge_validation.py
@@ -45,8 +45,11 @@ class TestUrlSchemes:
             "https://wiki.company.com/export/docs.md",
             "http://internal.corp/files/notes.txt",
             "s3://acme-bucket/policies/*",
+            "gs://acme-bucket/policies/*",
             "rsync://docs-server/knowledge/",
             "rsync+ssh://docs@server.com/knowledge/",
+            "ftp://files.corp/docs/*.pdf",
+            "sftp://user@host/docs/",
             "file:///mounted/path/",
         ],
     )
@@ -54,13 +57,27 @@ class TestUrlSchemes:
         result = validate_sources(validator, [remote(url)])
         assert result.is_valid, result.errors
 
-    @pytest.mark.parametrize(
-        "url", ["gs://bucket/x", "az://container/x", "ftp://h/x", "sftp://u@h/x"]
-    )
-    def test_planned_schemes_rejected_as_not_yet_supported(self, validator, url):
+    def test_az_scheme_accepted_with_auth(self, validator):
+        result = validate_sources(
+            validator,
+            [
+                remote(
+                    "az://container/docs/*",
+                    auth={"type": "azure", "connection_string": "${{ secrets.AZ_CONN }}"},
+                )
+            ],
+        )
+        assert result.is_valid, result.errors
+
+    def test_az_requires_auth_block(self, validator):
+        result = validate_sources(validator, [remote("az://container/docs/*")])
+        assert not result.is_valid
+        assert any("'auth'" in e for e in result.errors)
+
+    @pytest.mark.parametrize("url", ["gs:///prefix/*", "ftp:///x", "sftp:///x"])
+    def test_new_schemes_require_host_or_bucket(self, validator, url):
         result = validate_sources(validator, [remote(url)])
         assert not result.is_valid
-        assert any("not yet supported" in e for e in result.errors)
 
     def test_unknown_scheme_rejected(self, validator):
         result = validate_sources(validator, [remote("gopher://host/x")])
@@ -257,10 +274,12 @@ class TestOptions:
         assert not result.is_valid
         assert any("boolean" in e for e in result.errors)
 
-    def test_extract_rejected_in_phase_1(self, validator):
-        result = validate_sources(validator, [remote("https://h/a.zip", extract=True)])
-        assert not result.is_valid
-        assert any("extraction" in e for e in result.errors)
+    def test_accept_new_host_keys_valid_for_sftp(self, validator):
+        result = validate_sources(
+            validator,
+            [remote("sftp://user@host/docs/", accept_new_host_keys=True)],
+        )
+        assert result.is_valid, result.errors
 
     def test_schedule_cron_and_aliases_accepted(self, validator):
         result = validate_sources(
@@ -279,6 +298,180 @@ class TestOptions:
         )
         assert not result.is_valid
         assert any("schedule" in e for e in result.errors)
+
+
+class TestArchiveExtractionOptions:
+    def test_extract_zip_source_valid(self, validator):
+        result = validate_sources(
+            validator,
+            [remote("https://h/export.zip", extract=True, extract_pattern="**/*.md")],
+        )
+        assert result.is_valid, result.errors
+
+    def test_extract_must_be_boolean(self, validator):
+        result = validate_sources(validator, [remote("https://h/a.zip", extract="yes")])
+        assert not result.is_valid
+        assert any("boolean" in e for e in result.errors)
+
+    def test_extract_pattern_requires_extract(self, validator):
+        result = validate_sources(validator, [remote("https://h/a.zip", extract_pattern="**/*.md")])
+        assert not result.is_valid
+        assert any("requires 'extract: true'" in e for e in result.errors)
+
+    def test_extract_rejected_for_rsync(self, validator):
+        result = validate_sources(validator, [remote("rsync://server/docs/", extract=True)])
+        assert not result.is_valid
+        assert any("not valid for rsync" in e for e in result.errors)
+
+    def test_extract_rejected_with_glob_url(self, validator):
+        result = validate_sources(validator, [remote("s3://bucket/*.zip", extract=True)])
+        assert not result.is_valid
+        assert any("single archive" in e for e in result.errors)
+
+    @pytest.mark.parametrize("key", ["max_extracted_files", "max_extracted_size"])
+    def test_extraction_bounds_positive_integers(self, validator, key):
+        result = validate_sources(validator, [remote("https://h/a.zip", extract=True, **{key: 0})])
+        assert not result.is_valid
+        result2 = validate_sources(
+            FormationValidator(), [remote("https://h/a.zip", extract=True, **{key: 500})]
+        )
+        assert result2.is_valid, result2.errors
+
+    def test_extraction_bounds_require_extract(self, validator):
+        result = validate_sources(validator, [remote("https://h/a.zip", max_extracted_files=10)])
+        assert not result.is_valid
+        assert any("requires 'extract: true'" in e for e in result.errors)
+
+    def test_empty_extract_pattern_rejected(self, validator):
+        result = validate_sources(
+            validator, [remote("https://h/a.zip", extract=True, extract_pattern="  ")]
+        )
+        assert not result.is_valid
+
+
+class TestRetryBlock:
+    def test_full_retry_block_valid(self, validator):
+        result = validate_sources(
+            validator,
+            [
+                remote(
+                    "s3://bucket/docs/*",
+                    retry={
+                        "max_attempts": 5,
+                        "initial_delay": 2,
+                        "max_delay": 120.5,
+                        "exponential_base": 2,
+                    },
+                )
+            ],
+        )
+        assert result.is_valid, result.errors
+
+    def test_retry_must_be_mapping(self, validator):
+        result = validate_sources(validator, [remote("s3://bucket/x", retry=3)])
+        assert not result.is_valid
+        assert any("mapping" in e for e in result.errors)
+
+    def test_unknown_retry_key_rejected(self, validator):
+        result = validate_sources(validator, [remote("s3://bucket/x", retry={"delay": 5})])
+        assert not result.is_valid
+        assert any("not recognized" in e for e in result.errors)
+
+    def test_max_attempts_positive_integer(self, validator):
+        result = validate_sources(validator, [remote("s3://bucket/x", retry={"max_attempts": 0})])
+        assert not result.is_valid
+
+    @pytest.mark.parametrize("key", ["initial_delay", "max_delay"])
+    def test_delays_positive_numbers(self, validator, key):
+        result = validate_sources(validator, [remote("s3://bucket/x", retry={key: -1})])
+        assert not result.is_valid
+
+    def test_exponential_base_at_least_one(self, validator):
+        result = validate_sources(
+            validator, [remote("s3://bucket/x", retry={"exponential_base": 0.5})]
+        )
+        assert not result.is_valid
+
+
+class TestPhase4AuthBlocks:
+    def test_gcp_auth_with_credentials_json(self, validator):
+        result = validate_sources(
+            validator,
+            [
+                remote(
+                    "gs://bucket/docs/*",
+                    auth={"type": "gcp", "credentials_json": "${{ secrets.GCP_SA_JSON }}"},
+                )
+            ],
+        )
+        assert result.is_valid, result.errors
+
+    def test_gcp_auth_default_credential_chain(self, validator):
+        result = validate_sources(validator, [remote("gs://bucket/x", auth={"type": "gcp"})])
+        assert result.is_valid, result.errors
+
+    def test_gcp_auth_empty_credentials_json_rejected(self, validator):
+        result = validate_sources(
+            validator, [remote("gs://bucket/x", auth={"type": "gcp", "credentials_json": " "})]
+        )
+        assert not result.is_valid
+
+    def test_azure_auth_account_pair_valid(self, validator):
+        result = validate_sources(
+            validator,
+            [
+                remote(
+                    "az://container/x",
+                    auth={
+                        "type": "azure",
+                        "account_name": "acme",
+                        "account_key": "${{ secrets.AZ_KEY }}",
+                    },
+                )
+            ],
+        )
+        assert result.is_valid, result.errors
+
+    def test_azure_auth_account_name_without_key_rejected(self, validator):
+        result = validate_sources(
+            validator,
+            [remote("az://container/x", auth={"type": "azure", "account_name": "acme"})],
+        )
+        assert not result.is_valid
+        assert any("account_key" in e for e in result.errors)
+
+    def test_azure_auth_type_alone_rejected(self, validator):
+        result = validate_sources(validator, [remote("az://container/x", auth={"type": "azure"})])
+        assert not result.is_valid
+        assert any("connection_string" in e for e in result.errors)
+
+    def test_ftp_basic_auth_valid(self, validator):
+        result = validate_sources(
+            validator,
+            [remote("ftp://h/docs/", auth={"type": "basic", "username": "u", "password": "p"})],
+        )
+        assert result.is_valid, result.errors
+
+    def test_sftp_ssh_key_auth_valid(self, validator):
+        result = validate_sources(
+            validator,
+            [remote("sftp://u@h/docs/", auth={"type": "ssh_key", "key": "${{ secrets.K }}"})],
+        )
+        assert result.is_valid, result.errors
+
+    def test_sftp_password_auth_valid(self, validator):
+        result = validate_sources(
+            validator,
+            [remote("sftp://h/docs/", auth={"type": "basic", "username": "u", "password": "p"})],
+        )
+        assert result.is_valid, result.errors
+
+    def test_ftp_ssh_key_auth_rejected(self, validator):
+        result = validate_sources(
+            validator, [remote("ftp://h/docs/", auth={"type": "ssh_key", "key": "k"})]
+        )
+        assert not result.is_valid
+        assert any("not valid for" in e for e in result.errors)
 
 
 class TestFormationLevelKnowledge:

--- a/tests/unit/test_working_memory_partition_dim.py
+++ b/tests/unit/test_working_memory_partition_dim.py
@@ -1,0 +1,121 @@
+"""Unit tests for per-partition FAISS dimensionality in ``WorkingMemory``.
+
+Pre-computed embeddings (``add_with_embedding`` — the knowledge-chunk
+path) may carry a different dimensionality than the memory's own
+embedding model (e.g. 1536-dim OpenAI document embeddings inside the
+768-dim Nomic buffer memory). Partitions must be created — and rebuilt —
+at the dim of the vectors they store:
+
+* creation at the memory-wide dim used to make every ``index.add`` fail
+  silently (items landed in the buffer but never in FAISS), and
+* ``_rebuild_index`` (triggered by ``remove_by_metadata``) used to
+  shape-crash every subsequent vector search.
+
+``probe_dimension`` is patched so no OneLLM / network calls happen.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from muxi.runtime.services.memory.working import WorkingMemory, _IndexPartition
+
+MEMORY_DIM = 768
+DOC_DIM = 1536
+
+
+def _make_memory() -> WorkingMemory:
+    return WorkingMemory(
+        formation_id="test-formation",
+        max_size=10,
+        buffer_multiplier=2,
+        embedding_model="local/nomic-ai/nomic-embed-text-v1.5",
+    )
+
+
+def _probe_patch():
+    return patch(
+        "muxi.runtime.services.memory.working.probe_dimension",
+        new_callable=AsyncMock,
+        return_value=MEMORY_DIM,
+    )
+
+
+class TestGetPartitionDimension:
+    def test_explicit_dimension_wins_over_memory_dim(self):
+        memory = _make_memory()
+        partition = memory._get_partition("knowledge", dimension=DOC_DIM)
+        assert isinstance(partition, _IndexPartition)
+        assert partition.index.d == DOC_DIM
+
+    def test_absent_dimension_falls_back_to_memory_dim(self):
+        memory = _make_memory()
+        partition = memory._get_partition("buffer")
+        assert partition.index.d == memory.dimension
+
+    def test_explicit_none_falls_back_but_explicit_value_never_does(self):
+        """Only ``None`` means "no override" — the fallback is an explicit
+        ``is not None`` check, not truthiness."""
+        memory = _make_memory()
+        assert memory._get_partition("a", dimension=None).index.d == memory.dimension
+        assert memory._get_partition("b", dimension=DOC_DIM).index.d == DOC_DIM
+
+    def test_existing_partition_returned_unchanged(self):
+        memory = _make_memory()
+        first = memory._get_partition("knowledge", dimension=DOC_DIM)
+        second = memory._get_partition("knowledge")
+        assert second is first
+        assert second.index.d == DOC_DIM
+
+
+class TestPrecomputedEmbeddingIndexing:
+    async def test_add_with_embedding_indexes_foreign_dim_vectors(self):
+        """A pre-computed vector whose dim differs from the memory's own
+        model must actually land in FAISS (not just the buffer)."""
+        memory = _make_memory()
+        with _probe_patch():
+            await memory.add_with_embedding(
+                text="knowledge chunk",
+                embedding=[0.1] * DOC_DIM,
+                metadata={"source": "/mirror/a.md", "file_path": "/mirror/a.md"},
+                namespace="knowledge",
+            )
+        # Knowledge-namespace items land in the formation-global partition
+        key = memory._partition_key("knowledge", None)
+        partition = memory.partitions[key]
+        assert partition.index.d == DOC_DIM
+        assert partition.index_count == 1
+
+    async def test_rebuild_after_removal_preserves_partition_dims(self):
+        """remove_by_metadata marks the index for rebuild; the rebuild
+        must recreate each partition at its vectors' dim, and search with
+        a matching query vector must succeed (this used to shape-crash)."""
+        memory = _make_memory()
+        with _probe_patch():
+            for name in ("a", "b", "c"):
+                await memory.add_with_embedding(
+                    text=f"chunk {name}",
+                    embedding=[0.1] * DOC_DIM,
+                    metadata={"source": f"/mirror/{name}.md", "file_path": f"/mirror/{name}.md"},
+                    namespace="knowledge",
+                )
+
+            removed = memory.remove_by_metadata(
+                metadata_filter={"file_path": "/mirror/b.md"}, namespace="knowledge"
+            )
+            assert removed == 1
+            assert memory.needs_rebuild
+
+            results = await memory.search(
+                query="",
+                query_vector=[0.1] * DOC_DIM,
+                limit=5,
+                namespace="knowledge",
+            )
+
+        assert not memory.needs_rebuild
+        key = memory._partition_key("knowledge", None)
+        assert memory.partitions[key].index.d == DOC_DIM
+        assert memory.partitions[key].index_count == 2
+        texts = {result["text"] for result in results}
+        assert texts == {"chunk a", "chunk c"}

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -456,6 +456,34 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-core"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f3/b416179e408990df5db0d516283022dde0f5d0111d98c1a848e41853e81c/azure_core-1.41.0.tar.gz", hash = "sha256:f46ff5dfcd230f25cf1c19e8a34b8dc08a337b2503e268bb600a16c00db8ad5a", size = 381042, upload-time = "2026-05-07T23:30:54.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/db/325c6d7312d2200251c52323878281045aaffcb5586612296484e4280eaa/azure_core-1.41.0-py3-none-any.whl", hash = "sha256:522b4011e8180b1a3dcd2024396a4e7fe9ac37fb8597db47163d230b5efe892d", size = 220920, upload-time = "2026-05-07T23:30:56.357Z" },
+]
+
+[[package]]
+name = "azure-storage-blob"
+version = "12.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/48/84a820d898267f662b5c06f7cd76fdb8a9e272b44aa9376cef3ec0f6a294/azure_storage_blob-12.30.0.tar.gz", hash = "sha256:2cd74d4d5731e5eb6b8d5c5056ee115a5e88f8fdf22517b739836fda685018be", size = 618229, upload-time = "2026-06-08T11:45:35.575Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/0b/e106f0fd7fa785867d9ffcc47dc9e6237c0e58f51058473b777487a98edc/azure_storage_blob-12.30.0-py3-none-any.whl", hash = "sha256:d415ac50b67a8da6b3ae7e9f1014b1b55cd7aafa0b8d4ca9b380568dc7360423", size = 435610, upload-time = "2026-06-08T11:45:37.213Z" },
+]
+
+[[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -471,6 +499,76 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
+]
+
+[[package]]
+name = "bcrypt"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806, upload-time = "2025-09-25T19:49:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/44/dc/01eb79f12b177017a726cbf78330eb0eb442fae0e7b3dfd84ea2849552f3/bcrypt-5.0.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:200af71bc25f22006f4069060c88ed36f8aa4ff7f53e67ff04d2ab3f1e79a5b2", size = 268626, upload-time = "2025-09-25T19:49:06.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/cf/e82388ad5959c40d6afd94fb4743cc077129d45b952d46bdc3180310e2df/bcrypt-5.0.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:baade0a5657654c2984468efb7d6c110db87ea63ef5a4b54732e7e337253e44f", size = 271853, upload-time = "2025-09-25T19:49:08.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/86/7134b9dae7cf0efa85671651341f6afa695857fae172615e960fb6a466fa/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c58b56cdfb03202b3bcc9fd8daee8e8e9b6d7e3163aa97c631dfcfcc24d36c86", size = 269793, upload-time = "2025-09-25T19:49:09.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/6296688ac1b9e503d034e7d0614d56e80c5d1a08402ff856a4549cb59207/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4bfd2a34de661f34d0bda43c3e4e79df586e4716ef401fe31ea39d69d581ef23", size = 289930, upload-time = "2025-09-25T19:49:11.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/18/884a44aa47f2a3b88dd09bc05a1e40b57878ecd111d17e5bba6f09f8bb77/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ed2e1365e31fc73f1825fa830f1c8f8917ca1b3ca6185773b349c20fd606cec2", size = 272194, upload-time = "2025-09-25T19:49:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/8f/371a3ab33c6982070b674f1788e05b656cfbf5685894acbfef0c65483a59/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:83e787d7a84dbbfba6f250dd7a5efd689e935f03dd83b0f919d39349e1f23f83", size = 269381, upload-time = "2025-09-25T19:49:14.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/34/7e4e6abb7a8778db6422e88b1f06eb07c47682313997ee8a8f9352e5a6f1/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:137c5156524328a24b9fac1cb5db0ba618bc97d11970b39184c1d87dc4bf1746", size = 271750, upload-time = "2025-09-25T19:49:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f416be2499bd72123c70d98d36c6cd61a4e33d9b89562c22481c81bb30/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:38cac74101777a6a7d3b3e3cfefa57089b5ada650dce2baf0cbdd9d65db22a9e", size = 303757, upload-time = "2025-09-25T19:49:17.244Z" },
+    { url = "https://files.pythonhosted.org/packages/13/62/062c24c7bcf9d2826a1a843d0d605c65a755bc98002923d01fd61270705a/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:d8d65b564ec849643d9f7ea05c6d9f0cd7ca23bdd4ac0c2dbef1104ab504543d", size = 306740, upload-time = "2025-09-25T19:49:18.693Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c8/1fdbfc8c0f20875b6b4020f3c7dc447b8de60aa0be5faaf009d24242aec9/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:741449132f64b3524e95cd30e5cd3343006ce146088f074f31ab26b94e6c75ba", size = 334197, upload-time = "2025-09-25T19:49:20.523Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c1/8b84545382d75bef226fbc6588af0f7b7d095f7cd6a670b42a86243183cd/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:212139484ab3207b1f0c00633d3be92fef3c5f0af17cad155679d03ff2ee1e41", size = 352974, upload-time = "2025-09-25T19:49:22.254Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a6/ffb49d4254ed085e62e3e5dd05982b4393e32fe1e49bb1130186617c29cd/bcrypt-5.0.0-cp313-cp313t-win32.whl", hash = "sha256:9d52ed507c2488eddd6a95bccee4e808d3234fa78dd370e24bac65a21212b861", size = 148498, upload-time = "2025-09-25T19:49:24.134Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a9/259559edc85258b6d5fc5471a62a3299a6aa37a6611a169756bf4689323c/bcrypt-5.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f6984a24db30548fd39a44360532898c33528b74aedf81c26cf29c51ee47057e", size = 145853, upload-time = "2025-09-25T19:49:25.702Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/df/9714173403c7e8b245acf8e4be8876aac64a209d1b392af457c79e60492e/bcrypt-5.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9fffdb387abe6aa775af36ef16f55e318dcda4194ddbf82007a6f21da29de8f5", size = 139626, upload-time = "2025-09-25T19:49:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/14/c18006f91816606a4abe294ccc5d1e6f0e42304df5a33710e9e8e95416e1/bcrypt-5.0.0-cp314-cp314t-macosx_10_12_universal2.whl", hash = "sha256:4870a52610537037adb382444fefd3706d96d663ac44cbb2f37e3919dca3d7ef", size = 481862, upload-time = "2025-09-25T19:49:28.365Z" },
+    { url = "https://files.pythonhosted.org/packages/67/49/dd074d831f00e589537e07a0725cf0e220d1f0d5d8e85ad5bbff251c45aa/bcrypt-5.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48f753100931605686f74e27a7b49238122aa761a9aefe9373265b8b7aa43ea4", size = 268544, upload-time = "2025-09-25T19:49:30.39Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/91/50ccba088b8c474545b034a1424d05195d9fcbaaf802ab8bfe2be5a4e0d7/bcrypt-5.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f70aadb7a809305226daedf75d90379c397b094755a710d7014b8b117df1ebbf", size = 271787, upload-time = "2025-09-25T19:49:32.144Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e7/d7dba133e02abcda3b52087a7eea8c0d4f64d3e593b4fffc10c31b7061f3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:744d3c6b164caa658adcb72cb8cc9ad9b4b75c7db507ab4bc2480474a51989da", size = 269753, upload-time = "2025-09-25T19:49:33.885Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fc/5b145673c4b8d01018307b5c2c1fc87a6f5a436f0ad56607aee389de8ee3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a28bc05039bdf3289d757f49d616ab3efe8cf40d8e8001ccdd621cd4f98f4fc9", size = 289587, upload-time = "2025-09-25T19:49:35.144Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d7/1ff22703ec6d4f90e62f1a5654b8867ef96bafb8e8102c2288333e1a6ca6/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7f277a4b3390ab4bebe597800a90da0edae882c6196d3038a73adf446c4f969f", size = 272178, upload-time = "2025-09-25T19:49:36.793Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/88/815b6d558a1e4d40ece04a2f84865b0fef233513bd85fd0e40c294272d62/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:79cfa161eda8d2ddf29acad370356b47f02387153b11d46042e93a0a95127493", size = 269295, upload-time = "2025-09-25T19:49:38.164Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/e0db387c79ab4931fc89827d37608c31cc57b6edc08ccd2386139028dc0d/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a5393eae5722bcef046a990b84dff02b954904c36a194f6cfc817d7dca6c6f0b", size = 271700, upload-time = "2025-09-25T19:49:39.917Z" },
+    { url = "https://files.pythonhosted.org/packages/06/83/1570edddd150f572dbe9fc00f6203a89fc7d4226821f67328a85c330f239/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f4c94dec1b5ab5d522750cb059bb9409ea8872d4494fd152b53cca99f1ddd8c", size = 334034, upload-time = "2025-09-25T19:49:41.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f2/ea64e51a65e56ae7a8a4ec236c2bfbdd4b23008abd50ac33fbb2d1d15424/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0cae4cb350934dfd74c020525eeae0a5f79257e8a201c0c176f4b84fdbf2a4b4", size = 352766, upload-time = "2025-09-25T19:49:43.08Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d4/1a388d21ee66876f27d1a1f41287897d0c0f1712ef97d395d708ba93004c/bcrypt-5.0.0-cp314-cp314t-win32.whl", hash = "sha256:b17366316c654e1ad0306a6858e189fc835eca39f7eb2cafd6aaca8ce0c40a2e", size = 152449, upload-time = "2025-09-25T19:49:44.971Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/61/3291c2243ae0229e5bca5d19f4032cecad5dfb05a2557169d3a69dc0ba91/bcrypt-5.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:92864f54fb48b4c718fc92a32825d0e42265a627f956bc0361fe869f1adc3e7d", size = 149310, upload-time = "2025-09-25T19:49:46.162Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/89/4b01c52ae0c1a681d4021e5dd3e45b111a8fb47254a274fa9a378d8d834b/bcrypt-5.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dd19cf5184a90c873009244586396a6a884d591a5323f0e8a5922560718d4993", size = 143761, upload-time = "2025-09-25T19:49:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/6237f151fbfe295fe3e074ecc6d44228faa1e842a81f6d34a02937ee1736/bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b", size = 494553, upload-time = "2025-09-25T19:49:49.006Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009, upload-time = "2025-09-25T19:49:50.581Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029, upload-time = "2025-09-25T19:49:52.533Z" },
+    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907, upload-time = "2025-09-25T19:49:54.709Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7e/d4e47d2df1641a36d1212e5c0514f5291e1a956a7749f1e595c07a972038/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd", size = 296500, upload-time = "2025-09-25T19:49:56.013Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412, upload-time = "2025-09-25T19:49:57.356Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486, upload-time = "2025-09-25T19:49:59.116Z" },
+    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940, upload-time = "2025-09-25T19:50:00.869Z" },
+    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776, upload-time = "2025-09-25T19:50:02.393Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922, upload-time = "2025-09-25T19:50:04.232Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367, upload-time = "2025-09-25T19:50:05.559Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187, upload-time = "2025-09-25T19:50:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/461f352fdca663524b4643d8b09e8435b4990f17fbf4fea6bc2a90aa0cc7/bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538", size = 153752, upload-time = "2025-09-25T19:50:08.515Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/4190e60921927b7056820291f56fc57d00d04757c8b316b2d3c0d1d6da2c/bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9", size = 150881, upload-time = "2025-09-25T19:50:09.742Z" },
+    { url = "https://files.pythonhosted.org/packages/54/12/cd77221719d0b39ac0b55dbd39358db1cd1246e0282e104366ebbfb8266a/bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980", size = 144931, upload-time = "2025-09-25T19:50:11.016Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a", size = 495313, upload-time = "2025-09-25T19:50:12.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290, upload-time = "2025-09-25T19:50:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253, upload-time = "2025-09-25T19:50:15.089Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084, upload-time = "2025-09-25T19:50:16.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/fa6e16145e145e87f1fa351bbd54b429354fd72145cd3d4e0c5157cf4c70/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac", size = 297185, upload-time = "2025-09-25T19:50:18.525Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656, upload-time = "2025-09-25T19:50:19.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662, upload-time = "2025-09-25T19:50:21.567Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240, upload-time = "2025-09-25T19:50:23.305Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152, upload-time = "2025-09-25T19:50:24.597Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284, upload-time = "2025-09-25T19:50:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643, upload-time = "2025-09-25T19:50:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698, upload-time = "2025-09-25T19:50:31.347Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
+    { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/75/4aa9f5a4d40d762892066ba1046000b329c7cd58e888a6db878019b282dc/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:7edda91d5ab52b15636d9c30da87d2cc84f426c72b9dba7a9b4fe142ba11f534", size = 271180, upload-time = "2025-09-25T19:50:38.575Z" },
+    { url = "https://files.pythonhosted.org/packages/54/79/875f9558179573d40a9cc743038ac2bf67dfb79cecb1e8b5d70e88c94c3d/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:046ad6db88edb3c5ece4369af997938fb1c19d6a699b9c1b27b0db432faae4c4", size = 273791, upload-time = "2025-09-25T19:50:39.913Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/fe/975adb8c216174bf70fc17535f75e85ac06ed5252ea077be10d9cff5ce24/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:dcd58e2b3a908b5ecc9b9df2f0085592506ac2d5110786018ee5e160f28e0911", size = 270746, upload-time = "2025-09-25T19:50:43.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f8/972c96f5a2b6c4b3deca57009d93e946bbdbe2241dca9806d502f29dd3ee/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:6b8f520b61e8781efee73cba14e3e8c9556ccfb375623f4f97429544734545b4", size = 273375, upload-time = "2025-09-25T19:50:45.43Z" },
 ]
 
 [[package]]
@@ -2508,6 +2606,24 @@ wheels = [
 ]
 
 [[package]]
+name = "invoke"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/227c48c5fe47fa178ccf1fda8f047d16c97ba926567b661e9ce2045c600c/invoke-3.0.3.tar.gz", hash = "sha256:437b6a622223824380bfb4e64f612711a6b648c795f565efc8625af66fb57f0c", size = 343419, upload-time = "2026-04-07T15:17:48.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/de/bbc12563bbf979618d17625a4e753ff7a078523e28d870d3626daa97261a/invoke-3.0.3-py3-none-any.whl", hash = "sha256:f11327165e5cbb89b2ad1d88d3292b5113332c43b8553b494da435d6ec6f5053", size = 160958, upload-time = "2026-04-07T15:17:46.875Z" },
+]
+
+[[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
 name = "isort"
 version = "8.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3895,6 +4011,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+azure = [
+    { name = "azure-storage-blob" },
+]
 cuda = [
     { name = "faissx-gpu" },
     { name = "onellm", extra = ["local-cuda"] },
@@ -3902,16 +4021,21 @@ cuda = [
     { name = "torchvision" },
 ]
 dev = [
+    { name = "azure-storage-blob" },
     { name = "black" },
     { name = "flake8" },
     { name = "isort" },
     { name = "mypy" },
+    { name = "paramiko" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
     { name = "ruff" },
+]
+gcs = [
+    { name = "google-cloud-storage" },
 ]
 kafka = [
     { name = "kafka-python" },
@@ -3920,6 +4044,9 @@ pytorch = [
     { name = "onellm", extra = ["cache", "local-pytorch"] },
     { name = "torch" },
     { name = "torchvision" },
+]
+sftp = [
+    { name = "paramiko" },
 ]
 
 [package.metadata]
@@ -3931,6 +4058,8 @@ requires-dist = [
     { name = "altair", specifier = ">=6.2.1" },
     { name = "anyio", specifier = ">=4.14.0" },
     { name = "asyncpg", specifier = ">=0.31.0" },
+    { name = "azure-storage-blob", marker = "extra == 'azure'", specifier = ">=12.19.0" },
+    { name = "azure-storage-blob", marker = "extra == 'dev'", specifier = ">=12.19.0" },
     { name = "beautifulsoup4", specifier = ">=4.15.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=26.3.1" },
     { name = "bokeh", specifier = ">=3.9.1" },
@@ -3948,6 +4077,7 @@ requires-dist = [
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "fpdf2", specifier = ">=2.8.7" },
     { name = "google-cloud-aiplatform", specifier = ">=1.157.0" },
+    { name = "google-cloud-storage", marker = "extra == 'gcs'", specifier = ">=2.14.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "httpx-sse", specifier = ">=0.4.3" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
@@ -3971,6 +4101,8 @@ requires-dist = [
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "orjson", specifier = ">=3.11.9" },
     { name = "pandas", specifier = ">=2.3.3" },
+    { name = "paramiko", marker = "extra == 'dev'", specifier = ">=3.4.0" },
+    { name = "paramiko", marker = "extra == 'sftp'", specifier = ">=3.4.0" },
     { name = "pdf2image", specifier = ">=1.17.0" },
     { name = "pgvector", specifier = ">=0.4.2" },
     { name = "pillow", specifier = ">=12.2.0" },
@@ -4021,7 +4153,7 @@ requires-dist = [
     { name = "xlsxwriter", specifier = ">=3.2.9" },
     { name = "xlwt", specifier = ">=1.3.0" },
 ]
-provides-extras = ["kafka", "pytorch", "cuda", "dev"]
+provides-extras = ["kafka", "gcs", "azure", "sftp", "pytorch", "cuda", "dev"]
 
 [[package]]
 name = "mypy"
@@ -4954,6 +5086,21 @@ wheels = [
 ]
 
 [[package]]
+name = "paramiko"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bcrypt" },
+    { name = "cryptography" },
+    { name = "invoke" },
+    { name = "pynacl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/93/dcc25d52f49022ae6175d15e6bd751f1acc99b98bc61fc55e5155a7be2e7/paramiko-5.0.0.tar.gz", hash = "sha256:36763b5b95c2a0dcfdf1abc48e48156ee425b21efe2f0e787c2dd5a95c0e5e79", size = 1548586, upload-time = "2026-05-09T18:28:52.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/5b/eadf6d45de38d30ab603f49393b6cd2cbe7e233af8cf90197e32782b68a9/paramiko-5.0.0-py3-none-any.whl", hash = "sha256:b7044611c30140d9a75261653210e2002977b71a0497ff3ba0d98d7edbf62f7c", size = 208919, upload-time = "2026-05-09T18:28:50.295Z" },
+]
+
+[[package]]
 name = "pathable"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5755,6 +5902,41 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pynacl"
+version = "1.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/79/0e3c34dc3c4671f67d251c07aa8eb100916f250ee470df230b0ab89551b4/pynacl-1.6.2-cp314-cp314t-macosx_10_10_universal2.whl", hash = "sha256:622d7b07cc5c02c666795792931b50c91f3ce3c2649762efb1ef0d5684c81594", size = 390064, upload-time = "2026-01-01T17:31:57.264Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/1c/23a26e931736e13b16483795c8a6b2f641bf6a3d5238c22b070a5112722c/pynacl-1.6.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d071c6a9a4c94d79eb665db4ce5cedc537faf74f2355e4d502591d850d3913c0", size = 809370, upload-time = "2026-01-01T17:31:59.198Z" },
+    { url = "https://files.pythonhosted.org/packages/87/74/8d4b718f8a22aea9e8dcc8b95deb76d4aae380e2f5b570cc70b5fd0a852d/pynacl-1.6.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9", size = 1408304, upload-time = "2026-01-01T17:32:01.162Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/73/be4fdd3a6a87fe8a4553380c2b47fbd1f7f58292eb820902f5c8ac7de7b0/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04316d1fc625d860b6c162fff704eb8426b1a8bcd3abacea11142cbd99a6b574", size = 844871, upload-time = "2026-01-01T17:32:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ad/6efc57ab75ee4422e96b5f2697d51bbcf6cdcc091e66310df91fbdc144a8/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44081faff368d6c5553ccf55322ef2819abb40e25afaec7e740f159f74813634", size = 1446356, upload-time = "2026-01-01T17:32:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b7/928ee9c4779caa0a915844311ab9fb5f99585621c5d6e4574538a17dca07/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:a9f9932d8d2811ce1a8ffa79dcbdf3970e7355b5c8eb0c1a881a57e7f7d96e88", size = 826814, upload-time = "2026-01-01T17:32:06.078Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a9/1bdba746a2be20f8809fee75c10e3159d75864ef69c6b0dd168fc60e485d/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:bc4a36b28dd72fb4845e5d8f9760610588a96d5a51f01d84d8c6ff9849968c14", size = 1411742, upload-time = "2026-01-01T17:32:07.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/5e7ea8d85f9f3ea5b6b87db1d8388daa3587eed181bdeb0306816fdbbe79/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bffb6d0f6becacb6526f8f42adfb5efb26337056ee0831fb9a7044d1a964444", size = 801714, upload-time = "2026-01-01T17:32:09.558Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ea/43fe2f7eab5f200e40fb10d305bf6f87ea31b3bbc83443eac37cd34a9e1e/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fef529ef3ee487ad8113d287a593fa26f48ee3620d92ecc6f1d09ea38e0709b", size = 1372257, upload-time = "2026-01-01T17:32:11.026Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/54/c9ea116412788629b1347e415f72195c25eb2f3809b2d3e7b25f5c79f13a/pynacl-1.6.2-cp314-cp314t-win32.whl", hash = "sha256:a84bf1c20339d06dc0c85d9aea9637a24f718f375d861b2668b2f9f96fa51145", size = 231319, upload-time = "2026-01-01T17:32:12.46Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/04/64e9d76646abac2dccf904fccba352a86e7d172647557f35b9fe2a5ee4a1/pynacl-1.6.2-cp314-cp314t-win_amd64.whl", hash = "sha256:320ef68a41c87547c91a8b58903c9caa641ab01e8512ce291085b5fe2fcb7590", size = 244044, upload-time = "2026-01-01T17:32:13.781Z" },
+    { url = "https://files.pythonhosted.org/packages/33/33/7873dc161c6a06f43cda13dec67b6fe152cb2f982581151956fa5e5cdb47/pynacl-1.6.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2", size = 188740, upload-time = "2026-01-01T17:32:15.083Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465", size = 388458, upload-time = "2026-01-01T17:32:16.829Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
+    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
+    { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Completes the remote-knowledge-sources PRD (Phases 2-4) on top of the Phase 1 core sync shipped in #255.

## Phase 2 - Archive extraction

- `extract: true` sources download a single archive (`.zip`, `.tar`, `.tar.gz`/`.tgz`, `.tar.bz2`, `.tar.xz`) and extract it into the local mirror; `extract_pattern` keeps only matching members. New `remote/extractor.py::ArchiveExtractor` + a dedicated `_sync_archive` strategy in the SyncManager.
- **Security posture**: member names go through the manifest's `safe_relative_path`/`resolve_within` guards (no member can escape the extraction root), symlink/hardlink/device members are rejected, and decompression bombs are bounded by `max_extracted_files` (default 1000) and `max_extracted_size` (default 500MB) counted on the *decompressed* stream - header sizes are never trusted. A violation aborts the whole extraction.
- Extraction happens in a hidden temp dir next to the mirror (same filesystem, never ingested, always cleaned up); the mirror is only touched after extraction fully succeeds, so a corrupt/malicious archive degrades to the previously synced content (stale-wins). Unchanged archives (manifest `archive_hash` + size) skip download and extraction entirely.

## Phase 3 - Scheduling & automation

- New `remote/scheduler.py::KnowledgeSyncService`, registered with the existing SchedulerService via `register_periodic_task` (the same extension point the proactive heartbeat uses - no second loop). croniter (already used by the scheduler and config validation) drives per-source cron gating; `@hourly`/`@daily`/`@weekly` aliases supported, `@startup`/no-schedule stays startup-only (Phase 1 behavior preserved).
- Per-source `asyncio.Lock`s: overlapping syncs for the same source are skipped (new `knowledge.sync.skipped` event) whether scheduled or manual.
- Retry with exponential backoff on total sync failure (per-source `retry:` block - `max_attempts`/`initial_delay`/`max_delay`/`exponential_base`, defaults 3/5s/300s/2), then back to the next cron fire. Failure isolation throughout: `tick()` never raises, stale content keeps serving.
- **Incremental re-embedding**: `SyncResult` now carries `changed_paths`/`deleted_paths` and `KnowledgeHandler.refresh_remote_source` re-embeds only those files - never the whole mirror.
- **Manual trigger**: `POST /v1/agents/{agent_id}/knowledge/sync` (AdminKey, optional `{"source_id": ...}` body) with per-source results; works without the scheduler. Declared schedules without a running scheduler degrade to startup-only sync with a loud init warning (never a startup failure).
- Fixed a latent WorkingMemory bug surfaced by re-embedding: FAISS partitions were created/rebuilt at the memory-wide dimension, silently dropping pre-computed knowledge vectors on write (masked by the `index_count == 0` recency fallback) and shape-crashing every vector search after the first index rebuild. Partition dimensionality now follows the vectors it stores - knowledge semantic search over the buffer memory actually works now.

## Phase 4 - Additional protocols

- `GCSHandler` (`gs://`, Content-MD5 change detection, optional `auth: {type: gcp, credentials_json}` else ADC), `AzureHandler` (`az://`, Content-MD5/ETag; `auth: {type: azure}` with `connection_string` or `account_name`+`account_key` is required since the account is not in the URL), `FTPHandler` (`ftp://`, stdlib ftplib, size+mtime), `SFTPHandler` (`sftp://`, paramiko, size+mtime, strict host-key checking by default with the same `accept_new_host_keys` opt-in as rsync+ssh).
- All handlers use the shared `atomic_download` context manager; scheme auto-detection via the protocol registry. Optional SDKs ship as extras - `muxi-runtime[gcs]`, `[azure]`, `[sftp]` - with clear config-time `RemoteSyncError`s naming the extra when missing (boto3/kafka optional-dep pattern); ftp needs nothing.

## PRD open questions

Taken as recommended: remote-wins conflict resolution and stale-wins on partial failure (both already Phase 1 behavior); bandwidth limits deferred.

## Validation & tests

- All new config keys fail-fast validated at load time (extract options, retry block, new schemes/auth types); formations without remote sources never import the remote machinery; `validate_events.py` at 100%.
- Unit: 228 remote-knowledge tests including extraction safety (traversal/symlink/bomb), pattern filtering, cron scheduling + lock contention + backoff, each new handler mocked, auto-detection, validation. Full unit suite: 2759 passed.
- E2E: new `6_knowledge/test_6f3_remote_archive_source.py` (local http fixture serving a zip; asserts extraction, pattern filtering, manifest, and chat over extracted content) and `test_6f4_manual_sync_trigger.py` (admin endpoint: unchanged no-op, change detection, incremental re-embed proven via chat over post-startup content, 404s). Existing 6f1/6f2 re-run green.
- Regression `run_random_tests.py 5`: 12b2, 2f, 3a1, 5_11, 7a8 all pass (7a8 needed the gitignored formation `.key` replicated into the worktree; unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)