### PR TITLE
feat: memory benchmarking - tier 3 longitudinal scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 ## [unreleased]
 
+### Memory benchmarking - Tier 3 multi-session longitudinal scenarios
+
+Completes the memory-benchmarking PRD's Tier 3 in `bench/memory/`
+(Tiers 1/2/4 shipped in #220/#261) - the four longitudinal scenarios,
+run against a real formation with no mocks:
+
+- MemBench Generator (`longitudinal_corpus.py`): seeded, fully
+  deterministic multi-session corpora (no LLM), one per PRD scenario,
+  with a committed CI fixture and a `--preset full` PRD scale (30-day
+  corpora, 100 isolation users, 10,000 isolation retrieval ops).
+- Scenario A (buffer cycle compensation): raw turns replayed into the
+  real working memory under a small `--buffer-max-mb` budget with the
+  FIFO cleanup pass driven per session - the exact path the
+  pre-compaction flush (#260) guards; flush hand-offs are counted (an
+  opt-in `--flush-digest` runs the real silent-turn LLM digest).
+  Reports show evicted-fact R@5 through KG + Captain's Log vs the
+  working-memory baseline, a `recent_recall` control group, an
+  `evidence_evicted_fraction` validity check, and the PRD's
+  zero-lost-decisions audit. Fixture: structured R@5 100% on evicted
+  questions vs 0% working baseline (131/228 turns evicted).
+- Scenario B (cross-agent propagation): facts/artifacts produced in
+  one agent's sessions answered via another agent (question_meta
+  records the pair), plus the zero-artifact-orphans KG audit.
+- Scenario C (multi-user isolation): all users ingested side by side
+  with identical fact templates differing only in values; vector, KG,
+  and log retrieval ops audited for foreign `CANARY-*` tokens and
+  foreign session ids. Pass/fail per the PRD (fixture: 0 leaks / 600
+  ops; full preset: 10,000 ops across 100 users).
+- Scenario D (contradiction detection over time): manifests replayed
+  per-session through the live `store_extraction` path with per-fact
+  confidences, so the storage layer's supersede/conflict detection
+  and the substrate's `fact.contradicted` events (#259) fire as in
+  production; measures precision/recall plus detection-kind accuracy
+  against injected pairs (with duplicate/non-exclusive precision
+  distractors), tallies the substrate events, and re-audits after a
+  knowledge-graph projection rebuild from the event log
+  (`rebuild.consistent_with_live`).
+- `longitudinal_runner.py` keeps the harness conventions: cheap-model
+  config ($0 retrieval-only runs), per-scenario failure isolation with
+  reports always written (one per scenario under `results/`), nonzero
+  exit on incomplete runs; `--scenario all` spawns one subprocess per
+  scenario because the runtime's database manager is a process-level
+  singleton.
+- Fix in the Tier 2 structured adapter's KG retrieval rendering: when
+  several facts share a provenance turn (entity card + relationship
+  from the same utterance), their renderings are now merged into the
+  turn's text instead of dropping all but the first - rankings are
+  unchanged, but QA context no longer loses facts retrieval had
+  already found (`structured_recall_fixture_structured.json`
+  regenerated; retrieval metrics identical).
+
 ### Memory benchmarking - Tier 2 structured recall + Tier 4 cost efficiency
 
 Extends the `bench/memory/` harness (memory-benchmarking PRD; Tier 1

--- a/bench/memory/README.md
+++ b/bench/memory/README.md
@@ -11,11 +11,13 @@ Implements the memory benchmarking PRD
   categories no published system benchmarks (KG relationship recall,
   temporal validity, narrative recall, cross-agent knowledge,
   contradiction detection). See "Tier 2" below.
+- **Tier 3** — multi-session longitudinal: 30-90 day corpora proving
+  buffer-eviction compensation, cross-agent propagation, multi-user
+  isolation, and contradiction detection over time. See "Tier 3"
+  below.
 - **Tier 4** — cost efficiency: tokens-per-accurate-recall, cost per
   1,000 queries, retrieval latency percentiles under load, memory
   footprint. See "Tier 4" below.
-- **Tier 3** (longitudinal) is NOT implemented here yet — see the
-  "Tier 3 seam" section.
 
 ## Tier 1: what it measures
 
@@ -194,28 +196,98 @@ hardware-bound; compare runs on the same machine.
 Pricing lives in `pricing.json` (USD per 1M tokens) — update it as
 providers change list prices; every report echoes the table it used.
 
-## Tier 3 seam (not yet implemented)
+## Tier 3: multi-session longitudinal
 
-The longitudinal benchmark (30-90 day corpora, FIFO buffer-cycling
-compensation, multi-user isolation, cross-agent propagation over
-time) depends on the memory-substrate rebuild that is in flight. The
-seams left for it:
+Simulates 30-90 days of usage across users and agents. The corpus
+comes from the "MemBench Generator" (`longitudinal_corpus.py` —
+seeded, fully deterministic, no LLM), one sub-corpus per PRD scenario:
 
-- `structured_corpus.py` already generates dated, agent-attributed
-  sessions from a deterministic event schedule — the longitudinal
-  generator extends that schedule to 30-90 days and multiple users.
-- `structured` mode ingests ground truth via `apply_extraction`;
-  Tier 3 replays turns through `process_conversation_turn` instead,
-  measuring the full extraction pipeline end-to-end.
-- The report schema (partial-run envelope, per-category blocks)
-  carries over unchanged.
+| Scenario | Proves | PRD target |
+|----------|--------|-----------|
+| `buffer_cycle` (A) | KG + Captain's Log answer day-1 questions at day-30, after the source turns were FIFO-evicted from the buffer | evicted-fact R@5 >= 85%, zero lost decisions |
+| `cross_agent` (B) | Knowledge produced in one agent's sessions is answerable via another agent | R@5 >= 80%, zero artifact orphans |
+| `isolation` (C) | User A's memory never surfaces in user B's retrieval | 0 leaks (pass/fail) |
+| `contradiction` (D) | Conflicting facts across sessions are flagged (conflicted) or superseded, not merged | precision >= 90%, recall >= 80% |
+
+```bash
+# Committed fixture (CI-safe; retrieval-only runs are $0)
+uv run python -m bench.memory.longitudinal_runner --fixture
+uv run python -m bench.memory.longitudinal_runner --fixture --scenario buffer_cycle --qa
+
+# Full corpus (PRD scale: 30-day corpora, 100 isolation users,
+# 10,000 isolation retrieval operations)
+uv run python -m bench.memory.longitudinal_corpus --preset full \
+    --output ~/datasets/membench/longitudinal_full.json
+uv run python -m bench.memory.longitudinal_runner \
+    --dataset ~/datasets/membench/longitudinal_full.json
+```
+
+How each scenario runs (all against the real services, no mocks):
+
+- **A — buffer cycle.** Raw turns are replayed into the real working
+  memory under a small budget (`--buffer-max-mb`, default 0.4MB), and
+  the buffer's own FIFO cleanup runs once per ingested session
+  (benchmark time is compressed; production runs the same pass on a
+  wall-clock interval). That is exactly the path the pre-compaction
+  flush (memory-revamp Phase 3) guards: the runner counts flush
+  hand-offs, and `--flush-digest` additionally lets the silent-turn
+  digest make its real LLM calls (default off: deterministic, $0).
+  The persisted layers get the ground-truth manifest (Tier 2 style —
+  structured recall isolated from extraction quality), questions run
+  against both layers, and the report shows the compensation story:
+  working-baseline R@5 on evicted questions (expected ~0) vs
+  structured R@5, plus a `recent_recall` control group and the
+  zero-lost-decisions audit. `evidence_evicted_fraction` must be 1.0
+  for the scenario to prove anything — below that, raise the corpus
+  size or lower the budget.
+- **B — cross-agent.** Facts and artifacts enter the KG/log from each
+  agent's sessions; every question's evidence lives in a different
+  agent's session than the one nominally asking (`question_meta` in
+  the ground truth records the pair). The zero-orphan audit checks
+  every artifact is reachable in the KG (entity + `produced` edge).
+- **C — isolation.** Every user's corpus is ingested side by side
+  (working + persistent + KG + log; nothing is cleared between
+  users) and follows identical fact templates, differing only in
+  values — so a scoping bug would make another user's near-identical
+  turn the nearest neighbor. Retrieval operations (vector search, KG
+  reads, log reads, cycled to `--isolation-ops`) are audited for
+  foreign `CANARY-*` tokens and foreign session ids. Pass/fail.
+- **D — contradiction over time.** The manifest is replayed
+  per-session, in corpus order, through the live `store_extraction`
+  path with per-fact confidences — the storage layer's contradiction
+  detection fires exactly as in production (confidence delta above
+  0.3 supersedes; otherwise both facts are flagged conflicted), and
+  the event substrate records `fact.contradicted` audit events. The
+  audit measures precision/recall against the injected pairs plus
+  detection-kind accuracy, tallies the substrate events, then
+  rebuilds the knowledge-graph projection from the event log
+  (service layer, same path as the rebuild endpoint) and repeats the
+  audit — `rebuild.consistent_with_live` proves replay determinism.
+  Precision distractors (duplicate re-assertions, non-exclusive
+  predicate changes) are injected and must NOT be flagged.
+
+One process per scenario: `--scenario all` (the default) spawns a
+subprocess per scenario because the runtime's database manager is a
+process-level singleton — two formations in one process would share
+the first run's SQLite path. Reports land one-per-scenario under
+`results/` (`longitudinal_fixture_<scenario>.json`).
+
+The full LLM-extraction replay (raw turns through
+`process_conversation_turn`, measuring extraction quality end-to-end
+rather than structured recall) remains out of scope here: one LLM
+call per turn turns a $0 deterministic run into a multi-dollar
+nondeterministic one. The per-session `store_extraction` replay in
+Scenario D is the same write path with the extraction step supplied
+by the manifest.
 
 ## Datasets and licensing
 
 The committed files under `fixtures/` are small **synthetic** samples
 that follow each dataset's published schema — no third-party data is
-committed (`structured_recall_sample.json` is MUXI's own generated
-dataset, regenerable with `structured_corpus.py --preset fixture`).
+committed (`structured_recall_sample.json` and
+`longitudinal_sample.json` are MUXI's own generated datasets,
+regenerable with `structured_corpus.py --preset fixture` and
+`longitudinal_corpus.py --preset fixture`).
 The full third-party datasets are for local benchmarking only:
 
 | Dataset     | Source                                        | License |
@@ -271,6 +343,11 @@ bench/memory/
 ├── structured_adapter.py        # Tier 2 adapter (KG + Captain's Log mode)
 ├── structured_scoring.py        # Exact-string recall + contradiction metrics
 ├── structured_recall_runner.py  # Tier 2 entry point (K=5, 4 modes)
+├── longitudinal_corpus.py       # Tier 3 "MemBench Generator" (4 scenarios, seeded)
+├── longitudinal_dataset.py      # Tier 3 dataset loader (+ scenario manifests)
+├── longitudinal_adapter.py      # Tier 3 adapter (buffer cycling, audits, rebuild)
+├── longitudinal_scoring.py      # Tier 3 scenario aggregates (targets, leaks)
+├── longitudinal_runner.py       # Tier 3 entry point (one report per scenario)
 ├── cost_model.py                # Tier 4 math (percentiles, projections)
 ├── cost_runner.py               # Tier 4 entry point (latency/tokens/footprint)
 ├── pricing.json                 # Updatable per-model price table (USD/MTok)
@@ -281,5 +358,6 @@ bench/memory/
 ```
 
 Unit tests: `tests/unit/bench_memory/` (loaders, metrics, split,
-report, adapter logic, corpus generator determinism, cost-model math —
+report, adapter logic, corpus generator determinism, longitudinal
+scenario aggregates, cost-model math —
 `uv run python -m pytest tests/unit/bench_memory/`).

--- a/bench/memory/fixtures/longitudinal_sample.json
+++ b/bench/memory/fixtures/longitudinal_sample.json
@@ -1,0 +1,6453 @@
+{
+  "generator": {
+    "preset": "fixture",
+    "scenarios": [
+      "buffer_cycle",
+      "cross_agent",
+      "isolation",
+      "contradiction"
+    ],
+    "seed": 42
+  },
+  "name": "muxi-longitudinal",
+  "scenarios": {
+    "buffer_cycle": {
+      "cases": [
+        {
+          "case_id": "seq_buffer_cycle_000",
+          "ground_truth": {
+            "artifacts": [],
+            "canaries": [],
+            "contradictions": [],
+            "decisions": [
+              {
+                "date": "2026-03-22",
+                "decision": "Adopt Kafka for the search revamp (Ingrid Alvarez's recommendation)",
+                "session_id": "seq_buffer_cycle_000_s003"
+              }
+            ],
+            "distractors": [],
+            "early_window": {
+              "date_from": "2026-03-19",
+              "date_to": "2026-03-23"
+            },
+            "entities": [
+              {
+                "attributes": {
+                  "email": "mara.kovacs@vertexlabs.example.com",
+                  "role": "engineering lead"
+                },
+                "name": "Mara Kovacs",
+                "session_id": "seq_buffer_cycle_000_s001",
+                "turn_id": "seq_buffer_cycle_000_s001:2",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Vertex Labs",
+                "session_id": "seq_buffer_cycle_000_s001",
+                "turn_id": "seq_buffer_cycle_000_s001:2",
+                "type": "company"
+              },
+              {
+                "attributes": {
+                  "email": "petra.lindqvist@vertexlabs.example.com",
+                  "role": "product manager"
+                },
+                "name": "Petra Lindqvist",
+                "session_id": "seq_buffer_cycle_000_s002",
+                "turn_id": "seq_buffer_cycle_000_s002:2",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Vertex Labs",
+                "session_id": "seq_buffer_cycle_000_s002",
+                "turn_id": "seq_buffer_cycle_000_s002:2",
+                "type": "company"
+              },
+              {
+                "attributes": {},
+                "name": "Ingrid Alvarez",
+                "session_id": "seq_buffer_cycle_000_s003",
+                "turn_id": "seq_buffer_cycle_000_s003:2",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Kafka",
+                "session_id": "seq_buffer_cycle_000_s003",
+                "turn_id": "seq_buffer_cycle_000_s003:2",
+                "type": "topic"
+              },
+              {
+                "attributes": {},
+                "name": "search revamp",
+                "session_id": "seq_buffer_cycle_000_s003",
+                "turn_id": "seq_buffer_cycle_000_s003:2",
+                "type": "project"
+              },
+              {
+                "attributes": {},
+                "name": "Yuki Mensah",
+                "session_id": "seq_buffer_cycle_000_s001",
+                "turn_id": "seq_buffer_cycle_000_s001:4",
+                "type": "person"
+              },
+              {
+                "attributes": {
+                  "kind": "invoice",
+                  "project": "payments integration"
+                },
+                "name": "INV-5150-SK",
+                "session_id": "seq_buffer_cycle_000_s001",
+                "turn_id": "seq_buffer_cycle_000_s001:4",
+                "type": "reference"
+              },
+              {
+                "attributes": {
+                  "email": "dario.nakamura@vertexlabs.example.com",
+                  "role": "support specialist"
+                },
+                "name": "Dario Nakamura",
+                "session_id": "seq_buffer_cycle_000_s016",
+                "turn_id": "seq_buffer_cycle_000_s016:2",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Vertex Labs",
+                "session_id": "seq_buffer_cycle_000_s016",
+                "turn_id": "seq_buffer_cycle_000_s016:2",
+                "type": "company"
+              },
+              {
+                "attributes": {},
+                "name": "Owen Haddad",
+                "session_id": "seq_buffer_cycle_000_s017",
+                "turn_id": "seq_buffer_cycle_000_s017:2",
+                "type": "person"
+              },
+              {
+                "attributes": {
+                  "kind": "support ticket",
+                  "project": "auth migration"
+                },
+                "name": "TKT-7623-HB",
+                "session_id": "seq_buffer_cycle_000_s017",
+                "turn_id": "seq_buffer_cycle_000_s017:2",
+                "type": "reference"
+              }
+            ],
+            "log_entries": [
+              {
+                "date": "2026-03-19",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_buffer_cycle_000_s001"
+                ],
+                "summary": "Work on 2026-03-19: logged Mara Kovacs as engineering lead; Yuki Mensah opened invoice INV-5150-SK"
+              },
+              {
+                "date": "2026-03-20",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_buffer_cycle_000_s002"
+                ],
+                "summary": "Work on 2026-03-20: logged Petra Lindqvist as product manager"
+              },
+              {
+                "date": "2026-03-22",
+                "decisions": [
+                  "Adopt Kafka for the search revamp (Ingrid Alvarez's recommendation)"
+                ],
+                "projects": [
+                  "search revamp"
+                ],
+                "source_session_ids": [
+                  "seq_buffer_cycle_000_s003"
+                ],
+                "summary": "Work on 2026-03-22: Ingrid Alvarez recommended Kafka for the search revamp"
+              },
+              {
+                "date": "2026-04-13",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_buffer_cycle_000_s016"
+                ],
+                "summary": "Work on 2026-04-13: logged Dario Nakamura as support specialist"
+              },
+              {
+                "date": "2026-04-15",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_buffer_cycle_000_s017"
+                ],
+                "summary": "Work on 2026-04-15: Owen Haddad opened support ticket TKT-7623-HB"
+              }
+            ],
+            "question_meta": {},
+            "relationships": [
+              {
+                "attributes": {
+                  "role": "engineering lead",
+                  "stated_on": "2026-03-19"
+                },
+                "confidence": 0.85,
+                "from_name": "Mara Kovacs",
+                "from_type": "person",
+                "session_id": "seq_buffer_cycle_000_s001",
+                "to_name": "Vertex Labs",
+                "to_type": "company",
+                "turn_id": "seq_buffer_cycle_000_s001:2",
+                "type": "works_at"
+              },
+              {
+                "attributes": {
+                  "role": "product manager",
+                  "stated_on": "2026-03-20"
+                },
+                "confidence": 0.85,
+                "from_name": "Petra Lindqvist",
+                "from_type": "person",
+                "session_id": "seq_buffer_cycle_000_s002",
+                "to_name": "Vertex Labs",
+                "to_type": "company",
+                "turn_id": "seq_buffer_cycle_000_s002:2",
+                "type": "works_at"
+              },
+              {
+                "attributes": {
+                  "project": "search revamp",
+                  "stated_on": "2026-03-22"
+                },
+                "confidence": 0.85,
+                "from_name": "Ingrid Alvarez",
+                "from_type": "person",
+                "session_id": "seq_buffer_cycle_000_s003",
+                "to_name": "Kafka",
+                "to_type": "topic",
+                "turn_id": "seq_buffer_cycle_000_s003:2",
+                "type": "recommended"
+              },
+              {
+                "attributes": {
+                  "kind": "invoice",
+                  "project": "payments integration",
+                  "stated_on": "2026-03-19"
+                },
+                "confidence": 0.85,
+                "from_name": "Yuki Mensah",
+                "from_type": "person",
+                "session_id": "seq_buffer_cycle_000_s001",
+                "to_name": "INV-5150-SK",
+                "to_type": "reference",
+                "turn_id": "seq_buffer_cycle_000_s001:4",
+                "type": "opened"
+              },
+              {
+                "attributes": {
+                  "role": "support specialist",
+                  "stated_on": "2026-04-13"
+                },
+                "confidence": 0.85,
+                "from_name": "Dario Nakamura",
+                "from_type": "person",
+                "session_id": "seq_buffer_cycle_000_s016",
+                "to_name": "Vertex Labs",
+                "to_type": "company",
+                "turn_id": "seq_buffer_cycle_000_s016:2",
+                "type": "works_at"
+              },
+              {
+                "attributes": {
+                  "kind": "support ticket",
+                  "project": "auth migration",
+                  "stated_on": "2026-04-15"
+                },
+                "confidence": 0.85,
+                "from_name": "Owen Haddad",
+                "from_type": "person",
+                "session_id": "seq_buffer_cycle_000_s017",
+                "to_name": "TKT-7623-HB",
+                "to_type": "reference",
+                "turn_id": "seq_buffer_cycle_000_s017:2",
+                "type": "opened"
+              }
+            ]
+          },
+          "questions": [
+            {
+              "answer": "mara.kovacs@vertexlabs.example.com",
+              "category": "evicted_recall",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_buffer_cycle_000_s001"
+              ],
+              "evidence_turn_ids": [
+                "seq_buffer_cycle_000_s001:2"
+              ],
+              "exact_strings": [
+                "mara.kovacs@vertexlabs.example.com"
+              ],
+              "question": "What is Mara Kovacs's email address?",
+              "question_id": "seq_buffer_cycle_000_q001_evicted_recall"
+            },
+            {
+              "answer": "petra.lindqvist@vertexlabs.example.com",
+              "category": "evicted_recall",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_buffer_cycle_000_s002"
+              ],
+              "evidence_turn_ids": [
+                "seq_buffer_cycle_000_s002:2"
+              ],
+              "exact_strings": [
+                "petra.lindqvist@vertexlabs.example.com"
+              ],
+              "question": "What is Petra Lindqvist's email address?",
+              "question_id": "seq_buffer_cycle_000_q002_evicted_recall"
+            },
+            {
+              "answer": "Ingrid Alvarez",
+              "category": "evicted_recall",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_buffer_cycle_000_s003"
+              ],
+              "evidence_turn_ids": [
+                "seq_buffer_cycle_000_s003:2"
+              ],
+              "exact_strings": [],
+              "question": "Who recommended using Kafka for the search revamp?",
+              "question_id": "seq_buffer_cycle_000_q003_evicted_recall"
+            },
+            {
+              "answer": "INV-5150-SK",
+              "category": "evicted_recall",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_buffer_cycle_000_s001"
+              ],
+              "evidence_turn_ids": [
+                "seq_buffer_cycle_000_s001:4"
+              ],
+              "exact_strings": [
+                "INV-5150-SK"
+              ],
+              "question": "What was the reference number of the invoice Yuki Mensah opened for the payments integration?",
+              "question_id": "seq_buffer_cycle_000_q004_evicted_recall"
+            },
+            {
+              "answer": "dario.nakamura@vertexlabs.example.com",
+              "category": "recent_recall",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_buffer_cycle_000_s016"
+              ],
+              "evidence_turn_ids": [
+                "seq_buffer_cycle_000_s016:2"
+              ],
+              "exact_strings": [
+                "dario.nakamura@vertexlabs.example.com"
+              ],
+              "question": "What is Dario Nakamura's email address?",
+              "question_id": "seq_buffer_cycle_000_q005_recent_recall"
+            },
+            {
+              "answer": "TKT-7623-HB",
+              "category": "recent_recall",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_buffer_cycle_000_s017"
+              ],
+              "evidence_turn_ids": [
+                "seq_buffer_cycle_000_s017:2"
+              ],
+              "exact_strings": [
+                "TKT-7623-HB"
+              ],
+              "question": "What was the reference number of the support ticket Owen Haddad opened for the auth migration?",
+              "question_id": "seq_buffer_cycle_000_q006_recent_recall"
+            },
+            {
+              "answer": "Adopt Kafka for the search revamp (Ingrid Alvarez's recommendation)",
+              "category": "evicted_recall",
+              "date_from": "2026-03-22",
+              "date_to": "2026-03-22",
+              "evidence_session_ids": [
+                "seq_buffer_cycle_000_s003"
+              ],
+              "evidence_turn_ids": [],
+              "exact_strings": [],
+              "question": "What were the main decisions made on 2026-03-22?",
+              "question_id": "seq_buffer_cycle_000_q007_evicted_recall"
+            }
+          ],
+          "scenario": "buffer_cycle",
+          "sessions": [
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-19",
+              "session_id": "seq_buffer_cycle_000_s001",
+              "turns": [
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0000)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0000)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "For the record: Mara Kovacs is our engineering lead at Vertex Labs. You can reach them at mara.kovacs@vertexlabs.example.com.",
+                  "role": "user"
+                },
+                {
+                  "content": "Noted. Mara Kovacs (engineering lead, Vertex Labs) with contact mara.kovacs@vertexlabs.example.com.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Yuki Mensah opened invoice INV-5150-SK for the payments integration. Keep that reference handy.",
+                  "role": "user"
+                },
+                {
+                  "content": "Saved: invoice INV-5150-SK (payments integration, opened by Yuki Mensah).",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0017)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0017)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 0018)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0018)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0019)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0019)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 0020)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0020)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0021)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0021)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-20",
+              "session_id": "seq_buffer_cycle_000_s002",
+              "turns": [
+                {
+                  "content": "Remind me how to write a good standup update. (note 0034)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0034)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "For the record: Petra Lindqvist is our product manager at Vertex Labs. You can reach them at petra.lindqvist@vertexlabs.example.com.",
+                  "role": "user"
+                },
+                {
+                  "content": "Noted. Petra Lindqvist (product manager, Vertex Labs) with contact petra.lindqvist@vertexlabs.example.com.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0051)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0051)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 0052)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0052)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0053)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0053)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0054)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0054)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0055)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0055)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-22",
+              "session_id": "seq_buffer_cycle_000_s003",
+              "turns": [
+                {
+                  "content": "What's a good book on negotiation? (note 0068)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0068)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Ingrid Alvarez recommended switching to Kafka for the search revamp. Let's go with that.",
+                  "role": "user"
+                },
+                {
+                  "content": "Decision recorded: Kafka for the search revamp, recommended by Ingrid Alvarez.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0085)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0085)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0086)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0086)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0087)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0087)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0088)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0088)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0089)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0089)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-24",
+              "session_id": "seq_buffer_cycle_000_s004",
+              "turns": [
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0102)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0102)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0119)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0119)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0120)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0120)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0121)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0121)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 0122)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0122)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0123)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0123)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-25",
+              "session_id": "seq_buffer_cycle_000_s005",
+              "turns": [
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0136)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0136)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0153)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0153)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 0154)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0154)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0155)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0155)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 0156)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0156)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0157)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0157)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-27",
+              "session_id": "seq_buffer_cycle_000_s006",
+              "turns": [
+                {
+                  "content": "Remind me how to write a good standup update. (note 0170)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0170)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0187)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0187)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 0188)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0188)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0189)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0189)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0190)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0190)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0191)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0191)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-29",
+              "session_id": "seq_buffer_cycle_000_s007",
+              "turns": [
+                {
+                  "content": "What's a good book on negotiation? (note 0204)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0204)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0221)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0221)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0222)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0222)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0223)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0223)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0224)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0224)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0225)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0225)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-30",
+              "session_id": "seq_buffer_cycle_000_s008",
+              "turns": [
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0238)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0238)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0255)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0255)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0256)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0256)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0257)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0257)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 0258)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0258)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0259)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0259)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-04-01",
+              "session_id": "seq_buffer_cycle_000_s009",
+              "turns": [
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0272)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0272)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0289)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0289)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 0290)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0290)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0291)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0291)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 0292)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0292)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0293)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0293)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-04-03",
+              "session_id": "seq_buffer_cycle_000_s010",
+              "turns": [
+                {
+                  "content": "Remind me how to write a good standup update. (note 0306)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0306)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0323)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0323)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 0324)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0324)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0325)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0325)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0326)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0326)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0327)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0327)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-04-05",
+              "session_id": "seq_buffer_cycle_000_s011",
+              "turns": [
+                {
+                  "content": "What's a good book on negotiation? (note 0340)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0340)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0357)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0357)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0358)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0358)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0359)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0359)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0360)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0360)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0361)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0361)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-04-06",
+              "session_id": "seq_buffer_cycle_000_s012",
+              "turns": [
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0374)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0374)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0391)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0391)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0392)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0392)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0393)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0393)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 0394)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0394)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0395)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0395)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-04-08",
+              "session_id": "seq_buffer_cycle_000_s013",
+              "turns": [
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0408)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0408)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0425)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0425)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 0426)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0426)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0427)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0427)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 0428)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0428)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0429)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0429)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-04-10",
+              "session_id": "seq_buffer_cycle_000_s014",
+              "turns": [
+                {
+                  "content": "Remind me how to write a good standup update. (note 0442)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0442)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0459)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0459)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 0460)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0460)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0461)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0461)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0462)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0462)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0463)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0463)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-04-11",
+              "session_id": "seq_buffer_cycle_000_s015",
+              "turns": [
+                {
+                  "content": "What's a good book on negotiation? (note 0476)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0476)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0493)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0493)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0494)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0494)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0495)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0495)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0496)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0496)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0497)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0497)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-04-13",
+              "session_id": "seq_buffer_cycle_000_s016",
+              "turns": [
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0510)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0510)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "For the record: Dario Nakamura is our support specialist at Vertex Labs. You can reach them at dario.nakamura@vertexlabs.example.com.",
+                  "role": "user"
+                },
+                {
+                  "content": "Noted. Dario Nakamura (support specialist, Vertex Labs) with contact dario.nakamura@vertexlabs.example.com.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0527)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0527)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0528)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0528)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0529)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0529)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 0530)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0530)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0531)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0531)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-04-15",
+              "session_id": "seq_buffer_cycle_000_s017",
+              "turns": [
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0544)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0544)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Owen Haddad opened support ticket TKT-7623-HB for the auth migration. Keep that reference handy.",
+                  "role": "user"
+                },
+                {
+                  "content": "Saved: support ticket TKT-7623-HB (auth migration, opened by Owen Haddad).",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0561)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0561)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 0562)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0562)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0563)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0563)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 0564)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0564)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0565)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0565)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-04-17",
+              "session_id": "seq_buffer_cycle_000_s018",
+              "turns": [
+                {
+                  "content": "Remind me how to write a good standup update. (note 0578)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0578)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0595)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0595)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 0596)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0596)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0597)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0597)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0598)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0598)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0599)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0599)",
+                  "role": "assistant"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "config": {
+        "fact_sets": 1,
+        "filler_exchanges": 6,
+        "sessions": 18,
+        "span_days": 30
+      }
+    },
+    "contradiction": {
+      "cases": [
+        {
+          "case_id": "seq_contradiction_000",
+          "ground_truth": {
+            "artifacts": [],
+            "canaries": [],
+            "contradictions": [
+              {
+                "expected_detection": "conflicted",
+                "new_object": "Northwind Analytics",
+                "new_turn_id": "seq_contradiction_000_s005:0",
+                "old_object": "Vertex Labs",
+                "old_turn_id": "seq_contradiction_000_s001:0",
+                "predicate": "works_at",
+                "subject": "Kai Silva"
+              },
+              {
+                "expected_detection": "conflicted",
+                "new_object": "Toronto",
+                "new_turn_id": "seq_contradiction_000_s006:0",
+                "old_object": "Austin",
+                "old_turn_id": "seq_contradiction_000_s002:0",
+                "predicate": "lives_in",
+                "subject": "Mara Kovacs"
+              },
+              {
+                "expected_detection": "conflicted",
+                "new_object": "Quill Software",
+                "new_turn_id": "seq_contradiction_000_s007:0",
+                "old_object": "Aster Dynamics",
+                "old_turn_id": "seq_contradiction_000_s003:0",
+                "predicate": "works_at",
+                "subject": "Jonas Alvarez"
+              },
+              {
+                "expected_detection": "superseded",
+                "new_object": "Melbourne",
+                "new_turn_id": "seq_contradiction_000_s008:0",
+                "old_object": "Stockholm",
+                "old_turn_id": "seq_contradiction_000_s004:0",
+                "predicate": "lives_in",
+                "subject": "Priya Haddad"
+              },
+              {
+                "expected_detection": "superseded",
+                "new_object": "Northwind Analytics",
+                "new_turn_id": "seq_contradiction_000_s009:0",
+                "old_object": "Vertex Labs",
+                "old_turn_id": "seq_contradiction_000_s005:2",
+                "predicate": "works_at",
+                "subject": "Tomas Moreau"
+              },
+              {
+                "expected_detection": "superseded",
+                "new_object": "Toronto",
+                "new_turn_id": "seq_contradiction_000_s010:0",
+                "old_object": "Austin",
+                "old_turn_id": "seq_contradiction_000_s006:2",
+                "predicate": "lives_in",
+                "subject": "Lena Bergstrom"
+              }
+            ],
+            "decisions": [],
+            "distractors": [
+              {
+                "kind": "duplicate_fact",
+                "object": "Cobalt Works",
+                "predicate": "works_at",
+                "subject": "Ravi Fischer",
+                "turn_ids": [
+                  "seq_contradiction_000_s001:2",
+                  "seq_contradiction_000_s012:0"
+                ]
+              },
+              {
+                "kind": "non_exclusive_change",
+                "objects": [
+                  "PostgreSQL",
+                  "Clerk"
+                ],
+                "predicate": "recommended",
+                "subject": "Sofia Okafor",
+                "turn_ids": [
+                  "seq_contradiction_000_s002:2",
+                  "seq_contradiction_000_s006:4"
+                ]
+              }
+            ],
+            "entities": [
+              {
+                "attributes": {},
+                "name": "Kai Silva",
+                "session_id": "seq_contradiction_000_s001",
+                "turn_id": "seq_contradiction_000_s001:0",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Vertex Labs",
+                "session_id": "seq_contradiction_000_s001",
+                "turn_id": "seq_contradiction_000_s001:0",
+                "type": "company"
+              },
+              {
+                "attributes": {},
+                "name": "Kai Silva",
+                "session_id": "seq_contradiction_000_s005",
+                "turn_id": "seq_contradiction_000_s005:0",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Northwind Analytics",
+                "session_id": "seq_contradiction_000_s005",
+                "turn_id": "seq_contradiction_000_s005:0",
+                "type": "company"
+              },
+              {
+                "attributes": {},
+                "name": "Mara Kovacs",
+                "session_id": "seq_contradiction_000_s002",
+                "turn_id": "seq_contradiction_000_s002:0",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Austin",
+                "session_id": "seq_contradiction_000_s002",
+                "turn_id": "seq_contradiction_000_s002:0",
+                "type": "location"
+              },
+              {
+                "attributes": {},
+                "name": "Mara Kovacs",
+                "session_id": "seq_contradiction_000_s006",
+                "turn_id": "seq_contradiction_000_s006:0",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Toronto",
+                "session_id": "seq_contradiction_000_s006",
+                "turn_id": "seq_contradiction_000_s006:0",
+                "type": "location"
+              },
+              {
+                "attributes": {},
+                "name": "Jonas Alvarez",
+                "session_id": "seq_contradiction_000_s003",
+                "turn_id": "seq_contradiction_000_s003:0",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Aster Dynamics",
+                "session_id": "seq_contradiction_000_s003",
+                "turn_id": "seq_contradiction_000_s003:0",
+                "type": "company"
+              },
+              {
+                "attributes": {},
+                "name": "Jonas Alvarez",
+                "session_id": "seq_contradiction_000_s007",
+                "turn_id": "seq_contradiction_000_s007:0",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Quill Software",
+                "session_id": "seq_contradiction_000_s007",
+                "turn_id": "seq_contradiction_000_s007:0",
+                "type": "company"
+              },
+              {
+                "attributes": {},
+                "name": "Priya Haddad",
+                "session_id": "seq_contradiction_000_s004",
+                "turn_id": "seq_contradiction_000_s004:0",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Stockholm",
+                "session_id": "seq_contradiction_000_s004",
+                "turn_id": "seq_contradiction_000_s004:0",
+                "type": "location"
+              },
+              {
+                "attributes": {},
+                "name": "Priya Haddad",
+                "session_id": "seq_contradiction_000_s008",
+                "turn_id": "seq_contradiction_000_s008:0",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Melbourne",
+                "session_id": "seq_contradiction_000_s008",
+                "turn_id": "seq_contradiction_000_s008:0",
+                "type": "location"
+              },
+              {
+                "attributes": {},
+                "name": "Tomas Moreau",
+                "session_id": "seq_contradiction_000_s005",
+                "turn_id": "seq_contradiction_000_s005:2",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Vertex Labs",
+                "session_id": "seq_contradiction_000_s005",
+                "turn_id": "seq_contradiction_000_s005:2",
+                "type": "company"
+              },
+              {
+                "attributes": {},
+                "name": "Tomas Moreau",
+                "session_id": "seq_contradiction_000_s009",
+                "turn_id": "seq_contradiction_000_s009:0",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Northwind Analytics",
+                "session_id": "seq_contradiction_000_s009",
+                "turn_id": "seq_contradiction_000_s009:0",
+                "type": "company"
+              },
+              {
+                "attributes": {},
+                "name": "Lena Bergstrom",
+                "session_id": "seq_contradiction_000_s006",
+                "turn_id": "seq_contradiction_000_s006:2",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Austin",
+                "session_id": "seq_contradiction_000_s006",
+                "turn_id": "seq_contradiction_000_s006:2",
+                "type": "location"
+              },
+              {
+                "attributes": {},
+                "name": "Lena Bergstrom",
+                "session_id": "seq_contradiction_000_s010",
+                "turn_id": "seq_contradiction_000_s010:0",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Toronto",
+                "session_id": "seq_contradiction_000_s010",
+                "turn_id": "seq_contradiction_000_s010:0",
+                "type": "location"
+              },
+              {
+                "attributes": {},
+                "name": "Ravi Fischer",
+                "session_id": "seq_contradiction_000_s001",
+                "turn_id": "seq_contradiction_000_s001:2",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Cobalt Works",
+                "session_id": "seq_contradiction_000_s001",
+                "turn_id": "seq_contradiction_000_s001:2",
+                "type": "company"
+              },
+              {
+                "attributes": {},
+                "name": "Ravi Fischer",
+                "session_id": "seq_contradiction_000_s012",
+                "turn_id": "seq_contradiction_000_s012:0",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Cobalt Works",
+                "session_id": "seq_contradiction_000_s012",
+                "turn_id": "seq_contradiction_000_s012:0",
+                "type": "company"
+              },
+              {
+                "attributes": {},
+                "name": "Sofia Okafor",
+                "session_id": "seq_contradiction_000_s002",
+                "turn_id": "seq_contradiction_000_s002:2",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "PostgreSQL",
+                "session_id": "seq_contradiction_000_s002",
+                "turn_id": "seq_contradiction_000_s002:2",
+                "type": "topic"
+              },
+              {
+                "attributes": {},
+                "name": "Clerk",
+                "session_id": "seq_contradiction_000_s006",
+                "turn_id": "seq_contradiction_000_s006:4",
+                "type": "topic"
+              }
+            ],
+            "log_entries": [
+              {
+                "date": "2026-02-23",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_contradiction_000_s001"
+                ],
+                "summary": "Work on 2026-02-23: noted Kai Silva works at Vertex Labs; noted Ravi Fischer works at Cobalt Works"
+              },
+              {
+                "date": "2026-02-27",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_contradiction_000_s002"
+                ],
+                "summary": "Work on 2026-02-27: noted Mara Kovacs lives in Austin"
+              },
+              {
+                "date": "2026-03-03",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_contradiction_000_s003"
+                ],
+                "summary": "Work on 2026-03-03: noted Jonas Alvarez works at Aster Dynamics"
+              },
+              {
+                "date": "2026-03-07",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_contradiction_000_s004"
+                ],
+                "summary": "Work on 2026-03-07: noted Priya Haddad lives in Stockholm"
+              },
+              {
+                "date": "2026-03-11",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_contradiction_000_s005"
+                ],
+                "summary": "Work on 2026-03-11: noted Kai Silva works at Northwind Analytics; noted Tomas Moreau works at Vertex Labs"
+              },
+              {
+                "date": "2026-03-15",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_contradiction_000_s006"
+                ],
+                "summary": "Work on 2026-03-15: noted Mara Kovacs lives in Toronto; noted Lena Bergstrom lives in Austin"
+              },
+              {
+                "date": "2026-03-19",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_contradiction_000_s007"
+                ],
+                "summary": "Work on 2026-03-19: noted Jonas Alvarez works at Quill Software"
+              },
+              {
+                "date": "2026-03-23",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_contradiction_000_s008"
+                ],
+                "summary": "Work on 2026-03-23: noted Priya Haddad lives in Melbourne"
+              },
+              {
+                "date": "2026-03-27",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_contradiction_000_s009"
+                ],
+                "summary": "Work on 2026-03-27: noted Tomas Moreau works at Northwind Analytics"
+              },
+              {
+                "date": "2026-03-31",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_contradiction_000_s010"
+                ],
+                "summary": "Work on 2026-03-31: noted Lena Bergstrom lives in Toronto"
+              },
+              {
+                "date": "2026-04-08",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_contradiction_000_s012"
+                ],
+                "summary": "Work on 2026-04-08: noted Ravi Fischer works at Cobalt Works"
+              }
+            ],
+            "question_meta": {},
+            "relationships": [
+              {
+                "attributes": {
+                  "stated_on": "2026-02-23"
+                },
+                "confidence": 0.6,
+                "from_name": "Kai Silva",
+                "from_type": "person",
+                "session_id": "seq_contradiction_000_s001",
+                "to_name": "Vertex Labs",
+                "to_type": "company",
+                "turn_id": "seq_contradiction_000_s001:0",
+                "type": "works_at"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-03-11"
+                },
+                "confidence": 0.6,
+                "from_name": "Kai Silva",
+                "from_type": "person",
+                "session_id": "seq_contradiction_000_s005",
+                "to_name": "Northwind Analytics",
+                "to_type": "company",
+                "turn_id": "seq_contradiction_000_s005:0",
+                "type": "works_at"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-02-27"
+                },
+                "confidence": 0.6,
+                "from_name": "Mara Kovacs",
+                "from_type": "person",
+                "session_id": "seq_contradiction_000_s002",
+                "to_name": "Austin",
+                "to_type": "location",
+                "turn_id": "seq_contradiction_000_s002:0",
+                "type": "lives_in"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-03-15"
+                },
+                "confidence": 0.6,
+                "from_name": "Mara Kovacs",
+                "from_type": "person",
+                "session_id": "seq_contradiction_000_s006",
+                "to_name": "Toronto",
+                "to_type": "location",
+                "turn_id": "seq_contradiction_000_s006:0",
+                "type": "lives_in"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-03-03"
+                },
+                "confidence": 0.6,
+                "from_name": "Jonas Alvarez",
+                "from_type": "person",
+                "session_id": "seq_contradiction_000_s003",
+                "to_name": "Aster Dynamics",
+                "to_type": "company",
+                "turn_id": "seq_contradiction_000_s003:0",
+                "type": "works_at"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-03-19"
+                },
+                "confidence": 0.6,
+                "from_name": "Jonas Alvarez",
+                "from_type": "person",
+                "session_id": "seq_contradiction_000_s007",
+                "to_name": "Quill Software",
+                "to_type": "company",
+                "turn_id": "seq_contradiction_000_s007:0",
+                "type": "works_at"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-03-07"
+                },
+                "confidence": 0.55,
+                "from_name": "Priya Haddad",
+                "from_type": "person",
+                "session_id": "seq_contradiction_000_s004",
+                "to_name": "Stockholm",
+                "to_type": "location",
+                "turn_id": "seq_contradiction_000_s004:0",
+                "type": "lives_in"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-03-23"
+                },
+                "confidence": 0.95,
+                "from_name": "Priya Haddad",
+                "from_type": "person",
+                "session_id": "seq_contradiction_000_s008",
+                "to_name": "Melbourne",
+                "to_type": "location",
+                "turn_id": "seq_contradiction_000_s008:0",
+                "type": "lives_in"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-03-11"
+                },
+                "confidence": 0.55,
+                "from_name": "Tomas Moreau",
+                "from_type": "person",
+                "session_id": "seq_contradiction_000_s005",
+                "to_name": "Vertex Labs",
+                "to_type": "company",
+                "turn_id": "seq_contradiction_000_s005:2",
+                "type": "works_at"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-03-27"
+                },
+                "confidence": 0.95,
+                "from_name": "Tomas Moreau",
+                "from_type": "person",
+                "session_id": "seq_contradiction_000_s009",
+                "to_name": "Northwind Analytics",
+                "to_type": "company",
+                "turn_id": "seq_contradiction_000_s009:0",
+                "type": "works_at"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-03-15"
+                },
+                "confidence": 0.55,
+                "from_name": "Lena Bergstrom",
+                "from_type": "person",
+                "session_id": "seq_contradiction_000_s006",
+                "to_name": "Austin",
+                "to_type": "location",
+                "turn_id": "seq_contradiction_000_s006:2",
+                "type": "lives_in"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-03-31"
+                },
+                "confidence": 0.95,
+                "from_name": "Lena Bergstrom",
+                "from_type": "person",
+                "session_id": "seq_contradiction_000_s010",
+                "to_name": "Toronto",
+                "to_type": "location",
+                "turn_id": "seq_contradiction_000_s010:0",
+                "type": "lives_in"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-02-23"
+                },
+                "confidence": 0.85,
+                "from_name": "Ravi Fischer",
+                "from_type": "person",
+                "session_id": "seq_contradiction_000_s001",
+                "to_name": "Cobalt Works",
+                "to_type": "company",
+                "turn_id": "seq_contradiction_000_s001:2",
+                "type": "works_at"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-04-08"
+                },
+                "confidence": 0.85,
+                "from_name": "Ravi Fischer",
+                "from_type": "person",
+                "session_id": "seq_contradiction_000_s012",
+                "to_name": "Cobalt Works",
+                "to_type": "company",
+                "turn_id": "seq_contradiction_000_s012:0",
+                "type": "works_at"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-02-27"
+                },
+                "confidence": 0.85,
+                "from_name": "Sofia Okafor",
+                "from_type": "person",
+                "session_id": "seq_contradiction_000_s002",
+                "to_name": "PostgreSQL",
+                "to_type": "topic",
+                "turn_id": "seq_contradiction_000_s002:2",
+                "type": "recommended"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-03-15"
+                },
+                "confidence": 0.85,
+                "from_name": "Sofia Okafor",
+                "from_type": "person",
+                "session_id": "seq_contradiction_000_s006",
+                "to_name": "Clerk",
+                "to_type": "topic",
+                "turn_id": "seq_contradiction_000_s006:4",
+                "type": "recommended"
+              }
+            ]
+          },
+          "questions": [],
+          "scenario": "contradiction",
+          "sessions": [
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-02-23",
+              "session_id": "seq_contradiction_000_s001",
+              "turns": [
+                {
+                  "content": "Kai Silva works at Vertex Labs.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Kai Silva works at Vertex Labs.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Ravi Fischer works at Cobalt Works.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Ravi Fischer works at Cobalt Works.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0000)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0000)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0001)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0001)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-02-27",
+              "session_id": "seq_contradiction_000_s002",
+              "turns": [
+                {
+                  "content": "Mara Kovacs lives in Austin.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Mara Kovacs lives in Austin.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Sofia Okafor recommended PostgreSQL for the checkout service.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded Sofia Okafor's recommendation of PostgreSQL.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0017)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0017)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 0018)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0018)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-03",
+              "session_id": "seq_contradiction_000_s003",
+              "turns": [
+                {
+                  "content": "Jonas Alvarez works at Aster Dynamics.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Jonas Alvarez works at Aster Dynamics.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 0034)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0034)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0035)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0035)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-07",
+              "session_id": "seq_contradiction_000_s004",
+              "turns": [
+                {
+                  "content": "Priya Haddad lives in Stockholm.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Priya Haddad lives in Stockholm.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0051)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0051)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 0052)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0052)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-11",
+              "session_id": "seq_contradiction_000_s005",
+              "turns": [
+                {
+                  "content": "Wait - I heard Kai Silva actually works at Northwind Analytics, not Vertex Labs.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Kai Silva works at Northwind Analytics.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Tomas Moreau works at Vertex Labs.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Tomas Moreau works at Vertex Labs.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 0068)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0068)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0069)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0069)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-15",
+              "session_id": "seq_contradiction_000_s006",
+              "turns": [
+                {
+                  "content": "Wait - I heard Mara Kovacs actually lives in Toronto, not Austin.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Mara Kovacs lives in Toronto.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Lena Bergstrom lives in Austin.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Lena Bergstrom lives in Austin.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Sofia Okafor now also recommends Clerk for the checkout service.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded Sofia Okafor's recommendation of Clerk.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0085)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0085)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0086)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0086)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-19",
+              "session_id": "seq_contradiction_000_s007",
+              "turns": [
+                {
+                  "content": "Wait - I heard Jonas Alvarez actually works at Quill Software, not Aster Dynamics.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Jonas Alvarez works at Quill Software.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0102)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0102)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0103)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0103)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-23",
+              "session_id": "seq_contradiction_000_s008",
+              "turns": [
+                {
+                  "content": "Confirmed by HR: Priya Haddad now lives in Melbourne.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Priya Haddad lives in Melbourne.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0119)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0119)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0120)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0120)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-27",
+              "session_id": "seq_contradiction_000_s009",
+              "turns": [
+                {
+                  "content": "Confirmed by HR: Tomas Moreau now works at Northwind Analytics.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Tomas Moreau works at Northwind Analytics.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0136)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0136)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0137)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0137)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-31",
+              "session_id": "seq_contradiction_000_s010",
+              "turns": [
+                {
+                  "content": "Confirmed by HR: Lena Bergstrom now lives in Toronto.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Lena Bergstrom lives in Toronto.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0153)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0153)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 0154)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0154)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-04-04",
+              "session_id": "seq_contradiction_000_s011",
+              "turns": [
+                {
+                  "content": "Remind me how to write a good standup update. (note 0170)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0170)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0171)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0171)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-04-08",
+              "session_id": "seq_contradiction_000_s012",
+              "turns": [
+                {
+                  "content": "Just double-checking: Ravi Fischer still works at Cobalt Works, right?",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Ravi Fischer works at Cobalt Works.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0187)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0187)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 0188)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0188)",
+                  "role": "assistant"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "config": {
+        "conflicted": 3,
+        "sessions": 12,
+        "span_days": 45,
+        "superseded": 3
+      }
+    },
+    "cross_agent": {
+      "cases": [
+        {
+          "case_id": "seq_cross_agent_000",
+          "ground_truth": {
+            "agents": [
+              "research-agent",
+              "finance-agent",
+              "marketing-agent",
+              "engineering-agent"
+            ],
+            "artifacts": [
+              {
+                "agent": "research-agent",
+                "name": "market sizing memo",
+                "reference": "DOC-3723-MR",
+                "session_id": "seq_cross_agent_000_s001",
+                "turn_id": "seq_cross_agent_000_s001:0"
+              },
+              {
+                "agent": "finance-agent",
+                "name": "Q3 revenue forecast",
+                "reference": "DOC-2528-NT",
+                "session_id": "seq_cross_agent_000_s002",
+                "turn_id": "seq_cross_agent_000_s002:0"
+              },
+              {
+                "agent": "marketing-agent",
+                "name": "campaign performance report",
+                "reference": "DOC-8969-SF",
+                "session_id": "seq_cross_agent_000_s003",
+                "turn_id": "seq_cross_agent_000_s003:0"
+              },
+              {
+                "agent": "engineering-agent",
+                "name": "load test report",
+                "reference": "DOC-6310-PQ",
+                "session_id": "seq_cross_agent_000_s004",
+                "turn_id": "seq_cross_agent_000_s004:0"
+              },
+              {
+                "agent": "research-agent",
+                "name": "competitor teardown",
+                "reference": "DOC-1450-NX",
+                "session_id": "seq_cross_agent_000_s005",
+                "turn_id": "seq_cross_agent_000_s005:0"
+              },
+              {
+                "agent": "finance-agent",
+                "name": "budget variance report",
+                "reference": "DOC-9594-JC",
+                "session_id": "seq_cross_agent_000_s006",
+                "turn_id": "seq_cross_agent_000_s006:0"
+              },
+              {
+                "agent": "marketing-agent",
+                "name": "brand refresh brief",
+                "reference": "DOC-4146-JH",
+                "session_id": "seq_cross_agent_000_s007",
+                "turn_id": "seq_cross_agent_000_s007:0"
+              },
+              {
+                "agent": "engineering-agent",
+                "name": "API design document",
+                "reference": "DOC-1058-MM",
+                "session_id": "seq_cross_agent_000_s008",
+                "turn_id": "seq_cross_agent_000_s008:0"
+              }
+            ],
+            "canaries": [],
+            "contradictions": [],
+            "decisions": [
+              {
+                "date": "2026-02-16",
+                "decision": "Adopt PostgreSQL for the pricing revamp (Owen Okafor's recommendation)",
+                "session_id": "seq_cross_agent_000_s001"
+              },
+              {
+                "date": "2026-02-17",
+                "decision": "Adopt Clerk for the enterprise pipeline (Kai Rao's recommendation)",
+                "session_id": "seq_cross_agent_000_s002"
+              },
+              {
+                "date": "2026-02-19",
+                "decision": "Adopt Stripe for the search revamp (Yuki Lindqvist's recommendation)",
+                "session_id": "seq_cross_agent_000_s003"
+              },
+              {
+                "date": "2026-02-21",
+                "decision": "Adopt Kafka for the partner program (Mara Nakamura's recommendation)",
+                "session_id": "seq_cross_agent_000_s004"
+              },
+              {
+                "date": "2026-02-23",
+                "decision": "Adopt Terraform for the pricing revamp (Petra Silva's recommendation)",
+                "session_id": "seq_cross_agent_000_s005"
+              },
+              {
+                "date": "2026-02-25",
+                "decision": "Adopt Snowflake for the enterprise pipeline (Amara Mensah's recommendation)",
+                "session_id": "seq_cross_agent_000_s006"
+              },
+              {
+                "date": "2026-02-27",
+                "decision": "Adopt Redis for the search revamp (Owen Okafor's recommendation)",
+                "session_id": "seq_cross_agent_000_s007"
+              },
+              {
+                "date": "2026-03-01",
+                "decision": "Adopt Temporal for the partner program (Kai Rao's recommendation)",
+                "session_id": "seq_cross_agent_000_s008"
+              }
+            ],
+            "distractors": [],
+            "entities": [
+              {
+                "attributes": {},
+                "name": "research-agent",
+                "session_id": "seq_cross_agent_000_s001",
+                "turn_id": "seq_cross_agent_000_s001:0",
+                "type": "agent"
+              },
+              {
+                "attributes": {
+                  "reference": "DOC-3723-MR"
+                },
+                "name": "market sizing memo",
+                "session_id": "seq_cross_agent_000_s001",
+                "turn_id": "seq_cross_agent_000_s001:0",
+                "type": "artifact"
+              },
+              {
+                "attributes": {},
+                "name": "Owen Okafor",
+                "session_id": "seq_cross_agent_000_s001",
+                "turn_id": "seq_cross_agent_000_s001:2",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "PostgreSQL",
+                "session_id": "seq_cross_agent_000_s001",
+                "turn_id": "seq_cross_agent_000_s001:2",
+                "type": "topic"
+              },
+              {
+                "attributes": {},
+                "name": "pricing revamp",
+                "session_id": "seq_cross_agent_000_s001",
+                "turn_id": "seq_cross_agent_000_s001:2",
+                "type": "project"
+              },
+              {
+                "attributes": {},
+                "name": "finance-agent",
+                "session_id": "seq_cross_agent_000_s002",
+                "turn_id": "seq_cross_agent_000_s002:0",
+                "type": "agent"
+              },
+              {
+                "attributes": {
+                  "reference": "DOC-2528-NT"
+                },
+                "name": "Q3 revenue forecast",
+                "session_id": "seq_cross_agent_000_s002",
+                "turn_id": "seq_cross_agent_000_s002:0",
+                "type": "artifact"
+              },
+              {
+                "attributes": {},
+                "name": "Kai Rao",
+                "session_id": "seq_cross_agent_000_s002",
+                "turn_id": "seq_cross_agent_000_s002:2",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Clerk",
+                "session_id": "seq_cross_agent_000_s002",
+                "turn_id": "seq_cross_agent_000_s002:2",
+                "type": "topic"
+              },
+              {
+                "attributes": {},
+                "name": "enterprise pipeline",
+                "session_id": "seq_cross_agent_000_s002",
+                "turn_id": "seq_cross_agent_000_s002:2",
+                "type": "project"
+              },
+              {
+                "attributes": {},
+                "name": "marketing-agent",
+                "session_id": "seq_cross_agent_000_s003",
+                "turn_id": "seq_cross_agent_000_s003:0",
+                "type": "agent"
+              },
+              {
+                "attributes": {
+                  "reference": "DOC-8969-SF"
+                },
+                "name": "campaign performance report",
+                "session_id": "seq_cross_agent_000_s003",
+                "turn_id": "seq_cross_agent_000_s003:0",
+                "type": "artifact"
+              },
+              {
+                "attributes": {},
+                "name": "Yuki Lindqvist",
+                "session_id": "seq_cross_agent_000_s003",
+                "turn_id": "seq_cross_agent_000_s003:2",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Stripe",
+                "session_id": "seq_cross_agent_000_s003",
+                "turn_id": "seq_cross_agent_000_s003:2",
+                "type": "topic"
+              },
+              {
+                "attributes": {},
+                "name": "search revamp",
+                "session_id": "seq_cross_agent_000_s003",
+                "turn_id": "seq_cross_agent_000_s003:2",
+                "type": "project"
+              },
+              {
+                "attributes": {},
+                "name": "engineering-agent",
+                "session_id": "seq_cross_agent_000_s004",
+                "turn_id": "seq_cross_agent_000_s004:0",
+                "type": "agent"
+              },
+              {
+                "attributes": {
+                  "reference": "DOC-6310-PQ"
+                },
+                "name": "load test report",
+                "session_id": "seq_cross_agent_000_s004",
+                "turn_id": "seq_cross_agent_000_s004:0",
+                "type": "artifact"
+              },
+              {
+                "attributes": {},
+                "name": "Mara Nakamura",
+                "session_id": "seq_cross_agent_000_s004",
+                "turn_id": "seq_cross_agent_000_s004:2",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Kafka",
+                "session_id": "seq_cross_agent_000_s004",
+                "turn_id": "seq_cross_agent_000_s004:2",
+                "type": "topic"
+              },
+              {
+                "attributes": {},
+                "name": "partner program",
+                "session_id": "seq_cross_agent_000_s004",
+                "turn_id": "seq_cross_agent_000_s004:2",
+                "type": "project"
+              },
+              {
+                "attributes": {},
+                "name": "research-agent",
+                "session_id": "seq_cross_agent_000_s005",
+                "turn_id": "seq_cross_agent_000_s005:0",
+                "type": "agent"
+              },
+              {
+                "attributes": {
+                  "reference": "DOC-1450-NX"
+                },
+                "name": "competitor teardown",
+                "session_id": "seq_cross_agent_000_s005",
+                "turn_id": "seq_cross_agent_000_s005:0",
+                "type": "artifact"
+              },
+              {
+                "attributes": {},
+                "name": "Petra Silva",
+                "session_id": "seq_cross_agent_000_s005",
+                "turn_id": "seq_cross_agent_000_s005:2",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Terraform",
+                "session_id": "seq_cross_agent_000_s005",
+                "turn_id": "seq_cross_agent_000_s005:2",
+                "type": "topic"
+              },
+              {
+                "attributes": {},
+                "name": "pricing revamp",
+                "session_id": "seq_cross_agent_000_s005",
+                "turn_id": "seq_cross_agent_000_s005:2",
+                "type": "project"
+              },
+              {
+                "attributes": {},
+                "name": "finance-agent",
+                "session_id": "seq_cross_agent_000_s006",
+                "turn_id": "seq_cross_agent_000_s006:0",
+                "type": "agent"
+              },
+              {
+                "attributes": {
+                  "reference": "DOC-9594-JC"
+                },
+                "name": "budget variance report",
+                "session_id": "seq_cross_agent_000_s006",
+                "turn_id": "seq_cross_agent_000_s006:0",
+                "type": "artifact"
+              },
+              {
+                "attributes": {},
+                "name": "Amara Mensah",
+                "session_id": "seq_cross_agent_000_s006",
+                "turn_id": "seq_cross_agent_000_s006:2",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Snowflake",
+                "session_id": "seq_cross_agent_000_s006",
+                "turn_id": "seq_cross_agent_000_s006:2",
+                "type": "topic"
+              },
+              {
+                "attributes": {},
+                "name": "enterprise pipeline",
+                "session_id": "seq_cross_agent_000_s006",
+                "turn_id": "seq_cross_agent_000_s006:2",
+                "type": "project"
+              },
+              {
+                "attributes": {},
+                "name": "marketing-agent",
+                "session_id": "seq_cross_agent_000_s007",
+                "turn_id": "seq_cross_agent_000_s007:0",
+                "type": "agent"
+              },
+              {
+                "attributes": {
+                  "reference": "DOC-4146-JH"
+                },
+                "name": "brand refresh brief",
+                "session_id": "seq_cross_agent_000_s007",
+                "turn_id": "seq_cross_agent_000_s007:0",
+                "type": "artifact"
+              },
+              {
+                "attributes": {},
+                "name": "Owen Okafor",
+                "session_id": "seq_cross_agent_000_s007",
+                "turn_id": "seq_cross_agent_000_s007:2",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Redis",
+                "session_id": "seq_cross_agent_000_s007",
+                "turn_id": "seq_cross_agent_000_s007:2",
+                "type": "topic"
+              },
+              {
+                "attributes": {},
+                "name": "search revamp",
+                "session_id": "seq_cross_agent_000_s007",
+                "turn_id": "seq_cross_agent_000_s007:2",
+                "type": "project"
+              },
+              {
+                "attributes": {},
+                "name": "engineering-agent",
+                "session_id": "seq_cross_agent_000_s008",
+                "turn_id": "seq_cross_agent_000_s008:0",
+                "type": "agent"
+              },
+              {
+                "attributes": {
+                  "reference": "DOC-1058-MM"
+                },
+                "name": "API design document",
+                "session_id": "seq_cross_agent_000_s008",
+                "turn_id": "seq_cross_agent_000_s008:0",
+                "type": "artifact"
+              },
+              {
+                "attributes": {},
+                "name": "Kai Rao",
+                "session_id": "seq_cross_agent_000_s008",
+                "turn_id": "seq_cross_agent_000_s008:2",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Temporal",
+                "session_id": "seq_cross_agent_000_s008",
+                "turn_id": "seq_cross_agent_000_s008:2",
+                "type": "topic"
+              },
+              {
+                "attributes": {},
+                "name": "partner program",
+                "session_id": "seq_cross_agent_000_s008",
+                "turn_id": "seq_cross_agent_000_s008:2",
+                "type": "project"
+              }
+            ],
+            "log_entries": [
+              {
+                "date": "2026-02-16",
+                "decisions": [
+                  "Adopt PostgreSQL for the pricing revamp (Owen Okafor's recommendation)"
+                ],
+                "projects": [
+                  "pricing revamp"
+                ],
+                "source_session_ids": [
+                  "seq_cross_agent_000_s001"
+                ],
+                "summary": "Work on 2026-02-16: the research-agent delivered the market sizing memo; Owen Okafor recommended PostgreSQL for the pricing revamp"
+              },
+              {
+                "date": "2026-02-17",
+                "decisions": [
+                  "Adopt Clerk for the enterprise pipeline (Kai Rao's recommendation)"
+                ],
+                "projects": [
+                  "enterprise pipeline"
+                ],
+                "source_session_ids": [
+                  "seq_cross_agent_000_s002"
+                ],
+                "summary": "Work on 2026-02-17: the finance-agent delivered the Q3 revenue forecast; Kai Rao recommended Clerk for the enterprise pipeline"
+              },
+              {
+                "date": "2026-02-19",
+                "decisions": [
+                  "Adopt Stripe for the search revamp (Yuki Lindqvist's recommendation)"
+                ],
+                "projects": [
+                  "search revamp"
+                ],
+                "source_session_ids": [
+                  "seq_cross_agent_000_s003"
+                ],
+                "summary": "Work on 2026-02-19: the marketing-agent delivered the campaign performance report; Yuki Lindqvist recommended Stripe for the search revamp"
+              },
+              {
+                "date": "2026-02-21",
+                "decisions": [
+                  "Adopt Kafka for the partner program (Mara Nakamura's recommendation)"
+                ],
+                "projects": [
+                  "partner program"
+                ],
+                "source_session_ids": [
+                  "seq_cross_agent_000_s004"
+                ],
+                "summary": "Work on 2026-02-21: the engineering-agent delivered the load test report; Mara Nakamura recommended Kafka for the partner program"
+              },
+              {
+                "date": "2026-02-23",
+                "decisions": [
+                  "Adopt Terraform for the pricing revamp (Petra Silva's recommendation)"
+                ],
+                "projects": [
+                  "pricing revamp"
+                ],
+                "source_session_ids": [
+                  "seq_cross_agent_000_s005"
+                ],
+                "summary": "Work on 2026-02-23: the research-agent delivered the competitor teardown; Petra Silva recommended Terraform for the pricing revamp"
+              },
+              {
+                "date": "2026-02-25",
+                "decisions": [
+                  "Adopt Snowflake for the enterprise pipeline (Amara Mensah's recommendation)"
+                ],
+                "projects": [
+                  "enterprise pipeline"
+                ],
+                "source_session_ids": [
+                  "seq_cross_agent_000_s006"
+                ],
+                "summary": "Work on 2026-02-25: the finance-agent delivered the budget variance report; Amara Mensah recommended Snowflake for the enterprise pipeline"
+              },
+              {
+                "date": "2026-02-27",
+                "decisions": [
+                  "Adopt Redis for the search revamp (Owen Okafor's recommendation)"
+                ],
+                "projects": [
+                  "search revamp"
+                ],
+                "source_session_ids": [
+                  "seq_cross_agent_000_s007"
+                ],
+                "summary": "Work on 2026-02-27: the marketing-agent delivered the brand refresh brief; Owen Okafor recommended Redis for the search revamp"
+              },
+              {
+                "date": "2026-03-01",
+                "decisions": [
+                  "Adopt Temporal for the partner program (Kai Rao's recommendation)"
+                ],
+                "projects": [
+                  "partner program"
+                ],
+                "source_session_ids": [
+                  "seq_cross_agent_000_s008"
+                ],
+                "summary": "Work on 2026-03-01: the engineering-agent delivered the API design document; Kai Rao recommended Temporal for the partner program"
+              }
+            ],
+            "question_meta": {
+              "seq_cross_agent_000_q001_cross_agent_propagation": {
+                "asking_agent": "finance-agent",
+                "evidence_agent": "research-agent"
+              },
+              "seq_cross_agent_000_q002_cross_agent_propagation": {
+                "asking_agent": "finance-agent",
+                "evidence_agent": "research-agent"
+              },
+              "seq_cross_agent_000_q003_cross_agent_propagation": {
+                "asking_agent": "finance-agent",
+                "evidence_agent": "research-agent"
+              },
+              "seq_cross_agent_000_q004_cross_agent_propagation": {
+                "asking_agent": "marketing-agent",
+                "evidence_agent": "finance-agent"
+              },
+              "seq_cross_agent_000_q005_cross_agent_propagation": {
+                "asking_agent": "marketing-agent",
+                "evidence_agent": "finance-agent"
+              },
+              "seq_cross_agent_000_q006_cross_agent_propagation": {
+                "asking_agent": "marketing-agent",
+                "evidence_agent": "finance-agent"
+              },
+              "seq_cross_agent_000_q007_cross_agent_propagation": {
+                "asking_agent": "engineering-agent",
+                "evidence_agent": "marketing-agent"
+              },
+              "seq_cross_agent_000_q008_cross_agent_propagation": {
+                "asking_agent": "engineering-agent",
+                "evidence_agent": "marketing-agent"
+              },
+              "seq_cross_agent_000_q009_cross_agent_propagation": {
+                "asking_agent": "engineering-agent",
+                "evidence_agent": "marketing-agent"
+              },
+              "seq_cross_agent_000_q010_cross_agent_propagation": {
+                "asking_agent": "research-agent",
+                "evidence_agent": "engineering-agent"
+              },
+              "seq_cross_agent_000_q011_cross_agent_propagation": {
+                "asking_agent": "research-agent",
+                "evidence_agent": "engineering-agent"
+              },
+              "seq_cross_agent_000_q012_cross_agent_propagation": {
+                "asking_agent": "research-agent",
+                "evidence_agent": "engineering-agent"
+              },
+              "seq_cross_agent_000_q013_cross_agent_propagation": {
+                "asking_agent": "finance-agent",
+                "evidence_agent": "research-agent"
+              },
+              "seq_cross_agent_000_q014_cross_agent_propagation": {
+                "asking_agent": "finance-agent",
+                "evidence_agent": "research-agent"
+              },
+              "seq_cross_agent_000_q015_cross_agent_propagation": {
+                "asking_agent": "finance-agent",
+                "evidence_agent": "research-agent"
+              },
+              "seq_cross_agent_000_q016_cross_agent_propagation": {
+                "asking_agent": "marketing-agent",
+                "evidence_agent": "finance-agent"
+              },
+              "seq_cross_agent_000_q017_cross_agent_propagation": {
+                "asking_agent": "marketing-agent",
+                "evidence_agent": "finance-agent"
+              },
+              "seq_cross_agent_000_q018_cross_agent_propagation": {
+                "asking_agent": "marketing-agent",
+                "evidence_agent": "finance-agent"
+              },
+              "seq_cross_agent_000_q019_cross_agent_propagation": {
+                "asking_agent": "engineering-agent",
+                "evidence_agent": "marketing-agent"
+              },
+              "seq_cross_agent_000_q020_cross_agent_propagation": {
+                "asking_agent": "engineering-agent",
+                "evidence_agent": "marketing-agent"
+              },
+              "seq_cross_agent_000_q021_cross_agent_propagation": {
+                "asking_agent": "engineering-agent",
+                "evidence_agent": "marketing-agent"
+              },
+              "seq_cross_agent_000_q022_cross_agent_propagation": {
+                "asking_agent": "research-agent",
+                "evidence_agent": "engineering-agent"
+              },
+              "seq_cross_agent_000_q023_cross_agent_propagation": {
+                "asking_agent": "research-agent",
+                "evidence_agent": "engineering-agent"
+              },
+              "seq_cross_agent_000_q024_cross_agent_propagation": {
+                "asking_agent": "research-agent",
+                "evidence_agent": "engineering-agent"
+              }
+            },
+            "relationships": [
+              {
+                "attributes": {
+                  "reference": "DOC-3723-MR",
+                  "stated_on": "2026-02-16"
+                },
+                "confidence": 0.85,
+                "from_name": "research-agent",
+                "from_type": "agent",
+                "session_id": "seq_cross_agent_000_s001",
+                "to_name": "market sizing memo",
+                "to_type": "artifact",
+                "turn_id": "seq_cross_agent_000_s001:0",
+                "type": "produced"
+              },
+              {
+                "attributes": {
+                  "project": "pricing revamp",
+                  "stated_on": "2026-02-16"
+                },
+                "confidence": 0.85,
+                "from_name": "Owen Okafor",
+                "from_type": "person",
+                "session_id": "seq_cross_agent_000_s001",
+                "to_name": "PostgreSQL",
+                "to_type": "topic",
+                "turn_id": "seq_cross_agent_000_s001:2",
+                "type": "recommended"
+              },
+              {
+                "attributes": {
+                  "reference": "DOC-2528-NT",
+                  "stated_on": "2026-02-17"
+                },
+                "confidence": 0.85,
+                "from_name": "finance-agent",
+                "from_type": "agent",
+                "session_id": "seq_cross_agent_000_s002",
+                "to_name": "Q3 revenue forecast",
+                "to_type": "artifact",
+                "turn_id": "seq_cross_agent_000_s002:0",
+                "type": "produced"
+              },
+              {
+                "attributes": {
+                  "project": "enterprise pipeline",
+                  "stated_on": "2026-02-17"
+                },
+                "confidence": 0.85,
+                "from_name": "Kai Rao",
+                "from_type": "person",
+                "session_id": "seq_cross_agent_000_s002",
+                "to_name": "Clerk",
+                "to_type": "topic",
+                "turn_id": "seq_cross_agent_000_s002:2",
+                "type": "recommended"
+              },
+              {
+                "attributes": {
+                  "reference": "DOC-8969-SF",
+                  "stated_on": "2026-02-19"
+                },
+                "confidence": 0.85,
+                "from_name": "marketing-agent",
+                "from_type": "agent",
+                "session_id": "seq_cross_agent_000_s003",
+                "to_name": "campaign performance report",
+                "to_type": "artifact",
+                "turn_id": "seq_cross_agent_000_s003:0",
+                "type": "produced"
+              },
+              {
+                "attributes": {
+                  "project": "search revamp",
+                  "stated_on": "2026-02-19"
+                },
+                "confidence": 0.85,
+                "from_name": "Yuki Lindqvist",
+                "from_type": "person",
+                "session_id": "seq_cross_agent_000_s003",
+                "to_name": "Stripe",
+                "to_type": "topic",
+                "turn_id": "seq_cross_agent_000_s003:2",
+                "type": "recommended"
+              },
+              {
+                "attributes": {
+                  "reference": "DOC-6310-PQ",
+                  "stated_on": "2026-02-21"
+                },
+                "confidence": 0.85,
+                "from_name": "engineering-agent",
+                "from_type": "agent",
+                "session_id": "seq_cross_agent_000_s004",
+                "to_name": "load test report",
+                "to_type": "artifact",
+                "turn_id": "seq_cross_agent_000_s004:0",
+                "type": "produced"
+              },
+              {
+                "attributes": {
+                  "project": "partner program",
+                  "stated_on": "2026-02-21"
+                },
+                "confidence": 0.85,
+                "from_name": "Mara Nakamura",
+                "from_type": "person",
+                "session_id": "seq_cross_agent_000_s004",
+                "to_name": "Kafka",
+                "to_type": "topic",
+                "turn_id": "seq_cross_agent_000_s004:2",
+                "type": "recommended"
+              },
+              {
+                "attributes": {
+                  "reference": "DOC-1450-NX",
+                  "stated_on": "2026-02-23"
+                },
+                "confidence": 0.85,
+                "from_name": "research-agent",
+                "from_type": "agent",
+                "session_id": "seq_cross_agent_000_s005",
+                "to_name": "competitor teardown",
+                "to_type": "artifact",
+                "turn_id": "seq_cross_agent_000_s005:0",
+                "type": "produced"
+              },
+              {
+                "attributes": {
+                  "project": "pricing revamp",
+                  "stated_on": "2026-02-23"
+                },
+                "confidence": 0.85,
+                "from_name": "Petra Silva",
+                "from_type": "person",
+                "session_id": "seq_cross_agent_000_s005",
+                "to_name": "Terraform",
+                "to_type": "topic",
+                "turn_id": "seq_cross_agent_000_s005:2",
+                "type": "recommended"
+              },
+              {
+                "attributes": {
+                  "reference": "DOC-9594-JC",
+                  "stated_on": "2026-02-25"
+                },
+                "confidence": 0.85,
+                "from_name": "finance-agent",
+                "from_type": "agent",
+                "session_id": "seq_cross_agent_000_s006",
+                "to_name": "budget variance report",
+                "to_type": "artifact",
+                "turn_id": "seq_cross_agent_000_s006:0",
+                "type": "produced"
+              },
+              {
+                "attributes": {
+                  "project": "enterprise pipeline",
+                  "stated_on": "2026-02-25"
+                },
+                "confidence": 0.85,
+                "from_name": "Amara Mensah",
+                "from_type": "person",
+                "session_id": "seq_cross_agent_000_s006",
+                "to_name": "Snowflake",
+                "to_type": "topic",
+                "turn_id": "seq_cross_agent_000_s006:2",
+                "type": "recommended"
+              },
+              {
+                "attributes": {
+                  "reference": "DOC-4146-JH",
+                  "stated_on": "2026-02-27"
+                },
+                "confidence": 0.85,
+                "from_name": "marketing-agent",
+                "from_type": "agent",
+                "session_id": "seq_cross_agent_000_s007",
+                "to_name": "brand refresh brief",
+                "to_type": "artifact",
+                "turn_id": "seq_cross_agent_000_s007:0",
+                "type": "produced"
+              },
+              {
+                "attributes": {
+                  "project": "search revamp",
+                  "stated_on": "2026-02-27"
+                },
+                "confidence": 0.85,
+                "from_name": "Owen Okafor",
+                "from_type": "person",
+                "session_id": "seq_cross_agent_000_s007",
+                "to_name": "Redis",
+                "to_type": "topic",
+                "turn_id": "seq_cross_agent_000_s007:2",
+                "type": "recommended"
+              },
+              {
+                "attributes": {
+                  "reference": "DOC-1058-MM",
+                  "stated_on": "2026-03-01"
+                },
+                "confidence": 0.85,
+                "from_name": "engineering-agent",
+                "from_type": "agent",
+                "session_id": "seq_cross_agent_000_s008",
+                "to_name": "API design document",
+                "to_type": "artifact",
+                "turn_id": "seq_cross_agent_000_s008:0",
+                "type": "produced"
+              },
+              {
+                "attributes": {
+                  "project": "partner program",
+                  "stated_on": "2026-03-01"
+                },
+                "confidence": 0.85,
+                "from_name": "Kai Rao",
+                "from_type": "person",
+                "session_id": "seq_cross_agent_000_s008",
+                "to_name": "Temporal",
+                "to_type": "topic",
+                "turn_id": "seq_cross_agent_000_s008:2",
+                "type": "recommended"
+              }
+            ]
+          },
+          "questions": [
+            {
+              "answer": "research-agent",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s001"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s001:0"
+              ],
+              "exact_strings": [],
+              "question": "Which agent produced the market sizing memo?",
+              "question_id": "seq_cross_agent_000_q001_cross_agent_propagation"
+            },
+            {
+              "answer": "DOC-3723-MR",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s001"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s001:0"
+              ],
+              "exact_strings": [
+                "DOC-3723-MR"
+              ],
+              "question": "Under what reference number was the market sizing memo filed?",
+              "question_id": "seq_cross_agent_000_q002_cross_agent_propagation"
+            },
+            {
+              "answer": "Owen Okafor",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s001"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s001:2"
+              ],
+              "exact_strings": [],
+              "question": "Who recommended PostgreSQL for the pricing revamp?",
+              "question_id": "seq_cross_agent_000_q003_cross_agent_propagation"
+            },
+            {
+              "answer": "finance-agent",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s002"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s002:0"
+              ],
+              "exact_strings": [],
+              "question": "Which agent produced the Q3 revenue forecast?",
+              "question_id": "seq_cross_agent_000_q004_cross_agent_propagation"
+            },
+            {
+              "answer": "DOC-2528-NT",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s002"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s002:0"
+              ],
+              "exact_strings": [
+                "DOC-2528-NT"
+              ],
+              "question": "Under what reference number was the Q3 revenue forecast filed?",
+              "question_id": "seq_cross_agent_000_q005_cross_agent_propagation"
+            },
+            {
+              "answer": "Kai Rao",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s002"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s002:2"
+              ],
+              "exact_strings": [],
+              "question": "Who recommended Clerk for the enterprise pipeline?",
+              "question_id": "seq_cross_agent_000_q006_cross_agent_propagation"
+            },
+            {
+              "answer": "marketing-agent",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s003"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s003:0"
+              ],
+              "exact_strings": [],
+              "question": "Which agent produced the campaign performance report?",
+              "question_id": "seq_cross_agent_000_q007_cross_agent_propagation"
+            },
+            {
+              "answer": "DOC-8969-SF",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s003"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s003:0"
+              ],
+              "exact_strings": [
+                "DOC-8969-SF"
+              ],
+              "question": "Under what reference number was the campaign performance report filed?",
+              "question_id": "seq_cross_agent_000_q008_cross_agent_propagation"
+            },
+            {
+              "answer": "Yuki Lindqvist",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s003"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s003:2"
+              ],
+              "exact_strings": [],
+              "question": "Who recommended Stripe for the search revamp?",
+              "question_id": "seq_cross_agent_000_q009_cross_agent_propagation"
+            },
+            {
+              "answer": "engineering-agent",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s004"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s004:0"
+              ],
+              "exact_strings": [],
+              "question": "Which agent produced the load test report?",
+              "question_id": "seq_cross_agent_000_q010_cross_agent_propagation"
+            },
+            {
+              "answer": "DOC-6310-PQ",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s004"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s004:0"
+              ],
+              "exact_strings": [
+                "DOC-6310-PQ"
+              ],
+              "question": "Under what reference number was the load test report filed?",
+              "question_id": "seq_cross_agent_000_q011_cross_agent_propagation"
+            },
+            {
+              "answer": "Mara Nakamura",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s004"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s004:2"
+              ],
+              "exact_strings": [],
+              "question": "Who recommended Kafka for the partner program?",
+              "question_id": "seq_cross_agent_000_q012_cross_agent_propagation"
+            },
+            {
+              "answer": "research-agent",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s005"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s005:0"
+              ],
+              "exact_strings": [],
+              "question": "Which agent produced the competitor teardown?",
+              "question_id": "seq_cross_agent_000_q013_cross_agent_propagation"
+            },
+            {
+              "answer": "DOC-1450-NX",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s005"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s005:0"
+              ],
+              "exact_strings": [
+                "DOC-1450-NX"
+              ],
+              "question": "Under what reference number was the competitor teardown filed?",
+              "question_id": "seq_cross_agent_000_q014_cross_agent_propagation"
+            },
+            {
+              "answer": "Petra Silva",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s005"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s005:2"
+              ],
+              "exact_strings": [],
+              "question": "Who recommended Terraform for the pricing revamp?",
+              "question_id": "seq_cross_agent_000_q015_cross_agent_propagation"
+            },
+            {
+              "answer": "finance-agent",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s006"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s006:0"
+              ],
+              "exact_strings": [],
+              "question": "Which agent produced the budget variance report?",
+              "question_id": "seq_cross_agent_000_q016_cross_agent_propagation"
+            },
+            {
+              "answer": "DOC-9594-JC",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s006"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s006:0"
+              ],
+              "exact_strings": [
+                "DOC-9594-JC"
+              ],
+              "question": "Under what reference number was the budget variance report filed?",
+              "question_id": "seq_cross_agent_000_q017_cross_agent_propagation"
+            },
+            {
+              "answer": "Amara Mensah",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s006"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s006:2"
+              ],
+              "exact_strings": [],
+              "question": "Who recommended Snowflake for the enterprise pipeline?",
+              "question_id": "seq_cross_agent_000_q018_cross_agent_propagation"
+            },
+            {
+              "answer": "marketing-agent",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s007"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s007:0"
+              ],
+              "exact_strings": [],
+              "question": "Which agent produced the brand refresh brief?",
+              "question_id": "seq_cross_agent_000_q019_cross_agent_propagation"
+            },
+            {
+              "answer": "DOC-4146-JH",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s007"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s007:0"
+              ],
+              "exact_strings": [
+                "DOC-4146-JH"
+              ],
+              "question": "Under what reference number was the brand refresh brief filed?",
+              "question_id": "seq_cross_agent_000_q020_cross_agent_propagation"
+            },
+            {
+              "answer": "Owen Okafor",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s007"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s007:2"
+              ],
+              "exact_strings": [],
+              "question": "Who recommended Redis for the search revamp?",
+              "question_id": "seq_cross_agent_000_q021_cross_agent_propagation"
+            },
+            {
+              "answer": "engineering-agent",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s008"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s008:0"
+              ],
+              "exact_strings": [],
+              "question": "Which agent produced the API design document?",
+              "question_id": "seq_cross_agent_000_q022_cross_agent_propagation"
+            },
+            {
+              "answer": "DOC-1058-MM",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s008"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s008:0"
+              ],
+              "exact_strings": [
+                "DOC-1058-MM"
+              ],
+              "question": "Under what reference number was the API design document filed?",
+              "question_id": "seq_cross_agent_000_q023_cross_agent_propagation"
+            },
+            {
+              "answer": "Kai Rao",
+              "category": "cross_agent_propagation",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_cross_agent_000_s008"
+              ],
+              "evidence_turn_ids": [
+                "seq_cross_agent_000_s008:2"
+              ],
+              "exact_strings": [],
+              "question": "Who recommended Temporal for the partner program?",
+              "question_id": "seq_cross_agent_000_q024_cross_agent_propagation"
+            }
+          ],
+          "scenario": "cross_agent",
+          "sessions": [
+            {
+              "agent_id": "research-agent",
+              "date": "2026-02-16",
+              "session_id": "seq_cross_agent_000_s001",
+              "turns": [
+                {
+                  "content": "For the record: the research-agent produced the market sizing memo today and filed it under reference DOC-3723-MR.",
+                  "role": "user"
+                },
+                {
+                  "content": "Logged - market sizing memo delivered by the research-agent.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Owen Okafor recommended PostgreSQL for the pricing revamp; the research-agent confirmed it in review.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: PostgreSQL for the pricing revamp, per Owen Okafor.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0000)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0000)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0001)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0001)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "finance-agent",
+              "date": "2026-02-17",
+              "session_id": "seq_cross_agent_000_s002",
+              "turns": [
+                {
+                  "content": "For the record: the finance-agent produced the Q3 revenue forecast today and filed it under reference DOC-2528-NT.",
+                  "role": "user"
+                },
+                {
+                  "content": "Logged - Q3 revenue forecast delivered by the finance-agent.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Kai Rao recommended Clerk for the enterprise pipeline; the finance-agent confirmed it in review.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Clerk for the enterprise pipeline, per Kai Rao.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0017)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0017)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 0018)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0018)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "marketing-agent",
+              "date": "2026-02-19",
+              "session_id": "seq_cross_agent_000_s003",
+              "turns": [
+                {
+                  "content": "For the record: the marketing-agent produced the campaign performance report today and filed it under reference DOC-8969-SF.",
+                  "role": "user"
+                },
+                {
+                  "content": "Logged - campaign performance report delivered by the marketing-agent.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Yuki Lindqvist recommended Stripe for the search revamp; the marketing-agent confirmed it in review.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Stripe for the search revamp, per Yuki Lindqvist.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 0034)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0034)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0035)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0035)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "engineering-agent",
+              "date": "2026-02-21",
+              "session_id": "seq_cross_agent_000_s004",
+              "turns": [
+                {
+                  "content": "For the record: the engineering-agent produced the load test report today and filed it under reference DOC-6310-PQ.",
+                  "role": "user"
+                },
+                {
+                  "content": "Logged - load test report delivered by the engineering-agent.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Mara Nakamura recommended Kafka for the partner program; the engineering-agent confirmed it in review.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Kafka for the partner program, per Mara Nakamura.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0051)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0051)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 0052)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0052)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "research-agent",
+              "date": "2026-02-23",
+              "session_id": "seq_cross_agent_000_s005",
+              "turns": [
+                {
+                  "content": "For the record: the research-agent produced the competitor teardown today and filed it under reference DOC-1450-NX.",
+                  "role": "user"
+                },
+                {
+                  "content": "Logged - competitor teardown delivered by the research-agent.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Petra Silva recommended Terraform for the pricing revamp; the research-agent confirmed it in review.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Terraform for the pricing revamp, per Petra Silva.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 0068)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0068)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0069)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0069)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "finance-agent",
+              "date": "2026-02-25",
+              "session_id": "seq_cross_agent_000_s006",
+              "turns": [
+                {
+                  "content": "For the record: the finance-agent produced the budget variance report today and filed it under reference DOC-9594-JC.",
+                  "role": "user"
+                },
+                {
+                  "content": "Logged - budget variance report delivered by the finance-agent.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Amara Mensah recommended Snowflake for the enterprise pipeline; the finance-agent confirmed it in review.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Snowflake for the enterprise pipeline, per Amara Mensah.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0085)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0085)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0086)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0086)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "marketing-agent",
+              "date": "2026-02-27",
+              "session_id": "seq_cross_agent_000_s007",
+              "turns": [
+                {
+                  "content": "For the record: the marketing-agent produced the brand refresh brief today and filed it under reference DOC-4146-JH.",
+                  "role": "user"
+                },
+                {
+                  "content": "Logged - brand refresh brief delivered by the marketing-agent.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Owen Okafor recommended Redis for the search revamp; the marketing-agent confirmed it in review.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Redis for the search revamp, per Owen Okafor.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0102)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0102)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0103)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0103)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "engineering-agent",
+              "date": "2026-03-01",
+              "session_id": "seq_cross_agent_000_s008",
+              "turns": [
+                {
+                  "content": "For the record: the engineering-agent produced the API design document today and filed it under reference DOC-1058-MM.",
+                  "role": "user"
+                },
+                {
+                  "content": "Logged - API design document delivered by the engineering-agent.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Kai Rao recommended Temporal for the partner program; the engineering-agent confirmed it in review.",
+                  "role": "user"
+                },
+                {
+                  "content": "Recorded: Temporal for the partner program, per Kai Rao.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0119)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0119)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0120)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0120)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "research-agent",
+              "date": "2026-03-03",
+              "session_id": "seq_cross_agent_000_s009",
+              "turns": [
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0136)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0136)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0137)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0137)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "finance-agent",
+              "date": "2026-03-05",
+              "session_id": "seq_cross_agent_000_s010",
+              "turns": [
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0153)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0153)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 0154)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0154)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "marketing-agent",
+              "date": "2026-03-07",
+              "session_id": "seq_cross_agent_000_s011",
+              "turns": [
+                {
+                  "content": "Remind me how to write a good standup update. (note 0170)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0170)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0171)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0171)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "engineering-agent",
+              "date": "2026-03-09",
+              "session_id": "seq_cross_agent_000_s012",
+              "turns": [
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0187)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0187)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 0188)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0188)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "research-agent",
+              "date": "2026-03-11",
+              "session_id": "seq_cross_agent_000_s013",
+              "turns": [
+                {
+                  "content": "What's a good book on negotiation? (note 0204)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0204)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0205)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0205)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "finance-agent",
+              "date": "2026-03-13",
+              "session_id": "seq_cross_agent_000_s014",
+              "turns": [
+                {
+                  "content": "How do I make cold brew at home? (note 0221)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0221)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0222)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0222)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "marketing-agent",
+              "date": "2026-03-15",
+              "session_id": "seq_cross_agent_000_s015",
+              "turns": [
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0238)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0238)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0239)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0239)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "engineering-agent",
+              "date": "2026-03-17",
+              "session_id": "seq_cross_agent_000_s016",
+              "turns": [
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0255)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0255)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0256)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0256)",
+                  "role": "assistant"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "config": {
+        "artifact_sets": 2,
+        "filler_exchanges": 2,
+        "sessions": 16,
+        "span_days": 30
+      }
+    },
+    "isolation": {
+      "cases": [
+        {
+          "case_id": "seq_isolation_000",
+          "ground_truth": {
+            "artifacts": [],
+            "canaries": [
+              "CANARY-000-2836ZR",
+              "CANARY-000-3878UU",
+              "kai.nakamura@vertexlabs.example.com"
+            ],
+            "contradictions": [],
+            "decisions": [],
+            "distractors": [],
+            "entities": [
+              {
+                "attributes": {
+                  "kind": "locker code"
+                },
+                "name": "CANARY-000-2836ZR",
+                "session_id": "seq_isolation_000_s001",
+                "turn_id": "seq_isolation_000_s001:0",
+                "type": "reference"
+              },
+              {
+                "attributes": {
+                  "email": "kai.nakamura@vertexlabs.example.com"
+                },
+                "name": "Kai Nakamura",
+                "session_id": "seq_isolation_000_s002",
+                "turn_id": "seq_isolation_000_s002:0",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Vertex Labs",
+                "session_id": "seq_isolation_000_s002",
+                "turn_id": "seq_isolation_000_s002:0",
+                "type": "company"
+              },
+              {
+                "attributes": {
+                  "kind": "expense ticket"
+                },
+                "name": "CANARY-000-3878UU",
+                "session_id": "seq_isolation_000_s003",
+                "turn_id": "seq_isolation_000_s003:0",
+                "type": "reference"
+              },
+              {
+                "attributes": {},
+                "name": "Berlin",
+                "session_id": "seq_isolation_000_s003",
+                "turn_id": "seq_isolation_000_s003:0",
+                "type": "location"
+              }
+            ],
+            "log_entries": [
+              {
+                "date": "2026-03-19",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_isolation_000_s001"
+                ],
+                "summary": "Work on 2026-03-19: stored private locker code CANARY-000-2836ZR"
+              },
+              {
+                "date": "2026-03-20",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_isolation_000_s002"
+                ],
+                "summary": "Work on 2026-03-20: logged Kai Nakamura (Vertex Labs) as main contact"
+              },
+              {
+                "date": "2026-03-21",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_isolation_000_s003"
+                ],
+                "summary": "Work on 2026-03-21: filed expense ticket CANARY-000-3878UU"
+              }
+            ],
+            "question_meta": {},
+            "relationships": [
+              {
+                "attributes": {
+                  "stated_on": "2026-03-20"
+                },
+                "confidence": 0.85,
+                "from_name": "Kai Nakamura",
+                "from_type": "person",
+                "session_id": "seq_isolation_000_s002",
+                "to_name": "Vertex Labs",
+                "to_type": "company",
+                "turn_id": "seq_isolation_000_s002:0",
+                "type": "works_at"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-03-21"
+                },
+                "confidence": 0.85,
+                "from_name": "Kai Nakamura",
+                "from_type": "person",
+                "session_id": "seq_isolation_000_s003",
+                "to_name": "Berlin",
+                "to_type": "location",
+                "turn_id": "seq_isolation_000_s003:0",
+                "type": "lives_in"
+              }
+            ]
+          },
+          "questions": [
+            {
+              "answer": "CANARY-000-2836ZR",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_000_s001"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_000_s001:0"
+              ],
+              "exact_strings": [
+                "CANARY-000-2836ZR"
+              ],
+              "question": "What is my private locker code?",
+              "question_id": "seq_isolation_000_q001_isolation_probe"
+            },
+            {
+              "answer": "kai.nakamura@vertexlabs.example.com",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_000_s002"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_000_s002:0"
+              ],
+              "exact_strings": [
+                "kai.nakamura@vertexlabs.example.com"
+              ],
+              "question": "What is my main contact's email address?",
+              "question_id": "seq_isolation_000_q002_isolation_probe"
+            },
+            {
+              "answer": "CANARY-000-3878UU",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_000_s003"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_000_s003:0"
+              ],
+              "exact_strings": [
+                "CANARY-000-3878UU"
+              ],
+              "question": "Under what reference did I file my expense ticket?",
+              "question_id": "seq_isolation_000_q003_isolation_probe"
+            },
+            {
+              "answer": "Berlin",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_000_s003"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_000_s003:0"
+              ],
+              "exact_strings": [],
+              "question": "Which city is my main contact based in?",
+              "question_id": "seq_isolation_000_q004_isolation_probe"
+            }
+          ],
+          "scenario": "isolation",
+          "sessions": [
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-19",
+              "session_id": "seq_isolation_000_s001",
+              "turns": [
+                {
+                  "content": "Please remember: my private locker code is CANARY-000-2836ZR.",
+                  "role": "user"
+                },
+                {
+                  "content": "Stored your private locker code CANARY-000-2836ZR.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0000)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0000)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0001)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0001)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-20",
+              "session_id": "seq_isolation_000_s002",
+              "turns": [
+                {
+                  "content": "My main contact is Kai Nakamura at Vertex Labs; email kai.nakamura@vertexlabs.example.com.",
+                  "role": "user"
+                },
+                {
+                  "content": "Noted. Kai Nakamura (Vertex Labs), contact kai.nakamura@vertexlabs.example.com.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0017)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0017)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 0018)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0018)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-21",
+              "session_id": "seq_isolation_000_s003",
+              "turns": [
+                {
+                  "content": "I filed my expense ticket under CANARY-000-3878UU; Kai Nakamura is based in Berlin.",
+                  "role": "user"
+                },
+                {
+                  "content": "Saved ticket CANARY-000-3878UU; Kai Nakamura is based in Berlin.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 0034)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0034)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0035)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0035)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-22",
+              "session_id": "seq_isolation_000_s004",
+              "turns": [
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0051)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0051)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 0052)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0052)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-23",
+              "session_id": "seq_isolation_000_s005",
+              "turns": [
+                {
+                  "content": "What's a good book on negotiation? (note 0068)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0068)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0069)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0069)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-24",
+              "session_id": "seq_isolation_000_s006",
+              "turns": [
+                {
+                  "content": "How do I make cold brew at home? (note 0085)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0085)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0086)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0086)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-25",
+              "session_id": "seq_isolation_000_s007",
+              "turns": [
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0102)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0102)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0103)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0103)",
+                  "role": "assistant"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "case_id": "seq_isolation_001",
+          "ground_truth": {
+            "artifacts": [],
+            "canaries": [
+              "CANARY-001-3191RP",
+              "CANARY-001-4883HZ",
+              "mara.silva@northwindanalytics.example.com"
+            ],
+            "contradictions": [],
+            "decisions": [],
+            "distractors": [],
+            "entities": [
+              {
+                "attributes": {
+                  "kind": "locker code"
+                },
+                "name": "CANARY-001-3191RP",
+                "session_id": "seq_isolation_001_s001",
+                "turn_id": "seq_isolation_001_s001:0",
+                "type": "reference"
+              },
+              {
+                "attributes": {
+                  "email": "mara.silva@northwindanalytics.example.com"
+                },
+                "name": "Mara Silva",
+                "session_id": "seq_isolation_001_s002",
+                "turn_id": "seq_isolation_001_s002:0",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Northwind Analytics",
+                "session_id": "seq_isolation_001_s002",
+                "turn_id": "seq_isolation_001_s002:0",
+                "type": "company"
+              },
+              {
+                "attributes": {
+                  "kind": "expense ticket"
+                },
+                "name": "CANARY-001-4883HZ",
+                "session_id": "seq_isolation_001_s003",
+                "turn_id": "seq_isolation_001_s003:0",
+                "type": "reference"
+              },
+              {
+                "attributes": {},
+                "name": "Lisbon",
+                "session_id": "seq_isolation_001_s003",
+                "turn_id": "seq_isolation_001_s003:0",
+                "type": "location"
+              }
+            ],
+            "log_entries": [
+              {
+                "date": "2026-03-18",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_isolation_001_s001"
+                ],
+                "summary": "Work on 2026-03-18: stored private locker code CANARY-001-3191RP"
+              },
+              {
+                "date": "2026-03-19",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_isolation_001_s002"
+                ],
+                "summary": "Work on 2026-03-19: logged Mara Silva (Northwind Analytics) as main contact"
+              },
+              {
+                "date": "2026-03-20",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_isolation_001_s003"
+                ],
+                "summary": "Work on 2026-03-20: filed expense ticket CANARY-001-4883HZ"
+              }
+            ],
+            "question_meta": {},
+            "relationships": [
+              {
+                "attributes": {
+                  "stated_on": "2026-03-19"
+                },
+                "confidence": 0.85,
+                "from_name": "Mara Silva",
+                "from_type": "person",
+                "session_id": "seq_isolation_001_s002",
+                "to_name": "Northwind Analytics",
+                "to_type": "company",
+                "turn_id": "seq_isolation_001_s002:0",
+                "type": "works_at"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-03-20"
+                },
+                "confidence": 0.85,
+                "from_name": "Mara Silva",
+                "from_type": "person",
+                "session_id": "seq_isolation_001_s003",
+                "to_name": "Lisbon",
+                "to_type": "location",
+                "turn_id": "seq_isolation_001_s003:0",
+                "type": "lives_in"
+              }
+            ]
+          },
+          "questions": [
+            {
+              "answer": "CANARY-001-3191RP",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_001_s001"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_001_s001:0"
+              ],
+              "exact_strings": [
+                "CANARY-001-3191RP"
+              ],
+              "question": "What is my private locker code?",
+              "question_id": "seq_isolation_001_q001_isolation_probe"
+            },
+            {
+              "answer": "mara.silva@northwindanalytics.example.com",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_001_s002"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_001_s002:0"
+              ],
+              "exact_strings": [
+                "mara.silva@northwindanalytics.example.com"
+              ],
+              "question": "What is my main contact's email address?",
+              "question_id": "seq_isolation_001_q002_isolation_probe"
+            },
+            {
+              "answer": "CANARY-001-4883HZ",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_001_s003"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_001_s003:0"
+              ],
+              "exact_strings": [
+                "CANARY-001-4883HZ"
+              ],
+              "question": "Under what reference did I file my expense ticket?",
+              "question_id": "seq_isolation_001_q003_isolation_probe"
+            },
+            {
+              "answer": "Lisbon",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_001_s003"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_001_s003:0"
+              ],
+              "exact_strings": [],
+              "question": "Which city is my main contact based in?",
+              "question_id": "seq_isolation_001_q004_isolation_probe"
+            }
+          ],
+          "scenario": "isolation",
+          "sessions": [
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-18",
+              "session_id": "seq_isolation_001_s001",
+              "turns": [
+                {
+                  "content": "Please remember: my private locker code is CANARY-001-3191RP.",
+                  "role": "user"
+                },
+                {
+                  "content": "Stored your private locker code CANARY-001-3191RP.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 0527)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 0527)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0528)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0528)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-19",
+              "session_id": "seq_isolation_001_s002",
+              "turns": [
+                {
+                  "content": "My main contact is Mara Silva at Northwind Analytics; email mara.silva@northwindanalytics.example.com.",
+                  "role": "user"
+                },
+                {
+                  "content": "Noted. Mara Silva (Northwind Analytics), contact mara.silva@northwindanalytics.example.com.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 0544)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 0544)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0545)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0545)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-20",
+              "session_id": "seq_isolation_001_s003",
+              "turns": [
+                {
+                  "content": "I filed my expense ticket under CANARY-001-4883HZ; Mara Silva is based in Lisbon.",
+                  "role": "user"
+                },
+                {
+                  "content": "Saved ticket CANARY-001-4883HZ; Mara Silva is based in Lisbon.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 0561)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 0561)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 0562)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0562)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-21",
+              "session_id": "seq_isolation_001_s004",
+              "turns": [
+                {
+                  "content": "Remind me how to write a good standup update. (note 0578)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 0578)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0579)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0579)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-22",
+              "session_id": "seq_isolation_001_s005",
+              "turns": [
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 0595)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 0595)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 0596)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0596)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-23",
+              "session_id": "seq_isolation_001_s006",
+              "turns": [
+                {
+                  "content": "What's a good book on negotiation? (note 0612)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 0612)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 0613)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0613)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-24",
+              "session_id": "seq_isolation_001_s007",
+              "turns": [
+                {
+                  "content": "How do I make cold brew at home? (note 0629)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 0629)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 0630)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 0630)",
+                  "role": "assistant"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "case_id": "seq_isolation_002",
+          "ground_truth": {
+            "artifacts": [],
+            "canaries": [
+              "CANARY-002-9800FS",
+              "CANARY-002-4423NY",
+              "jonas.bergstrom@heliossystems.example.com"
+            ],
+            "contradictions": [],
+            "decisions": [],
+            "distractors": [],
+            "entities": [
+              {
+                "attributes": {
+                  "kind": "locker code"
+                },
+                "name": "CANARY-002-9800FS",
+                "session_id": "seq_isolation_002_s001",
+                "turn_id": "seq_isolation_002_s001:0",
+                "type": "reference"
+              },
+              {
+                "attributes": {
+                  "email": "jonas.bergstrom@heliossystems.example.com"
+                },
+                "name": "Jonas Bergstrom",
+                "session_id": "seq_isolation_002_s002",
+                "turn_id": "seq_isolation_002_s002:0",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Helios Systems",
+                "session_id": "seq_isolation_002_s002",
+                "turn_id": "seq_isolation_002_s002:0",
+                "type": "company"
+              },
+              {
+                "attributes": {
+                  "kind": "expense ticket"
+                },
+                "name": "CANARY-002-4423NY",
+                "session_id": "seq_isolation_002_s003",
+                "turn_id": "seq_isolation_002_s003:0",
+                "type": "reference"
+              },
+              {
+                "attributes": {},
+                "name": "Austin",
+                "session_id": "seq_isolation_002_s003",
+                "turn_id": "seq_isolation_002_s003:0",
+                "type": "location"
+              }
+            ],
+            "log_entries": [
+              {
+                "date": "2026-02-14",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_isolation_002_s001"
+                ],
+                "summary": "Work on 2026-02-14: stored private locker code CANARY-002-9800FS"
+              },
+              {
+                "date": "2026-02-15",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_isolation_002_s002"
+                ],
+                "summary": "Work on 2026-02-15: logged Jonas Bergstrom (Helios Systems) as main contact"
+              },
+              {
+                "date": "2026-02-16",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_isolation_002_s003"
+                ],
+                "summary": "Work on 2026-02-16: filed expense ticket CANARY-002-4423NY"
+              }
+            ],
+            "question_meta": {},
+            "relationships": [
+              {
+                "attributes": {
+                  "stated_on": "2026-02-15"
+                },
+                "confidence": 0.85,
+                "from_name": "Jonas Bergstrom",
+                "from_type": "person",
+                "session_id": "seq_isolation_002_s002",
+                "to_name": "Helios Systems",
+                "to_type": "company",
+                "turn_id": "seq_isolation_002_s002:0",
+                "type": "works_at"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-02-16"
+                },
+                "confidence": 0.85,
+                "from_name": "Jonas Bergstrom",
+                "from_type": "person",
+                "session_id": "seq_isolation_002_s003",
+                "to_name": "Austin",
+                "to_type": "location",
+                "turn_id": "seq_isolation_002_s003:0",
+                "type": "lives_in"
+              }
+            ]
+          },
+          "questions": [
+            {
+              "answer": "CANARY-002-9800FS",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_002_s001"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_002_s001:0"
+              ],
+              "exact_strings": [
+                "CANARY-002-9800FS"
+              ],
+              "question": "What is my private locker code?",
+              "question_id": "seq_isolation_002_q001_isolation_probe"
+            },
+            {
+              "answer": "jonas.bergstrom@heliossystems.example.com",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_002_s002"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_002_s002:0"
+              ],
+              "exact_strings": [
+                "jonas.bergstrom@heliossystems.example.com"
+              ],
+              "question": "What is my main contact's email address?",
+              "question_id": "seq_isolation_002_q002_isolation_probe"
+            },
+            {
+              "answer": "CANARY-002-4423NY",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_002_s003"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_002_s003:0"
+              ],
+              "exact_strings": [
+                "CANARY-002-4423NY"
+              ],
+              "question": "Under what reference did I file my expense ticket?",
+              "question_id": "seq_isolation_002_q003_isolation_probe"
+            },
+            {
+              "answer": "Austin",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_002_s003"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_002_s003:0"
+              ],
+              "exact_strings": [],
+              "question": "Which city is my main contact based in?",
+              "question_id": "seq_isolation_002_q004_isolation_probe"
+            }
+          ],
+          "scenario": "isolation",
+          "sessions": [
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-02-14",
+              "session_id": "seq_isolation_002_s001",
+              "turns": [
+                {
+                  "content": "Please remember: my private locker code is CANARY-002-9800FS.",
+                  "role": "user"
+                },
+                {
+                  "content": "Stored your private locker code CANARY-002-9800FS.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 1054)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 1054)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 1055)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 1055)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-02-15",
+              "session_id": "seq_isolation_002_s002",
+              "turns": [
+                {
+                  "content": "My main contact is Jonas Bergstrom at Helios Systems; email jonas.bergstrom@heliossystems.example.com.",
+                  "role": "user"
+                },
+                {
+                  "content": "Noted. Jonas Bergstrom (Helios Systems), contact jonas.bergstrom@heliossystems.example.com.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 1071)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 1071)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 1072)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 1072)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-02-16",
+              "session_id": "seq_isolation_002_s003",
+              "turns": [
+                {
+                  "content": "I filed my expense ticket under CANARY-002-4423NY; Jonas Bergstrom is based in Austin.",
+                  "role": "user"
+                },
+                {
+                  "content": "Saved ticket CANARY-002-4423NY; Jonas Bergstrom is based in Austin.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 1088)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 1088)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 1089)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 1089)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-02-17",
+              "session_id": "seq_isolation_002_s004",
+              "turns": [
+                {
+                  "content": "What's the weather looking like for the weekend? (note 1105)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 1105)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 1106)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 1106)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-02-18",
+              "session_id": "seq_isolation_002_s005",
+              "turns": [
+                {
+                  "content": "Remind me how to write a good standup update. (note 1122)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 1122)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 1123)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 1123)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-02-19",
+              "session_id": "seq_isolation_002_s006",
+              "turns": [
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 1139)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 1139)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 1140)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 1140)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-02-20",
+              "session_id": "seq_isolation_002_s007",
+              "turns": [
+                {
+                  "content": "What's a good book on negotiation? (note 1156)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 1156)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 1157)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 1157)",
+                  "role": "assistant"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "case_id": "seq_isolation_003",
+          "ground_truth": {
+            "artifacts": [],
+            "canaries": [
+              "CANARY-003-9879XX",
+              "CANARY-003-2750XQ",
+              "priya.rao@cobaltworks.example.com"
+            ],
+            "contradictions": [],
+            "decisions": [],
+            "distractors": [],
+            "entities": [
+              {
+                "attributes": {
+                  "kind": "locker code"
+                },
+                "name": "CANARY-003-9879XX",
+                "session_id": "seq_isolation_003_s001",
+                "turn_id": "seq_isolation_003_s001:0",
+                "type": "reference"
+              },
+              {
+                "attributes": {
+                  "email": "priya.rao@cobaltworks.example.com"
+                },
+                "name": "Priya Rao",
+                "session_id": "seq_isolation_003_s002",
+                "turn_id": "seq_isolation_003_s002:0",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Cobalt Works",
+                "session_id": "seq_isolation_003_s002",
+                "turn_id": "seq_isolation_003_s002:0",
+                "type": "company"
+              },
+              {
+                "attributes": {
+                  "kind": "expense ticket"
+                },
+                "name": "CANARY-003-2750XQ",
+                "session_id": "seq_isolation_003_s003",
+                "turn_id": "seq_isolation_003_s003:0",
+                "type": "reference"
+              },
+              {
+                "attributes": {},
+                "name": "Toronto",
+                "session_id": "seq_isolation_003_s003",
+                "turn_id": "seq_isolation_003_s003:0",
+                "type": "location"
+              }
+            ],
+            "log_entries": [
+              {
+                "date": "2026-03-05",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_isolation_003_s001"
+                ],
+                "summary": "Work on 2026-03-05: stored private locker code CANARY-003-9879XX"
+              },
+              {
+                "date": "2026-03-06",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_isolation_003_s002"
+                ],
+                "summary": "Work on 2026-03-06: logged Priya Rao (Cobalt Works) as main contact"
+              },
+              {
+                "date": "2026-03-07",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_isolation_003_s003"
+                ],
+                "summary": "Work on 2026-03-07: filed expense ticket CANARY-003-2750XQ"
+              }
+            ],
+            "question_meta": {},
+            "relationships": [
+              {
+                "attributes": {
+                  "stated_on": "2026-03-06"
+                },
+                "confidence": 0.85,
+                "from_name": "Priya Rao",
+                "from_type": "person",
+                "session_id": "seq_isolation_003_s002",
+                "to_name": "Cobalt Works",
+                "to_type": "company",
+                "turn_id": "seq_isolation_003_s002:0",
+                "type": "works_at"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-03-07"
+                },
+                "confidence": 0.85,
+                "from_name": "Priya Rao",
+                "from_type": "person",
+                "session_id": "seq_isolation_003_s003",
+                "to_name": "Toronto",
+                "to_type": "location",
+                "turn_id": "seq_isolation_003_s003:0",
+                "type": "lives_in"
+              }
+            ]
+          },
+          "questions": [
+            {
+              "answer": "CANARY-003-9879XX",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_003_s001"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_003_s001:0"
+              ],
+              "exact_strings": [
+                "CANARY-003-9879XX"
+              ],
+              "question": "What is my private locker code?",
+              "question_id": "seq_isolation_003_q001_isolation_probe"
+            },
+            {
+              "answer": "priya.rao@cobaltworks.example.com",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_003_s002"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_003_s002:0"
+              ],
+              "exact_strings": [
+                "priya.rao@cobaltworks.example.com"
+              ],
+              "question": "What is my main contact's email address?",
+              "question_id": "seq_isolation_003_q002_isolation_probe"
+            },
+            {
+              "answer": "CANARY-003-2750XQ",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_003_s003"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_003_s003:0"
+              ],
+              "exact_strings": [
+                "CANARY-003-2750XQ"
+              ],
+              "question": "Under what reference did I file my expense ticket?",
+              "question_id": "seq_isolation_003_q003_isolation_probe"
+            },
+            {
+              "answer": "Toronto",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_003_s003"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_003_s003:0"
+              ],
+              "exact_strings": [],
+              "question": "Which city is my main contact based in?",
+              "question_id": "seq_isolation_003_q004_isolation_probe"
+            }
+          ],
+          "scenario": "isolation",
+          "sessions": [
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-05",
+              "session_id": "seq_isolation_003_s001",
+              "turns": [
+                {
+                  "content": "Please remember: my private locker code is CANARY-003-9879XX.",
+                  "role": "user"
+                },
+                {
+                  "content": "Stored your private locker code CANARY-003-9879XX.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 1581)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 1581)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 1582)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 1582)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-06",
+              "session_id": "seq_isolation_003_s002",
+              "turns": [
+                {
+                  "content": "My main contact is Priya Rao at Cobalt Works; email priya.rao@cobaltworks.example.com.",
+                  "role": "user"
+                },
+                {
+                  "content": "Noted. Priya Rao (Cobalt Works), contact priya.rao@cobaltworks.example.com.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 1598)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 1598)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 1599)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 1599)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-07",
+              "session_id": "seq_isolation_003_s003",
+              "turns": [
+                {
+                  "content": "I filed my expense ticket under CANARY-003-2750XQ; Priya Rao is based in Toronto.",
+                  "role": "user"
+                },
+                {
+                  "content": "Saved ticket CANARY-003-2750XQ; Priya Rao is based in Toronto.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 1615)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 1615)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 1616)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 1616)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-08",
+              "session_id": "seq_isolation_003_s004",
+              "turns": [
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 1632)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 1632)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 1633)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 1633)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-09",
+              "session_id": "seq_isolation_003_s005",
+              "turns": [
+                {
+                  "content": "What's the weather looking like for the weekend? (note 1649)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 1649)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 1650)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 1650)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-10",
+              "session_id": "seq_isolation_003_s006",
+              "turns": [
+                {
+                  "content": "Remind me how to write a good standup update. (note 1666)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 1666)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 1667)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 1667)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-11",
+              "session_id": "seq_isolation_003_s007",
+              "turns": [
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 1683)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 1683)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 1684)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 1684)",
+                  "role": "assistant"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "case_id": "seq_isolation_004",
+          "ground_truth": {
+            "artifacts": [],
+            "canaries": [
+              "CANARY-004-5649YD",
+              "CANARY-004-8830AU",
+              "tomas.kovacs@asterdynamics.example.com"
+            ],
+            "contradictions": [],
+            "decisions": [],
+            "distractors": [],
+            "entities": [
+              {
+                "attributes": {
+                  "kind": "locker code"
+                },
+                "name": "CANARY-004-5649YD",
+                "session_id": "seq_isolation_004_s001",
+                "turn_id": "seq_isolation_004_s001:0",
+                "type": "reference"
+              },
+              {
+                "attributes": {
+                  "email": "tomas.kovacs@asterdynamics.example.com"
+                },
+                "name": "Tomas Kovacs",
+                "session_id": "seq_isolation_004_s002",
+                "turn_id": "seq_isolation_004_s002:0",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Aster Dynamics",
+                "session_id": "seq_isolation_004_s002",
+                "turn_id": "seq_isolation_004_s002:0",
+                "type": "company"
+              },
+              {
+                "attributes": {
+                  "kind": "expense ticket"
+                },
+                "name": "CANARY-004-8830AU",
+                "session_id": "seq_isolation_004_s003",
+                "turn_id": "seq_isolation_004_s003:0",
+                "type": "reference"
+              },
+              {
+                "attributes": {},
+                "name": "Singapore",
+                "session_id": "seq_isolation_004_s003",
+                "turn_id": "seq_isolation_004_s003:0",
+                "type": "location"
+              }
+            ],
+            "log_entries": [
+              {
+                "date": "2026-03-17",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_isolation_004_s001"
+                ],
+                "summary": "Work on 2026-03-17: stored private locker code CANARY-004-5649YD"
+              },
+              {
+                "date": "2026-03-18",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_isolation_004_s002"
+                ],
+                "summary": "Work on 2026-03-18: logged Tomas Kovacs (Aster Dynamics) as main contact"
+              },
+              {
+                "date": "2026-03-19",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_isolation_004_s003"
+                ],
+                "summary": "Work on 2026-03-19: filed expense ticket CANARY-004-8830AU"
+              }
+            ],
+            "question_meta": {},
+            "relationships": [
+              {
+                "attributes": {
+                  "stated_on": "2026-03-18"
+                },
+                "confidence": 0.85,
+                "from_name": "Tomas Kovacs",
+                "from_type": "person",
+                "session_id": "seq_isolation_004_s002",
+                "to_name": "Aster Dynamics",
+                "to_type": "company",
+                "turn_id": "seq_isolation_004_s002:0",
+                "type": "works_at"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-03-19"
+                },
+                "confidence": 0.85,
+                "from_name": "Tomas Kovacs",
+                "from_type": "person",
+                "session_id": "seq_isolation_004_s003",
+                "to_name": "Singapore",
+                "to_type": "location",
+                "turn_id": "seq_isolation_004_s003:0",
+                "type": "lives_in"
+              }
+            ]
+          },
+          "questions": [
+            {
+              "answer": "CANARY-004-5649YD",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_004_s001"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_004_s001:0"
+              ],
+              "exact_strings": [
+                "CANARY-004-5649YD"
+              ],
+              "question": "What is my private locker code?",
+              "question_id": "seq_isolation_004_q001_isolation_probe"
+            },
+            {
+              "answer": "tomas.kovacs@asterdynamics.example.com",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_004_s002"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_004_s002:0"
+              ],
+              "exact_strings": [
+                "tomas.kovacs@asterdynamics.example.com"
+              ],
+              "question": "What is my main contact's email address?",
+              "question_id": "seq_isolation_004_q002_isolation_probe"
+            },
+            {
+              "answer": "CANARY-004-8830AU",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_004_s003"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_004_s003:0"
+              ],
+              "exact_strings": [
+                "CANARY-004-8830AU"
+              ],
+              "question": "Under what reference did I file my expense ticket?",
+              "question_id": "seq_isolation_004_q003_isolation_probe"
+            },
+            {
+              "answer": "Singapore",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_004_s003"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_004_s003:0"
+              ],
+              "exact_strings": [],
+              "question": "Which city is my main contact based in?",
+              "question_id": "seq_isolation_004_q004_isolation_probe"
+            }
+          ],
+          "scenario": "isolation",
+          "sessions": [
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-17",
+              "session_id": "seq_isolation_004_s001",
+              "turns": [
+                {
+                  "content": "Please remember: my private locker code is CANARY-004-5649YD.",
+                  "role": "user"
+                },
+                {
+                  "content": "Stored your private locker code CANARY-004-5649YD.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 2108)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 2108)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 2109)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 2109)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-18",
+              "session_id": "seq_isolation_004_s002",
+              "turns": [
+                {
+                  "content": "My main contact is Tomas Kovacs at Aster Dynamics; email tomas.kovacs@asterdynamics.example.com.",
+                  "role": "user"
+                },
+                {
+                  "content": "Noted. Tomas Kovacs (Aster Dynamics), contact tomas.kovacs@asterdynamics.example.com.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 2125)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 2125)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 2126)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 2126)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-19",
+              "session_id": "seq_isolation_004_s003",
+              "turns": [
+                {
+                  "content": "I filed my expense ticket under CANARY-004-8830AU; Tomas Kovacs is based in Singapore.",
+                  "role": "user"
+                },
+                {
+                  "content": "Saved ticket CANARY-004-8830AU; Tomas Kovacs is based in Singapore.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 2142)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 2142)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 2143)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 2143)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-20",
+              "session_id": "seq_isolation_004_s004",
+              "turns": [
+                {
+                  "content": "What time zone is our Thursday sync in? (note 2159)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 2159)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 2160)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 2160)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-21",
+              "session_id": "seq_isolation_004_s005",
+              "turns": [
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 2176)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 2176)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 2177)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 2177)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-22",
+              "session_id": "seq_isolation_004_s006",
+              "turns": [
+                {
+                  "content": "What's the weather looking like for the weekend? (note 2193)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 2193)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 2194)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 2194)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-03-23",
+              "session_id": "seq_isolation_004_s007",
+              "turns": [
+                {
+                  "content": "Remind me how to write a good standup update. (note 2210)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 2210)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 2211)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 2211)",
+                  "role": "assistant"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "case_id": "seq_isolation_005",
+          "ground_truth": {
+            "artifacts": [],
+            "canaries": [
+              "CANARY-005-6306HW",
+              "CANARY-005-4120KF",
+              "lena.fischer@quillsoftware.example.com"
+            ],
+            "contradictions": [],
+            "decisions": [],
+            "distractors": [],
+            "entities": [
+              {
+                "attributes": {
+                  "kind": "locker code"
+                },
+                "name": "CANARY-005-6306HW",
+                "session_id": "seq_isolation_005_s001",
+                "turn_id": "seq_isolation_005_s001:0",
+                "type": "reference"
+              },
+              {
+                "attributes": {
+                  "email": "lena.fischer@quillsoftware.example.com"
+                },
+                "name": "Lena Fischer",
+                "session_id": "seq_isolation_005_s002",
+                "turn_id": "seq_isolation_005_s002:0",
+                "type": "person"
+              },
+              {
+                "attributes": {},
+                "name": "Quill Software",
+                "session_id": "seq_isolation_005_s002",
+                "turn_id": "seq_isolation_005_s002:0",
+                "type": "company"
+              },
+              {
+                "attributes": {
+                  "kind": "expense ticket"
+                },
+                "name": "CANARY-005-4120KF",
+                "session_id": "seq_isolation_005_s003",
+                "turn_id": "seq_isolation_005_s003:0",
+                "type": "reference"
+              },
+              {
+                "attributes": {},
+                "name": "Amsterdam",
+                "session_id": "seq_isolation_005_s003",
+                "turn_id": "seq_isolation_005_s003:0",
+                "type": "location"
+              }
+            ],
+            "log_entries": [
+              {
+                "date": "2026-02-16",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_isolation_005_s001"
+                ],
+                "summary": "Work on 2026-02-16: stored private locker code CANARY-005-6306HW"
+              },
+              {
+                "date": "2026-02-17",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_isolation_005_s002"
+                ],
+                "summary": "Work on 2026-02-17: logged Lena Fischer (Quill Software) as main contact"
+              },
+              {
+                "date": "2026-02-18",
+                "decisions": [],
+                "projects": [],
+                "source_session_ids": [
+                  "seq_isolation_005_s003"
+                ],
+                "summary": "Work on 2026-02-18: filed expense ticket CANARY-005-4120KF"
+              }
+            ],
+            "question_meta": {},
+            "relationships": [
+              {
+                "attributes": {
+                  "stated_on": "2026-02-17"
+                },
+                "confidence": 0.85,
+                "from_name": "Lena Fischer",
+                "from_type": "person",
+                "session_id": "seq_isolation_005_s002",
+                "to_name": "Quill Software",
+                "to_type": "company",
+                "turn_id": "seq_isolation_005_s002:0",
+                "type": "works_at"
+              },
+              {
+                "attributes": {
+                  "stated_on": "2026-02-18"
+                },
+                "confidence": 0.85,
+                "from_name": "Lena Fischer",
+                "from_type": "person",
+                "session_id": "seq_isolation_005_s003",
+                "to_name": "Amsterdam",
+                "to_type": "location",
+                "turn_id": "seq_isolation_005_s003:0",
+                "type": "lives_in"
+              }
+            ]
+          },
+          "questions": [
+            {
+              "answer": "CANARY-005-6306HW",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_005_s001"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_005_s001:0"
+              ],
+              "exact_strings": [
+                "CANARY-005-6306HW"
+              ],
+              "question": "What is my private locker code?",
+              "question_id": "seq_isolation_005_q001_isolation_probe"
+            },
+            {
+              "answer": "lena.fischer@quillsoftware.example.com",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_005_s002"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_005_s002:0"
+              ],
+              "exact_strings": [
+                "lena.fischer@quillsoftware.example.com"
+              ],
+              "question": "What is my main contact's email address?",
+              "question_id": "seq_isolation_005_q002_isolation_probe"
+            },
+            {
+              "answer": "CANARY-005-4120KF",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_005_s003"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_005_s003:0"
+              ],
+              "exact_strings": [
+                "CANARY-005-4120KF"
+              ],
+              "question": "Under what reference did I file my expense ticket?",
+              "question_id": "seq_isolation_005_q003_isolation_probe"
+            },
+            {
+              "answer": "Amsterdam",
+              "category": "isolation_probe",
+              "date_from": null,
+              "date_to": null,
+              "evidence_session_ids": [
+                "seq_isolation_005_s003"
+              ],
+              "evidence_turn_ids": [
+                "seq_isolation_005_s003:0"
+              ],
+              "exact_strings": [],
+              "question": "Which city is my main contact based in?",
+              "question_id": "seq_isolation_005_q004_isolation_probe"
+            }
+          ],
+          "scenario": "isolation",
+          "sessions": [
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-02-16",
+              "session_id": "seq_isolation_005_s001",
+              "turns": [
+                {
+                  "content": "Please remember: my private locker code is CANARY-005-6306HW.",
+                  "role": "user"
+                },
+                {
+                  "content": "Stored your private locker code CANARY-005-6306HW.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Any tips for staying focused during long meetings? (note 2635)",
+                  "role": "user"
+                },
+                {
+                  "content": "Take brief notes by hand and ask one clarifying question early to stay engaged. (ref 2635)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 2636)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 2636)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-02-17",
+              "session_id": "seq_isolation_005_s002",
+              "turns": [
+                {
+                  "content": "My main contact is Lena Fischer at Quill Software; email lena.fischer@quillsoftware.example.com.",
+                  "role": "user"
+                },
+                {
+                  "content": "Noted. Lena Fischer (Quill Software), contact lena.fischer@quillsoftware.example.com.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's a good book on negotiation? (note 2652)",
+                  "role": "user"
+                },
+                {
+                  "content": "Never Split the Difference is a practical starting point. (ref 2652)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 2653)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 2653)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-02-18",
+              "session_id": "seq_isolation_005_s003",
+              "turns": [
+                {
+                  "content": "I filed my expense ticket under CANARY-005-4120KF; Lena Fischer is based in Amsterdam.",
+                  "role": "user"
+                },
+                {
+                  "content": "Saved ticket CANARY-005-4120KF; Lena Fischer is based in Amsterdam.",
+                  "role": "assistant"
+                },
+                {
+                  "content": "How do I make cold brew at home? (note 2669)",
+                  "role": "user"
+                },
+                {
+                  "content": "Steep coarse grounds in cold water for 16 hours, then strain twice. (ref 2669)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 2670)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 2670)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-02-19",
+              "session_id": "seq_isolation_005_s004",
+              "turns": [
+                {
+                  "content": "Can you recommend a stretch for wrist pain? (note 2686)",
+                  "role": "user"
+                },
+                {
+                  "content": "Gentle wrist extensor stretches, ten seconds each side, a few times a day. (ref 2686)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What time zone is our Thursday sync in? (note 2687)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 2687)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-02-20",
+              "session_id": "seq_isolation_005_s005",
+              "turns": [
+                {
+                  "content": "What time zone is our Thursday sync in? (note 2703)",
+                  "role": "user"
+                },
+                {
+                  "content": "It is pinned to 15:00 UTC, which shifts locally with daylight saving. (ref 2703)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 2704)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 2704)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-02-21",
+              "session_id": "seq_isolation_005_s006",
+              "turns": [
+                {
+                  "content": "Can you suggest a quick lunch spot near the office? (note 2720)",
+                  "role": "user"
+                },
+                {
+                  "content": "The noodle bar on the corner is fast, and the salad place next door has a lunch deal. (ref 2720)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "What's the weather looking like for the weekend? (note 2721)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 2721)",
+                  "role": "assistant"
+                }
+              ]
+            },
+            {
+              "agent_id": "membench-agent",
+              "date": "2026-02-22",
+              "session_id": "seq_isolation_005_s007",
+              "turns": [
+                {
+                  "content": "What's the weather looking like for the weekend? (note 2737)",
+                  "role": "user"
+                },
+                {
+                  "content": "Mostly sunny with a chance of showers on Sunday afternoon. (ref 2737)",
+                  "role": "assistant"
+                },
+                {
+                  "content": "Remind me how to write a good standup update. (note 2738)",
+                  "role": "user"
+                },
+                {
+                  "content": "Cover what you finished, what you're doing next, and anything blocking you. (ref 2738)",
+                  "role": "assistant"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "config": {
+        "sessions_per_user": 7,
+        "span_days": 7,
+        "target_ops": 600,
+        "users": 6
+      }
+    }
+  },
+  "schema_version": "1.0"
+}

--- a/bench/memory/longitudinal_adapter.py
+++ b/bench/memory/longitudinal_adapter.py
@@ -1,0 +1,420 @@
+"""Real-formation adapter for the Tier 3 longitudinal benchmark.
+
+Extends the Tier 2 :class:`~bench.memory.structured_adapter.StructuredMemoryAdapter`
+with the scenario-specific instrumentation Tier 3 needs. Everything
+runs against the real services — no mocks:
+
+- **Buffer cycling (Scenario A)** — sessions are replayed into the
+  real working-memory buffer under a small ``max_memory_mb`` budget,
+  and the buffer's own FIFO cleanup (``check_memory_usage_and_cleanup``)
+  is driven once per ingested session (benchmark time is compressed;
+  in production the same pass runs on a wall-clock interval). That is
+  the exact path the pre-compaction flush (memory-revamp Phase 3)
+  guards: the adapter wraps the flush service's eviction listener to
+  count hand-offs, and — by default — resolves the flush digest model
+  to ``None`` so runs stay deterministic and $0 (the trigger and
+  hand-off mechanics are still exercised end-to-end). Pass
+  ``flush_digest=True`` to let the silent-turn digest make its real
+  LLM calls.
+- **Per-session extraction replay (Scenario D)** — the ground-truth
+  manifest is applied through ``KnowledgeGraphService.store_extraction``
+  one session batch at a time, in corpus order, with per-fact
+  confidences. That is the live dual-write path: the storage layer's
+  contradiction detection fires exactly as it would in production and
+  the event substrate records ``graph.extracted`` +
+  ``fact.contradicted`` events, enabling the substrate-event tally and
+  the projection-rebuild consistency check.
+- **Audits** — contradiction pair audit (detection kind aware),
+  zero-lost-decisions (Captain's Log), zero-artifact-orphans (KG
+  reachability), and the isolation leak probes (vector / graph / log
+  read paths).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from .datasets import Session
+from .longitudinal_dataset import LongitudinalGroundTruth
+from .longitudinal_scoring import (
+    ArtifactAuditItem,
+    ContradictionPairAudit,
+    DecisionAuditItem,
+)
+from .structured_adapter import STRUCTURED_MODE, StructuredMemoryAdapter, _name_key
+
+# The substrate audit event type recorded by the live extraction path
+# (services/memory/events/models.py::EVENT_FACT_CONTRADICTED; literal
+# here so the bench package stays importable without the runtime).
+FACT_CONTRADICTED_EVENT = "fact.contradicted"
+
+
+def _turn_order_key(item: Dict[str, Any]) -> Tuple[str, int]:
+    turn_id = str(item.get("turn_id", ""))
+    session_id, _, turn_index = turn_id.rpartition(":")
+    return (session_id, int(turn_index) if turn_index.isdigit() else 0)
+
+
+class LongitudinalMemoryAdapter(StructuredMemoryAdapter):
+    """Tier 3 adapter: Tier 2 machinery plus longitudinal instrumentation."""
+
+    def __init__(
+        self,
+        mode: str = STRUCTURED_MODE,
+        buffer_max_mb: Optional[float] = None,
+        flush_digest: bool = False,
+        **kwargs,
+    ):
+        super().__init__(mode=mode, **kwargs)
+        self.buffer_max_mb = buffer_max_mb
+        self.flush_digest = flush_digest
+        self.buffer_ingested_turns = 0
+        self.cleanup_passes = 0
+        self.flush_hand_offs = 0
+        self.flush_items_handed = 0
+
+    # -- lifecycle -----------------------------------------------------------
+
+    async def start(self) -> None:
+        await super().start()
+        buffer = self.overlord.buffer_memory
+        if buffer is None:
+            return
+
+        if self.buffer_max_mb is not None:
+            # The buffer's memory budget is a constructor default (not
+            # formation-configurable); the benchmark shrinks it so a
+            # 30-day corpus cycles the buffer in minutes.
+            buffer.max_memory_mb = float(self.buffer_max_mb)
+
+        # Interpose on the pre-compaction flush hand-off (installed by
+        # the Overlord at startup) to count triggers without changing
+        # the real path.
+        original_listener = buffer._eviction_listener
+        threshold = buffer._eviction_flush_threshold
+
+        def _counting_listener(items: List[Dict[str, Any]]) -> None:
+            self.flush_hand_offs += 1
+            self.flush_items_handed += len(items)
+            if original_listener is not None:
+                original_listener(items)
+
+        buffer.set_eviction_listener(_counting_listener, threshold)
+
+        flush_service = getattr(self.overlord, "precompaction_flush", None)
+        if flush_service is not None and not self.flush_digest:
+            # Counting-only mode (default): the trigger and hand-off
+            # mechanics run for real, but the silent-turn digest
+            # resolves no model — deterministic, $0. flush_items()
+            # no-ops on a None model by design.
+            flush_service._model_getter = lambda: None
+
+    # -- Scenario A: buffer ingestion under a cycling budget -------------------
+
+    async def ingest_session_buffer(self, user_id: str, session: Session) -> None:
+        """Replay one session into the working-memory buffer, then run
+        the FIFO cleanup pass (threshold flush + eviction) once."""
+        buffer = self.overlord.buffer_memory
+        for turn in session.turns:
+            text = self._render_turn_text(session, turn)
+            if not text.strip():
+                continue
+            metadata = {
+                "user_id": user_id,
+                "bench_session_id": session.session_id,
+                "bench_turn_id": turn.turn_id,
+                "role": turn.role,
+            }
+            await buffer.add(text, metadata=metadata)
+            self.ingested_turns += 1
+            self.buffer_ingested_turns += 1
+
+        buffer.check_memory_usage_and_cleanup()
+        self.cleanup_passes += 1
+        # A triggered flush is scheduled onto this loop; yield so the
+        # (counting-only) coroutine can run between sessions.
+        await asyncio.sleep(0)
+
+    def buffer_resident_turn_ids(self) -> Set[str]:
+        """Bench turn ids still resident in the buffer (post-eviction)."""
+        buffer = self.overlord.buffer_memory
+        resident: Set[str] = set()
+        for item in buffer.buffer:
+            turn_id = (item.get("metadata") or {}).get("bench_turn_id")
+            if turn_id:
+                resident.add(str(turn_id))
+        return resident
+
+    async def search_working(self, user_id: str, query: str, fetch_limit: int):
+        """Working-memory-only retrieval (the Scenario A baseline)."""
+        self.searches += 1
+        raw = await self.overlord.buffer_memory.search(
+            query,
+            limit=fetch_limit,
+            filter_metadata={"user_id": user_id},
+            recency_bias=0.0,
+            namespace="buffer",
+        )
+        return self._items_from_working(raw)
+
+    def eviction_stats(self) -> Dict[str, Any]:
+        resident = self.buffer_resident_turn_ids()
+        return {
+            "ingested_turns": self.buffer_ingested_turns,
+            "resident_turns": len(resident),
+            "evicted_turns": self.buffer_ingested_turns - len(resident),
+            "max_memory_mb": (
+                self.overlord.buffer_memory.max_memory_mb
+                if self.overlord and self.overlord.buffer_memory
+                else None
+            ),
+            "cleanup_passes": self.cleanup_passes,
+        }
+
+    def flush_stats(self) -> Dict[str, Any]:
+        return {
+            "hand_offs": self.flush_hand_offs,
+            "items_handed": self.flush_items_handed,
+            "digest_enabled": self.flush_digest,
+            "attached": getattr(self.overlord, "precompaction_flush", None) is not None,
+        }
+
+    # -- Scenario A/B audits ----------------------------------------------------
+
+    async def audit_decisions(
+        self, user_id: str, truth: LongitudinalGroundTruth
+    ) -> List[DecisionAuditItem]:
+        """Zero-lost-decisions: every ground-truth decision must be
+        findable in the Captain's Log."""
+        log_storage = self.overlord.captains_log.storage
+        entries = await log_storage.list_entries(user_id, limit=1000)
+        logged: Set[str] = set()
+        for entry in entries:
+            for decision in entry.get("decisions") or []:
+                logged.add(str(decision))
+        return [
+            DecisionAuditItem(
+                decision=str(item["decision"]),
+                date=str(item["date"]),
+                found=str(item["decision"]) in logged,
+            )
+            for item in truth.decisions
+        ]
+
+    async def audit_artifacts(
+        self, user_id: str, truth: LongitudinalGroundTruth
+    ) -> List[ArtifactAuditItem]:
+        """Zero-artifact-orphans: every artifact must be reachable from
+        the KG (entity present + produced edge from its agent)."""
+        graph = self.overlord.knowledge_graph
+        entities = await graph.storage.list_entities(user_id, status=None, limit=1000)
+        relationships = await graph.storage.list_relationships(user_id, status=None, limit=2000)
+        names = {entity["id"]: _name_key(entity["name"]) for entity in entities}
+        entity_keys = {(_name_key(entity["name"]), entity["type"]) for entity in entities}
+        produced = {
+            (names.get(rel["from_entity_id"]), names.get(rel["to_entity_id"]))
+            for rel in relationships
+            if rel["type"] == "produced"
+        }
+        items: List[ArtifactAuditItem] = []
+        for artifact in truth.artifacts:
+            name = _name_key(str(artifact["name"]))
+            agent = _name_key(str(artifact["agent"]))
+            items.append(
+                ArtifactAuditItem(
+                    name=str(artifact["name"]),
+                    agent=str(artifact["agent"]),
+                    entity_found=(name, "artifact") in entity_keys,
+                    produced_link_found=(agent, name) in produced,
+                )
+            )
+        return items
+
+    # -- Scenario C: isolation probes -------------------------------------------
+
+    async def isolation_vector_op(
+        self, user_id: str, query: str, fetch_limit: int
+    ) -> Tuple[List[str], List[str]]:
+        """One vector retrieval op; returns (texts, session ids)."""
+        items = await self.search(user_id, query, fetch_limit)
+        return [item.text for item in items], [item.session_id for item in items]
+
+    async def isolation_graph_op(self, user_id: str) -> Tuple[List[str], List[str]]:
+        """One KG read op: every entity/relationship visible to the user."""
+        graph = self.overlord.knowledge_graph
+        entities = await graph.storage.list_entities(user_id, status=None, limit=1000)
+        relationships = await graph.storage.list_relationships(user_id, status=None, limit=2000)
+        names = {entity["id"]: entity["name"] for entity in entities}
+        texts = [
+            f"{entity['name']} ({entity['type']}) {entity.get('attributes') or {}}"
+            for entity in entities
+        ]
+        texts.extend(
+            f"{names.get(rel['from_entity_id'], '?')} -[{rel['type']}]-> "
+            f"{names.get(rel['to_entity_id'], '?')}"
+            for rel in relationships
+        )
+        return texts, []
+
+    async def isolation_log_op(self, user_id: str) -> Tuple[List[str], List[str]]:
+        """One Captain's-Log read op: every entry visible to the user."""
+        log_storage = self.overlord.captains_log.storage
+        entries = await log_storage.list_entries(user_id, limit=1000)
+        texts = []
+        for entry in entries:
+            parts = [str(entry.get("summary") or "")]
+            parts.extend(str(decision) for decision in entry.get("decisions") or [])
+            texts.append(" | ".join(part for part in parts if part))
+        return texts, []
+
+    # -- Scenario D: per-session extraction replay + audits ----------------------
+
+    async def ingest_extraction_sessions(self, user_id: str, truth: LongitudinalGroundTruth) -> int:
+        """Replay the manifest through ``store_extraction`` one session
+        at a time, in corpus order (the live dual-write path: storage
+        contradiction detection + substrate event recording)."""
+        graph = self.overlord.knowledge_graph
+
+        entities = sorted(truth.entities, key=_turn_order_key)
+        relationships = sorted(truth.relationships, key=_turn_order_key)
+        session_ids = sorted({str(item["session_id"]) for item in (*entities, *relationships)})
+
+        batches = 0
+        for session_id in session_ids:
+            extraction = {
+                "entities": [
+                    {
+                        "type": entity["type"],
+                        "name": entity["name"],
+                        "attributes": dict(entity.get("attributes") or {}),
+                        "confidence": 0.85,
+                    }
+                    for entity in entities
+                    if str(entity["session_id"]) == session_id
+                ],
+                "relationships": [
+                    {
+                        "from": rel["from_name"],
+                        "from_type": rel["from_type"],
+                        "type": rel["type"],
+                        "to": rel["to_name"],
+                        "to_type": rel["to_type"],
+                        "attributes": dict(rel.get("attributes") or {}),
+                        "confidence": float(rel.get("confidence", 0.85)),
+                    }
+                    for rel in relationships
+                    if str(rel["session_id"]) == session_id
+                ],
+            }
+            if not extraction["entities"] and not extraction["relationships"]:
+                continue
+            await graph.store_extraction(user_id, extraction, source="interaction")
+            batches += 1
+            self.ingested_turns += 1
+        return batches
+
+    async def _kg_flag_state(
+        self, user_id: str
+    ) -> Tuple[Dict[int, Dict[str, Any]], Dict[int, str]]:
+        graph = self.overlord.knowledge_graph
+        relationships = await graph.storage.list_relationships(user_id, status=None, limit=2000)
+        entities = await graph.storage.list_entities(user_id, status=None, limit=1000)
+        by_id = {rel["id"]: rel for rel in relationships}
+        names = {entity["id"]: _name_key(entity["name"]) for entity in entities}
+        return by_id, names
+
+    async def audit_contradiction_pairs(
+        self, user_id: str, truth: LongitudinalGroundTruth
+    ) -> Tuple[List[ContradictionPairAudit], List[Tuple[str, str, str, str]]]:
+        """Compare KG conflict/supersede flags against the injected
+        pairs; returns (per-pair audits, false-positive signatures)."""
+        by_id, names = await self._kg_flag_state(user_id)
+
+        def _rel_lookup(subject: str, predicate: str, obj: str) -> Optional[Dict[str, Any]]:
+            for rel in by_id.values():
+                if (
+                    names.get(rel["from_entity_id"]) == _name_key(subject)
+                    and str(rel["type"]) == predicate
+                    and names.get(rel["to_entity_id"]) == _name_key(obj)
+                ):
+                    return rel
+            return None
+
+        pairs: List[ContradictionPairAudit] = []
+        for contradiction in truth.contradictions:
+            audit = ContradictionPairAudit(
+                subject=str(contradiction["subject"]),
+                predicate=str(contradiction["predicate"]),
+                old_object=str(contradiction["old_object"]),
+                new_object=str(contradiction["new_object"]),
+                expected_detection=str(contradiction["expected_detection"]),
+            )
+            old_rel = _rel_lookup(audit.subject, audit.predicate, audit.old_object)
+            new_rel = _rel_lookup(audit.subject, audit.predicate, audit.new_object)
+            if old_rel is not None and new_rel is not None:
+                if old_rel.get("superseded_by") == new_rel["id"]:
+                    audit.detected = True
+                    audit.detected_kind = "superseded"
+                elif old_rel.get("contradicted_by") == new_rel["id"]:
+                    audit.detected = True
+                    audit.detected_kind = "conflicted"
+            pairs.append(audit)
+
+        # Every flagged pair in the graph, as unordered signatures, to
+        # count detections outside the injected ground truth.
+        detected_signatures = set()
+        for rel in by_id.values():
+            for link in ("contradicted_by", "superseded_by"):
+                other_id = rel.get(link)
+                other = by_id.get(other_id)
+                if other is None:
+                    continue
+                subject = names.get(rel["from_entity_id"], "?")
+                objects = sorted(
+                    (
+                        names.get(rel["to_entity_id"], "?"),
+                        names.get(other["to_entity_id"], "?"),
+                    )
+                )
+                detected_signatures.add((subject, str(rel["type"]), objects[0], objects[1]))
+        expected_signatures = {
+            (
+                _name_key(str(c["subject"])),
+                str(c["predicate"]),
+                *sorted((_name_key(str(c["old_object"])), _name_key(str(c["new_object"])))),
+            )
+            for c in truth.contradictions
+        }
+        false_positives = sorted(detected_signatures - expected_signatures)
+        return pairs, false_positives
+
+    async def contradiction_event_stats(self, user_id: str, detected_total: int) -> Dict[str, Any]:
+        """Tally the substrate's fact.contradicted audit events."""
+        service = getattr(self.overlord, "memory_events", None)
+        if service is None or not getattr(service, "enabled", False):
+            return {"available": False, "events": 0, "matches_detections": None}
+        events = await service.list_events(user_id, event_types=[FACT_CONTRADICTED_EVENT])
+        return {
+            "available": True,
+            "events": len(events),
+            "matches_detections": len(events) == detected_total,
+        }
+
+    async def rebuild_knowledge_graph(self, user_id: str) -> Dict[str, Any]:
+        """Rebuild the KG projection from the event log (service layer,
+        same path as the /memory rebuild endpoint)."""
+        service = getattr(self.overlord, "memory_events", None)
+        if service is None or not getattr(service, "enabled", False):
+            return {"available": False}
+        report = await service.rebuild(user_id, projection="knowledge_graph")
+        return {"available": True, **report.get("knowledge_graph", {})}
+
+    # -- reporting ---------------------------------------------------------------
+
+    def config_snapshot(self) -> Dict[str, Any]:
+        config = super().config_snapshot()
+        if self.buffer_max_mb is not None:
+            config["buffer_max_mb"] = self.buffer_max_mb
+        config["flush_digest"] = self.flush_digest
+        return config

--- a/bench/memory/longitudinal_adapter.py
+++ b/bench/memory/longitudinal_adapter.py
@@ -110,6 +110,20 @@ class LongitudinalMemoryAdapter(StructuredMemoryAdapter):
             # no-ops on a None model by design.
             flush_service._model_getter = lambda: None
 
+    def clear_case(self) -> None:
+        """Reset per-case state, including the Scenario A counters.
+
+        The eviction/flush counters are per-case measurements; without
+        the reset they would accumulate across cases and misreport
+        every case after the first (the runner sums per-case snapshots
+        itself).
+        """
+        super().clear_case()
+        self.buffer_ingested_turns = 0
+        self.cleanup_passes = 0
+        self.flush_hand_offs = 0
+        self.flush_items_handed = 0
+
     # -- Scenario A: buffer ingestion under a cycling budget -------------------
 
     async def ingest_session_buffer(self, user_id: str, session: Session) -> None:

--- a/bench/memory/longitudinal_corpus.py
+++ b/bench/memory/longitudinal_corpus.py
@@ -1,0 +1,1097 @@
+"""Longitudinal corpus generator for Tier 3 (Multi-Session Longitudinal).
+
+The Tier 3 benchmark simulates 30-90 days of realistic usage across
+multiple users and agents (memory-benchmarking PRD, Tier 3). This is
+the PRD's "MemBench Generator": seeded and fully deterministic, no
+LLM calls — the same (seed, preset) inputs produce byte-identical
+dataset files. It extends the Tier 2 generator's dated, agent-
+attributed session skeleton (``structured_corpus.py``) to longitudinal
+multi-session corpora, one per PRD scenario:
+
+- ``buffer_cycle`` (Scenario A) — one user, a conversation-heavy
+  workload whose turns overflow a small working-memory budget. Facts
+  and decisions are concentrated in the first days ("day 1-5") and
+  questioned at the end of the window ("day 30"), after their source
+  turns have been FIFO-evicted. A ``recent_recall`` control group
+  (facts from the last days, still buffer-resident) separates
+  "the persisted layers compensate" from "retrieval is broken".
+- ``cross_agent`` (Scenario B) — one user, four agents (research,
+  finance, marketing, engineering per the PRD). Each agent produces
+  artifacts and KG facts in its own sessions; every question is asked
+  "via" a different agent than the one whose session carries the
+  evidence (``question_meta`` records the pair). The artifact manifest
+  backs the zero-orphan audit.
+- ``isolation`` (Scenario C) — N users, 7 days each, one case per
+  user. Every user's facts follow IDENTICAL templates (same fact
+  wording, same probe questions) differing only in values, so if
+  isolation ever broke, another user's turn would be the nearest
+  neighbor. Each user carries unique ``CANARY-{user}-...`` tokens;
+  a canary from user A in user B's retrieval is an unambiguous leak.
+- ``contradiction`` (Scenario D) — one user, contradictions injected
+  across sessions with day gaps: conflicted pairs (confidence delta
+  within SUPERSEDE_CONFIDENCE_DELTA, expect ``conflicted``),
+  supersession pairs (delta above it, expect ``superseded``), plus
+  precision distractors (duplicate re-assertions and non-exclusive
+  predicate changes that must NOT be flagged). Relationships carry
+  per-fact confidence and turn provenance so the runner can replay
+  them per-session, in corpus order, through the real
+  ``store_extraction`` write path (which records the substrate's
+  ``fact.contradicted`` events from the event-substrate PRD).
+
+CLI
+---
+::
+
+    # Regenerate the committed CI fixture
+    uv run python -m bench.memory.longitudinal_corpus --preset fixture \
+        --output bench/memory/fixtures/longitudinal_sample.json
+
+    # Full dataset (PRD scale: 30-day corpora, 100 isolation users,
+    # 10,000 isolation retrieval ops)
+    uv run python -m bench.memory.longitudinal_corpus --preset full \
+        --output ~/datasets/membench/longitudinal_full.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+from dataclasses import asdict
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from .structured_corpus import (
+    CITIES,
+    COMPANIES,
+    DISTRACTOR_EXCHANGES,
+    FIRST_NAMES,
+    LAST_NAMES,
+    ROLES,
+    TECHNOLOGIES,
+    GTEntity,
+    GTLogEntry,
+    GTQuestion,
+    GTRelationship,
+    _code,
+    _email_for,
+    _iso,
+    write_dataset,
+)
+
+DATASET_NAME = "muxi-longitudinal"
+DATASET_SCHEMA_VERSION = "1.0"
+
+DEFAULT_SEED = 42
+
+# The four PRD Tier 3 scenarios.
+SCENARIO_BUFFER_CYCLE = "buffer_cycle"
+SCENARIO_CROSS_AGENT = "cross_agent"
+SCENARIO_ISOLATION = "isolation"
+SCENARIO_CONTRADICTION = "contradiction"
+SCENARIOS = (
+    SCENARIO_BUFFER_CYCLE,
+    SCENARIO_CROSS_AGENT,
+    SCENARIO_ISOLATION,
+    SCENARIO_CONTRADICTION,
+)
+
+# Question categories (mapped onto question_type by the loader).
+CATEGORY_EVICTED = "evicted_recall"
+CATEGORY_RECENT = "recent_recall"
+CATEGORY_PROPAGATION = "cross_agent_propagation"
+CATEGORY_ISOLATION_PROBE = "isolation_probe"
+CATEGORIES = (
+    CATEGORY_EVICTED,
+    CATEGORY_RECENT,
+    CATEGORY_PROPAGATION,
+    CATEGORY_ISOLATION_PROBE,
+)
+
+# The PRD's Scenario A window: questions target facts from days 1-5,
+# asked after the full span has been ingested ("at day 30").
+EARLY_WINDOW_DAYS = 5
+
+# Contradiction-detection confidences (graph/models.py:
+# SUPERSEDE_CONFIDENCE_DELTA = 0.3 — a delta above it supersedes, at
+# or below it both facts are flagged conflicted).
+CONFLICTED_OLD_CONFIDENCE = 0.6
+CONFLICTED_NEW_CONFIDENCE = 0.6
+SUPERSEDED_OLD_CONFIDENCE = 0.55
+SUPERSEDED_NEW_CONFIDENCE = 0.95
+DEFAULT_FACT_CONFIDENCE = 0.85
+
+# Scenario B agents, per the PRD ("research, finance, marketing,
+# engineering").
+CROSS_AGENT_AGENTS = (
+    "research-agent",
+    "finance-agent",
+    "marketing-agent",
+    "engineering-agent",
+)
+
+# Artifact pool for Scenario B: one per (set, agent); names stay unique
+# so the zero-orphan audit can key on them. 3 sets x 4 agents = 12.
+CROSS_AGENT_ARTIFACTS = (
+    "market sizing memo",
+    "Q3 revenue forecast",
+    "campaign performance report",
+    "load test report",
+    "competitor teardown",
+    "budget variance report",
+    "brand refresh brief",
+    "API design document",
+    "user interview digest",
+    "pricing comparison sheet",
+    "onboarding funnel analysis",
+    "capacity plan",
+)
+
+# Presets: fixture = committed CI sample (small, minutes to run);
+# full = the PRD's documented scale (30-day corpora, 100 isolation
+# users, 10,000 isolation retrieval operations).
+PRESETS = {
+    "fixture": {
+        SCENARIO_BUFFER_CYCLE: {
+            "span_days": 30,
+            "sessions": 18,
+            "filler_exchanges": 6,
+            "fact_sets": 1,
+        },
+        SCENARIO_CROSS_AGENT: {
+            "span_days": 30,
+            "sessions": 16,
+            "filler_exchanges": 2,
+            "artifact_sets": 2,
+        },
+        SCENARIO_ISOLATION: {
+            "users": 6,
+            "span_days": 7,
+            "sessions_per_user": 7,
+            "target_ops": 600,
+        },
+        SCENARIO_CONTRADICTION: {
+            "span_days": 45,
+            "sessions": 12,
+            "conflicted": 3,
+            "superseded": 3,
+        },
+    },
+    "full": {
+        SCENARIO_BUFFER_CYCLE: {
+            "span_days": 30,
+            "sessions": 60,
+            "filler_exchanges": 10,
+            "fact_sets": 3,
+        },
+        SCENARIO_CROSS_AGENT: {
+            "span_days": 30,
+            "sessions": 60,
+            "filler_exchanges": 4,
+            "artifact_sets": 3,
+        },
+        SCENARIO_ISOLATION: {
+            "users": 100,
+            "span_days": 7,
+            "sessions_per_user": 7,
+            "target_ops": 10000,
+        },
+        SCENARIO_CONTRADICTION: {
+            "span_days": 90,
+            "sessions": 45,
+            "conflicted": 10,
+            "superseded": 10,
+        },
+    },
+}
+
+
+def _rng(seed: int, *scope: Any) -> random.Random:
+    return random.Random(":".join(str(part) for part in (seed, "longitudinal", *scope)))
+
+
+def _spread_dates(rng: random.Random, span_days: int, sessions: int) -> List[date]:
+    """Session dates covering ``span_days`` (first day 0, last day span-1)."""
+    start = date(2026, 2, 2) + timedelta(days=rng.randint(0, 45))
+    if sessions == 1:
+        return [start]
+    return [
+        start + timedelta(days=(i * (span_days - 1)) // (sessions - 1)) for i in range(sessions)
+    ]
+
+
+class _SessionWriter:
+    """Accumulates one session's turns, handing back stable turn ids."""
+
+    def __init__(self, case_id: str, index: int, session_date: date, agent_id: str):
+        self.session_id = f"{case_id}_s{index + 1:03d}"
+        self.date = _iso(session_date)
+        self.agent_id = agent_id
+        self.turns: List[Dict[str, str]] = []
+
+    def add(self, role: str, content: str) -> str:
+        turn_id = f"{self.session_id}:{len(self.turns)}"
+        self.turns.append({"role": role, "content": content})
+        return turn_id
+
+    def add_filler(self, count: int, salt: int) -> None:
+        """Deterministic small-talk exchanges padding the buffer workload.
+
+        Each exchange carries a distinct note number so no two filler
+        turns embed identically (a buffer full of duplicate vectors
+        would make the eviction workload unrealistically compressible).
+        """
+        for exchange_index in range(count):
+            question, answer = DISTRACTOR_EXCHANGES[
+                (salt + exchange_index) % len(DISTRACTOR_EXCHANGES)
+            ]
+            note = salt * 17 + exchange_index
+            self.add("user", f"{question} (note {note:04d})")
+            self.add("assistant", f"{answer} (ref {note:04d})")
+
+    def render(self) -> Dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "date": self.date,
+            "agent_id": self.agent_id,
+            "turns": self.turns,
+        }
+
+
+class _CaseBuilder:
+    """Shared ground-truth bookkeeping for one longitudinal case."""
+
+    def __init__(self, case_id: str, scenario: str):
+        self.case_id = case_id
+        self.scenario = scenario
+        self.writers: List[_SessionWriter] = []
+        self.entities: List[GTEntity] = []
+        self.relationships: List[GTRelationship] = []
+        self.log_entries: List[GTLogEntry] = []
+        self.contradictions: List[Dict[str, Any]] = []
+        self.distractors: List[Dict[str, Any]] = []
+        self.decisions: List[Dict[str, Any]] = []
+        self.artifacts: List[Dict[str, Any]] = []
+        self.canaries: List[str] = []
+        self.questions: List[GTQuestion] = []
+        self.question_meta: Dict[str, Dict[str, Any]] = {}
+        self._question_counter = 0
+        # Per-date log accumulation: date -> (summary parts, decisions,
+        # projects, session ids).
+        self._log_days: Dict[str, Dict[str, Any]] = {}
+
+    # -- ground truth ---------------------------------------------------------
+
+    def entity(
+        self,
+        writer: _SessionWriter,
+        turn_id: str,
+        name: str,
+        entity_type: str,
+        attributes: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.entities.append(
+            GTEntity(
+                name=name,
+                type=entity_type,
+                attributes=dict(attributes or {}),
+                session_id=writer.session_id,
+                turn_id=turn_id,
+            )
+        )
+
+    def relationship(
+        self,
+        writer: _SessionWriter,
+        turn_id: str,
+        from_name: str,
+        from_type: str,
+        rel_type: str,
+        to_name: str,
+        to_type: str,
+        attributes: Optional[Dict[str, Any]] = None,
+        confidence: float = DEFAULT_FACT_CONFIDENCE,
+    ) -> None:
+        attrs = dict(attributes or {})
+        attrs.setdefault("stated_on", writer.date)
+        self.relationships.append(
+            GTRelationship(
+                from_name=from_name,
+                from_type=from_type,
+                type=rel_type,
+                to_name=to_name,
+                to_type=to_type,
+                attributes=attrs,
+                confidence=confidence,
+                session_id=writer.session_id,
+                turn_id=turn_id,
+            )
+        )
+
+    def log_day(
+        self,
+        writer: _SessionWriter,
+        highlight: str,
+        decision: Optional[str] = None,
+        project: Optional[str] = None,
+    ) -> None:
+        day = self._log_days.setdefault(
+            writer.date,
+            {"highlights": [], "decisions": [], "projects": [], "session_ids": []},
+        )
+        day["highlights"].append(highlight)
+        if decision:
+            day["decisions"].append(decision)
+            self.decisions.append(
+                {"decision": decision, "date": writer.date, "session_id": writer.session_id}
+            )
+        if project and project not in day["projects"]:
+            day["projects"].append(project)
+        if writer.session_id not in day["session_ids"]:
+            day["session_ids"].append(writer.session_id)
+
+    def question(
+        self,
+        category: str,
+        question: str,
+        answer: str,
+        evidence: Sequence[Tuple[str, str]],
+        exact_strings: Sequence[str] = (),
+        date_from: Optional[str] = None,
+        date_to: Optional[str] = None,
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self._question_counter += 1
+        question_id = f"{self.case_id}_q{self._question_counter:03d}_{category}"
+        self.questions.append(
+            GTQuestion(
+                question_id=question_id,
+                category=category,
+                question=question,
+                answer=answer,
+                evidence_session_ids=sorted({session_id for session_id, _ in evidence}),
+                evidence_turn_ids=[turn_id for _, turn_id in evidence if turn_id],
+                exact_strings=list(exact_strings),
+                date_from=date_from,
+                date_to=date_to,
+            )
+        )
+        if meta:
+            self.question_meta[question_id] = dict(meta)
+
+    # -- output ---------------------------------------------------------------
+
+    def build(self, extra_ground_truth: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        for day in sorted(self._log_days):
+            info = self._log_days[day]
+            summary = f"Work on {day}: " + "; ".join(info["highlights"])
+            self.log_entries.append(
+                GTLogEntry(
+                    date=day,
+                    summary=summary,
+                    decisions=list(info["decisions"]),
+                    projects=list(info["projects"]),
+                    source_session_ids=list(info["session_ids"]),
+                )
+            )
+        ground_truth: Dict[str, Any] = {
+            "entities": [asdict(entity) for entity in self.entities],
+            "relationships": [asdict(rel) for rel in self.relationships],
+            "log_entries": [asdict(entry) for entry in self.log_entries],
+            "contradictions": list(self.contradictions),
+            "distractors": list(self.distractors),
+            "decisions": list(self.decisions),
+            "artifacts": list(self.artifacts),
+            "canaries": list(self.canaries),
+            "question_meta": dict(self.question_meta),
+        }
+        ground_truth.update(extra_ground_truth or {})
+        return {
+            "case_id": self.case_id,
+            "scenario": self.scenario,
+            "sessions": [writer.render() for writer in self.writers],
+            "questions": [asdict(question) for question in self.questions],
+            "ground_truth": ground_truth,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Scenario A: buffer cycle compensation
+# ---------------------------------------------------------------------------
+
+
+def _build_buffer_cycle(seed: int, params: Dict[str, Any]) -> Dict[str, Any]:
+    rng = _rng(seed, SCENARIO_BUFFER_CYCLE)
+    case = _CaseBuilder("seq_buffer_cycle_000", SCENARIO_BUFFER_CYCLE)
+    span_days = params["span_days"]
+    sessions = params["sessions"]
+    fact_sets = params["fact_sets"]
+
+    dates = _spread_dates(rng, span_days, sessions)
+    start = dates[0]
+    early_indices = [i for i, d in enumerate(dates) if (d - start).days < EARLY_WINDOW_DAYS]
+    recent_indices = [
+        i for i, d in enumerate(dates) if (d - start).days >= span_days - EARLY_WINDOW_DAYS
+    ]
+
+    company = rng.choice(COMPANIES)
+    firsts = rng.sample(FIRST_NAMES, min(len(FIRST_NAMES), 4 * fact_sets + 2))
+    lasts = rng.sample(LAST_NAMES, min(len(LAST_NAMES), 4 * fact_sets + 2))
+    people = [f"{first} {last}" for first, last in zip(firsts, lasts)]
+    technologies = list(TECHNOLOGIES)
+    projects = ["checkout service", "payments integration", "auth migration", "search revamp"]
+
+    writers = [
+        _SessionWriter(case.case_id, index, dates[index], "membench-agent")
+        for index in range(sessions)
+    ]
+    case.writers = writers
+
+    # Opening filler so fact turns never sit at turn index 0.
+    for index, writer in enumerate(writers):
+        writer.add_filler(1, salt=index * 2)
+
+    person_cursor = 0
+    code_cursor = 0
+
+    def _employment(writer: _SessionWriter, category: str) -> None:
+        nonlocal person_cursor
+        person = people[person_cursor % len(people)]
+        person_cursor += 1
+        role = ROLES[person_cursor % len(ROLES)]
+        email = _email_for(person, company)
+        turn_id = writer.add(
+            "user",
+            f"For the record: {person} is our {role} at {company}. "
+            f"You can reach them at {email}.",
+        )
+        writer.add("assistant", f"Noted. {person} ({role}, {company}) with contact {email}.")
+        case.entity(writer, turn_id, person, "person", {"role": role, "email": email})
+        case.entity(writer, turn_id, company, "company")
+        case.relationship(
+            writer, turn_id, person, "person", "works_at", company, "company", {"role": role}
+        )
+        case.log_day(writer, f"logged {person} as {role}")
+        case.question(
+            category,
+            f"What is {person}'s email address?",
+            email,
+            [(writer.session_id, turn_id)],
+            exact_strings=[email],
+        )
+
+    def _recommendation(writer: _SessionWriter, category: str) -> None:
+        nonlocal person_cursor
+        person = people[person_cursor % len(people)]
+        person_cursor += 1
+        tech = technologies[person_cursor % len(technologies)]
+        project = projects[person_cursor % len(projects)]
+        decision = f"Adopt {tech} for the {project} ({person}'s recommendation)"
+        turn_id = writer.add(
+            "user",
+            f"{person} recommended switching to {tech} for the {project}. Let's go with that.",
+        )
+        writer.add(
+            "assistant",
+            f"Decision recorded: {tech} for the {project}, recommended by {person}.",
+        )
+        case.entity(writer, turn_id, person, "person")
+        case.entity(writer, turn_id, tech, "topic")
+        case.entity(writer, turn_id, project, "project")
+        case.relationship(
+            writer, turn_id, person, "person", "recommended", tech, "topic", {"project": project}
+        )
+        case.log_day(
+            writer,
+            f"{person} recommended {tech} for the {project}",
+            decision=decision,
+            project=project,
+        )
+        case.question(
+            category,
+            f"Who recommended using {tech} for the {project}?",
+            person,
+            [(writer.session_id, turn_id)],
+        )
+
+    def _code_fact(writer: _SessionWriter, category: str) -> None:
+        nonlocal person_cursor, code_cursor
+        person = people[person_cursor % len(people)]
+        person_cursor += 1
+        kind, prefix = [("invoice", "INV"), ("support ticket", "TKT")][code_cursor % 2]
+        code_cursor += 1
+        code = _code(rng, prefix)
+        project = projects[code_cursor % len(projects)]
+        turn_id = writer.add(
+            "user",
+            f"{person} opened {kind} {code} for the {project}. Keep that reference handy.",
+        )
+        writer.add("assistant", f"Saved: {kind} {code} ({project}, opened by {person}).")
+        case.entity(writer, turn_id, person, "person")
+        case.entity(writer, turn_id, code, "reference", {"kind": kind, "project": project})
+        case.relationship(
+            writer,
+            turn_id,
+            person,
+            "person",
+            "opened",
+            code,
+            "reference",
+            {"kind": kind, "project": project},
+        )
+        case.log_day(writer, f"{person} opened {kind} {code}")
+        case.question(
+            category,
+            f"What was the reference number of the {kind} {person} opened for the {project}?",
+            code,
+            [(writer.session_id, turn_id)],
+            exact_strings=[code],
+        )
+
+    # Early-window facts (Scenario A's subject: asked at "day 30" after
+    # their source turns have been evicted).
+    early_events = (
+        [_employment] * (2 * fact_sets) + [_recommendation] * fact_sets + [_code_fact] * fact_sets
+    )
+    for event_index, event in enumerate(early_events):
+        writer = writers[early_indices[event_index % len(early_indices)]]
+        event(writer, CATEGORY_EVICTED)
+
+    # Recent-window control facts (still buffer-resident at question time).
+    recent_events = [_employment, _code_fact] * fact_sets
+    for event_index, event in enumerate(recent_events):
+        writer = writers[recent_indices[event_index % len(recent_indices)]]
+        event(writer, CATEGORY_RECENT)
+
+    # Narrative questions: the decisions of each decision-bearing day
+    # (Captain's-Log recall; answers list every decision of the date).
+    decisions_by_date: Dict[str, List[Dict[str, Any]]] = {}
+    for decision in case.decisions:
+        decisions_by_date.setdefault(decision["date"], []).append(decision)
+    early_cutoff = _iso(dates[0] + timedelta(days=EARLY_WINDOW_DAYS - 1))
+    recent_cutoff = _iso(dates[0] + timedelta(days=span_days - EARLY_WINDOW_DAYS))
+    for day in sorted(decisions_by_date):
+        if day <= early_cutoff:
+            category = CATEGORY_EVICTED
+        elif day >= recent_cutoff:
+            category = CATEGORY_RECENT
+        else:
+            continue
+        day_decisions = decisions_by_date[day]
+        case.question(
+            category,
+            f"What were the main decisions made on {day}?",
+            "; ".join(item["decision"] for item in day_decisions),
+            [(item["session_id"], None) for item in day_decisions],
+            date_from=day,
+            date_to=day,
+        )
+
+    # Filler workload: the conversation-heavy noise that cycles the buffer.
+    for index, writer in enumerate(writers):
+        writer.add_filler(max(0, params["filler_exchanges"] - 1), salt=index * 2 + 1)
+
+    return case.build(
+        extra_ground_truth={
+            "early_window": {
+                "date_from": _iso(dates[0]),
+                "date_to": _iso(dates[0] + timedelta(days=EARLY_WINDOW_DAYS - 1)),
+            }
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenario B: cross-agent knowledge propagation
+# ---------------------------------------------------------------------------
+
+
+def _build_cross_agent(seed: int, params: Dict[str, Any]) -> Dict[str, Any]:
+    rng = _rng(seed, SCENARIO_CROSS_AGENT)
+    case = _CaseBuilder("seq_cross_agent_000", SCENARIO_CROSS_AGENT)
+    sessions = params["sessions"]
+    dates = _spread_dates(rng, params["span_days"], sessions)
+
+    agents = list(CROSS_AGENT_AGENTS)
+    writers = [
+        _SessionWriter(case.case_id, index, dates[index], agents[index % len(agents)])
+        for index in range(sessions)
+    ]
+    case.writers = writers
+    writers_by_agent: Dict[str, List[_SessionWriter]] = {}
+    for writer in writers:
+        writers_by_agent.setdefault(writer.agent_id, []).append(writer)
+
+    firsts = rng.sample(FIRST_NAMES, 6)
+    lasts = rng.sample(LAST_NAMES, 6)
+    people = [f"{first} {last}" for first, last in zip(firsts, lasts)]
+    technologies = list(TECHNOLOGIES)
+    projects = ["pricing revamp", "enterprise pipeline", "search revamp", "partner program"]
+
+    artifact_names = list(CROSS_AGENT_ARTIFACTS)
+    artifact_cursor = 0
+    fact_cursor = 0
+
+    for set_index in range(params["artifact_sets"]):
+        for agent_index, agent in enumerate(agents):
+            asking_agent = agents[(agent_index + 1) % len(agents)]
+            own_writers = writers_by_agent[agent]
+            writer = own_writers[set_index % len(own_writers)]
+
+            # The agent produces an artifact in its own session.
+            artifact = artifact_names[artifact_cursor % len(artifact_names)]
+            artifact_cursor += 1
+            reference = _code(rng, "DOC")
+            turn_id = writer.add(
+                "user",
+                f"For the record: the {agent} produced the {artifact} today "
+                f"and filed it under reference {reference}.",
+            )
+            writer.add("assistant", f"Logged - {artifact} delivered by the {agent}.")
+            case.entity(writer, turn_id, agent, "agent")
+            case.entity(writer, turn_id, artifact, "artifact", {"reference": reference})
+            case.relationship(
+                writer,
+                turn_id,
+                agent,
+                "agent",
+                "produced",
+                artifact,
+                "artifact",
+                {"reference": reference},
+            )
+            case.log_day(writer, f"the {agent} delivered the {artifact}")
+            case.artifacts.append(
+                {
+                    "name": artifact,
+                    "agent": agent,
+                    "reference": reference,
+                    "session_id": writer.session_id,
+                    "turn_id": turn_id,
+                }
+            )
+            meta = {"evidence_agent": agent, "asking_agent": asking_agent}
+            case.question(
+                CATEGORY_PROPAGATION,
+                f"Which agent produced the {artifact}?",
+                agent,
+                [(writer.session_id, turn_id)],
+                meta=meta,
+            )
+            case.question(
+                CATEGORY_PROPAGATION,
+                f"Under what reference number was the {artifact} filed?",
+                reference,
+                [(writer.session_id, turn_id)],
+                exact_strings=[reference],
+                meta=meta,
+            )
+
+            # The agent also logs a KG fact another agent must recall.
+            # (tech, project) pairs stay unique across the corpus so
+            # "who recommended X for Y" always has exactly one answer.
+            person = people[fact_cursor % len(people)]
+            tech = technologies[fact_cursor % len(technologies)]
+            project = projects[(fact_cursor + fact_cursor // len(technologies)) % len(projects)]
+            fact_cursor += 1
+            fact_turn = writer.add(
+                "user",
+                f"{person} recommended {tech} for the {project}; the {agent} "
+                f"confirmed it in review.",
+            )
+            writer.add("assistant", f"Recorded: {tech} for the {project}, per {person}.")
+            case.entity(writer, fact_turn, person, "person")
+            case.entity(writer, fact_turn, tech, "topic")
+            case.entity(writer, fact_turn, project, "project")
+            case.relationship(
+                writer,
+                fact_turn,
+                person,
+                "person",
+                "recommended",
+                tech,
+                "topic",
+                {"project": project},
+            )
+            case.log_day(
+                writer,
+                f"{person} recommended {tech} for the {project}",
+                decision=f"Adopt {tech} for the {project} ({person}'s recommendation)",
+                project=project,
+            )
+            case.question(
+                CATEGORY_PROPAGATION,
+                f"Who recommended {tech} for the {project}?",
+                person,
+                [(writer.session_id, fact_turn)],
+                meta=meta,
+            )
+
+    for index, writer in enumerate(writers):
+        writer.add_filler(params["filler_exchanges"], salt=index)
+
+    return case.build(extra_ground_truth={"agents": agents})
+
+
+# ---------------------------------------------------------------------------
+# Scenario C: multi-user isolation
+# ---------------------------------------------------------------------------
+
+
+def _canary(rng: random.Random, user_index: int) -> str:
+    letters = "".join(rng.choice("ABCDEFGHJKMNPQRSTUVWXYZ") for _ in range(2))
+    return f"CANARY-{user_index:03d}-{rng.randint(1000, 9999)}{letters}"
+
+
+def _build_isolation_user(seed: int, user_index: int, params: Dict[str, Any]) -> Dict[str, Any]:
+    rng = _rng(seed, SCENARIO_ISOLATION, user_index)
+    case = _CaseBuilder(f"seq_isolation_{user_index:03d}", SCENARIO_ISOLATION)
+    sessions = params["sessions_per_user"]
+    dates = _spread_dates(rng, params["span_days"], sessions)
+
+    writers = [
+        _SessionWriter(case.case_id, index, dates[index], "membench-agent")
+        for index in range(sessions)
+    ]
+    case.writers = writers
+
+    # Identical fact templates across users — only the values differ.
+    # If isolation broke, another user's near-identical turn would be
+    # the nearest neighbor for these probes.
+    person = (
+        f"{FIRST_NAMES[user_index % len(FIRST_NAMES)]} "
+        f"{LAST_NAMES[user_index % len(LAST_NAMES)]}"
+    )
+    company = COMPANIES[user_index % len(COMPANIES)]
+    city = CITIES[user_index % len(CITIES)]
+    email = _email_for(person, company)
+    locker_canary = _canary(rng, user_index)
+    ticket_canary = _canary(rng, user_index)
+    case.canaries = [locker_canary, ticket_canary, email]
+
+    writer = writers[0]
+    turn_id = writer.add(
+        "user",
+        f"Please remember: my private locker code is {locker_canary}.",
+    )
+    writer.add("assistant", f"Stored your private locker code {locker_canary}.")
+    case.entity(writer, turn_id, locker_canary, "reference", {"kind": "locker code"})
+    case.log_day(writer, f"stored private locker code {locker_canary}")
+    case.question(
+        CATEGORY_ISOLATION_PROBE,
+        "What is my private locker code?",
+        locker_canary,
+        [(writer.session_id, turn_id)],
+        exact_strings=[locker_canary],
+    )
+
+    writer = writers[1 % sessions]
+    turn_id = writer.add(
+        "user",
+        f"My main contact is {person} at {company}; email {email}.",
+    )
+    writer.add("assistant", f"Noted. {person} ({company}), contact {email}.")
+    case.entity(writer, turn_id, person, "person", {"email": email})
+    case.entity(writer, turn_id, company, "company")
+    case.relationship(writer, turn_id, person, "person", "works_at", company, "company")
+    case.log_day(writer, f"logged {person} ({company}) as main contact")
+    case.question(
+        CATEGORY_ISOLATION_PROBE,
+        "What is my main contact's email address?",
+        email,
+        [(writer.session_id, turn_id)],
+        exact_strings=[email],
+    )
+
+    writer = writers[2 % sessions]
+    turn_id = writer.add(
+        "user",
+        f"I filed my expense ticket under {ticket_canary}; {person} is based in {city}.",
+    )
+    writer.add("assistant", f"Saved ticket {ticket_canary}; {person} is based in {city}.")
+    case.entity(writer, turn_id, ticket_canary, "reference", {"kind": "expense ticket"})
+    case.entity(writer, turn_id, city, "location")
+    case.relationship(writer, turn_id, person, "person", "lives_in", city, "location")
+    case.log_day(writer, f"filed expense ticket {ticket_canary}")
+    case.question(
+        CATEGORY_ISOLATION_PROBE,
+        "Under what reference did I file my expense ticket?",
+        ticket_canary,
+        [(writer.session_id, turn_id)],
+        exact_strings=[ticket_canary],
+    )
+    case.question(
+        CATEGORY_ISOLATION_PROBE,
+        "Which city is my main contact based in?",
+        city,
+        [(writer.session_id, turn_id)],
+    )
+
+    for index, writer in enumerate(writers):
+        writer.add_filler(2, salt=user_index * 31 + index)
+
+    return case.build()
+
+
+# ---------------------------------------------------------------------------
+# Scenario D: contradiction detection over time
+# ---------------------------------------------------------------------------
+
+
+def _build_contradiction(seed: int, params: Dict[str, Any]) -> Dict[str, Any]:
+    rng = _rng(seed, SCENARIO_CONTRADICTION)
+    case = _CaseBuilder("seq_contradiction_000", SCENARIO_CONTRADICTION)
+    sessions = params["sessions"]
+    dates = _spread_dates(rng, params["span_days"], sessions)
+    writers = [
+        _SessionWriter(case.case_id, index, dates[index], "membench-agent")
+        for index in range(sessions)
+    ]
+    case.writers = writers
+
+    conflicted = params["conflicted"]
+    superseded = params["superseded"]
+    needed_people = conflicted + superseded + 2  # + distractor subjects
+    firsts = [FIRST_NAMES[i % len(FIRST_NAMES)] for i in range(needed_people)]
+    lasts = [LAST_NAMES[(i * 3 + 1) % len(LAST_NAMES)] for i in range(needed_people)]
+    people = [f"{first} {last}" for first, last in zip(firsts, lasts)]
+
+    def _assert_fact(
+        writer: _SessionWriter,
+        person: str,
+        predicate: str,
+        obj: str,
+        obj_type: str,
+        confidence: float,
+        phrasing: str,
+    ) -> str:
+        turn_id = writer.add("user", phrasing)
+        writer.add("assistant", f"Recorded: {person} {predicate.replace('_', ' ')} {obj}.")
+        case.entity(writer, turn_id, person, "person")
+        case.entity(writer, turn_id, obj, obj_type)
+        case.relationship(
+            writer,
+            turn_id,
+            person,
+            "person",
+            predicate,
+            obj,
+            obj_type,
+            confidence=confidence,
+        )
+        case.log_day(writer, f"noted {person} {predicate.replace('_', ' ')} {obj}")
+        return turn_id
+
+    # Alternate exclusive predicates across pairs; spread old/new facts
+    # across the timeline with a session gap between assertion and
+    # contradiction (the "over time" in the PRD's Scenario D).
+    pair_specs = [("conflicted", i) for i in range(conflicted)] + [
+        ("superseded", i) for i in range(superseded)
+    ]
+    gap = max(2, sessions // 3)
+    for pair_index, (kind, _) in enumerate(pair_specs):
+        person = people[pair_index]
+        predicate = ("works_at", "lives_in")[pair_index % 2]
+        if predicate == "works_at":
+            pool = COMPANIES
+            obj_type = "company"
+        else:
+            pool = CITIES
+            obj_type = "location"
+        old_obj = pool[(pair_index * 2) % len(pool)]
+        new_obj = pool[(pair_index * 2 + 1) % len(pool)]
+        old_slot = pair_index % max(1, sessions - gap)
+        new_slot = min(sessions - 1, old_slot + gap)
+
+        if kind == "conflicted":
+            old_confidence = CONFLICTED_OLD_CONFIDENCE
+            new_confidence = CONFLICTED_NEW_CONFIDENCE
+            new_phrasing = (
+                f"Wait - I heard {person} actually "
+                f"{'works at' if predicate == 'works_at' else 'lives in'} {new_obj}, "
+                f"not {old_obj}."
+            )
+        else:
+            old_confidence = SUPERSEDED_OLD_CONFIDENCE
+            new_confidence = SUPERSEDED_NEW_CONFIDENCE
+            new_phrasing = (
+                f"Confirmed by HR: {person} now "
+                f"{'works at' if predicate == 'works_at' else 'lives in'} {new_obj}."
+            )
+
+        old_turn = _assert_fact(
+            writers[old_slot],
+            person,
+            predicate,
+            old_obj,
+            obj_type,
+            old_confidence,
+            f"{person} {'works at' if predicate == 'works_at' else 'lives in'} {old_obj}.",
+        )
+        new_turn = _assert_fact(
+            writers[new_slot], person, predicate, new_obj, obj_type, new_confidence, new_phrasing
+        )
+        case.contradictions.append(
+            {
+                "subject": person,
+                "predicate": predicate,
+                "old_object": old_obj,
+                "new_object": new_obj,
+                "old_turn_id": old_turn,
+                "new_turn_id": new_turn,
+                "expected_detection": kind,
+            }
+        )
+
+    # Precision distractors: must NOT be flagged.
+    # 1. Duplicate re-assertion (same subject, predicate, AND object).
+    dup_person = people[len(pair_specs)]
+    dup_company = COMPANIES[3 % len(COMPANIES)]
+    first_turn = _assert_fact(
+        writers[0],
+        dup_person,
+        "works_at",
+        dup_company,
+        "company",
+        DEFAULT_FACT_CONFIDENCE,
+        f"{dup_person} works at {dup_company}.",
+    )
+    dup_turn = _assert_fact(
+        writers[-1],
+        dup_person,
+        "works_at",
+        dup_company,
+        "company",
+        DEFAULT_FACT_CONFIDENCE,
+        f"Just double-checking: {dup_person} still works at {dup_company}, right?",
+    )
+    case.distractors.append(
+        {
+            "kind": "duplicate_fact",
+            "subject": dup_person,
+            "predicate": "works_at",
+            "object": dup_company,
+            "turn_ids": [first_turn, dup_turn],
+        }
+    )
+
+    # 2. Non-exclusive predicate change (a person may recommend many
+    #    technologies; a changed object is an addition, not a conflict).
+    rec_person = people[len(pair_specs) + 1]
+    tech_a, tech_b = TECHNOLOGIES[0], TECHNOLOGIES[1]
+    rec_turn_a = writers[1].add(
+        "user", f"{rec_person} recommended {tech_a} for the checkout service."
+    )
+    writers[1].add("assistant", f"Recorded {rec_person}'s recommendation of {tech_a}.")
+    case.entity(writers[1], rec_turn_a, rec_person, "person")
+    case.entity(writers[1], rec_turn_a, tech_a, "topic")
+    case.relationship(writers[1], rec_turn_a, rec_person, "person", "recommended", tech_a, "topic")
+    rec_turn_b = writers[min(sessions - 1, 1 + gap)].add(
+        "user", f"{rec_person} now also recommends {tech_b} for the checkout service."
+    )
+    writers[min(sessions - 1, 1 + gap)].add(
+        "assistant", f"Recorded {rec_person}'s recommendation of {tech_b}."
+    )
+    case.entity(writers[min(sessions - 1, 1 + gap)], rec_turn_b, tech_b, "topic")
+    case.relationship(
+        writers[min(sessions - 1, 1 + gap)],
+        rec_turn_b,
+        rec_person,
+        "person",
+        "recommended",
+        tech_b,
+        "topic",
+    )
+    case.distractors.append(
+        {
+            "kind": "non_exclusive_change",
+            "subject": rec_person,
+            "predicate": "recommended",
+            "objects": [tech_a, tech_b],
+            "turn_ids": [rec_turn_a, rec_turn_b],
+        }
+    )
+
+    for index, writer in enumerate(writers):
+        writer.add_filler(2, salt=index)
+
+    return case.build()
+
+
+# ---------------------------------------------------------------------------
+# Dataset assembly
+# ---------------------------------------------------------------------------
+
+
+def generate_dataset(preset: str = "fixture", seed: int = DEFAULT_SEED) -> Dict[str, Any]:
+    """Generate the Tier 3 longitudinal dataset as a plain dict.
+
+    Deterministic: identical ``(preset, seed)`` produce an identical
+    dict (and, through :func:`write_dataset`, byte-identical files).
+    """
+    if preset not in PRESETS:
+        raise ValueError(f"Unknown preset {preset!r} (expected one of {sorted(PRESETS)})")
+    params = PRESETS[preset]
+
+    scenarios: Dict[str, Any] = {
+        SCENARIO_BUFFER_CYCLE: {
+            "config": dict(params[SCENARIO_BUFFER_CYCLE]),
+            "cases": [_build_buffer_cycle(seed, params[SCENARIO_BUFFER_CYCLE])],
+        },
+        SCENARIO_CROSS_AGENT: {
+            "config": dict(params[SCENARIO_CROSS_AGENT]),
+            "cases": [_build_cross_agent(seed, params[SCENARIO_CROSS_AGENT])],
+        },
+        SCENARIO_ISOLATION: {
+            "config": dict(params[SCENARIO_ISOLATION]),
+            "cases": [
+                _build_isolation_user(seed, user_index, params[SCENARIO_ISOLATION])
+                for user_index in range(params[SCENARIO_ISOLATION]["users"])
+            ],
+        },
+        SCENARIO_CONTRADICTION: {
+            "config": dict(params[SCENARIO_CONTRADICTION]),
+            "cases": [_build_contradiction(seed, params[SCENARIO_CONTRADICTION])],
+        },
+    }
+    return {
+        "name": DATASET_NAME,
+        "schema_version": DATASET_SCHEMA_VERSION,
+        "generator": {"preset": preset, "seed": seed, "scenarios": list(SCENARIOS)},
+        "scenarios": scenarios,
+    }
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate the Tier 3 longitudinal corpus (four PRD scenarios; "
+            "deterministic, seeded, no LLM calls)."
+        )
+    )
+    parser.add_argument("--preset", choices=sorted(PRESETS), default="fixture")
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--output", required=True, help="Output JSON path.")
+    args = parser.parse_args(argv)
+
+    dataset = generate_dataset(preset=args.preset, seed=args.seed)
+    path = write_dataset(dataset, Path(args.output))
+    for key, scenario in dataset["scenarios"].items():
+        cases = scenario["cases"]
+        sessions = sum(len(case["sessions"]) for case in cases)
+        turns = sum(len(s["turns"]) for case in cases for s in case["sessions"])
+        questions = sum(len(case["questions"]) for case in cases)
+        print(
+            f"  {key:<16} cases={len(cases):<4} sessions={sessions:<5} "
+            f"turns={turns:<6} questions={questions}"
+        )
+    print(f"Wrote {path} (preset={args.preset}, seed={args.seed})")
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    if __package__ in (None, ""):
+        sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    sys.exit(main())

--- a/bench/memory/longitudinal_dataset.py
+++ b/bench/memory/longitudinal_dataset.py
@@ -1,0 +1,190 @@
+"""Loader for the Tier 3 longitudinal dataset.
+
+The dataset file is produced by :mod:`bench.memory.longitudinal_corpus`
+(committed fixture sample or a full generated run). Loading yields one
+:class:`LongitudinalScenario` per PRD scenario:
+
+- A :class:`~bench.memory.datasets.BenchmarkDataset` in the exact
+  Tier 1/2 shape (cases -> sessions -> turns, questions with evidence
+  ids), so the shared adapter/scoring/report machinery applies
+  unchanged. Question categories map onto ``question_type``.
+- A :class:`LongitudinalGroundTruth` per case: the Tier 2 manifest
+  (entities, relationships with per-fact confidence and turn-level
+  provenance, Captain's-Log entries, contradictions) plus the Tier 3
+  extras — decisions (zero-lost-decisions audit), artifacts
+  (zero-orphan audit), canaries (isolation leak detection),
+  ``question_meta`` (asking/evidence agent pairs), and expected
+  contradiction detection kinds.
+- The scenario's generator ``config`` (isolation user count, target
+  retrieval-op count, corpus spans) for the runner.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Tuple, Union
+
+from .datasets import BenchmarkCase, BenchmarkDataset, Question, Session, Turn
+from .longitudinal_corpus import CATEGORIES, DATASET_NAME, SCENARIOS
+
+BENCHMARK_NAME = "longitudinal"
+
+
+@dataclass(frozen=True)
+class LongitudinalGroundTruth:
+    """Per-case manifest consumed by the longitudinal runner."""
+
+    case_id: str
+    scenario: str
+    entities: Tuple[Dict[str, Any], ...] = ()
+    relationships: Tuple[Dict[str, Any], ...] = ()
+    log_entries: Tuple[Dict[str, Any], ...] = ()
+    contradictions: Tuple[Dict[str, Any], ...] = ()
+    distractors: Tuple[Dict[str, Any], ...] = ()
+    decisions: Tuple[Dict[str, Any], ...] = ()
+    artifacts: Tuple[Dict[str, Any], ...] = ()
+    canaries: Tuple[str, ...] = ()
+    question_meta: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    # session_id -> date, for mapping log entries back to sessions.
+    session_dates: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class LongitudinalScenario:
+    """One PRD scenario: dataset + ground truth + generator config."""
+
+    key: str
+    config: Dict[str, Any]
+    dataset: BenchmarkDataset
+    ground_truth: Dict[str, LongitudinalGroundTruth]
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _load_case(raw_case: Dict[str, Any]) -> Tuple[BenchmarkCase, LongitudinalGroundTruth]:
+    case_id = str(raw_case["case_id"])
+
+    sessions: List[Session] = []
+    session_dates: Dict[str, str] = {}
+    for raw_session in raw_case.get("sessions") or []:
+        session_id = str(raw_session["session_id"])
+        session_date = raw_session.get("date")
+        if session_date:
+            session_dates[session_id] = str(session_date)
+        turns = tuple(
+            Turn(
+                turn_id=f"{session_id}:{turn_index}",
+                role=str(raw_turn.get("role", "user")),
+                content=str(raw_turn.get("content", "")),
+            )
+            for turn_index, raw_turn in enumerate(raw_session.get("turns") or [])
+        )
+        sessions.append(
+            Session(
+                session_id=session_id,
+                turns=turns,
+                date=str(session_date) if session_date is not None else None,
+            )
+        )
+
+    questions: List[Question] = []
+    for raw_question in raw_case.get("questions") or []:
+        category = str(raw_question.get("category", "unknown"))
+        _require(
+            category in CATEGORIES,
+            f"Question {raw_question.get('question_id')}: unknown category {category!r}",
+        )
+        questions.append(
+            Question(
+                question_id=str(raw_question["question_id"]),
+                question=str(raw_question.get("question", "")),
+                answer=(
+                    str(raw_question["answer"]) if raw_question.get("answer") is not None else None
+                ),
+                question_type=category,
+                evidence_session_ids=tuple(
+                    str(s) for s in (raw_question.get("evidence_session_ids") or [])
+                ),
+                evidence_turn_ids=tuple(
+                    str(t) for t in (raw_question.get("evidence_turn_ids") or [])
+                ),
+                exact_strings=tuple(str(s) for s in (raw_question.get("exact_strings") or [])),
+                date_from=(
+                    str(raw_question["date_from"]) if raw_question.get("date_from") else None
+                ),
+                date_to=(str(raw_question["date_to"]) if raw_question.get("date_to") else None),
+            )
+        )
+
+    raw_truth = raw_case.get("ground_truth") or {}
+    truth = LongitudinalGroundTruth(
+        case_id=case_id,
+        scenario=str(raw_case.get("scenario", "unknown")),
+        entities=tuple(raw_truth.get("entities") or ()),
+        relationships=tuple(raw_truth.get("relationships") or ()),
+        log_entries=tuple(raw_truth.get("log_entries") or ()),
+        contradictions=tuple(raw_truth.get("contradictions") or ()),
+        distractors=tuple(raw_truth.get("distractors") or ()),
+        decisions=tuple(raw_truth.get("decisions") or ()),
+        artifacts=tuple(raw_truth.get("artifacts") or ()),
+        canaries=tuple(str(c) for c in (raw_truth.get("canaries") or ())),
+        question_meta=dict(raw_truth.get("question_meta") or {}),
+        session_dates=session_dates,
+    )
+    case = BenchmarkCase(
+        case_id=case_id,
+        sessions=tuple(sessions),
+        questions=tuple(questions),
+    )
+    return case, truth
+
+
+def load_longitudinal(path: Union[str, Path]) -> Dict[str, LongitudinalScenario]:
+    """Load a longitudinal dataset file.
+
+    Returns ``{scenario_key: LongitudinalScenario}`` for every scenario
+    present in the file (all four for generator output).
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Dataset file not found: {path}")
+    with open(path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+
+    _require(isinstance(data, dict), "Longitudinal dataset file must be a JSON object")
+    _require(
+        data.get("name") == DATASET_NAME,
+        f"Unexpected dataset name: {data.get('name')!r} (expected {DATASET_NAME!r})",
+    )
+    raw_scenarios = data.get("scenarios")
+    _require(
+        isinstance(raw_scenarios, dict) and bool(raw_scenarios),
+        "Dataset contains no scenarios",
+    )
+
+    scenarios: Dict[str, LongitudinalScenario] = {}
+    for key, raw_scenario in raw_scenarios.items():
+        _require(key in SCENARIOS, f"Unknown scenario {key!r} (expected one of {SCENARIOS})")
+        raw_cases = raw_scenario.get("cases")
+        _require(
+            isinstance(raw_cases, list) and bool(raw_cases),
+            f"Scenario {key!r} contains no cases",
+        )
+        cases: List[BenchmarkCase] = []
+        ground_truth: Dict[str, LongitudinalGroundTruth] = {}
+        for raw_case in raw_cases:
+            case, truth = _load_case(raw_case)
+            cases.append(case)
+            ground_truth[case.case_id] = truth
+        scenarios[key] = LongitudinalScenario(
+            key=key,
+            config=dict(raw_scenario.get("config") or {}),
+            dataset=BenchmarkDataset(name=f"{BENCHMARK_NAME}_{key}", cases=tuple(cases)),
+            ground_truth=ground_truth,
+        )
+    return scenarios

--- a/bench/memory/longitudinal_runner.py
+++ b/bench/memory/longitudinal_runner.py
@@ -1,0 +1,691 @@
+#!/usr/bin/env python3
+"""Longitudinal benchmark runner (Tier 3).
+
+Runs the four PRD Tier 3 scenarios against a real MUXI formation
+(memory-benchmarking PRD, "Multi-Session Longitudinal"):
+
+- ``buffer_cycle`` (A) — sessions replayed into the real working-memory
+  buffer under a small memory budget so the FIFO cleanup evicts the
+  early days (exercising the pre-compaction flush hand-off); questions
+  about day 1-5 facts are then answered from the persisted layers
+  (KG + Captain's Log manifest ingestion, Tier 2 style) with a
+  working-memory baseline alongside, plus the zero-lost-decisions
+  audit.
+- ``cross_agent`` (B) — knowledge produced in one agent's sessions is
+  queried "via" other agents; zero-artifact-orphans audit.
+- ``isolation`` (C) — every user's memory ingested side by side
+  (working + persistent + KG + log); retrieval operations are then
+  audited for cross-user canary/session leaks. Pass/fail.
+- ``contradiction`` (D) — the manifest replayed per-session through
+  the live ``store_extraction`` path with per-fact confidences; the
+  KG's conflict/supersede flags are audited against the injected
+  pairs (precision / recall / detection-kind accuracy), the memory
+  event substrate's ``fact.contradicted`` events are tallied, and the
+  audit is repeated after a knowledge-graph projection rebuild from
+  the event log (replay consistency).
+
+Every scenario is failure-isolated and writes its own report; the
+process exits nonzero when any scenario was partial or errored.
+Each scenario boots its own formation, and ``--scenario all`` runs
+one subprocess per scenario: the runtime's database manager is a
+process-level singleton, so two formations in one process would
+silently share the first run's (already removed) SQLite path.
+
+Usage
+-----
+::
+
+    # Committed fixture corpus (CI-safe, no downloads, retrieval-only = $0)
+    uv run python -m bench.memory.longitudinal_runner --fixture
+
+    # One scenario, with end-to-end QA accuracy
+    uv run python -m bench.memory.longitudinal_runner --fixture \
+        --scenario buffer_cycle --qa
+
+    # Full corpus (PRD scale)
+    uv run python -m bench.memory.longitudinal_corpus --preset full \
+        --output ~/datasets/membench/longitudinal_full.json
+    uv run python -m bench.memory.longitudinal_runner \
+        --dataset ~/datasets/membench/longitudinal_full.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+if __package__ in (None, ""):  # direct script invocation
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from bench.memory.adapter import DEFAULT_FORMATION_YAML  # noqa: E402
+from bench.memory.datasets import BenchmarkCase, Question  # noqa: E402
+from bench.memory.longitudinal_adapter import LongitudinalMemoryAdapter  # noqa: E402
+from bench.memory.longitudinal_corpus import (  # noqa: E402
+    SCENARIO_BUFFER_CYCLE,
+    SCENARIO_CONTRADICTION,
+    SCENARIO_CROSS_AGENT,
+    SCENARIO_ISOLATION,
+    SCENARIOS,
+)
+from bench.memory.longitudinal_dataset import (  # noqa: E402
+    BENCHMARK_NAME,
+    LongitudinalScenario,
+    load_longitudinal,
+)
+from bench.memory.longitudinal_scoring import (  # noqa: E402
+    LAYER_STRUCTURED,
+    LAYER_WORKING,
+    IsolationOpResult,
+    LongitudinalQuestionResult,
+    aggregate_buffer_cycle,
+    aggregate_contradiction,
+    aggregate_cross_agent,
+    aggregate_isolation,
+    find_leaks,
+    render_longitudinal_extras,
+)
+from bench.memory.report import build_report, render_summary, write_report  # noqa: E402
+from bench.memory.runner import FIXTURES_DIR, REPO_ROOT, RESULTS_DIR  # noqa: E402
+from bench.memory.structured_adapter import STRUCTURED_MODE  # noqa: E402
+from bench.memory.structured_scoring import exact_string_rank  # noqa: E402
+
+DEFAULT_K = 5
+FIXTURE_FILENAME = "longitudinal_sample.json"
+
+# Scenario A default working-memory budget: small enough that the
+# fixture corpus (a few hundred turns at ~3 KB/item with 768-dim
+# embeddings) cycles the buffer several times.
+DEFAULT_BUFFER_MAX_MB = 0.4
+
+ISOLATION_OP_KINDS = ("vector_search", "graph", "log")
+
+
+def fixture_path() -> Path:
+    return FIXTURES_DIR / FIXTURE_FILENAME
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the Tier 3 longitudinal benchmark (four PRD scenarios) "
+            "against a real MUXI formation. Defaults to the committed "
+            "fixture corpus; generate a full dataset with "
+            "bench.memory.longitudinal_corpus for publishable numbers."
+        )
+    )
+    parser.add_argument(
+        "--dataset",
+        default=None,
+        help="Path to a longitudinal dataset JSON (default: committed fixture).",
+    )
+    parser.add_argument(
+        "--fixture", action="store_true", help="Force the committed fixture sample."
+    )
+    parser.add_argument(
+        "--scenario",
+        choices=("all",) + SCENARIOS,
+        default="all",
+        help="Scenario to run (default: all four).",
+    )
+    parser.add_argument("--k", type=int, default=DEFAULT_K, help="Recall@K cutoff.")
+    parser.add_argument(
+        "--fetch-limit",
+        type=int,
+        default=None,
+        help="Results fetched per query (default: max(25, 5*k)).",
+    )
+    parser.add_argument(
+        "--qa",
+        action="store_true",
+        help=(
+            "Also measure end-to-end QA accuracy on scenarios A/B "
+            "(answer + LLM judge; costs tokens)."
+        ),
+    )
+    parser.add_argument(
+        "--qa-context",
+        type=int,
+        default=10,
+        help="Retrieved excerpts injected into the QA answer prompt.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Run only the first N questions per case (smoke runs).",
+    )
+    parser.add_argument(
+        "--buffer-max-mb",
+        type=float,
+        default=DEFAULT_BUFFER_MAX_MB,
+        help=(
+            "Scenario A working-memory budget in MB; must be small enough "
+            "that the corpus cycles the buffer (checked via the "
+            "evidence_evicted_fraction metric)."
+        ),
+    )
+    parser.add_argument(
+        "--flush-digest",
+        action="store_true",
+        help=(
+            "Let the pre-compaction flush run its real silent-turn LLM "
+            "digest during Scenario A (costs tokens, nondeterministic; "
+            "default counts trigger/hand-off mechanics only)."
+        ),
+    )
+    parser.add_argument(
+        "--isolation-ops",
+        type=int,
+        default=None,
+        help=(
+            "Scenario C retrieval-operation count (default: the dataset's "
+            "target_ops — 10,000 at PRD full scale)."
+        ),
+    )
+    parser.add_argument("--formation", default=str(DEFAULT_FORMATION_YAML))
+    parser.add_argument("--run-dir", default=None)
+    parser.add_argument(
+        "--keep-run-dir",
+        action="store_true",
+        help="Keep the temp run dir (also honored via MUXI_BENCH_KEEP_RUN_DIR=1).",
+    )
+    parser.add_argument("--secrets-dir", default=None)
+    parser.add_argument(
+        "--output",
+        default=None,
+        help=(
+            "Report JSON path (single-scenario runs only; default: "
+            f"bench/memory/results/{BENCHMARK_NAME}_fixture_<scenario>.json "
+            "for fixture runs, timestamped otherwise)."
+        ),
+    )
+    return parser
+
+
+def default_output_path(scenario: str, used_fixture: bool) -> Path:
+    if used_fixture:
+        return RESULTS_DIR / f"{BENCHMARK_NAME}_fixture_{scenario}.json"
+    stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    return RESULTS_DIR / f"{BENCHMARK_NAME}_{scenario}_{stamp}.json"
+
+
+def _case_questions(case: BenchmarkCase, limit: Optional[int]) -> Tuple[Question, ...]:
+    return case.questions[:limit] if limit is not None else case.questions
+
+
+def _new_result(
+    question: Question, layer: str, evidence_evicted: Optional[bool] = None
+) -> LongitudinalQuestionResult:
+    return LongitudinalQuestionResult(
+        question_id=(
+            f"{question.question_id}#{layer}" if layer != LAYER_STRUCTURED else question.question_id
+        ),
+        question_type=question.question_type,
+        is_abstention=question.is_abstention,
+        evidence_session_ids=list(question.evidence_session_ids),
+        evidence_turn_ids=list(question.evidence_turn_ids),
+        category=question.question_type,
+        exact_strings=list(question.exact_strings),
+        layer=layer,
+        evidence_evicted=evidence_evicted,
+    )
+
+
+async def _score_retrieval(
+    adapter: LongitudinalMemoryAdapter,
+    result: LongitudinalQuestionResult,
+    question: Question,
+    items,
+    qa: bool,
+    qa_context: int,
+) -> None:
+    result.retrieved_session_ids = adapter.ranked_session_ids(items)
+    result.retrieved_turn_ids = adapter.ranked_turn_ids(items)
+    if question.exact_strings:
+        result.exact_string_rank = exact_string_rank(
+            [item.text for item in items], question.exact_strings
+        )
+    if qa:
+        predicted = await adapter.answer_question(question, items, context_limit=qa_context)
+        result.qa_answer = predicted
+        result.qa_correct = await adapter.judge_answer(question, predicted)
+
+
+# ---------------------------------------------------------------------------
+# Scenario A: buffer cycle compensation
+# ---------------------------------------------------------------------------
+
+
+async def _scenario_buffer_cycle(
+    adapter: LongitudinalMemoryAdapter,
+    scenario: LongitudinalScenario,
+    args: argparse.Namespace,
+    fetch_limit: int,
+) -> Tuple[Dict[str, Any], List[LongitudinalQuestionResult]]:
+    results: List[LongitudinalQuestionResult] = []
+    decision_items = []
+    for case in scenario.dataset.cases:
+        adapter.clear_case()
+        user_id = f"bench-{BENCHMARK_NAME}-{case.case_id}"
+        truth = scenario.ground_truth[case.case_id]
+
+        # Persisted layers get the ground-truth manifest (Tier 2 style:
+        # isolates structured recall from extraction quality); the
+        # buffer gets the raw turns, session by session, under the
+        # cycling budget.
+        await adapter.ingest_ground_truth(user_id, truth)
+        for session in case.sessions:
+            await adapter.ingest_session_buffer(user_id, session)
+        resident = adapter.buffer_resident_turn_ids()
+
+        for question in _case_questions(case, args.limit):
+            evidence_evicted = (
+                all(turn_id not in resident for turn_id in question.evidence_turn_ids)
+                if question.evidence_turn_ids
+                else None
+            )
+
+            structured = _new_result(question, LAYER_STRUCTURED, evidence_evicted)
+            started = time.monotonic()
+            try:
+                items = await adapter.search_question(user_id, question, fetch_limit)
+                await _score_retrieval(
+                    adapter, structured, question, items, args.qa, args.qa_context
+                )
+            except Exception as exc:
+                structured.error = f"{type(exc).__name__}: {exc}"
+            structured.elapsed_seconds = round(time.monotonic() - started, 3)
+            results.append(structured)
+
+            working = _new_result(question, LAYER_WORKING, evidence_evicted)
+            started = time.monotonic()
+            try:
+                items = await adapter.search_working(user_id, question.question, fetch_limit)
+                await _score_retrieval(adapter, working, question, items, False, args.qa_context)
+            except Exception as exc:
+                working.error = f"{type(exc).__name__}: {exc}"
+            working.elapsed_seconds = round(time.monotonic() - started, 3)
+            results.append(working)
+
+        decision_items.extend(await adapter.audit_decisions(user_id, truth))
+
+    metrics = aggregate_buffer_cycle(
+        results, args.k, adapter.eviction_stats(), adapter.flush_stats(), decision_items
+    )
+    return metrics, results
+
+
+# ---------------------------------------------------------------------------
+# Scenario B: cross-agent knowledge propagation
+# ---------------------------------------------------------------------------
+
+
+async def _scenario_cross_agent(
+    adapter: LongitudinalMemoryAdapter,
+    scenario: LongitudinalScenario,
+    args: argparse.Namespace,
+    fetch_limit: int,
+) -> Tuple[Dict[str, Any], List[LongitudinalQuestionResult]]:
+    results: List[LongitudinalQuestionResult] = []
+    artifact_items = []
+    for case in scenario.dataset.cases:
+        adapter.clear_case()
+        user_id = f"bench-{BENCHMARK_NAME}-{case.case_id}"
+        truth = scenario.ground_truth[case.case_id]
+        await adapter.ingest_ground_truth(user_id, truth)
+
+        for question in _case_questions(case, args.limit):
+            result = _new_result(question, LAYER_STRUCTURED)
+            started = time.monotonic()
+            try:
+                items = await adapter.search_question(user_id, question, fetch_limit)
+                await _score_retrieval(adapter, result, question, items, args.qa, args.qa_context)
+            except Exception as exc:
+                result.error = f"{type(exc).__name__}: {exc}"
+            result.elapsed_seconds = round(time.monotonic() - started, 3)
+            results.append(result)
+
+        artifact_items.extend(await adapter.audit_artifacts(user_id, truth))
+
+    metrics = aggregate_cross_agent(results, args.k, artifact_items)
+    return metrics, results
+
+
+# ---------------------------------------------------------------------------
+# Scenario C: multi-user isolation
+# ---------------------------------------------------------------------------
+
+
+async def _scenario_isolation(
+    adapter: LongitudinalMemoryAdapter,
+    scenario: LongitudinalScenario,
+    args: argparse.Namespace,
+    fetch_limit: int,
+) -> Tuple[Dict[str, Any], List]:
+    cases = scenario.dataset.cases
+    canary_owners: Dict[str, str] = {}
+    user_ids: Dict[str, str] = {}
+
+    # Every user's memory is ingested side by side — working,
+    # persistent, KG, and log all populated; no clearing between
+    # users. Isolation must come from the runtime's own scoping.
+    for case in cases:
+        user_id = f"bench-{BENCHMARK_NAME}-{case.case_id}"
+        user_ids[case.case_id] = user_id
+        truth = scenario.ground_truth[case.case_id]
+        for session in case.sessions:
+            await adapter.ingest_session(user_id, session)
+        await adapter.ingest_ground_truth(user_id, truth)
+        for canary in truth.canaries:
+            canary_owners[canary] = case.case_id
+
+    target_ops = args.isolation_ops or int(scenario.config.get("target_ops", 0)) or 100
+    ops: List[IsolationOpResult] = []
+    for op_index in range(target_ops):
+        case = cases[op_index % len(cases)]
+        user_id = user_ids[case.case_id]
+        questions = case.questions
+        question = questions[(op_index // len(cases)) % len(questions)]
+        op_kind = ISOLATION_OP_KINDS[op_index % len(ISOLATION_OP_KINDS)]
+        op = IsolationOpResult(case_id=case.case_id, op_kind=op_kind, query=question.question)
+        try:
+            if op_kind == "vector_search":
+                texts, session_ids = await adapter.isolation_vector_op(
+                    user_id, question.question, fetch_limit
+                )
+            elif op_kind == "graph":
+                texts, session_ids = await adapter.isolation_graph_op(user_id)
+            else:
+                texts, session_ids = await adapter.isolation_log_op(user_id)
+            op.leaks = find_leaks(texts, session_ids, case.case_id, canary_owners)
+        except Exception as exc:
+            op.error = f"{type(exc).__name__}: {exc}"
+        ops.append(op)
+        if (op_index + 1) % 500 == 0:
+            print(f"[membench]   isolation ops: {op_index + 1}/{target_ops}")
+
+    metrics = aggregate_isolation(ops, users=len(cases), target_ops=target_ops)
+    return metrics, []
+
+
+# ---------------------------------------------------------------------------
+# Scenario D: contradiction detection over time
+# ---------------------------------------------------------------------------
+
+
+async def _scenario_contradiction(
+    adapter: LongitudinalMemoryAdapter,
+    scenario: LongitudinalScenario,
+    args: argparse.Namespace,
+    fetch_limit: int,
+) -> Tuple[Dict[str, Any], List]:
+    del fetch_limit  # audit-only scenario
+    all_live_pairs = []
+    all_live_fps: List[Tuple[str, str, str, str]] = []
+    all_rebuild_pairs = []
+    all_rebuild_fps: List[Tuple[str, str, str, str]] = []
+    events_total = 0
+    events_available = False
+    rebuild_available = False
+    rebuild_report: Dict[str, Any] = {}
+    batches_total = 0
+
+    for case in scenario.dataset.cases:
+        adapter.clear_case()
+        user_id = f"bench-{BENCHMARK_NAME}-{case.case_id}"
+        truth = scenario.ground_truth[case.case_id]
+
+        batches_total += await adapter.ingest_extraction_sessions(user_id, truth)
+        live_pairs, live_fps = await adapter.audit_contradiction_pairs(user_id, truth)
+        all_live_pairs.extend(live_pairs)
+        all_live_fps.extend(live_fps)
+
+        detected_total = sum(pair.detected for pair in live_pairs) + len(live_fps)
+        events = await adapter.contradiction_event_stats(user_id, detected_total)
+        events_available = events_available or bool(events.get("available"))
+        events_total += int(events.get("events", 0))
+
+        rebuild = await adapter.rebuild_knowledge_graph(user_id)
+        if rebuild.get("available"):
+            rebuild_available = True
+            rebuild_report = {
+                key: rebuild_report.get(key, 0) + int(rebuild.get(key, 0))
+                for key in ("events", "applied", "failed")
+            }
+            rebuild_pairs, rebuild_fps = await adapter.audit_contradiction_pairs(user_id, truth)
+            all_rebuild_pairs.extend(rebuild_pairs)
+            all_rebuild_fps.extend(rebuild_fps)
+
+    live_detected_total = sum(pair.detected for pair in all_live_pairs) + len(all_live_fps)
+    metrics = aggregate_contradiction(
+        all_live_pairs,
+        all_live_fps,
+        events={
+            "available": events_available,
+            "events": events_total,
+            "matches_detections": (
+                (events_total == live_detected_total) if events_available else None
+            ),
+        },
+        rebuild_pairs=all_rebuild_pairs if rebuild_available else None,
+        rebuild_false_positives=all_rebuild_fps,
+        rebuild_report=rebuild_report if rebuild_available else None,
+    )
+    metrics["ingest"] = {"extraction_batches": batches_total}
+    return metrics, []
+
+
+SCENARIO_RUNNERS = {
+    SCENARIO_BUFFER_CYCLE: _scenario_buffer_cycle,
+    SCENARIO_CROSS_AGENT: _scenario_cross_agent,
+    SCENARIO_ISOLATION: _scenario_isolation,
+    SCENARIO_CONTRADICTION: _scenario_contradiction,
+}
+
+
+def render_scenario_summary(report: Dict[str, Any]) -> str:
+    """Shared summary for retrieval scenarios; compact header otherwise."""
+    metrics = report["metrics"]
+    if metrics.get("retrieval") is not None:
+        base = render_summary(report)
+    else:
+        lines = ["=" * 64]
+        lines.append(
+            f"Memory benchmark: {report['benchmark']}  "
+            f"(scenario={report['mode']}, k={report['k']})"
+        )
+        lines.append("=" * 64)
+        dataset = report["dataset"]
+        lines.append(
+            f"Dataset: {dataset['path']}  "
+            f"(cases={dataset.get('cases', '?')}, sessions={dataset.get('sessions', '?')})"
+        )
+        if report.get("partial"):
+            lines.append("")
+            lines.append(f"PARTIAL RUN — aborted: {report['run'].get('abort_reason')}")
+        lines.append(f"Wall time: {report['run']['wall_seconds']}s")
+        base = "\n".join(lines)
+    extras = render_longitudinal_extras(report["mode"], metrics, report["k"])
+    return base + (("\n" + extras) if extras else "")
+
+
+async def run_scenario(
+    key: str,
+    scenario: LongitudinalScenario,
+    args: argparse.Namespace,
+    dataset_path: Path,
+    used_fixture: bool,
+) -> int:
+    """Execute one scenario end-to-end; returns its exit code."""
+    fetch_limit = args.fetch_limit or max(25, 5 * args.k)
+    adapter = LongitudinalMemoryAdapter(
+        # Scenario C exercises the vector read paths of every user side
+        # by side; the others exercise the persisted structured layers.
+        mode="combined" if key == SCENARIO_ISOLATION else STRUCTURED_MODE,
+        buffer_max_mb=args.buffer_max_mb if key == SCENARIO_BUFFER_CYCLE else None,
+        flush_digest=args.flush_digest,
+        formation_yaml=Path(args.formation),
+        run_dir=Path(args.run_dir) if args.run_dir else None,
+        secrets_dir=Path(args.secrets_dir) if args.secrets_dir else None,
+        keep_run_dir=args.keep_run_dir,
+    )
+
+    print(
+        f"[membench] {BENCHMARK_NAME}/{key}: {len(scenario.dataset.cases)} cases / "
+        f"{scenario.dataset.question_count} questions "
+        f"(fixture={used_fixture}, qa={args.qa})"
+    )
+
+    started_at = datetime.now(timezone.utc)
+    started = time.monotonic()
+    partial = False
+    report_failed = False
+    abort_reason: Optional[str] = None
+    usage: Dict[str, Any] = {}
+    config: Dict[str, Any] = {}
+    metrics: Dict[str, Any] = {}
+    results: List[Any] = []
+
+    # Tier 1 failure envelope: the report is built and written in the
+    # finally path, so every exit — clean finish, crash,
+    # KeyboardInterrupt — leaves a report with whatever completed.
+    try:
+        await adapter.start()
+        metrics, results = await SCENARIO_RUNNERS[key](adapter, scenario, args, fetch_limit)
+    finally:
+        in_flight = sys.exc_info()[1]
+        if in_flight is not None and abort_reason is None:
+            partial = True
+            abort_reason = f"{type(in_flight).__name__}: {in_flight}"
+
+        try:
+            usage = adapter.usage_snapshot()
+            config = adapter.config_snapshot()
+        except Exception:
+            pass
+        await adapter.stop()
+
+        try:
+            report = build_report(
+                benchmark=BENCHMARK_NAME,
+                mode=key,
+                k=args.k,
+                dataset_path=str(dataset_path),
+                dataset_stats={
+                    "cases": len(scenario.dataset.cases),
+                    "questions": scenario.dataset.question_count,
+                    "sessions": scenario.dataset.session_count,
+                    "fixture": used_fixture,
+                    "scenario_config": dict(scenario.config),
+                },
+                config={**config, "fetch_limit": fetch_limit, "qa": args.qa},
+                metrics=metrics,
+                results=results,
+                usage=usage,
+                started_at=started_at,
+                wall_seconds=time.monotonic() - started,
+                partial=partial,
+                abort_reason=abort_reason,
+                repo_root=REPO_ROOT,
+            )
+            output = Path(args.output) if args.output else default_output_path(key, used_fixture)
+            write_report(report, output)
+            print(render_scenario_summary(report))
+            print(f"Report written to {output}")
+        except Exception as report_exc:
+            report_failed = True
+            print(f"[membench] failed to write report: {report_exc}", file=sys.stderr)
+
+    incomplete = bool(
+        partial
+        or report_failed
+        or metrics.get("questions_errored")
+        or metrics.get("operations_errored")
+    )
+    return 1 if incomplete else 0
+
+
+def _scenario_argv(args: argparse.Namespace, key: str) -> List[str]:
+    """Rebuild the CLI for one scenario's subprocess."""
+    argv = ["--scenario", key, "--k", str(args.k)]
+    if args.dataset:
+        argv += ["--dataset", args.dataset]
+    if args.fixture:
+        argv += ["--fixture"]
+    if args.fetch_limit is not None:
+        argv += ["--fetch-limit", str(args.fetch_limit)]
+    if args.qa:
+        argv += ["--qa", "--qa-context", str(args.qa_context)]
+    if args.limit is not None:
+        argv += ["--limit", str(args.limit)]
+    argv += ["--buffer-max-mb", str(args.buffer_max_mb)]
+    if args.flush_digest:
+        argv += ["--flush-digest"]
+    if args.isolation_ops is not None:
+        argv += ["--isolation-ops", str(args.isolation_ops)]
+    argv += ["--formation", args.formation]
+    if args.run_dir:
+        # One formation per scenario: give each its own run directory.
+        argv += ["--run-dir", str(Path(args.run_dir) / key)]
+    if args.keep_run_dir:
+        argv += ["--keep-run-dir"]
+    if args.secrets_dir:
+        argv += ["--secrets-dir", args.secrets_dir]
+    return argv
+
+
+async def _run_all_scenarios(args: argparse.Namespace) -> int:
+    """Run every scenario in its own subprocess (fresh formation each).
+
+    The runtime's database manager is a process-level singleton keyed
+    to the first connection string it sees, so a second formation in
+    the same process would reuse the first scenario's (already
+    removed) run-local SQLite path.
+    """
+    exit_code = 0
+    for key in SCENARIOS:
+        process = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-m",
+            "bench.memory.longitudinal_runner",
+            *_scenario_argv(args, key),
+            cwd=str(REPO_ROOT),
+        )
+        exit_code = max(exit_code, await process.wait())
+    return exit_code
+
+
+async def run_benchmark(args: argparse.Namespace) -> int:
+    """Run the selected scenarios; returns the process exit code."""
+    if args.scenario == "all":
+        return await _run_all_scenarios(args)
+
+    dataset_path = Path(args.dataset) if (args.dataset and not args.fixture) else fixture_path()
+    used_fixture = dataset_path == fixture_path()
+    scenarios = load_longitudinal(dataset_path)
+
+    key = args.scenario
+    if key not in scenarios:
+        print(f"Dataset has no scenario: {key}", file=sys.stderr)
+        return 1
+    try:
+        return await run_scenario(key, scenarios[key], args, dataset_path, used_fixture)
+    except Exception as exc:
+        # run_scenario already wrote a partial report in its finally.
+        print(f"[membench] scenario {key} failed: {exc}", file=sys.stderr)
+        return 1
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    return asyncio.run(run_benchmark(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/memory/longitudinal_runner.py
+++ b/bench/memory/longitudinal_runner.py
@@ -269,7 +269,11 @@ async def _scenario_buffer_cycle(
 ) -> Tuple[Dict[str, Any], List[LongitudinalQuestionResult]]:
     results: List[LongitudinalQuestionResult] = []
     decision_items = []
+    eviction_totals: Dict[str, Any] = {}
+    flush_totals: Dict[str, Any] = {}
     for case in scenario.dataset.cases:
+        # clear_case() resets the adapter's per-case eviction/flush
+        # counters, so each case's snapshot is summed here.
         adapter.clear_case()
         user_id = f"bench-{BENCHMARK_NAME}-{case.case_id}"
         truth = scenario.ground_truth[case.case_id]
@@ -314,9 +318,21 @@ async def _scenario_buffer_cycle(
 
         decision_items.extend(await adapter.audit_decisions(user_id, truth))
 
-    metrics = aggregate_buffer_cycle(
-        results, args.k, adapter.eviction_stats(), adapter.flush_stats(), decision_items
-    )
+        for totals, snapshot in (
+            (eviction_totals, adapter.eviction_stats()),
+            (flush_totals, adapter.flush_stats()),
+        ):
+            for key, value in snapshot.items():
+                if (
+                    key == "max_memory_mb"  # run config, not a counter
+                    or isinstance(value, bool)
+                    or not isinstance(value, (int, float))
+                ):
+                    totals[key] = value
+                else:
+                    totals[key] = totals.get(key, 0) + value
+
+    metrics = aggregate_buffer_cycle(results, args.k, eviction_totals, flush_totals, decision_items)
     return metrics, results
 
 
@@ -418,6 +434,20 @@ async def _scenario_isolation(
 # ---------------------------------------------------------------------------
 
 
+def merge_rebuild_report(totals: Dict[str, Any], rebuild: Dict[str, Any]) -> Dict[str, int]:
+    """Sum one rebuild response into the running per-case totals.
+
+    The service response can carry explicit ``None`` values for
+    events/applied/failed (not just missing keys), so ``or 0`` guards
+    the ``int()`` conversion — ``dict.get(key, 0)`` alone would raise
+    ``TypeError`` and kill the scenario mid-run.
+    """
+    return {
+        key: int(totals.get(key) or 0) + int(rebuild.get(key) or 0)
+        for key in ("events", "applied", "failed")
+    }
+
+
 async def _scenario_contradiction(
     adapter: LongitudinalMemoryAdapter,
     scenario: LongitudinalScenario,
@@ -448,15 +478,12 @@ async def _scenario_contradiction(
         detected_total = sum(pair.detected for pair in live_pairs) + len(live_fps)
         events = await adapter.contradiction_event_stats(user_id, detected_total)
         events_available = events_available or bool(events.get("available"))
-        events_total += int(events.get("events", 0))
+        events_total += int(events.get("events") or 0)
 
         rebuild = await adapter.rebuild_knowledge_graph(user_id)
         if rebuild.get("available"):
             rebuild_available = True
-            rebuild_report = {
-                key: rebuild_report.get(key, 0) + int(rebuild.get(key, 0))
-                for key in ("events", "applied", "failed")
-            }
+            rebuild_report = merge_rebuild_report(rebuild_report, rebuild)
             rebuild_pairs, rebuild_fps = await adapter.audit_contradiction_pairs(user_id, truth)
             all_rebuild_pairs.extend(rebuild_pairs)
             all_rebuild_fps.extend(rebuild_fps)
@@ -639,24 +666,40 @@ def _scenario_argv(args: argparse.Namespace, key: str) -> List[str]:
     return argv
 
 
+async def _run_scenario_subprocess(args: argparse.Namespace, key: str) -> Tuple[str, int, str]:
+    """Run one scenario subprocess; returns (key, exit code, output)."""
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "bench.memory.longitudinal_runner",
+        *_scenario_argv(args, key),
+        cwd=str(REPO_ROOT),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    output, _ = await process.communicate()
+    return key, process.returncode or 0, output.decode(errors="replace")
+
+
 async def _run_all_scenarios(args: argparse.Namespace) -> int:
     """Run every scenario in its own subprocess (fresh formation each).
 
-    The runtime's database manager is a process-level singleton keyed
-    to the first connection string it sees, so a second formation in
-    the same process would reuse the first scenario's (already
-    removed) run-local SQLite path.
+    One subprocess per scenario because the runtime's database manager
+    is a process-level singleton keyed to the first connection string
+    it sees — a second formation in the same process would reuse the
+    first scenario's (already removed) run-local SQLite path. The
+    subprocesses run CONCURRENTLY (each has its own temp run dir and
+    report file); output is buffered per scenario and printed whole as
+    each finishes, so summaries never interleave.
     """
+    tasks = [asyncio.create_task(_run_scenario_subprocess(args, key)) for key in SCENARIOS]
     exit_code = 0
-    for key in SCENARIOS:
-        process = await asyncio.create_subprocess_exec(
-            sys.executable,
-            "-m",
-            "bench.memory.longitudinal_runner",
-            *_scenario_argv(args, key),
-            cwd=str(REPO_ROOT),
-        )
-        exit_code = max(exit_code, await process.wait())
+    for completed in asyncio.as_completed(tasks):
+        key, code, output = await completed
+        print(f"[membench] ===== {key} finished (exit {code}) =====")
+        sys.stdout.write(output)
+        sys.stdout.flush()
+        exit_code = max(exit_code, code)
     return exit_code
 
 

--- a/bench/memory/longitudinal_scoring.py
+++ b/bench/memory/longitudinal_scoring.py
@@ -1,0 +1,485 @@
+"""Scoring extensions for the Tier 3 longitudinal benchmark.
+
+Adds the four scenario-specific measurement blocks on top of the
+Tier 1/2 machinery (memory-benchmarking PRD, Tier 3):
+
+- **Buffer cycle compensation (A)** — retrieval over the persisted
+  layers (KG + Captain's Log) vs the working-memory baseline, split by
+  ``evicted_recall`` / ``recent_recall``; eviction and pre-compaction
+  flush statistics; the zero-lost-decisions audit. PRD targets:
+  day-1 recall at day-30 >= 0.85, zero lost decisions.
+- **Cross-agent propagation (B)** — recall over questions whose
+  evidence was produced in a different agent's sessions, plus the
+  zero-artifact-orphans audit. PRD targets: R@5 >= 0.80, zero orphans.
+- **Multi-user isolation (C)** — leak detection over retrieval
+  operations: a leak is a foreign user's canary token in retrieved
+  text, or a retrieved item attributed to another user's sessions.
+  Pass/fail per the PRD: zero leaks.
+- **Contradiction detection over time (D)** — precision/recall of the
+  KG's conflict/supersede flags against injected pairs, detection-kind
+  accuracy (conflicted vs superseded), the substrate's
+  ``fact.contradicted`` event tally, and a rebuild consistency check
+  (the same audit after an event-log projection rebuild). PRD
+  targets: precision >= 0.90, recall >= 0.80.
+
+All functions are pure and deterministic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+from .scoring import aggregate_results
+from .structured_scoring import StructuredQuestionResult, aggregate_structured_results
+
+# PRD Tier 3 targets (Success Criteria table).
+TARGET_BUFFER_CYCLE_RECALL = 0.85
+TARGET_CROSS_AGENT_RECALL = 0.80
+TARGET_CONTRADICTION_PRECISION = 0.90
+TARGET_CONTRADICTION_RECALL = 0.80
+
+# Retrieval layers measured in Scenario A.
+LAYER_STRUCTURED = "structured"
+LAYER_WORKING = "working"
+
+# Cap on leak details embedded in a report (a systematic leak would
+# otherwise bloat the JSON with thousands of identical entries).
+MAX_LEAK_DETAILS = 50
+
+
+@dataclass
+class LongitudinalQuestionResult(StructuredQuestionResult):
+    """Tier 2 result plus the Tier 3 measurements."""
+
+    # Which retrieval layer produced this result (Scenario A runs every
+    # question against both the persisted layers and the buffer).
+    layer: str = LAYER_STRUCTURED
+    # Scenario A: were ALL evidence turns already evicted from the
+    # working-memory buffer when the question was asked?
+    evidence_evicted: Optional[bool] = None
+
+
+# ---------------------------------------------------------------------------
+# Scenario A: buffer cycle compensation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DecisionAuditItem:
+    """One ground-truth decision checked against the Captain's Log."""
+
+    decision: str
+    date: str
+    found: bool
+
+
+def aggregate_decisions(items: Sequence[DecisionAuditItem]) -> Dict[str, Any]:
+    """The PRD's "zero lost decisions" audit block."""
+    lost = [item for item in items if not item.found]
+    return {
+        "expected": len(items),
+        "found": len(items) - len(lost),
+        "lost": len(lost),
+        "lost_decisions": sorted(f"[{item.date}] {item.decision}" for item in lost),
+        "zero_lost_met": not lost,
+    }
+
+
+def _category_recall(metrics: Dict[str, Any], category: str, k: int) -> Optional[float]:
+    """Session-level recall@k for one question category, if measured."""
+    level = (metrics.get("retrieval") or {}).get("session_level") or {}
+    stats = (level.get("by_question_type") or {}).get(category)
+    if not stats:
+        return None
+    return stats.get(f"recall@{k}")
+
+
+def aggregate_buffer_cycle(
+    results: Sequence[LongitudinalQuestionResult],
+    k: int,
+    eviction: Dict[str, Any],
+    flush: Dict[str, Any],
+    decision_items: Sequence[DecisionAuditItem],
+) -> Dict[str, Any]:
+    """Scenario A metrics: structured headline + working baseline + audits."""
+    structured = [result for result in results if result.layer == LAYER_STRUCTURED]
+    working = [result for result in results if result.layer == LAYER_WORKING]
+
+    metrics = aggregate_structured_results(structured, k)
+    metrics["working_baseline"] = aggregate_results(working, k)
+    metrics["eviction"] = dict(eviction)
+    metrics["flush"] = dict(flush)
+    metrics["decisions"] = aggregate_decisions(decision_items)
+
+    evicted_flags = [
+        result.evidence_evicted
+        for result in structured
+        if result.question_type == "evicted_recall" and result.evidence_evicted is not None
+    ]
+    evicted_recall = _category_recall(metrics, "evicted_recall", k)
+    metrics["compensation"] = {
+        "evicted_recall_structured": evicted_recall,
+        "evicted_recall_working": _category_recall(
+            metrics["working_baseline"], "evicted_recall", k
+        ),
+        "recent_recall_structured": _category_recall(metrics, "recent_recall", k),
+        "recent_recall_working": _category_recall(metrics["working_baseline"], "recent_recall", k),
+        # Fraction of evicted-category questions whose evidence turns
+        # were actually gone from the buffer (must be 1.0 for the
+        # scenario to prove anything; below that the workload/budget
+        # did not cycle the buffer far enough).
+        "evidence_evicted_fraction": (
+            sum(float(flag) for flag in evicted_flags) / len(evicted_flags)
+            if evicted_flags
+            else None
+        ),
+        "target": TARGET_BUFFER_CYCLE_RECALL,
+        "target_met": (evicted_recall is not None and evicted_recall >= TARGET_BUFFER_CYCLE_RECALL),
+    }
+    return metrics
+
+
+# ---------------------------------------------------------------------------
+# Scenario B: cross-agent knowledge propagation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ArtifactAuditItem:
+    """One ground-truth artifact checked for KG reachability."""
+
+    name: str
+    agent: str
+    entity_found: bool
+    produced_link_found: bool
+
+    @property
+    def reachable(self) -> bool:
+        return self.entity_found and self.produced_link_found
+
+
+def aggregate_cross_agent(
+    results: Sequence[LongitudinalQuestionResult],
+    k: int,
+    artifact_items: Sequence[ArtifactAuditItem],
+) -> Dict[str, Any]:
+    """Scenario B metrics: propagation recall + zero-orphan audit."""
+    metrics = aggregate_structured_results(results, k)
+
+    orphans = [item for item in artifact_items if not item.reachable]
+    metrics["artifacts"] = {
+        "expected": len(artifact_items),
+        "reachable": len(artifact_items) - len(orphans),
+        "orphans": len(orphans),
+        "orphan_names": sorted(f"{item.name} ({item.agent})" for item in orphans),
+        "zero_orphans_met": not orphans,
+    }
+
+    recall = _category_recall(metrics, "cross_agent_propagation", k)
+    metrics["propagation"] = {
+        f"recall@{k}": recall,
+        "target": TARGET_CROSS_AGENT_RECALL,
+        "target_met": recall is not None and recall >= TARGET_CROSS_AGENT_RECALL,
+    }
+    return metrics
+
+
+# ---------------------------------------------------------------------------
+# Scenario C: multi-user isolation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class IsolationOpResult:
+    """One retrieval operation checked for cross-user leaks."""
+
+    case_id: str
+    op_kind: str  # vector_search | graph | log
+    query: str
+    leaks: List[Dict[str, str]] = field(default_factory=list)
+    error: Optional[str] = None
+
+
+def find_leaks(
+    texts: Sequence[str],
+    session_ids: Sequence[str],
+    own_case_id: str,
+    canary_owners: Dict[str, str],
+) -> List[Dict[str, str]]:
+    """Detect cross-user leaks in one operation's retrieved items.
+
+    ``canary_owners`` maps every canary token (all users) to its owner
+    case id. A leak is (a) a canary owned by another case appearing in
+    retrieved text, or (b) a retrieved item attributed to another
+    case's session id.
+    """
+    leaks: List[Dict[str, str]] = []
+    for text in texts:
+        haystack = str(text).lower()
+        for canary, owner in canary_owners.items():
+            if owner != own_case_id and canary.lower() in haystack:
+                leaks.append(
+                    {
+                        "kind": "foreign_canary",
+                        "canary_owner": owner,
+                        "detail": canary,
+                    }
+                )
+    for session_id in session_ids:
+        if session_id and not str(session_id).startswith(own_case_id):
+            leaks.append(
+                {
+                    "kind": "foreign_session",
+                    "canary_owner": "",
+                    "detail": str(session_id),
+                }
+            )
+    return leaks
+
+
+def aggregate_isolation(
+    ops: Sequence[IsolationOpResult], users: int, target_ops: int
+) -> Dict[str, Any]:
+    """Scenario C metrics: pass/fail leak audit over retrieval ops."""
+    errored = [op for op in ops if op.error]
+    leaks: List[Dict[str, str]] = []
+    by_kind: Dict[str, Dict[str, int]] = {}
+    for op in ops:
+        stats = by_kind.setdefault(op.op_kind, {"operations": 0, "leaks": 0, "errors": 0})
+        stats["operations"] += 1
+        if op.error:
+            stats["errors"] += 1
+            continue
+        stats["leaks"] += len(op.leaks)
+        for leak in op.leaks:
+            leaks.append({**leak, "case_id": op.case_id, "op_kind": op.op_kind})
+
+    return {
+        "users": users,
+        "operations": len(ops),
+        "target_operations": target_ops,
+        "operations_errored": len(errored),
+        "leaks": len(leaks),
+        "leak_details": sorted(
+            (leaks[:MAX_LEAK_DETAILS]),
+            key=lambda leak: (leak["case_id"], leak["kind"], leak["detail"]),
+        ),
+        "by_op_kind": {kind: stats for kind, stats in sorted(by_kind.items())},
+        # Pass/fail per the PRD: zero leaks across every completed
+        # operation. Errored operations do not count as leak-free.
+        "passed": not leaks and not errored and len(ops) > 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Scenario D: contradiction detection over time
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ContradictionPairAudit:
+    """One injected contradiction pair checked against the KG flags."""
+
+    subject: str
+    predicate: str
+    old_object: str
+    new_object: str
+    expected_detection: str  # conflicted | superseded
+    detected: bool = False
+    detected_kind: Optional[str] = None
+
+
+def summarize_contradiction_audit(
+    pairs: Sequence[ContradictionPairAudit],
+    false_positive_pairs: Sequence[Sequence[str]],
+) -> Dict[str, Any]:
+    """Precision/recall/kind-accuracy for one audit pass."""
+    expected = len(pairs)
+    detected_expected = [pair for pair in pairs if pair.detected]
+    true_positives = len(detected_expected)
+    detected_total = true_positives + len(false_positive_pairs)
+    kind_correct = [
+        pair for pair in detected_expected if pair.detected_kind == pair.expected_detection
+    ]
+    precision = (true_positives / detected_total) if detected_total else None
+    recall = (true_positives / expected) if expected else None
+    return {
+        "expected": expected,
+        "detected": detected_total,
+        "true_positives": true_positives,
+        "false_positives": len(false_positive_pairs),
+        "false_positive_pairs": sorted(list(pair) for pair in false_positive_pairs),
+        "missed_pairs": sorted(
+            f"{pair.subject} {pair.predicate} {pair.old_object} -> {pair.new_object}"
+            for pair in pairs
+            if not pair.detected
+        ),
+        "precision": precision,
+        "recall": recall,
+        "detection_kind_accuracy": (len(kind_correct) / true_positives if true_positives else None),
+        "kind_mismatches": sorted(
+            f"{pair.subject} {pair.predicate}: expected {pair.expected_detection}, "
+            f"detected {pair.detected_kind}"
+            for pair in detected_expected
+            if pair.detected_kind != pair.expected_detection
+        ),
+    }
+
+
+def aggregate_contradiction(
+    live_pairs: Sequence[ContradictionPairAudit],
+    live_false_positives: Sequence[Sequence[str]],
+    events: Dict[str, Any],
+    rebuild_pairs: Optional[Sequence[ContradictionPairAudit]] = None,
+    rebuild_false_positives: Sequence[Sequence[str]] = (),
+    rebuild_report: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Scenario D metrics: live audit + substrate events + rebuild check."""
+    live = summarize_contradiction_audit(live_pairs, live_false_positives)
+    metrics: Dict[str, Any] = {
+        "contradiction_detection": live,
+        "substrate_events": dict(events),
+        "targets": {
+            "precision_target": TARGET_CONTRADICTION_PRECISION,
+            "recall_target": TARGET_CONTRADICTION_RECALL,
+            "precision_met": (
+                live["precision"] is not None
+                and live["precision"] >= TARGET_CONTRADICTION_PRECISION
+            ),
+            "recall_met": (
+                live["recall"] is not None and live["recall"] >= TARGET_CONTRADICTION_RECALL
+            ),
+        },
+    }
+    if rebuild_pairs is not None:
+        rebuilt = summarize_contradiction_audit(rebuild_pairs, rebuild_false_positives)
+        metrics["rebuild"] = {
+            "audit": rebuilt,
+            "projection_report": dict(rebuild_report or {}),
+            "consistent_with_live": (
+                rebuilt["true_positives"] == live["true_positives"]
+                and rebuilt["false_positives"] == live["false_positives"]
+                and rebuilt["detection_kind_accuracy"] == live["detection_kind_accuracy"]
+            ),
+        }
+    return metrics
+
+
+# ---------------------------------------------------------------------------
+# Stdout rendering
+# ---------------------------------------------------------------------------
+
+
+def _pct(value: Optional[float]) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value * 100:.1f}%"
+
+
+def render_longitudinal_extras(scenario: str, metrics: Dict[str, Any], k: int) -> str:
+    """Scenario-specific stdout lines appended to the shared summary."""
+    lines: List[str] = []
+
+    if scenario == "buffer_cycle":
+        compensation = metrics.get("compensation") or {}
+        eviction = metrics.get("eviction") or {}
+        flush = metrics.get("flush") or {}
+        decisions = metrics.get("decisions") or {}
+        lines.append("")
+        lines.append("BUFFER CYCLE COMPENSATION (evicted day-1 facts at day-30):")
+        lines.append(
+            f"  evicted_recall: structured R@{k}="
+            f"{_pct(compensation.get('evicted_recall_structured'))}  "
+            f"working-baseline R@{k}={_pct(compensation.get('evicted_recall_working'))}  "
+            f"(target >= {_pct(compensation.get('target'))}: "
+            f"{'MET' if compensation.get('target_met') else 'NOT MET'})"
+        )
+        lines.append(
+            f"  recent_recall:  structured R@{k}="
+            f"{_pct(compensation.get('recent_recall_structured'))}  "
+            f"working-baseline R@{k}={_pct(compensation.get('recent_recall_working'))}"
+        )
+        lines.append(
+            f"  eviction: {eviction.get('evicted_turns', 0)}/"
+            f"{eviction.get('ingested_turns', 0)} turns evicted "
+            f"(budget {eviction.get('max_memory_mb')}MB, cycles="
+            f"{eviction.get('cleanup_passes', 0)}), evidence evicted for "
+            f"{_pct(compensation.get('evidence_evicted_fraction'))} of evicted questions"
+        )
+        lines.append(
+            f"  pre-compaction flush: {flush.get('hand_offs', 0)} hand-offs / "
+            f"{flush.get('items_handed', 0)} items "
+            f"(digest {'ON' if flush.get('digest_enabled') else 'off - counting only'})"
+        )
+        lines.append(
+            f"  decisions: {decisions.get('found', 0)}/{decisions.get('expected', 0)} "
+            f"findable via Captain's Log "
+            f"(zero lost: {'MET' if decisions.get('zero_lost_met') else 'NOT MET'})"
+        )
+        lost = decisions.get("lost_decisions") or []
+        if lost:
+            lines.append(f"  LOST: {'; '.join(lost)}")
+
+    elif scenario == "cross_agent":
+        propagation = metrics.get("propagation") or {}
+        artifacts = metrics.get("artifacts") or {}
+        lines.append("")
+        lines.append(
+            f"Cross-agent propagation: R@{k}={_pct(propagation.get(f'recall@{k}'))} "
+            f"(target >= {_pct(propagation.get('target'))}: "
+            f"{'MET' if propagation.get('target_met') else 'NOT MET'})"
+        )
+        lines.append(
+            f"Artifact orphans: {artifacts.get('orphans', 0)}/{artifacts.get('expected', 0)} "
+            f"(zero orphans: {'MET' if artifacts.get('zero_orphans_met') else 'NOT MET'})"
+        )
+        orphan_names = artifacts.get("orphan_names") or []
+        if orphan_names:
+            lines.append(f"  ORPHANS: {', '.join(orphan_names)}")
+
+    elif scenario == "isolation":
+        lines.append("")
+        lines.append(
+            f"Multi-user isolation: {metrics.get('leaks', 0)} leaks across "
+            f"{metrics.get('operations', 0)} retrieval operations / "
+            f"{metrics.get('users', 0)} users -> "
+            f"{'PASSED' if metrics.get('passed') else 'FAILED'}"
+        )
+        for kind, stats in (metrics.get("by_op_kind") or {}).items():
+            lines.append(
+                f"  {kind:<16} operations={stats['operations']:<6} "
+                f"leaks={stats['leaks']}  errors={stats['errors']}"
+            )
+
+    elif scenario == "contradiction":
+        detection = metrics.get("contradiction_detection") or {}
+        targets = metrics.get("targets") or {}
+        events = metrics.get("substrate_events") or {}
+        lines.append("")
+        lines.append(
+            f"Contradiction detection: precision={_pct(detection.get('precision'))} "
+            f"(target >= {_pct(targets.get('precision_target'))}: "
+            f"{'MET' if targets.get('precision_met') else 'NOT MET'})  "
+            f"recall={_pct(detection.get('recall'))} "
+            f"(target >= {_pct(targets.get('recall_target'))}: "
+            f"{'MET' if targets.get('recall_met') else 'NOT MET'})"
+        )
+        lines.append(
+            f"  detection kind accuracy (conflicted vs superseded): "
+            f"{_pct(detection.get('detection_kind_accuracy'))}  "
+            f"(expected={detection.get('expected')}, detected={detection.get('detected')}, "
+            f"false_positives={detection.get('false_positives')})"
+        )
+        lines.append(
+            f"  substrate fact.contradicted events: {events.get('events', 0)} "
+            f"(matches detections: {events.get('matches_detections')})"
+        )
+        rebuild = metrics.get("rebuild")
+        if rebuild:
+            lines.append(
+                f"  rebuild consistency (event-log replay): "
+                f"{'CONSISTENT' if rebuild.get('consistent_with_live') else 'DIVERGED'}"
+            )
+
+    return "\n".join(lines)

--- a/bench/memory/results/longitudinal_fixture_buffer_cycle.json
+++ b/bench/memory/results/longitudinal_fixture_buffer_cycle.json
@@ -1,0 +1,844 @@
+{
+  "benchmark": "longitudinal",
+  "config": {
+    "buffer_max_mb": 0.4,
+    "fetch_limit": 25,
+    "flush_digest": false,
+    "formation_yaml": "bench/memory/formation/formation.yaml",
+    "ground_truth_ingestion": "manifest via apply_extraction (no LLM extraction; see README Tier 2)",
+    "max_embed_chars": 6000,
+    "mode": "structured",
+    "qa": true,
+    "structured_backends": [
+      "knowledge_graph",
+      "captains_log"
+    ],
+    "text_model": "openai/gpt-4o-mini",
+    "working_embedding_model": "local/nomic-ai/nomic-embed-text-v1.5"
+  },
+  "dataset": {
+    "cases": 1,
+    "fixture": true,
+    "path": "bench/memory/fixtures/longitudinal_sample.json",
+    "questions": 7,
+    "scenario_config": {
+      "fact_sets": 1,
+      "filler_exchanges": 6,
+      "sessions": 18,
+      "span_days": 30
+    },
+    "sessions": 18
+  },
+  "k": 5,
+  "metrics": {
+    "compensation": {
+      "evicted_recall_structured": 1.0,
+      "evicted_recall_working": 0.0,
+      "evidence_evicted_fraction": 1.0,
+      "recent_recall_structured": 1.0,
+      "recent_recall_working": 1.0,
+      "target": 0.85,
+      "target_met": true
+    },
+    "contradiction_detection": null,
+    "decisions": {
+      "expected": 1,
+      "found": 1,
+      "lost": 0,
+      "lost_decisions": [],
+      "zero_lost_met": true
+    },
+    "eviction": {
+      "cleanup_passes": 18,
+      "evicted_turns": 131,
+      "ingested_turns": 228,
+      "max_memory_mb": 0.4,
+      "resident_turns": 97
+    },
+    "exact_strings": {
+      "by_category": {
+        "evicted_recall": {
+          "missed_question_ids": [],
+          "questions": 3,
+          "recall@5": 1.0,
+          "recall@fetch": 1.0
+        },
+        "recent_recall": {
+          "missed_question_ids": [],
+          "questions": 2,
+          "recall@5": 1.0,
+          "recall@fetch": 1.0
+        }
+      },
+      "overall": {
+        "missed_question_ids": [],
+        "questions": 5,
+        "recall@5": 1.0,
+        "recall@fetch": 1.0
+      }
+    },
+    "flush": {
+      "attached": true,
+      "digest_enabled": false,
+      "hand_offs": 11,
+      "items_handed": 131
+    },
+    "k": 5,
+    "qa": {
+      "by_question_type": {
+        "evicted_recall": {
+          "accuracy": 1.0,
+          "questions": 5
+        },
+        "recent_recall": {
+          "accuracy": 1.0,
+          "questions": 2
+        }
+      },
+      "overall": {
+        "accuracy": 1.0,
+        "questions": 7
+      }
+    },
+    "questions_abstention": 0,
+    "questions_errored": 0,
+    "questions_scored": 7,
+    "questions_total": 7,
+    "retrieval": {
+      "session_level": {
+        "by_question_type": {
+          "evicted_recall": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 5,
+            "recall@5": 1.0
+          },
+          "recent_recall": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 2,
+            "recall@5": 1.0
+          }
+        },
+        "overall": {
+          "coverage@5": 1.0,
+          "mrr": 1.0,
+          "questions": 7,
+          "recall@5": 1.0
+        }
+      },
+      "turn_level": {
+        "by_question_type": {
+          "evicted_recall": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 4,
+            "recall@5": 1.0
+          },
+          "recent_recall": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 2,
+            "recall@5": 1.0
+          }
+        },
+        "overall": {
+          "coverage@5": 1.0,
+          "mrr": 1.0,
+          "questions": 6,
+          "recall@5": 1.0
+        }
+      }
+    },
+    "working_baseline": {
+      "k": 5,
+      "qa": null,
+      "questions_abstention": 0,
+      "questions_errored": 0,
+      "questions_scored": 7,
+      "questions_total": 7,
+      "retrieval": {
+        "session_level": {
+          "by_question_type": {
+            "evicted_recall": {
+              "coverage@5": 0.0,
+              "mrr": 0.0,
+              "questions": 5,
+              "recall@5": 0.0
+            },
+            "recent_recall": {
+              "coverage@5": 1.0,
+              "mrr": 1.0,
+              "questions": 2,
+              "recall@5": 1.0
+            }
+          },
+          "overall": {
+            "coverage@5": 0.2857142857142857,
+            "mrr": 0.2857142857142857,
+            "questions": 7,
+            "recall@5": 0.2857142857142857
+          }
+        },
+        "turn_level": {
+          "by_question_type": {
+            "evicted_recall": {
+              "coverage@5": 0.0,
+              "mrr": 0.0,
+              "questions": 4,
+              "recall@5": 0.0
+            },
+            "recent_recall": {
+              "coverage@5": 1.0,
+              "mrr": 1.0,
+              "questions": 2,
+              "recall@5": 1.0
+            }
+          },
+          "overall": {
+            "coverage@5": 0.3333333333333333,
+            "mrr": 0.3333333333333333,
+            "questions": 6,
+            "recall@5": 0.3333333333333333
+          }
+        }
+      }
+    }
+  },
+  "mode": "buffer_cycle",
+  "results": [
+    {
+      "category": "evicted_recall",
+      "elapsed_seconds": 1.487,
+      "error": null,
+      "evidence_evicted": true,
+      "evidence_session_ids": [
+        "seq_buffer_cycle_000_s001"
+      ],
+      "evidence_turn_ids": [
+        "seq_buffer_cycle_000_s001:2"
+      ],
+      "exact_string_rank": 1,
+      "exact_strings": [
+        "mara.kovacs@vertexlabs.example.com"
+      ],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "Mara Kovacs's email address is mara.kovacs@vertexlabs.example.com.",
+      "qa_correct": true,
+      "question_id": "seq_buffer_cycle_000_q001_evicted_recall",
+      "question_type": "evicted_recall",
+      "retrieved_session_ids": [
+        "seq_buffer_cycle_000_s001"
+      ],
+      "retrieved_turn_ids": [
+        "seq_buffer_cycle_000_s001:2"
+      ]
+    },
+    {
+      "category": "evicted_recall",
+      "elapsed_seconds": 0.022,
+      "error": null,
+      "evidence_evicted": true,
+      "evidence_session_ids": [
+        "seq_buffer_cycle_000_s001"
+      ],
+      "evidence_turn_ids": [
+        "seq_buffer_cycle_000_s001:2"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [
+        "mara.kovacs@vertexlabs.example.com"
+      ],
+      "is_abstention": false,
+      "layer": "working",
+      "qa_answer": null,
+      "qa_correct": null,
+      "question_id": "seq_buffer_cycle_000_q001_evicted_recall#working",
+      "question_type": "evicted_recall",
+      "retrieved_session_ids": [
+        "seq_buffer_cycle_000_s017",
+        "seq_buffer_cycle_000_s016",
+        "seq_buffer_cycle_000_s012",
+        "seq_buffer_cycle_000_s013",
+        "seq_buffer_cycle_000_s014",
+        "seq_buffer_cycle_000_s018",
+        "seq_buffer_cycle_000_s011",
+        "seq_buffer_cycle_000_s015"
+      ],
+      "retrieved_turn_ids": [
+        "seq_buffer_cycle_000_s017:3",
+        "seq_buffer_cycle_000_s017:2",
+        "seq_buffer_cycle_000_s016:2",
+        "seq_buffer_cycle_000_s016:3",
+        "seq_buffer_cycle_000_s012:9",
+        "seq_buffer_cycle_000_s012:8",
+        "seq_buffer_cycle_000_s013:5",
+        "seq_buffer_cycle_000_s013:4",
+        "seq_buffer_cycle_000_s014:1",
+        "seq_buffer_cycle_000_s018:1",
+        "seq_buffer_cycle_000_s016:11",
+        "seq_buffer_cycle_000_s014:0",
+        "seq_buffer_cycle_000_s017:7",
+        "seq_buffer_cycle_000_s011:11",
+        "seq_buffer_cycle_000_s015:11",
+        "seq_buffer_cycle_000_s015:1",
+        "seq_buffer_cycle_000_s012:7",
+        "seq_buffer_cycle_000_s014:11",
+        "seq_buffer_cycle_000_s018:5",
+        "seq_buffer_cycle_000_s016:5",
+        "seq_buffer_cycle_000_s017:5",
+        "seq_buffer_cycle_000_s012:1",
+        "seq_buffer_cycle_000_s013:9",
+        "seq_buffer_cycle_000_s015:5",
+        "seq_buffer_cycle_000_s018:11"
+      ]
+    },
+    {
+      "category": "evicted_recall",
+      "elapsed_seconds": 1.539,
+      "error": null,
+      "evidence_evicted": true,
+      "evidence_session_ids": [
+        "seq_buffer_cycle_000_s002"
+      ],
+      "evidence_turn_ids": [
+        "seq_buffer_cycle_000_s002:2"
+      ],
+      "exact_string_rank": 1,
+      "exact_strings": [
+        "petra.lindqvist@vertexlabs.example.com"
+      ],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "Petra Lindqvist's email address is petra.lindqvist@vertexlabs.example.com.",
+      "qa_correct": true,
+      "question_id": "seq_buffer_cycle_000_q002_evicted_recall",
+      "question_type": "evicted_recall",
+      "retrieved_session_ids": [
+        "seq_buffer_cycle_000_s002"
+      ],
+      "retrieved_turn_ids": [
+        "seq_buffer_cycle_000_s002:2"
+      ]
+    },
+    {
+      "category": "evicted_recall",
+      "elapsed_seconds": 0.025,
+      "error": null,
+      "evidence_evicted": true,
+      "evidence_session_ids": [
+        "seq_buffer_cycle_000_s002"
+      ],
+      "evidence_turn_ids": [
+        "seq_buffer_cycle_000_s002:2"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [
+        "petra.lindqvist@vertexlabs.example.com"
+      ],
+      "is_abstention": false,
+      "layer": "working",
+      "qa_answer": null,
+      "qa_correct": null,
+      "question_id": "seq_buffer_cycle_000_q002_evicted_recall#working",
+      "question_type": "evicted_recall",
+      "retrieved_session_ids": [
+        "seq_buffer_cycle_000_s017",
+        "seq_buffer_cycle_000_s016",
+        "seq_buffer_cycle_000_s012",
+        "seq_buffer_cycle_000_s018",
+        "seq_buffer_cycle_000_s013",
+        "seq_buffer_cycle_000_s015",
+        "seq_buffer_cycle_000_s014"
+      ],
+      "retrieved_turn_ids": [
+        "seq_buffer_cycle_000_s017:3",
+        "seq_buffer_cycle_000_s017:2",
+        "seq_buffer_cycle_000_s016:3",
+        "seq_buffer_cycle_000_s012:9",
+        "seq_buffer_cycle_000_s016:2",
+        "seq_buffer_cycle_000_s018:5",
+        "seq_buffer_cycle_000_s013:7",
+        "seq_buffer_cycle_000_s012:11",
+        "seq_buffer_cycle_000_s015:1",
+        "seq_buffer_cycle_000_s017:11",
+        "seq_buffer_cycle_000_s013:0",
+        "seq_buffer_cycle_000_s014:1",
+        "seq_buffer_cycle_000_s016:11",
+        "seq_buffer_cycle_000_s018:1",
+        "seq_buffer_cycle_000_s013:9",
+        "seq_buffer_cycle_000_s017:0",
+        "seq_buffer_cycle_000_s014:3",
+        "seq_buffer_cycle_000_s017:9",
+        "seq_buffer_cycle_000_s012:4",
+        "seq_buffer_cycle_000_s016:13",
+        "seq_buffer_cycle_000_s018:3",
+        "seq_buffer_cycle_000_s014:5",
+        "seq_buffer_cycle_000_s013:5",
+        "seq_buffer_cycle_000_s015:8",
+        "seq_buffer_cycle_000_s017:7"
+      ]
+    },
+    {
+      "category": "evicted_recall",
+      "elapsed_seconds": 1.153,
+      "error": null,
+      "evidence_evicted": true,
+      "evidence_session_ids": [
+        "seq_buffer_cycle_000_s003"
+      ],
+      "evidence_turn_ids": [
+        "seq_buffer_cycle_000_s003:2"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "Ingrid Alvarez recommended using Kafka for the search revamp.",
+      "qa_correct": true,
+      "question_id": "seq_buffer_cycle_000_q003_evicted_recall",
+      "question_type": "evicted_recall",
+      "retrieved_session_ids": [
+        "seq_buffer_cycle_000_s003"
+      ],
+      "retrieved_turn_ids": [
+        "seq_buffer_cycle_000_s003:2"
+      ]
+    },
+    {
+      "category": "evicted_recall",
+      "elapsed_seconds": 0.02,
+      "error": null,
+      "evidence_evicted": true,
+      "evidence_session_ids": [
+        "seq_buffer_cycle_000_s003"
+      ],
+      "evidence_turn_ids": [
+        "seq_buffer_cycle_000_s003:2"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "working",
+      "qa_answer": null,
+      "qa_correct": null,
+      "question_id": "seq_buffer_cycle_000_q003_evicted_recall#working",
+      "question_type": "evicted_recall",
+      "retrieved_session_ids": [
+        "seq_buffer_cycle_000_s017",
+        "seq_buffer_cycle_000_s016",
+        "seq_buffer_cycle_000_s018",
+        "seq_buffer_cycle_000_s014",
+        "seq_buffer_cycle_000_s015",
+        "seq_buffer_cycle_000_s013",
+        "seq_buffer_cycle_000_s011",
+        "seq_buffer_cycle_000_s012"
+      ],
+      "retrieved_turn_ids": [
+        "seq_buffer_cycle_000_s017:3",
+        "seq_buffer_cycle_000_s017:2",
+        "seq_buffer_cycle_000_s016:3",
+        "seq_buffer_cycle_000_s016:2",
+        "seq_buffer_cycle_000_s018:1",
+        "seq_buffer_cycle_000_s017:13",
+        "seq_buffer_cycle_000_s014:7",
+        "seq_buffer_cycle_000_s018:7",
+        "seq_buffer_cycle_000_s015:3",
+        "seq_buffer_cycle_000_s013:11",
+        "seq_buffer_cycle_000_s011:3",
+        "seq_buffer_cycle_000_s016:11",
+        "seq_buffer_cycle_000_s014:1",
+        "seq_buffer_cycle_000_s013:5",
+        "seq_buffer_cycle_000_s012:9",
+        "seq_buffer_cycle_000_s017:7",
+        "seq_buffer_cycle_000_s018:0",
+        "seq_buffer_cycle_000_s015:1",
+        "seq_buffer_cycle_000_s013:9",
+        "seq_buffer_cycle_000_s018:5",
+        "seq_buffer_cycle_000_s017:11",
+        "seq_buffer_cycle_000_s014:0",
+        "seq_buffer_cycle_000_s014:5",
+        "seq_buffer_cycle_000_s016:10",
+        "seq_buffer_cycle_000_s013:4"
+      ]
+    },
+    {
+      "category": "evicted_recall",
+      "elapsed_seconds": 1.353,
+      "error": null,
+      "evidence_evicted": true,
+      "evidence_session_ids": [
+        "seq_buffer_cycle_000_s001"
+      ],
+      "evidence_turn_ids": [
+        "seq_buffer_cycle_000_s001:4"
+      ],
+      "exact_string_rank": 1,
+      "exact_strings": [
+        "INV-5150-SK"
+      ],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "The reference number of the invoice Yuki Mensah opened for the payments integration is INV-5150-SK.",
+      "qa_correct": true,
+      "question_id": "seq_buffer_cycle_000_q004_evicted_recall",
+      "question_type": "evicted_recall",
+      "retrieved_session_ids": [
+        "seq_buffer_cycle_000_s001"
+      ],
+      "retrieved_turn_ids": [
+        "seq_buffer_cycle_000_s001:4"
+      ]
+    },
+    {
+      "category": "evicted_recall",
+      "elapsed_seconds": 0.025,
+      "error": null,
+      "evidence_evicted": true,
+      "evidence_session_ids": [
+        "seq_buffer_cycle_000_s001"
+      ],
+      "evidence_turn_ids": [
+        "seq_buffer_cycle_000_s001:4"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [
+        "INV-5150-SK"
+      ],
+      "is_abstention": false,
+      "layer": "working",
+      "qa_answer": null,
+      "qa_correct": null,
+      "question_id": "seq_buffer_cycle_000_q004_evicted_recall#working",
+      "question_type": "evicted_recall",
+      "retrieved_session_ids": [
+        "seq_buffer_cycle_000_s017",
+        "seq_buffer_cycle_000_s016",
+        "seq_buffer_cycle_000_s012",
+        "seq_buffer_cycle_000_s011",
+        "seq_buffer_cycle_000_s013",
+        "seq_buffer_cycle_000_s018",
+        "seq_buffer_cycle_000_s015",
+        "seq_buffer_cycle_000_s014"
+      ],
+      "retrieved_turn_ids": [
+        "seq_buffer_cycle_000_s017:3",
+        "seq_buffer_cycle_000_s016:3",
+        "seq_buffer_cycle_000_s017:2",
+        "seq_buffer_cycle_000_s016:2",
+        "seq_buffer_cycle_000_s012:9",
+        "seq_buffer_cycle_000_s017:1",
+        "seq_buffer_cycle_000_s011:9",
+        "seq_buffer_cycle_000_s011:5",
+        "seq_buffer_cycle_000_s012:1",
+        "seq_buffer_cycle_000_s013:1",
+        "seq_buffer_cycle_000_s018:1",
+        "seq_buffer_cycle_000_s015:7",
+        "seq_buffer_cycle_000_s016:5",
+        "seq_buffer_cycle_000_s013:5",
+        "seq_buffer_cycle_000_s018:9",
+        "seq_buffer_cycle_000_s015:9",
+        "seq_buffer_cycle_000_s015:5",
+        "seq_buffer_cycle_000_s011:7",
+        "seq_buffer_cycle_000_s014:11",
+        "seq_buffer_cycle_000_s012:5",
+        "seq_buffer_cycle_000_s018:11",
+        "seq_buffer_cycle_000_s014:9",
+        "seq_buffer_cycle_000_s016:1",
+        "seq_buffer_cycle_000_s016:7",
+        "seq_buffer_cycle_000_s012:3"
+      ]
+    },
+    {
+      "category": "recent_recall",
+      "elapsed_seconds": 1.529,
+      "error": null,
+      "evidence_evicted": false,
+      "evidence_session_ids": [
+        "seq_buffer_cycle_000_s016"
+      ],
+      "evidence_turn_ids": [
+        "seq_buffer_cycle_000_s016:2"
+      ],
+      "exact_string_rank": 1,
+      "exact_strings": [
+        "dario.nakamura@vertexlabs.example.com"
+      ],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "Dario Nakamura's email address is dario.nakamura@vertexlabs.example.com.",
+      "qa_correct": true,
+      "question_id": "seq_buffer_cycle_000_q005_recent_recall",
+      "question_type": "recent_recall",
+      "retrieved_session_ids": [
+        "seq_buffer_cycle_000_s016"
+      ],
+      "retrieved_turn_ids": [
+        "seq_buffer_cycle_000_s016:2"
+      ]
+    },
+    {
+      "category": "recent_recall",
+      "elapsed_seconds": 0.019,
+      "error": null,
+      "evidence_evicted": false,
+      "evidence_session_ids": [
+        "seq_buffer_cycle_000_s016"
+      ],
+      "evidence_turn_ids": [
+        "seq_buffer_cycle_000_s016:2"
+      ],
+      "exact_string_rank": 1,
+      "exact_strings": [
+        "dario.nakamura@vertexlabs.example.com"
+      ],
+      "is_abstention": false,
+      "layer": "working",
+      "qa_answer": null,
+      "qa_correct": null,
+      "question_id": "seq_buffer_cycle_000_q005_recent_recall#working",
+      "question_type": "recent_recall",
+      "retrieved_session_ids": [
+        "seq_buffer_cycle_000_s016",
+        "seq_buffer_cycle_000_s017",
+        "seq_buffer_cycle_000_s013",
+        "seq_buffer_cycle_000_s015",
+        "seq_buffer_cycle_000_s012",
+        "seq_buffer_cycle_000_s011",
+        "seq_buffer_cycle_000_s014",
+        "seq_buffer_cycle_000_s018"
+      ],
+      "retrieved_turn_ids": [
+        "seq_buffer_cycle_000_s016:2",
+        "seq_buffer_cycle_000_s016:3",
+        "seq_buffer_cycle_000_s017:2",
+        "seq_buffer_cycle_000_s017:3",
+        "seq_buffer_cycle_000_s013:1",
+        "seq_buffer_cycle_000_s017:1",
+        "seq_buffer_cycle_000_s015:9",
+        "seq_buffer_cycle_000_s012:5",
+        "seq_buffer_cycle_000_s016:7",
+        "seq_buffer_cycle_000_s011:9",
+        "seq_buffer_cycle_000_s012:8",
+        "seq_buffer_cycle_000_s014:0",
+        "seq_buffer_cycle_000_s013:4",
+        "seq_buffer_cycle_000_s016:10",
+        "seq_buffer_cycle_000_s017:0",
+        "seq_buffer_cycle_000_s016:5",
+        "seq_buffer_cycle_000_s014:11",
+        "seq_buffer_cycle_000_s012:4",
+        "seq_buffer_cycle_000_s016:6",
+        "seq_buffer_cycle_000_s018:0",
+        "seq_buffer_cycle_000_s011:7",
+        "seq_buffer_cycle_000_s013:0",
+        "seq_buffer_cycle_000_s015:8",
+        "seq_buffer_cycle_000_s018:11",
+        "seq_buffer_cycle_000_s015:7"
+      ]
+    },
+    {
+      "category": "recent_recall",
+      "elapsed_seconds": 1.618,
+      "error": null,
+      "evidence_evicted": false,
+      "evidence_session_ids": [
+        "seq_buffer_cycle_000_s017"
+      ],
+      "evidence_turn_ids": [
+        "seq_buffer_cycle_000_s017:2"
+      ],
+      "exact_string_rank": 1,
+      "exact_strings": [
+        "TKT-7623-HB"
+      ],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "The reference number of the support ticket Owen Haddad opened for the auth migration is TKT-7623-HB.",
+      "qa_correct": true,
+      "question_id": "seq_buffer_cycle_000_q006_recent_recall",
+      "question_type": "recent_recall",
+      "retrieved_session_ids": [
+        "seq_buffer_cycle_000_s017"
+      ],
+      "retrieved_turn_ids": [
+        "seq_buffer_cycle_000_s017:2"
+      ]
+    },
+    {
+      "category": "recent_recall",
+      "elapsed_seconds": 0.029,
+      "error": null,
+      "evidence_evicted": false,
+      "evidence_session_ids": [
+        "seq_buffer_cycle_000_s017"
+      ],
+      "evidence_turn_ids": [
+        "seq_buffer_cycle_000_s017:2"
+      ],
+      "exact_string_rank": 1,
+      "exact_strings": [
+        "TKT-7623-HB"
+      ],
+      "is_abstention": false,
+      "layer": "working",
+      "qa_answer": null,
+      "qa_correct": null,
+      "question_id": "seq_buffer_cycle_000_q006_recent_recall#working",
+      "question_type": "recent_recall",
+      "retrieved_session_ids": [
+        "seq_buffer_cycle_000_s017",
+        "seq_buffer_cycle_000_s016",
+        "seq_buffer_cycle_000_s014",
+        "seq_buffer_cycle_000_s012",
+        "seq_buffer_cycle_000_s011",
+        "seq_buffer_cycle_000_s018",
+        "seq_buffer_cycle_000_s015",
+        "seq_buffer_cycle_000_s013"
+      ],
+      "retrieved_turn_ids": [
+        "seq_buffer_cycle_000_s017:2",
+        "seq_buffer_cycle_000_s017:3",
+        "seq_buffer_cycle_000_s016:3",
+        "seq_buffer_cycle_000_s016:2",
+        "seq_buffer_cycle_000_s014:11",
+        "seq_buffer_cycle_000_s016:5",
+        "seq_buffer_cycle_000_s012:3",
+        "seq_buffer_cycle_000_s011:7",
+        "seq_buffer_cycle_000_s018:11",
+        "seq_buffer_cycle_000_s015:7",
+        "seq_buffer_cycle_000_s012:9",
+        "seq_buffer_cycle_000_s013:5",
+        "seq_buffer_cycle_000_s014:1",
+        "seq_buffer_cycle_000_s018:1",
+        "seq_buffer_cycle_000_s018:10",
+        "seq_buffer_cycle_000_s017:7",
+        "seq_buffer_cycle_000_s016:11",
+        "seq_buffer_cycle_000_s015:6",
+        "seq_buffer_cycle_000_s012:2",
+        "seq_buffer_cycle_000_s014:10",
+        "seq_buffer_cycle_000_s011:6",
+        "seq_buffer_cycle_000_s016:4",
+        "seq_buffer_cycle_000_s013:9",
+        "seq_buffer_cycle_000_s015:1",
+        "seq_buffer_cycle_000_s017:11"
+      ]
+    },
+    {
+      "category": "evicted_recall",
+      "elapsed_seconds": 2.805,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_buffer_cycle_000_s003"
+      ],
+      "evidence_turn_ids": [],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "The main decision made on 2026-03-22 was to adopt Kafka for the search revamp, based on Ingrid Alvarez's recommendation.",
+      "qa_correct": true,
+      "question_id": "seq_buffer_cycle_000_q007_evicted_recall",
+      "question_type": "evicted_recall",
+      "retrieved_session_ids": [
+        "seq_buffer_cycle_000_s003"
+      ],
+      "retrieved_turn_ids": [
+        "seq_buffer_cycle_000_s003:log:2026-03-22"
+      ]
+    },
+    {
+      "category": "evicted_recall",
+      "elapsed_seconds": 0.02,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_buffer_cycle_000_s003"
+      ],
+      "evidence_turn_ids": [],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "working",
+      "qa_answer": null,
+      "qa_correct": null,
+      "question_id": "seq_buffer_cycle_000_q007_evicted_recall#working",
+      "question_type": "evicted_recall",
+      "retrieved_session_ids": [
+        "seq_buffer_cycle_000_s013",
+        "seq_buffer_cycle_000_s011",
+        "seq_buffer_cycle_000_s015",
+        "seq_buffer_cycle_000_s014",
+        "seq_buffer_cycle_000_s012",
+        "seq_buffer_cycle_000_s018",
+        "seq_buffer_cycle_000_s017",
+        "seq_buffer_cycle_000_s016"
+      ],
+      "retrieved_turn_ids": [
+        "seq_buffer_cycle_000_s013:9",
+        "seq_buffer_cycle_000_s011:7",
+        "seq_buffer_cycle_000_s015:1",
+        "seq_buffer_cycle_000_s014:11",
+        "seq_buffer_cycle_000_s014:5",
+        "seq_buffer_cycle_000_s012:3",
+        "seq_buffer_cycle_000_s018:5",
+        "seq_buffer_cycle_000_s017:11",
+        "seq_buffer_cycle_000_s013:7",
+        "seq_buffer_cycle_000_s012:11",
+        "seq_buffer_cycle_000_s017:3",
+        "seq_buffer_cycle_000_s015:7",
+        "seq_buffer_cycle_000_s016:5",
+        "seq_buffer_cycle_000_s017:9",
+        "seq_buffer_cycle_000_s018:11",
+        "seq_buffer_cycle_000_s011:10",
+        "seq_buffer_cycle_000_s017:2",
+        "seq_buffer_cycle_000_s014:3",
+        "seq_buffer_cycle_000_s016:13",
+        "seq_buffer_cycle_000_s018:3",
+        "seq_buffer_cycle_000_s011:8",
+        "seq_buffer_cycle_000_s013:5",
+        "seq_buffer_cycle_000_s012:9",
+        "seq_buffer_cycle_000_s012:6",
+        "seq_buffer_cycle_000_s017:7"
+      ]
+    }
+  ],
+  "run": {
+    "git_commit": "04736f7960212883e1f851c735714fbcb8ff60d4",
+    "python": "3.11.13",
+    "started_at": "2026-07-09T23:42:09Z",
+    "wall_seconds": 32.05
+  },
+  "schema_version": "1.0",
+  "usage": {
+    "cost": {
+      "estimated_usd": 0.00044,
+      "note": "List-price estimate for reporting only; local/* models are free.",
+      "per_model_usd": {
+        "openai/gpt-4o-mini": 0.00044
+      },
+      "unpriced_models": []
+    },
+    "ingested_turns": 233,
+    "llm_requests": 14,
+    "searches": 14,
+    "tokens": {
+      "in": 2290,
+      "out": 160,
+      "total": 2450,
+      "total_cached": 0
+    },
+    "tokens_by_model": {
+      "openai/gpt-4o-mini": [
+        2450,
+        2290,
+        160,
+        0,
+        0,
+        0
+      ]
+    },
+    "truncated_turns": 0
+  }
+}

--- a/bench/memory/results/longitudinal_fixture_buffer_cycle.json
+++ b/bench/memory/results/longitudinal_fixture_buffer_cycle.json
@@ -209,7 +209,7 @@
   "results": [
     {
       "category": "evicted_recall",
-      "elapsed_seconds": 1.487,
+      "elapsed_seconds": 1.658,
       "error": null,
       "evidence_evicted": true,
       "evidence_session_ids": [
@@ -237,7 +237,7 @@
     },
     {
       "category": "evicted_recall",
-      "elapsed_seconds": 0.022,
+      "elapsed_seconds": 0.03,
       "error": null,
       "evidence_evicted": true,
       "evidence_session_ids": [
@@ -296,7 +296,7 @@
     },
     {
       "category": "evicted_recall",
-      "elapsed_seconds": 1.539,
+      "elapsed_seconds": 2.002,
       "error": null,
       "evidence_evicted": true,
       "evidence_session_ids": [
@@ -324,7 +324,7 @@
     },
     {
       "category": "evicted_recall",
-      "elapsed_seconds": 0.025,
+      "elapsed_seconds": 0.161,
       "error": null,
       "evidence_evicted": true,
       "evidence_session_ids": [
@@ -382,7 +382,7 @@
     },
     {
       "category": "evicted_recall",
-      "elapsed_seconds": 1.153,
+      "elapsed_seconds": 1.7,
       "error": null,
       "evidence_evicted": true,
       "evidence_session_ids": [
@@ -408,7 +408,7 @@
     },
     {
       "category": "evicted_recall",
-      "elapsed_seconds": 0.02,
+      "elapsed_seconds": 0.037,
       "error": null,
       "evidence_evicted": true,
       "evidence_session_ids": [
@@ -465,7 +465,7 @@
     },
     {
       "category": "evicted_recall",
-      "elapsed_seconds": 1.353,
+      "elapsed_seconds": 1.626,
       "error": null,
       "evidence_evicted": true,
       "evidence_session_ids": [
@@ -493,7 +493,7 @@
     },
     {
       "category": "evicted_recall",
-      "elapsed_seconds": 0.025,
+      "elapsed_seconds": 0.137,
       "error": null,
       "evidence_evicted": true,
       "evidence_session_ids": [
@@ -552,7 +552,7 @@
     },
     {
       "category": "recent_recall",
-      "elapsed_seconds": 1.529,
+      "elapsed_seconds": 1.929,
       "error": null,
       "evidence_evicted": false,
       "evidence_session_ids": [
@@ -580,7 +580,7 @@
     },
     {
       "category": "recent_recall",
-      "elapsed_seconds": 0.019,
+      "elapsed_seconds": 0.043,
       "error": null,
       "evidence_evicted": false,
       "evidence_session_ids": [
@@ -639,7 +639,7 @@
     },
     {
       "category": "recent_recall",
-      "elapsed_seconds": 1.618,
+      "elapsed_seconds": 1.853,
       "error": null,
       "evidence_evicted": false,
       "evidence_session_ids": [
@@ -667,7 +667,7 @@
     },
     {
       "category": "recent_recall",
-      "elapsed_seconds": 0.029,
+      "elapsed_seconds": 0.035,
       "error": null,
       "evidence_evicted": false,
       "evidence_session_ids": [
@@ -726,7 +726,7 @@
     },
     {
       "category": "evicted_recall",
-      "elapsed_seconds": 2.805,
+      "elapsed_seconds": 1.611,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -750,7 +750,7 @@
     },
     {
       "category": "evicted_recall",
-      "elapsed_seconds": 0.02,
+      "elapsed_seconds": 0.044,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -805,10 +805,10 @@
     }
   ],
   "run": {
-    "git_commit": "04736f7960212883e1f851c735714fbcb8ff60d4",
+    "git_commit": "28912ca727011da682788ed39b322970e6349e08",
     "python": "3.11.13",
-    "started_at": "2026-07-09T23:42:09Z",
-    "wall_seconds": 32.05
+    "started_at": "2026-07-10T01:29:37Z",
+    "wall_seconds": 64.84
   },
   "schema_version": "1.0",
   "usage": {

--- a/bench/memory/results/longitudinal_fixture_contradiction.json
+++ b/bench/memory/results/longitudinal_fixture_contradiction.json
@@ -1,0 +1,108 @@
+{
+  "benchmark": "longitudinal",
+  "config": {
+    "fetch_limit": 25,
+    "flush_digest": false,
+    "formation_yaml": "bench/memory/formation/formation.yaml",
+    "ground_truth_ingestion": "manifest via apply_extraction (no LLM extraction; see README Tier 2)",
+    "max_embed_chars": 6000,
+    "mode": "structured",
+    "qa": true,
+    "structured_backends": [
+      "knowledge_graph",
+      "captains_log"
+    ],
+    "text_model": "openai/gpt-4o-mini",
+    "working_embedding_model": "local/nomic-ai/nomic-embed-text-v1.5"
+  },
+  "dataset": {
+    "cases": 1,
+    "fixture": true,
+    "path": "bench/memory/fixtures/longitudinal_sample.json",
+    "questions": 0,
+    "scenario_config": {
+      "conflicted": 3,
+      "sessions": 12,
+      "span_days": 45,
+      "superseded": 3
+    },
+    "sessions": 12
+  },
+  "k": 5,
+  "metrics": {
+    "contradiction_detection": {
+      "detected": 6,
+      "detection_kind_accuracy": 1.0,
+      "expected": 6,
+      "false_positive_pairs": [],
+      "false_positives": 0,
+      "kind_mismatches": [],
+      "missed_pairs": [],
+      "precision": 1.0,
+      "recall": 1.0,
+      "true_positives": 6
+    },
+    "ingest": {
+      "extraction_batches": 11
+    },
+    "rebuild": {
+      "audit": {
+        "detected": 6,
+        "detection_kind_accuracy": 1.0,
+        "expected": 6,
+        "false_positive_pairs": [],
+        "false_positives": 0,
+        "kind_mismatches": [],
+        "missed_pairs": [],
+        "precision": 1.0,
+        "recall": 1.0,
+        "true_positives": 6
+      },
+      "consistent_with_live": true,
+      "projection_report": {
+        "applied": 11,
+        "events": 11,
+        "failed": 0
+      }
+    },
+    "substrate_events": {
+      "available": true,
+      "events": 6,
+      "matches_detections": true
+    },
+    "targets": {
+      "precision_met": true,
+      "precision_target": 0.9,
+      "recall_met": true,
+      "recall_target": 0.8
+    }
+  },
+  "mode": "contradiction",
+  "results": [],
+  "run": {
+    "git_commit": "04736f7960212883e1f851c735714fbcb8ff60d4",
+    "python": "3.11.13",
+    "started_at": "2026-07-09T23:44:08Z",
+    "wall_seconds": 13.05
+  },
+  "schema_version": "1.0",
+  "usage": {
+    "cost": {
+      "estimated_usd": 0.0,
+      "note": "List-price estimate for reporting only; local/* models are free.",
+      "per_model_usd": {},
+      "unpriced_models": []
+    },
+    "ingested_turns": 11,
+    "llm_requests": 0,
+    "searches": 0,
+    "tokens": {
+      "in": 0,
+      "out": 0,
+      "total": 0,
+      "total_cached": 0
+    },
+    "tokens_by_model": {},
+    "truncated_turns": 0
+  }
+}

--- a/bench/memory/results/longitudinal_fixture_contradiction.json
+++ b/bench/memory/results/longitudinal_fixture_contradiction.json
@@ -80,10 +80,10 @@
   "mode": "contradiction",
   "results": [],
   "run": {
-    "git_commit": "04736f7960212883e1f851c735714fbcb8ff60d4",
+    "git_commit": "28912ca727011da682788ed39b322970e6349e08",
     "python": "3.11.13",
-    "started_at": "2026-07-09T23:44:08Z",
-    "wall_seconds": 13.05
+    "started_at": "2026-07-10T01:29:37Z",
+    "wall_seconds": 24.14
   },
   "schema_version": "1.0",
   "usage": {

--- a/bench/memory/results/longitudinal_fixture_cross_agent.json
+++ b/bench/memory/results/longitudinal_fixture_cross_agent.json
@@ -115,7 +115,7 @@
   "results": [
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.344,
+      "elapsed_seconds": 1.835,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -141,7 +141,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.665,
+      "elapsed_seconds": 1.799,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -169,7 +169,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.353,
+      "elapsed_seconds": 1.56,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -195,7 +195,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.662,
+      "elapsed_seconds": 2.52,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -221,7 +221,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.54,
+      "elapsed_seconds": 1.628,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -249,7 +249,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.305,
+      "elapsed_seconds": 2.232,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -275,7 +275,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.254,
+      "elapsed_seconds": 1.517,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -301,7 +301,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.522,
+      "elapsed_seconds": 1.479,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -329,7 +329,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.383,
+      "elapsed_seconds": 1.739,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -355,7 +355,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.46,
+      "elapsed_seconds": 1.611,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -381,7 +381,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.355,
+      "elapsed_seconds": 1.636,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -409,7 +409,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 2.776,
+      "elapsed_seconds": 1.675,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -435,7 +435,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.576,
+      "elapsed_seconds": 1.509,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -448,7 +448,7 @@
       "exact_strings": [],
       "is_abstention": false,
       "layer": "structured",
-      "qa_answer": "The competitor teardown was produced by the research-agent.",
+      "qa_answer": "The research-agent produced the competitor teardown.",
       "qa_correct": true,
       "question_id": "seq_cross_agent_000_q013_cross_agent_propagation",
       "question_type": "cross_agent_propagation",
@@ -461,7 +461,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.482,
+      "elapsed_seconds": 1.991,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -476,7 +476,7 @@
       ],
       "is_abstention": false,
       "layer": "structured",
-      "qa_answer": "The competitor teardown was filed under reference number DOC-1450-NX.",
+      "qa_answer": "The competitor teardown was filed under the reference number DOC-1450-NX.",
       "qa_correct": true,
       "question_id": "seq_cross_agent_000_q014_cross_agent_propagation",
       "question_type": "cross_agent_propagation",
@@ -489,7 +489,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.281,
+      "elapsed_seconds": 1.466,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -515,7 +515,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.928,
+      "elapsed_seconds": 1.452,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -541,7 +541,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.478,
+      "elapsed_seconds": 1.752,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -569,7 +569,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.447,
+      "elapsed_seconds": 2.514,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -595,7 +595,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.797,
+      "elapsed_seconds": 1.793,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -621,7 +621,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.493,
+      "elapsed_seconds": 1.596,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -636,7 +636,7 @@
       ],
       "is_abstention": false,
       "layer": "structured",
-      "qa_answer": "The brand refresh brief was filed under the reference number DOC-4146-JH.",
+      "qa_answer": "The brand refresh brief was filed under reference number DOC-4146-JH.",
       "qa_correct": true,
       "question_id": "seq_cross_agent_000_q020_cross_agent_propagation",
       "question_type": "cross_agent_propagation",
@@ -649,7 +649,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.269,
+      "elapsed_seconds": 1.657,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -675,7 +675,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.436,
+      "elapsed_seconds": 1.713,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -688,7 +688,7 @@
       "exact_strings": [],
       "is_abstention": false,
       "layer": "structured",
-      "qa_answer": "The engineering agent produced the API design document.",
+      "qa_answer": "The API design document was produced by the engineering-agent.",
       "qa_correct": true,
       "question_id": "seq_cross_agent_000_q022_cross_agent_propagation",
       "question_type": "cross_agent_propagation",
@@ -701,7 +701,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.556,
+      "elapsed_seconds": 1.925,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -729,7 +729,7 @@
     },
     {
       "category": "cross_agent_propagation",
-      "elapsed_seconds": 1.268,
+      "elapsed_seconds": 1.64,
       "error": null,
       "evidence_evicted": null,
       "evidence_session_ids": [
@@ -755,10 +755,10 @@
     }
   ],
   "run": {
-    "git_commit": "04736f7960212883e1f851c735714fbcb8ff60d4",
+    "git_commit": "28912ca727011da682788ed39b322970e6349e08",
     "python": "3.11.13",
-    "started_at": "2026-07-09T23:42:42Z",
-    "wall_seconds": 49.92
+    "started_at": "2026-07-10T01:29:37Z",
+    "wall_seconds": 66.33
   },
   "schema_version": "1.0",
   "usage": {

--- a/bench/memory/results/longitudinal_fixture_cross_agent.json
+++ b/bench/memory/results/longitudinal_fixture_cross_agent.json
@@ -1,0 +1,794 @@
+{
+  "benchmark": "longitudinal",
+  "config": {
+    "fetch_limit": 25,
+    "flush_digest": false,
+    "formation_yaml": "bench/memory/formation/formation.yaml",
+    "ground_truth_ingestion": "manifest via apply_extraction (no LLM extraction; see README Tier 2)",
+    "max_embed_chars": 6000,
+    "mode": "structured",
+    "qa": true,
+    "structured_backends": [
+      "knowledge_graph",
+      "captains_log"
+    ],
+    "text_model": "openai/gpt-4o-mini",
+    "working_embedding_model": "local/nomic-ai/nomic-embed-text-v1.5"
+  },
+  "dataset": {
+    "cases": 1,
+    "fixture": true,
+    "path": "bench/memory/fixtures/longitudinal_sample.json",
+    "questions": 24,
+    "scenario_config": {
+      "artifact_sets": 2,
+      "filler_exchanges": 2,
+      "sessions": 16,
+      "span_days": 30
+    },
+    "sessions": 16
+  },
+  "k": 5,
+  "metrics": {
+    "artifacts": {
+      "expected": 8,
+      "orphan_names": [],
+      "orphans": 0,
+      "reachable": 8,
+      "zero_orphans_met": true
+    },
+    "contradiction_detection": null,
+    "exact_strings": {
+      "by_category": {
+        "cross_agent_propagation": {
+          "missed_question_ids": [],
+          "questions": 8,
+          "recall@5": 1.0,
+          "recall@fetch": 1.0
+        }
+      },
+      "overall": {
+        "missed_question_ids": [],
+        "questions": 8,
+        "recall@5": 1.0,
+        "recall@fetch": 1.0
+      }
+    },
+    "k": 5,
+    "propagation": {
+      "recall@5": 1.0,
+      "target": 0.8,
+      "target_met": true
+    },
+    "qa": {
+      "by_question_type": {
+        "cross_agent_propagation": {
+          "accuracy": 1.0,
+          "questions": 24
+        }
+      },
+      "overall": {
+        "accuracy": 1.0,
+        "questions": 24
+      }
+    },
+    "questions_abstention": 0,
+    "questions_errored": 0,
+    "questions_scored": 24,
+    "questions_total": 24,
+    "retrieval": {
+      "session_level": {
+        "by_question_type": {
+          "cross_agent_propagation": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 24,
+            "recall@5": 1.0
+          }
+        },
+        "overall": {
+          "coverage@5": 1.0,
+          "mrr": 1.0,
+          "questions": 24,
+          "recall@5": 1.0
+        }
+      },
+      "turn_level": {
+        "by_question_type": {
+          "cross_agent_propagation": {
+            "coverage@5": 1.0,
+            "mrr": 1.0,
+            "questions": 24,
+            "recall@5": 1.0
+          }
+        },
+        "overall": {
+          "coverage@5": 1.0,
+          "mrr": 1.0,
+          "questions": 24,
+          "recall@5": 1.0
+        }
+      }
+    }
+  },
+  "mode": "cross_agent",
+  "results": [
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.344,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s001"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s001:0"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "The market sizing memo was produced by the research-agent.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q001_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s001"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s001:0"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.665,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s001"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s001:0"
+      ],
+      "exact_string_rank": 1,
+      "exact_strings": [
+        "DOC-3723-MR"
+      ],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "The market sizing memo was filed under reference number DOC-3723-MR.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q002_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s001"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s001:0"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.353,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s001"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s001:2"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "Owen Okafor recommended PostgreSQL for the pricing revamp.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q003_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s001"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s001:2"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.662,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s002"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s002:0"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "The Q3 revenue forecast was produced by the finance-agent.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q004_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s002"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s002:0"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.54,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s002"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s002:0"
+      ],
+      "exact_string_rank": 1,
+      "exact_strings": [
+        "DOC-2528-NT"
+      ],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "The Q3 revenue forecast was filed under reference number DOC-2528-NT.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q005_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s002"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s002:0"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.305,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s002"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s002:2"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "Kai Rao recommended Clerk for the enterprise pipeline.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q006_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s002"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s002:2"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.254,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s003"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s003:0"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "The marketing agent produced the campaign performance report.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q007_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s003"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s003:0"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.522,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s003"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s003:0"
+      ],
+      "exact_string_rank": 1,
+      "exact_strings": [
+        "DOC-8969-SF"
+      ],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "The campaign performance report was filed under the reference number DOC-8969-SF.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q008_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s003"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s003:0"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.383,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s003"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s003:2"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "Yuki Lindqvist recommended Stripe for the search revamp.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q009_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s003"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s003:2"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.46,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s004"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s004:0"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "The load test report was produced by the engineering agent.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q010_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s004"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s004:0"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.355,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s004"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s004:0"
+      ],
+      "exact_string_rank": 1,
+      "exact_strings": [
+        "DOC-6310-PQ"
+      ],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "The load test report was filed under the reference number DOC-6310-PQ.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q011_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s004"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s004:0"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 2.776,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s004"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s004:2"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "Mara Nakamura recommended Kafka for the partner program.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q012_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s004"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s004:2"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.576,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s005"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s005:0"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "The competitor teardown was produced by the research-agent.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q013_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s005"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s005:0"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.482,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s005"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s005:0"
+      ],
+      "exact_string_rank": 1,
+      "exact_strings": [
+        "DOC-1450-NX"
+      ],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "The competitor teardown was filed under reference number DOC-1450-NX.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q014_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s005"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s005:0"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.281,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s005"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s005:2"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "Petra Silva recommended Terraform for the pricing revamp.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q015_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s005"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s005:2"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.928,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s006"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s006:0"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "The budget variance report was produced by the finance-agent.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q016_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s006"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s006:0"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.478,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s006"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s006:0"
+      ],
+      "exact_string_rank": 1,
+      "exact_strings": [
+        "DOC-9594-JC"
+      ],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "The budget variance report was filed under the reference number DOC-9594-JC.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q017_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s006"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s006:0"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.447,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s006"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s006:2"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "Amara Mensah recommended Snowflake for the enterprise pipeline.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q018_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s006"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s006:2"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.797,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s007"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s007:0"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "The brand refresh brief was produced by the marketing agent.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q019_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s007"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s007:0"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.493,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s007"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s007:0"
+      ],
+      "exact_string_rank": 1,
+      "exact_strings": [
+        "DOC-4146-JH"
+      ],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "The brand refresh brief was filed under the reference number DOC-4146-JH.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q020_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s007"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s007:0"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.269,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s007"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s007:2"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "Owen Okafor recommended Redis for the search revamp.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q021_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s007"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s007:2"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.436,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s008"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s008:0"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "The engineering agent produced the API design document.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q022_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s008"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s008:0"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.556,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s008"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s008:0"
+      ],
+      "exact_string_rank": 1,
+      "exact_strings": [
+        "DOC-1058-MM"
+      ],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "The API design document was filed under reference number DOC-1058-MM.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q023_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s008"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s008:0"
+      ]
+    },
+    {
+      "category": "cross_agent_propagation",
+      "elapsed_seconds": 1.268,
+      "error": null,
+      "evidence_evicted": null,
+      "evidence_session_ids": [
+        "seq_cross_agent_000_s008"
+      ],
+      "evidence_turn_ids": [
+        "seq_cross_agent_000_s008:2"
+      ],
+      "exact_string_rank": null,
+      "exact_strings": [],
+      "is_abstention": false,
+      "layer": "structured",
+      "qa_answer": "Kai Rao recommended Temporal for the partner program.",
+      "qa_correct": true,
+      "question_id": "seq_cross_agent_000_q024_cross_agent_propagation",
+      "question_type": "cross_agent_propagation",
+      "retrieved_session_ids": [
+        "seq_cross_agent_000_s008"
+      ],
+      "retrieved_turn_ids": [
+        "seq_cross_agent_000_s008:2"
+      ]
+    }
+  ],
+  "run": {
+    "git_commit": "04736f7960212883e1f851c735714fbcb8ff60d4",
+    "python": "3.11.13",
+    "started_at": "2026-07-09T23:42:42Z",
+    "wall_seconds": 49.92
+  },
+  "schema_version": "1.0",
+  "usage": {
+    "cost": {
+      "estimated_usd": 0.001305,
+      "note": "List-price estimate for reporting only; local/* models are free.",
+      "per_model_usd": {
+        "openai/gpt-4o-mini": 0.001305
+      },
+      "unpriced_models": []
+    },
+    "ingested_turns": 8,
+    "llm_requests": 48,
+    "searches": 24,
+    "tokens": {
+      "in": 7280,
+      "out": 355,
+      "total": 7635,
+      "total_cached": 0
+    },
+    "tokens_by_model": {
+      "openai/gpt-4o-mini": [
+        7635,
+        7280,
+        355,
+        0,
+        0,
+        0
+      ]
+    },
+    "truncated_turns": 0
+  }
+}

--- a/bench/memory/results/longitudinal_fixture_isolation.json
+++ b/bench/memory/results/longitudinal_fixture_isolation.json
@@ -53,10 +53,10 @@
   "mode": "isolation",
   "results": [],
   "run": {
-    "git_commit": "04736f7960212883e1f851c735714fbcb8ff60d4",
+    "git_commit": "28912ca727011da682788ed39b322970e6349e08",
     "python": "3.11.13",
-    "started_at": "2026-07-09T23:43:33Z",
-    "wall_seconds": 33.56
+    "started_at": "2026-07-10T01:29:37Z",
+    "wall_seconds": 72.16
   },
   "schema_version": "1.0",
   "usage": {

--- a/bench/memory/results/longitudinal_fixture_isolation.json
+++ b/bench/memory/results/longitudinal_fixture_isolation.json
@@ -1,0 +1,81 @@
+{
+  "benchmark": "longitudinal",
+  "config": {
+    "fetch_limit": 25,
+    "flush_digest": false,
+    "formation_yaml": "bench/memory/formation/formation.yaml",
+    "max_embed_chars": 6000,
+    "mode": "combined",
+    "qa": true,
+    "text_model": "openai/gpt-4o-mini",
+    "working_embedding_model": "local/nomic-ai/nomic-embed-text-v1.5"
+  },
+  "dataset": {
+    "cases": 6,
+    "fixture": true,
+    "path": "bench/memory/fixtures/longitudinal_sample.json",
+    "questions": 24,
+    "scenario_config": {
+      "sessions_per_user": 7,
+      "span_days": 7,
+      "target_ops": 600,
+      "users": 6
+    },
+    "sessions": 42
+  },
+  "k": 5,
+  "metrics": {
+    "by_op_kind": {
+      "graph": {
+        "errors": 0,
+        "leaks": 0,
+        "operations": 200
+      },
+      "log": {
+        "errors": 0,
+        "leaks": 0,
+        "operations": 200
+      },
+      "vector_search": {
+        "errors": 0,
+        "leaks": 0,
+        "operations": 200
+      }
+    },
+    "leak_details": [],
+    "leaks": 0,
+    "operations": 600,
+    "operations_errored": 0,
+    "passed": true,
+    "target_operations": 600,
+    "users": 6
+  },
+  "mode": "isolation",
+  "results": [],
+  "run": {
+    "git_commit": "04736f7960212883e1f851c735714fbcb8ff60d4",
+    "python": "3.11.13",
+    "started_at": "2026-07-09T23:43:33Z",
+    "wall_seconds": 33.56
+  },
+  "schema_version": "1.0",
+  "usage": {
+    "cost": {
+      "estimated_usd": 0.0,
+      "note": "List-price estimate for reporting only; local/* models are free.",
+      "per_model_usd": {},
+      "unpriced_models": []
+    },
+    "ingested_turns": 222,
+    "llm_requests": 0,
+    "searches": 200,
+    "tokens": {
+      "in": 0,
+      "out": 0,
+      "total": 0,
+      "total_cached": 0
+    },
+    "tokens_by_model": {},
+    "truncated_turns": 0
+  }
+}

--- a/bench/memory/results/structured_recall_fixture_structured.json
+++ b/bench/memory/results/structured_recall_fixture_structured.json
@@ -3,7 +3,7 @@
   "config": {
     "fetch_limit": 25,
     "formation_yaml": "bench/memory/formation/formation.yaml",
-    "ground_truth_ingestion": "manifest via apply_extraction (no LLM extraction; see README Tier 3 seam)",
+    "ground_truth_ingestion": "manifest via apply_extraction (no LLM extraction; see README Tier 2)",
     "max_embed_chars": 6000,
     "mode": "structured",
     "qa": true,
@@ -75,11 +75,11 @@
     "qa": {
       "by_question_type": {
         "contradiction_detection": {
-          "accuracy": 0.0,
+          "accuracy": 0.6666666666666666,
           "questions": 6
         },
         "cross_agent": {
-          "accuracy": 0.5,
+          "accuracy": 1.0,
           "questions": 6
         },
         "kg_relationship": {
@@ -91,12 +91,12 @@
           "questions": 6
         },
         "temporal_validity": {
-          "accuracy": 0.5,
+          "accuracy": 0.6666666666666666,
           "questions": 6
         }
       },
       "overall": {
-        "accuracy": 0.5333333333333333,
+        "accuracy": 0.8,
         "questions": 30
       }
     },
@@ -185,7 +185,7 @@
   "results": [
     {
       "category": "kg_relationship",
-      "elapsed_seconds": 1.556,
+      "elapsed_seconds": 1.349,
       "error": null,
       "evidence_session_ids": [
         "seq_personal_assistant_002_s02"
@@ -209,7 +209,7 @@
     },
     {
       "category": "kg_relationship",
-      "elapsed_seconds": 2.097,
+      "elapsed_seconds": 1.504,
       "error": null,
       "evidence_session_ids": [
         "seq_personal_assistant_002_s04"
@@ -241,7 +241,7 @@
     },
     {
       "category": "temporal_validity",
-      "elapsed_seconds": 2.452,
+      "elapsed_seconds": 1.566,
       "error": null,
       "evidence_session_ids": [
         "seq_personal_assistant_002_s01"
@@ -252,8 +252,8 @@
       "exact_string_rank": null,
       "exact_strings": [],
       "is_abstention": false,
-      "qa_answer": "Malik Rao's role at Quill Software on 2026-01-27 was backend engineer.",
-      "qa_correct": false,
+      "qa_answer": "The excerpts do not provide information about Malik Rao's role at Quill Software on 2026-01-27. Therefore, I do not know.",
+      "qa_correct": true,
       "question_id": "seq_personal_assistant_002_q003_temporal_validity",
       "question_type": "temporal_validity",
       "retrieved_session_ids": [
@@ -274,7 +274,7 @@
     },
     {
       "category": "temporal_validity",
-      "elapsed_seconds": 1.861,
+      "elapsed_seconds": 1.57,
       "error": null,
       "evidence_session_ids": [
         "seq_personal_assistant_002_s07"
@@ -306,7 +306,7 @@
     },
     {
       "category": "narrative_recall",
-      "elapsed_seconds": 2.246,
+      "elapsed_seconds": 1.401,
       "error": null,
       "evidence_session_ids": [
         "seq_personal_assistant_002_s04"
@@ -328,7 +328,7 @@
     },
     {
       "category": "narrative_recall",
-      "elapsed_seconds": 2.183,
+      "elapsed_seconds": 1.945,
       "error": null,
       "evidence_session_ids": [
         "seq_personal_assistant_002_s07"
@@ -350,7 +350,7 @@
     },
     {
       "category": "cross_agent",
-      "elapsed_seconds": 1.946,
+      "elapsed_seconds": 1.555,
       "error": null,
       "evidence_session_ids": [
         "seq_personal_assistant_002_s10"
@@ -361,8 +361,8 @@
       "exact_string_rank": null,
       "exact_strings": [],
       "is_abstention": false,
-      "qa_answer": "I do not know.",
-      "qa_correct": false,
+      "qa_answer": "The travel itinerary was produced by the inbox-agent.",
+      "qa_correct": true,
       "question_id": "seq_personal_assistant_002_q007_cross_agent",
       "question_type": "cross_agent",
       "retrieved_session_ids": [
@@ -374,7 +374,7 @@
     },
     {
       "category": "cross_agent",
-      "elapsed_seconds": 3.201,
+      "elapsed_seconds": 1.901,
       "error": null,
       "evidence_session_ids": [
         "seq_personal_assistant_002_s10"
@@ -387,7 +387,7 @@
         "DOC-4041-PR"
       ],
       "is_abstention": false,
-      "qa_answer": "The travel itinerary was filed under reference number DOC-4041-PR.",
+      "qa_answer": "The travel itinerary was filed under the reference number DOC-4041-PR.",
       "qa_correct": true,
       "question_id": "seq_personal_assistant_002_q008_cross_agent",
       "question_type": "cross_agent",
@@ -400,7 +400,7 @@
     },
     {
       "category": "contradiction_detection",
-      "elapsed_seconds": 2.776,
+      "elapsed_seconds": 1.469,
       "error": null,
       "evidence_session_ids": [
         "seq_personal_assistant_002_s02",
@@ -413,7 +413,7 @@
       "exact_string_rank": null,
       "exact_strings": [],
       "is_abstention": false,
-      "qa_answer": "Dario Alvarez works at Northwind Analytics.",
+      "qa_answer": "Dario Alvarez works at Quill Software as an engineering lead.",
       "qa_correct": false,
       "question_id": "seq_personal_assistant_002_q009_contradiction_detection",
       "question_type": "contradiction_detection",
@@ -429,7 +429,7 @@
     },
     {
       "category": "contradiction_detection",
-      "elapsed_seconds": 1.94,
+      "elapsed_seconds": 1.699,
       "error": null,
       "evidence_session_ids": [
         "seq_personal_assistant_002_s01",
@@ -442,8 +442,8 @@
       "exact_string_rank": null,
       "exact_strings": [],
       "is_abstention": false,
-      "qa_answer": "Kai Bergstrom lives in Singapore.",
-      "qa_correct": false,
+      "qa_answer": "Kai Bergstrom has stated that he lives in both Berlin and Singapore, but the status is conflicted for both. Therefore, it is unclear which city he currently lives in.",
+      "qa_correct": true,
       "question_id": "seq_personal_assistant_002_q010_contradiction_detection",
       "question_type": "contradiction_detection",
       "retrieved_session_ids": [
@@ -461,7 +461,7 @@
     },
     {
       "category": "kg_relationship",
-      "elapsed_seconds": 1.943,
+      "elapsed_seconds": 1.543,
       "error": null,
       "evidence_session_ids": [
         "seq_sales_ops_001_s01"
@@ -491,7 +491,7 @@
     },
     {
       "category": "kg_relationship",
-      "elapsed_seconds": 1.416,
+      "elapsed_seconds": 1.434,
       "error": null,
       "evidence_session_ids": [
         "seq_sales_ops_001_s07"
@@ -515,7 +515,7 @@
     },
     {
       "category": "temporal_validity",
-      "elapsed_seconds": 1.598,
+      "elapsed_seconds": 1.621,
       "error": null,
       "evidence_session_ids": [
         "seq_sales_ops_001_s01"
@@ -548,7 +548,7 @@
     },
     {
       "category": "temporal_validity",
-      "elapsed_seconds": 1.576,
+      "elapsed_seconds": 1.439,
       "error": null,
       "evidence_session_ids": [
         "seq_sales_ops_001_s07"
@@ -580,7 +580,7 @@
     },
     {
       "category": "narrative_recall",
-      "elapsed_seconds": 1.402,
+      "elapsed_seconds": 1.26,
       "error": null,
       "evidence_session_ids": [
         "seq_sales_ops_001_s07"
@@ -602,7 +602,7 @@
     },
     {
       "category": "narrative_recall",
-      "elapsed_seconds": 0.74,
+      "elapsed_seconds": 0.817,
       "error": null,
       "evidence_session_ids": [
         "seq_sales_ops_001_s07"
@@ -624,7 +624,7 @@
     },
     {
       "category": "cross_agent",
-      "elapsed_seconds": 1.488,
+      "elapsed_seconds": 1.576,
       "error": null,
       "evidence_session_ids": [
         "seq_sales_ops_001_s03"
@@ -635,8 +635,8 @@
       "exact_string_rank": null,
       "exact_strings": [],
       "is_abstention": false,
-      "qa_answer": "I do not know.",
-      "qa_correct": false,
+      "qa_answer": "The sales agent produced the pricing comparison sheet.",
+      "qa_correct": true,
       "question_id": "seq_sales_ops_001_q007_cross_agent",
       "question_type": "cross_agent",
       "retrieved_session_ids": [
@@ -648,7 +648,7 @@
     },
     {
       "category": "cross_agent",
-      "elapsed_seconds": 1.68,
+      "elapsed_seconds": 1.433,
       "error": null,
       "evidence_session_ids": [
         "seq_sales_ops_001_s10"
@@ -661,7 +661,7 @@
         "DOC-9458-JH"
       ],
       "is_abstention": false,
-      "qa_answer": "The finance-agent filed the pipeline health report under reference number DOC-9458-JH.",
+      "qa_answer": "The finance-agent filed the pipeline health report under the reference number DOC-9458-JH.",
       "qa_correct": true,
       "question_id": "seq_sales_ops_001_q008_cross_agent",
       "question_type": "cross_agent",
@@ -674,7 +674,7 @@
     },
     {
       "category": "contradiction_detection",
-      "elapsed_seconds": 1.501,
+      "elapsed_seconds": 1.771,
       "error": null,
       "evidence_session_ids": [
         "seq_sales_ops_001_s01",
@@ -687,8 +687,8 @@
       "exact_string_rank": null,
       "exact_strings": [],
       "is_abstention": false,
-      "qa_answer": "Sofia Moreau lives in Melbourne.",
-      "qa_correct": false,
+      "qa_answer": "Sofia Moreau has been stated to live in both Amsterdam and Melbourne, but the most recent information indicates she lives in Melbourne.",
+      "qa_correct": true,
       "question_id": "seq_sales_ops_001_q009_contradiction_detection",
       "question_type": "contradiction_detection",
       "retrieved_session_ids": [
@@ -706,7 +706,7 @@
     },
     {
       "category": "contradiction_detection",
-      "elapsed_seconds": 2.044,
+      "elapsed_seconds": 1.554,
       "error": null,
       "evidence_session_ids": [
         "seq_sales_ops_001_s02",
@@ -719,8 +719,8 @@
       "exact_string_rank": null,
       "exact_strings": [],
       "is_abstention": false,
-      "qa_answer": "Ingrid Okafor works at Sundial Health.",
-      "qa_correct": false,
+      "qa_answer": "Ingrid Okafor works at Aster Dynamics and Sundial Health, but her status is conflicted for both.",
+      "qa_correct": true,
       "question_id": "seq_sales_ops_001_q010_contradiction_detection",
       "question_type": "contradiction_detection",
       "retrieved_session_ids": [
@@ -735,7 +735,7 @@
     },
     {
       "category": "kg_relationship",
-      "elapsed_seconds": 2.582,
+      "elapsed_seconds": 1.493,
       "error": null,
       "evidence_session_ids": [
         "seq_software_team_000_s02"
@@ -764,7 +764,7 @@
     },
     {
       "category": "kg_relationship",
-      "elapsed_seconds": 1.401,
+      "elapsed_seconds": 1.234,
       "error": null,
       "evidence_session_ids": [
         "seq_software_team_000_s07"
@@ -788,7 +788,7 @@
     },
     {
       "category": "temporal_validity",
-      "elapsed_seconds": 1.915,
+      "elapsed_seconds": 1.805,
       "error": null,
       "evidence_session_ids": [
         "seq_software_team_000_s01"
@@ -821,7 +821,7 @@
     },
     {
       "category": "temporal_validity",
-      "elapsed_seconds": 1.65,
+      "elapsed_seconds": 1.378,
       "error": null,
       "evidence_session_ids": [
         "seq_software_team_000_s07"
@@ -853,7 +853,7 @@
     },
     {
       "category": "narrative_recall",
-      "elapsed_seconds": 1.898,
+      "elapsed_seconds": 1.684,
       "error": null,
       "evidence_session_ids": [
         "seq_software_team_000_s04"
@@ -875,7 +875,7 @@
     },
     {
       "category": "narrative_recall",
-      "elapsed_seconds": 0.719,
+      "elapsed_seconds": 0.661,
       "error": null,
       "evidence_session_ids": [
         "seq_software_team_000_s04"
@@ -897,7 +897,7 @@
     },
     {
       "category": "cross_agent",
-      "elapsed_seconds": 1.626,
+      "elapsed_seconds": 1.473,
       "error": null,
       "evidence_session_ids": [
         "seq_software_team_000_s06"
@@ -910,7 +910,7 @@
         "DOC-4784-NM"
       ],
       "is_abstention": false,
-      "qa_answer": "The load test report was filed under reference number DOC-4784-NM.",
+      "qa_answer": "The engineering-agent filed the load test report under the reference number DOC-4784-NM.",
       "qa_correct": true,
       "question_id": "seq_software_team_000_q007_cross_agent",
       "question_type": "cross_agent",
@@ -923,7 +923,7 @@
     },
     {
       "category": "cross_agent",
-      "elapsed_seconds": 3.735,
+      "elapsed_seconds": 1.309,
       "error": null,
       "evidence_session_ids": [
         "seq_software_team_000_s03"
@@ -934,8 +934,8 @@
       "exact_string_rank": null,
       "exact_strings": [],
       "is_abstention": false,
-      "qa_answer": "I do not know.",
-      "qa_correct": false,
+      "qa_answer": "The incident postmortem was produced by the research-agent.",
+      "qa_correct": true,
       "question_id": "seq_software_team_000_q008_cross_agent",
       "question_type": "cross_agent",
       "retrieved_session_ids": [
@@ -947,7 +947,7 @@
     },
     {
       "category": "contradiction_detection",
-      "elapsed_seconds": 1.583,
+      "elapsed_seconds": 1.531,
       "error": null,
       "evidence_session_ids": [
         "seq_software_team_000_s02",
@@ -976,7 +976,7 @@
     },
     {
       "category": "contradiction_detection",
-      "elapsed_seconds": 1.517,
+      "elapsed_seconds": 1.756,
       "error": null,
       "evidence_session_ids": [
         "seq_software_team_000_s01",
@@ -989,8 +989,8 @@
       "exact_string_rank": null,
       "exact_strings": [],
       "is_abstention": false,
-      "qa_answer": "Ravi Alvarez lives in Toronto.",
-      "qa_correct": false,
+      "qa_answer": "Ravi Alvarez has stated that he lives in both Lisbon and Toronto, but the status is conflicted. Therefore, it is unclear which city he currently resides in.",
+      "qa_correct": true,
       "question_id": "seq_software_team_000_q010_contradiction_detection",
       "question_type": "contradiction_detection",
       "retrieved_session_ids": [
@@ -1013,18 +1013,18 @@
       "failed": 0,
       "skipped": 0
     },
-    "git_commit": "01647a226d9fc4b44dc7931357188b1d0061f7d9",
+    "git_commit": "04736f7960212883e1f851c735714fbcb8ff60d4",
     "python": "3.11.13",
-    "started_at": "2026-07-09T21:59:00Z",
-    "wall_seconds": 75.89
+    "started_at": "2026-07-09T23:41:00Z",
+    "wall_seconds": 58.45
   },
   "schema_version": "1.0",
   "usage": {
     "cost": {
-      "estimated_usd": 0.00201,
+      "estimated_usd": 0.002231,
       "note": "List-price estimate for reporting only; local/* models are free.",
       "per_model_usd": {
-        "openai/gpt-4o-mini": 0.00201
+        "openai/gpt-4o-mini": 0.002231
       },
       "unpriced_models": []
     },
@@ -1032,16 +1032,16 @@
     "llm_requests": 60,
     "searches": 30,
     "tokens": {
-      "in": 11209,
-      "out": 547,
-      "total": 11756,
+      "in": 12240,
+      "out": 659,
+      "total": 12899,
       "total_cached": 0
     },
     "tokens_by_model": {
       "openai/gpt-4o-mini": [
-        11756,
-        11209,
-        547,
+        12899,
+        12240,
+        659,
         0,
         0,
         0

--- a/bench/memory/structured_adapter.py
+++ b/bench/memory/structured_adapter.py
@@ -11,10 +11,11 @@ Knowledge Graph and Captain's Log services instead of vector search:
   chronological order. No LLM is involved: ingesting the manifest
   directly isolates *structured recall* (can the KG/log query surface
   answer the question?) from *extraction quality* (can the LLM build
-  the right graph from raw text?). The extraction-quality half is the
-  Tier 3 seam: once the memory-substrate rebuild lands, the same
-  dataset can be replayed turn-by-turn through
-  ``process_conversation_turn`` to measure the full pipeline.
+  the right graph from raw text?). Tier 3 builds on this adapter
+  (:mod:`bench.memory.longitudinal_adapter`): its Scenario D replays
+  manifests per-session through the live ``store_extraction`` path;
+  the full LLM replay via ``process_conversation_turn`` remains a
+  documented non-goal (one LLM call per turn — see the README).
 - **Retrieval** matches question text against KG entities (whole-word,
   longest-first), ranks the relationships touching matched entities by
   confidence, and — for date-scoped questions — fetches Captain's-Log
@@ -218,7 +219,7 @@ class StructuredMemoryAdapter(MuxiMemoryAdapter):
         # relationship-only rendering would lose them (that gap showed up
         # as 0% exact-string recall on entity-attribute questions).
         items: List[RetrievedItem] = []
-        seen_turns = set()
+        by_turn: Dict[str, RetrievedItem] = {}
         for entity in matched:
             attributes = dict(entity.get("attributes") or {})
             if not attributes:
@@ -227,18 +228,17 @@ class StructuredMemoryAdapter(MuxiMemoryAdapter):
             for session_id, turn_id in self._entity_provenance.get(_name_key(entity["name"]), [])[
                 :1
             ]:
-                if turn_id in seen_turns:
+                if turn_id in by_turn:
                     continue
-                seen_turns.add(turn_id)
-                items.append(
-                    RetrievedItem(
-                        turn_id=turn_id,
-                        session_id=session_id,
-                        text=text,
-                        score=float(entity.get("confidence") or 0.0),
-                        source="knowledge_graph",
-                    )
+                item = RetrievedItem(
+                    turn_id=turn_id,
+                    session_id=session_id,
+                    text=text,
+                    score=float(entity.get("confidence") or 0.0),
+                    source="knowledge_graph",
                 )
+                by_turn[turn_id] = item
+                items.append(item)
 
         relationships = await graph.storage.list_relationships(user_id, status=None, limit=1000)
         touching = [
@@ -259,18 +259,26 @@ class StructuredMemoryAdapter(MuxiMemoryAdapter):
                 attributes["status"] = status
             text = f"{from_name} -[{rel['type']}]-> {to_name}{_render_attributes(attributes)}"
             for session_id, turn_id in self._rel_provenance.get(key, []):
-                if turn_id in seen_turns:
+                existing = by_turn.get(turn_id)
+                if existing is not None:
+                    # Several facts can share a provenance turn (an
+                    # entity card and the relationship stated by the
+                    # same utterance). The turn stays at its best rank,
+                    # but its TEXT must carry every fact — dropping the
+                    # relationship here starved the QA context of
+                    # answers retrieval had already found.
+                    if text not in existing.text:
+                        existing.text = f"{existing.text} | {text}"
                     continue
-                seen_turns.add(turn_id)
-                items.append(
-                    RetrievedItem(
-                        turn_id=turn_id,
-                        session_id=session_id,
-                        text=text,
-                        score=float(rel["confidence"] or 0.0),
-                        source="knowledge_graph",
-                    )
+                item = RetrievedItem(
+                    turn_id=turn_id,
+                    session_id=session_id,
+                    text=text,
+                    score=float(rel["confidence"] or 0.0),
+                    source="knowledge_graph",
                 )
+                by_turn[turn_id] = item
+                items.append(item)
             if len(items) >= fetch_limit:
                 break
         return items[:fetch_limit]
@@ -374,6 +382,6 @@ class StructuredMemoryAdapter(MuxiMemoryAdapter):
         if self.mode == STRUCTURED_MODE:
             config["structured_backends"] = ["knowledge_graph", "captains_log"]
             config["ground_truth_ingestion"] = (
-                "manifest via apply_extraction (no LLM extraction; see README Tier 3 seam)"
+                "manifest via apply_extraction (no LLM extraction; see README Tier 2)"
             )
         return config

--- a/bench/memory/structured_adapter.py
+++ b/bench/memory/structured_adapter.py
@@ -220,6 +220,34 @@ class StructuredMemoryAdapter(MuxiMemoryAdapter):
         # as 0% exact-string recall on entity-attribute questions).
         items: List[RetrievedItem] = []
         by_turn: Dict[str, RetrievedItem] = {}
+        # Exact fact renderings already carried by each turn's item:
+        # substring checks against the concatenated text would be
+        # fragile (one fact's rendering can be a prefix of another's).
+        texts_by_turn: Dict[str, set] = {}
+
+        def _attach(turn_id: str, session_id: str, text: str, score: float) -> None:
+            existing = by_turn.get(turn_id)
+            if existing is None:
+                item = RetrievedItem(
+                    turn_id=turn_id,
+                    session_id=session_id,
+                    text=text,
+                    score=score,
+                    source="knowledge_graph",
+                )
+                by_turn[turn_id] = item
+                texts_by_turn[turn_id] = {text}
+                items.append(item)
+                return
+            # Several facts can share a provenance turn (an entity card
+            # and the relationship stated by the same utterance). The
+            # turn stays at its best rank, but its TEXT must carry
+            # every fact — dropping later facts starved the QA context
+            # of answers retrieval had already found.
+            if text not in texts_by_turn[turn_id]:
+                texts_by_turn[turn_id].add(text)
+                existing.text = f"{existing.text} | {text}"
+
         for entity in matched:
             attributes = dict(entity.get("attributes") or {})
             if not attributes:
@@ -228,17 +256,7 @@ class StructuredMemoryAdapter(MuxiMemoryAdapter):
             for session_id, turn_id in self._entity_provenance.get(_name_key(entity["name"]), [])[
                 :1
             ]:
-                if turn_id in by_turn:
-                    continue
-                item = RetrievedItem(
-                    turn_id=turn_id,
-                    session_id=session_id,
-                    text=text,
-                    score=float(entity.get("confidence") or 0.0),
-                    source="knowledge_graph",
-                )
-                by_turn[turn_id] = item
-                items.append(item)
+                _attach(turn_id, session_id, text, float(entity.get("confidence") or 0.0))
 
         relationships = await graph.storage.list_relationships(user_id, status=None, limit=1000)
         touching = [
@@ -259,26 +277,7 @@ class StructuredMemoryAdapter(MuxiMemoryAdapter):
                 attributes["status"] = status
             text = f"{from_name} -[{rel['type']}]-> {to_name}{_render_attributes(attributes)}"
             for session_id, turn_id in self._rel_provenance.get(key, []):
-                existing = by_turn.get(turn_id)
-                if existing is not None:
-                    # Several facts can share a provenance turn (an
-                    # entity card and the relationship stated by the
-                    # same utterance). The turn stays at its best rank,
-                    # but its TEXT must carry every fact — dropping the
-                    # relationship here starved the QA context of
-                    # answers retrieval had already found.
-                    if text not in existing.text:
-                        existing.text = f"{existing.text} | {text}"
-                    continue
-                item = RetrievedItem(
-                    turn_id=turn_id,
-                    session_id=session_id,
-                    text=text,
-                    score=float(rel["confidence"] or 0.0),
-                    source="knowledge_graph",
-                )
-                by_turn[turn_id] = item
-                items.append(item)
+                _attach(turn_id, session_id, text, float(rel["confidence"] or 0.0))
             if len(items) >= fetch_limit:
                 break
         return items[:fetch_limit]

--- a/bench/memory/structured_corpus.py
+++ b/bench/memory/structured_corpus.py
@@ -27,11 +27,11 @@ produce byte-identical dataset files. No LLM is involved; the PRD's
 "automated generation layer" (LLM-expanded questions validated by
 human review) can extend this corpus later without replacing it.
 
-Tier 3 seam: the longitudinal benchmark (30-90 day corpora, buffer
-cycling, multi-user isolation) builds on the same event-scheduling
-skeleton — sessions here already carry real dates and per-agent
-attribution — but requires the memory-substrate rebuild to land
-first. See bench/memory/README.md ("Tier 3").
+Tier 3: the longitudinal benchmark (30-90 day corpora, buffer
+cycling, multi-user isolation) builds on this module's dated,
+agent-attributed session skeleton — see
+:mod:`bench.memory.longitudinal_corpus`, which imports the shared
+pools and ground-truth dataclasses from here.
 
 CLI
 ---

--- a/tests/unit/bench_memory/test_longitudinal_adapter.py
+++ b/tests/unit/bench_memory/test_longitudinal_adapter.py
@@ -1,0 +1,31 @@
+"""Longitudinal adapter tests (state handling; no formation boot)."""
+
+from bench.memory.longitudinal_adapter import LongitudinalMemoryAdapter
+
+
+class TestClearCase:
+    def test_resets_per_case_counters(self):
+        adapter = LongitudinalMemoryAdapter(buffer_max_mb=0.4)
+        adapter.buffer_ingested_turns = 228
+        adapter.cleanup_passes = 18
+        adapter.flush_hand_offs = 11
+        adapter.flush_items_handed = 131
+
+        adapter.clear_case()
+
+        assert adapter.buffer_ingested_turns == 0
+        assert adapter.cleanup_passes == 0
+        assert adapter.flush_hand_offs == 0
+        assert adapter.flush_items_handed == 0
+
+    def test_still_resets_tier2_provenance(self):
+        adapter = LongitudinalMemoryAdapter()
+        adapter._rel_provenance = {("a", "works_at", "b"): [("s1", "s1:0")]}
+        adapter._entity_provenance = {"a": [("s1", "s1:0")]}
+        adapter._log_sources = {"2026-01-01": ["s1"]}
+
+        adapter.clear_case()
+
+        assert adapter._rel_provenance == {}
+        assert adapter._entity_provenance == {}
+        assert adapter._log_sources == {}

--- a/tests/unit/bench_memory/test_longitudinal_corpus.py
+++ b/tests/unit/bench_memory/test_longitudinal_corpus.py
@@ -1,0 +1,317 @@
+"""Longitudinal corpus generator tests (determinism + scenario coverage)."""
+
+import json
+from datetime import date, timedelta
+
+import pytest
+
+from bench.memory.longitudinal_corpus import (
+    CONFLICTED_NEW_CONFIDENCE,
+    CONFLICTED_OLD_CONFIDENCE,
+    CROSS_AGENT_AGENTS,
+    EARLY_WINDOW_DAYS,
+    PRESETS,
+    SCENARIO_BUFFER_CYCLE,
+    SCENARIO_CONTRADICTION,
+    SCENARIO_CROSS_AGENT,
+    SCENARIO_ISOLATION,
+    SCENARIOS,
+    SUPERSEDED_NEW_CONFIDENCE,
+    SUPERSEDED_OLD_CONFIDENCE,
+    generate_dataset,
+)
+from bench.memory.structured_corpus import write_dataset
+
+EXCLUSIVE_PREDICATES = {"works_at", "lives_in"}
+# graph/models.py: delta above 0.3 supersedes, at/below flags conflicted.
+SUPERSEDE_CONFIDENCE_DELTA = 0.3
+
+
+@pytest.fixture(scope="module")
+def dataset():
+    return generate_dataset(preset="fixture", seed=42)
+
+
+def _case(dataset, scenario):
+    return dataset["scenarios"][scenario]["cases"][0]
+
+
+def _turn_ids(case):
+    return {
+        f"{session['session_id']}:{index}"
+        for session in case["sessions"]
+        for index in range(len(session["turns"]))
+    }
+
+
+class TestDeterminism:
+    def test_same_seed_identical(self):
+        a = generate_dataset(preset="fixture", seed=7)
+        b = generate_dataset(preset="fixture", seed=7)
+        assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
+
+    def test_different_seed_differs(self):
+        a = generate_dataset(preset="fixture", seed=7)
+        b = generate_dataset(preset="fixture", seed=8)
+        assert json.dumps(a, sort_keys=True) != json.dumps(b, sort_keys=True)
+
+    def test_written_file_bytes_stable(self, tmp_path):
+        dataset = generate_dataset(preset="fixture", seed=3)
+        first = write_dataset(dataset, tmp_path / "a.json")
+        second = write_dataset(dataset, tmp_path / "b.json")
+        assert first.read_text() == second.read_text()
+
+    def test_unknown_preset_rejected(self):
+        with pytest.raises(ValueError, match="Unknown preset"):
+            generate_dataset(preset="nope")
+
+
+class TestStructure:
+    def test_all_scenarios_present(self, dataset):
+        assert set(dataset["scenarios"]) == set(SCENARIOS)
+
+    def test_every_scenario_has_cases_and_sessions(self, dataset):
+        for scenario in SCENARIOS:
+            cases = dataset["scenarios"][scenario]["cases"]
+            assert cases, scenario
+            for case in cases:
+                assert case["sessions"], case["case_id"]
+                for session in case["sessions"]:
+                    assert session["date"]
+                    assert session["turns"]
+
+    def test_evidence_ids_exist_in_corpus(self, dataset):
+        for scenario in SCENARIOS:
+            for case in dataset["scenarios"][scenario]["cases"]:
+                session_ids = {session["session_id"] for session in case["sessions"]}
+                turn_ids = _turn_ids(case)
+                for question in case["questions"]:
+                    assert question["evidence_session_ids"], question["question_id"]
+                    for session_id in question["evidence_session_ids"]:
+                        assert session_id in session_ids
+                    for turn_id in question["evidence_turn_ids"]:
+                        assert turn_id in turn_ids
+
+    def test_exact_strings_appear_in_evidence_turns(self, dataset):
+        for scenario in SCENARIOS:
+            for case in dataset["scenarios"][scenario]["cases"]:
+                texts_by_turn = {
+                    f"{session['session_id']}:{index}": turn["content"]
+                    for session in case["sessions"]
+                    for index, turn in enumerate(session["turns"])
+                }
+                for question in case["questions"]:
+                    if not question["exact_strings"] or not question["evidence_turn_ids"]:
+                        continue
+                    evidence_texts = [
+                        texts_by_turn[turn_id] for turn_id in question["evidence_turn_ids"]
+                    ]
+                    for exact in question["exact_strings"]:
+                        assert any(exact.lower() in text.lower() for text in evidence_texts), (
+                            question["question_id"],
+                            exact,
+                        )
+
+    def test_relationship_provenance_points_at_real_turns(self, dataset):
+        for scenario in SCENARIOS:
+            for case in dataset["scenarios"][scenario]["cases"]:
+                turn_ids = _turn_ids(case)
+                for rel in case["ground_truth"]["relationships"]:
+                    assert rel["turn_id"] in turn_ids, rel
+
+
+class TestBufferCycleScenario:
+    def test_evicted_questions_target_early_window(self, dataset):
+        case = _case(dataset, SCENARIO_BUFFER_CYCLE)
+        dates = {session["session_id"]: session["date"] for session in case["sessions"]}
+        window = case["ground_truth"]["early_window"]
+        for question in case["questions"]:
+            if question["category"] != "evicted_recall":
+                continue
+            for session_id in question["evidence_session_ids"]:
+                assert window["date_from"] <= dates[session_id] <= window["date_to"], question
+
+    def test_recent_questions_target_late_window(self, dataset):
+        case = _case(dataset, SCENARIO_BUFFER_CYCLE)
+        params = PRESETS["fixture"][SCENARIO_BUFFER_CYCLE]
+        dates = {session["session_id"]: session["date"] for session in case["sessions"]}
+        start = date.fromisoformat(case["ground_truth"]["early_window"]["date_from"])
+        recent_cutoff = (
+            start + timedelta(days=params["span_days"] - EARLY_WINDOW_DAYS)
+        ).isoformat()
+        for question in case["questions"]:
+            if question["category"] != "recent_recall":
+                continue
+            for session_id in question["evidence_session_ids"]:
+                assert dates[session_id] >= recent_cutoff, question
+
+    def test_both_categories_present(self, dataset):
+        case = _case(dataset, SCENARIO_BUFFER_CYCLE)
+        categories = {question["category"] for question in case["questions"]}
+        assert categories == {"evicted_recall", "recent_recall"}
+
+    def test_corpus_spans_the_configured_window(self, dataset):
+        case = _case(dataset, SCENARIO_BUFFER_CYCLE)
+        params = PRESETS["fixture"][SCENARIO_BUFFER_CYCLE]
+        dates = sorted(session["date"] for session in case["sessions"])
+        first = date.fromisoformat(dates[0])
+        last = date.fromisoformat(dates[-1])
+        assert (last - first).days == params["span_days"] - 1
+
+    def test_decisions_match_log_entries(self, dataset):
+        case = _case(dataset, SCENARIO_BUFFER_CYCLE)
+        truth = case["ground_truth"]
+        assert truth["decisions"]
+        logged = {decision for entry in truth["log_entries"] for decision in entry["decisions"]}
+        for item in truth["decisions"]:
+            assert item["decision"] in logged
+
+
+class TestCrossAgentScenario:
+    def test_four_prd_agents(self, dataset):
+        case = _case(dataset, SCENARIO_CROSS_AGENT)
+        agents = {session["agent_id"] for session in case["sessions"]}
+        assert agents == set(CROSS_AGENT_AGENTS)
+
+    def test_every_question_crosses_agents(self, dataset):
+        case = _case(dataset, SCENARIO_CROSS_AGENT)
+        meta = case["ground_truth"]["question_meta"]
+        assert case["questions"]
+        for question in case["questions"]:
+            pair = meta[question["question_id"]]
+            assert pair["asking_agent"] != pair["evidence_agent"], question["question_id"]
+            assert pair["asking_agent"] in CROSS_AGENT_AGENTS
+
+    def test_evidence_sessions_belong_to_evidence_agent(self, dataset):
+        case = _case(dataset, SCENARIO_CROSS_AGENT)
+        meta = case["ground_truth"]["question_meta"]
+        agents = {session["session_id"]: session["agent_id"] for session in case["sessions"]}
+        for question in case["questions"]:
+            expected = meta[question["question_id"]]["evidence_agent"]
+            for session_id in question["evidence_session_ids"]:
+                assert agents[session_id] == expected
+
+    def test_question_texts_unambiguous(self, dataset):
+        # Every "who recommended X for Y" must have exactly one answer:
+        # duplicate question texts would make the gold answer ambiguous.
+        case = _case(dataset, SCENARIO_CROSS_AGENT)
+        texts = [question["question"] for question in case["questions"]]
+        assert len(texts) == len(set(texts))
+
+    def test_artifacts_unique_with_provenance(self, dataset):
+        case = _case(dataset, SCENARIO_CROSS_AGENT)
+        artifacts = case["ground_truth"]["artifacts"]
+        assert artifacts
+        names = [artifact["name"] for artifact in artifacts]
+        assert len(names) == len(set(names))
+        turn_ids = _turn_ids(case)
+        for artifact in artifacts:
+            assert artifact["turn_id"] in turn_ids
+            assert artifact["agent"] in CROSS_AGENT_AGENTS
+
+
+class TestIsolationScenario:
+    def test_one_case_per_user(self, dataset):
+        cases = dataset["scenarios"][SCENARIO_ISOLATION]["cases"]
+        assert len(cases) == PRESETS["fixture"][SCENARIO_ISOLATION]["users"]
+        assert len({case["case_id"] for case in cases}) == len(cases)
+
+    def test_canaries_globally_unique(self, dataset):
+        cases = dataset["scenarios"][SCENARIO_ISOLATION]["cases"]
+        all_canaries = [canary for case in cases for canary in case["ground_truth"]["canaries"]]
+        assert all_canaries
+        assert len(all_canaries) == len(set(all_canaries))
+
+    def test_canaries_never_leak_into_other_users_corpora(self, dataset):
+        cases = dataset["scenarios"][SCENARIO_ISOLATION]["cases"]
+        corpora = {
+            case["case_id"]: " ".join(
+                turn["content"] for session in case["sessions"] for turn in session["turns"]
+            ).lower()
+            for case in cases
+        }
+        for case in cases:
+            for canary in case["ground_truth"]["canaries"]:
+                for other_id, text in corpora.items():
+                    if other_id == case["case_id"]:
+                        assert canary.lower() in text
+                    else:
+                        assert canary.lower() not in text, (case["case_id"], other_id, canary)
+
+    def test_probe_questions_carry_exact_strings(self, dataset):
+        for case in dataset["scenarios"][SCENARIO_ISOLATION]["cases"]:
+            tagged = [q for q in case["questions"] if q["exact_strings"]]
+            assert tagged, case["case_id"]
+
+    def test_identical_probe_templates_across_users(self, dataset):
+        # The isolation stressor: every user asks the same questions, so
+        # a scoping bug would surface another user's near-identical turn.
+        cases = dataset["scenarios"][SCENARIO_ISOLATION]["cases"]
+        reference = [q["question"] for q in cases[0]["questions"]]
+        for case in cases[1:]:
+            assert [q["question"] for q in case["questions"]] == reference
+
+    def test_full_preset_matches_prd_scale(self):
+        params = PRESETS["full"][SCENARIO_ISOLATION]
+        assert params["users"] == 100
+        assert params["span_days"] == 7
+        assert params["target_ops"] == 10000
+
+
+class TestContradictionScenario:
+    def test_both_detection_kinds_injected(self, dataset):
+        case = _case(dataset, SCENARIO_CONTRADICTION)
+        kinds = {c["expected_detection"] for c in case["ground_truth"]["contradictions"]}
+        assert kinds == {"conflicted", "superseded"}
+
+    def test_contradictions_use_exclusive_predicates(self, dataset):
+        case = _case(dataset, SCENARIO_CONTRADICTION)
+        contradictions = case["ground_truth"]["contradictions"]
+        assert len(contradictions) == (
+            PRESETS["fixture"][SCENARIO_CONTRADICTION]["conflicted"]
+            + PRESETS["fixture"][SCENARIO_CONTRADICTION]["superseded"]
+        )
+        for contradiction in contradictions:
+            assert contradiction["predicate"] in EXCLUSIVE_PREDICATES
+            assert contradiction["old_turn_id"]
+            assert contradiction["new_turn_id"]
+
+    def test_confidences_drive_the_expected_detection(self, dataset):
+        # The storage layer supersedes above SUPERSEDE_CONFIDENCE_DELTA
+        # and flags conflicted otherwise; the corpus encodes that rule.
+        assert SUPERSEDED_NEW_CONFIDENCE - SUPERSEDED_OLD_CONFIDENCE > SUPERSEDE_CONFIDENCE_DELTA
+        assert CONFLICTED_NEW_CONFIDENCE - CONFLICTED_OLD_CONFIDENCE <= SUPERSEDE_CONFIDENCE_DELTA
+        case = _case(dataset, SCENARIO_CONTRADICTION)
+        by_key = {
+            (rel["from_name"], rel["type"], rel["to_name"]): rel["confidence"]
+            for rel in case["ground_truth"]["relationships"]
+        }
+        for contradiction in case["ground_truth"]["contradictions"]:
+            old_conf = by_key[
+                (contradiction["subject"], contradiction["predicate"], contradiction["old_object"])
+            ]
+            new_conf = by_key[
+                (contradiction["subject"], contradiction["predicate"], contradiction["new_object"])
+            ]
+            if contradiction["expected_detection"] == "superseded":
+                assert new_conf - old_conf > SUPERSEDE_CONFIDENCE_DELTA
+            else:
+                assert new_conf - old_conf <= SUPERSEDE_CONFIDENCE_DELTA
+
+    def test_new_fact_stated_after_old_fact(self, dataset):
+        case = _case(dataset, SCENARIO_CONTRADICTION)
+        for contradiction in case["ground_truth"]["contradictions"]:
+            old_session = contradiction["old_turn_id"].rsplit(":", 1)[0]
+            new_session = contradiction["new_turn_id"].rsplit(":", 1)[0]
+            assert old_session < new_session, contradiction
+
+    def test_precision_distractors_present(self, dataset):
+        case = _case(dataset, SCENARIO_CONTRADICTION)
+        kinds = {d["kind"] for d in case["ground_truth"]["distractors"]}
+        assert kinds == {"duplicate_fact", "non_exclusive_change"}
+
+    def test_distractor_subjects_do_not_overlap_contradictions(self, dataset):
+        case = _case(dataset, SCENARIO_CONTRADICTION)
+        contradiction_subjects = {c["subject"] for c in case["ground_truth"]["contradictions"]}
+        for distractor in case["ground_truth"]["distractors"]:
+            assert distractor["subject"] not in contradiction_subjects

--- a/tests/unit/bench_memory/test_longitudinal_dataset.py
+++ b/tests/unit/bench_memory/test_longitudinal_dataset.py
@@ -1,0 +1,101 @@
+"""Longitudinal dataset loader tests (fixture + generated roundtrips)."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bench.memory.longitudinal_corpus import SCENARIOS, generate_dataset
+from bench.memory.longitudinal_dataset import load_longitudinal
+from bench.memory.structured_corpus import write_dataset
+
+FIXTURE = Path(__file__).resolve().parents[3] / "bench" / "memory" / "fixtures"
+
+
+@pytest.fixture(scope="module")
+def scenarios(tmp_path_factory):
+    path = tmp_path_factory.mktemp("longitudinal") / "dataset.json"
+    write_dataset(generate_dataset(preset="fixture", seed=42), path)
+    return load_longitudinal(path)
+
+
+class TestLoader:
+    def test_all_scenarios_loaded(self, scenarios):
+        assert set(scenarios) == set(SCENARIOS)
+        for key, scenario in scenarios.items():
+            assert scenario.key == key
+            assert scenario.dataset.cases
+            assert scenario.config
+
+    def test_question_categories_map_to_question_type(self, scenarios):
+        buffer_cycle = scenarios["buffer_cycle"]
+        types = {question.question_type for _, question in buffer_cycle.dataset.iter_questions()}
+        assert types == {"evicted_recall", "recent_recall"}
+
+    def test_ground_truth_extras_loaded(self, scenarios):
+        cross = scenarios["cross_agent"]
+        truth = next(iter(cross.ground_truth.values()))
+        assert truth.artifacts
+        assert truth.question_meta
+        assert truth.decisions
+
+        isolation = scenarios["isolation"]
+        for truth in isolation.ground_truth.values():
+            assert truth.canaries
+
+        contradiction = scenarios["contradiction"]
+        truth = next(iter(contradiction.ground_truth.values()))
+        assert truth.contradictions
+        assert truth.distractors
+        assert {c["expected_detection"] for c in truth.contradictions} == {
+            "conflicted",
+            "superseded",
+        }
+
+    def test_relationships_keep_confidence(self, scenarios):
+        truth = next(iter(scenarios["contradiction"].ground_truth.values()))
+        confidences = {rel["confidence"] for rel in truth.relationships}
+        assert len(confidences) > 1  # per-fact confidences survived the roundtrip
+
+    def test_session_dates_mapped(self, scenarios):
+        truth = next(iter(scenarios["buffer_cycle"].ground_truth.values()))
+        case = scenarios["buffer_cycle"].dataset.cases[0]
+        assert set(truth.session_dates) == {s.session_id for s in case.sessions}
+
+    def test_zero_question_scenario_allowed(self, scenarios):
+        assert scenarios["contradiction"].dataset.question_count == 0
+
+    def test_committed_fixture_loads(self):
+        scenarios = load_longitudinal(FIXTURE / "longitudinal_sample.json")
+        assert set(scenarios) == set(SCENARIOS)
+
+    def test_committed_fixture_is_regenerable(self):
+        # The committed fixture must equal the generator's output for
+        # the documented (preset, seed) so it can always be rebuilt.
+        committed = json.loads((FIXTURE / "longitudinal_sample.json").read_text())
+        assert committed == json.loads(
+            json.dumps(generate_dataset(preset="fixture", seed=42), sort_keys=True)
+        )
+
+    def test_wrong_name_rejected(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text(json.dumps({"name": "other", "scenarios": {}}))
+        with pytest.raises(ValueError, match="Unexpected dataset name"):
+            load_longitudinal(path)
+
+    def test_missing_file_rejected(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_longitudinal(tmp_path / "absent.json")
+
+    def test_unknown_scenario_rejected(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "name": "muxi-longitudinal",
+                    "scenarios": {"mystery": {"cases": [{"case_id": "x"}]}},
+                }
+            )
+        )
+        with pytest.raises(ValueError, match="Unknown scenario"):
+            load_longitudinal(path)

--- a/tests/unit/bench_memory/test_longitudinal_runner.py
+++ b/tests/unit/bench_memory/test_longitudinal_runner.py
@@ -1,0 +1,24 @@
+"""Longitudinal runner helper tests (pure logic; no formation boot)."""
+
+from bench.memory.longitudinal_runner import merge_rebuild_report
+
+
+class TestMergeRebuildReport:
+    def test_sums_counts(self):
+        totals = merge_rebuild_report(
+            {"events": 5, "applied": 5, "failed": 0},
+            {"events": 6, "applied": 6, "failed": 1},
+        )
+        assert totals == {"events": 11, "applied": 11, "failed": 1}
+
+    def test_none_values_treated_as_zero(self):
+        # The service response can carry explicit None values (not just
+        # missing keys); int(None) killed Scenario D mid-run.
+        totals = merge_rebuild_report(
+            {"events": None, "applied": 2, "failed": None},
+            {"events": 3, "applied": None, "failed": None, "available": True},
+        )
+        assert totals == {"events": 3, "applied": 2, "failed": 0}
+
+    def test_missing_keys_treated_as_zero(self):
+        assert merge_rebuild_report({}, {}) == {"events": 0, "applied": 0, "failed": 0}

--- a/tests/unit/bench_memory/test_longitudinal_scoring.py
+++ b/tests/unit/bench_memory/test_longitudinal_scoring.py
@@ -1,0 +1,311 @@
+"""Longitudinal scoring tests (scenario aggregates + leak detection)."""
+
+from bench.memory.longitudinal_scoring import (
+    LAYER_STRUCTURED,
+    LAYER_WORKING,
+    ArtifactAuditItem,
+    ContradictionPairAudit,
+    DecisionAuditItem,
+    IsolationOpResult,
+    LongitudinalQuestionResult,
+    aggregate_buffer_cycle,
+    aggregate_contradiction,
+    aggregate_cross_agent,
+    aggregate_decisions,
+    aggregate_isolation,
+    find_leaks,
+    render_longitudinal_extras,
+    summarize_contradiction_audit,
+)
+
+
+def _result(
+    question_id: str,
+    category: str,
+    layer: str = LAYER_STRUCTURED,
+    retrieved=("s1",),
+    evidence=("s1",),
+    evidence_evicted=None,
+):
+    return LongitudinalQuestionResult(
+        question_id=question_id,
+        question_type=category,
+        is_abstention=False,
+        evidence_session_ids=list(evidence),
+        evidence_turn_ids=[],
+        retrieved_session_ids=list(retrieved),
+        category=category,
+        layer=layer,
+        evidence_evicted=evidence_evicted,
+    )
+
+
+class TestBufferCycleAggregate:
+    def test_layers_split_and_compensation_computed(self):
+        results = [
+            # Structured layer answers the evicted question...
+            _result("q1", "evicted_recall", LAYER_STRUCTURED, evidence_evicted=True),
+            # ...the working baseline misses it (evidence evicted).
+            _result(
+                "q1#working",
+                "evicted_recall",
+                LAYER_WORKING,
+                retrieved=("s9",),
+                evidence_evicted=True,
+            ),
+            # Both layers answer the recent control question.
+            _result("q2", "recent_recall", LAYER_STRUCTURED, evidence_evicted=False),
+            _result("q2#working", "recent_recall", LAYER_WORKING, evidence_evicted=False),
+        ]
+        metrics = aggregate_buffer_cycle(
+            results,
+            k=5,
+            eviction={"ingested_turns": 100, "resident_turns": 40, "evicted_turns": 60},
+            flush={"hand_offs": 3, "items_handed": 45, "digest_enabled": False},
+            decision_items=[DecisionAuditItem("Adopt X", "2026-01-05", True)],
+        )
+        compensation = metrics["compensation"]
+        assert compensation["evicted_recall_structured"] == 1.0
+        assert compensation["evicted_recall_working"] == 0.0
+        assert compensation["recent_recall_structured"] == 1.0
+        assert compensation["recent_recall_working"] == 1.0
+        assert compensation["evidence_evicted_fraction"] == 1.0
+        assert compensation["target_met"] is True
+        # The headline retrieval block covers the structured layer only.
+        assert metrics["retrieval"]["session_level"]["overall"]["questions"] == 2
+        assert (
+            metrics["working_baseline"]["retrieval"]["session_level"]["overall"]["recall@5"] == 0.5
+        )
+        assert metrics["decisions"]["zero_lost_met"] is True
+
+    def test_target_not_met_below_threshold(self):
+        results = [
+            _result("q1", "evicted_recall", retrieved=("s9",), evidence_evicted=True),
+            _result("q2", "evicted_recall", retrieved=("s1",), evidence_evicted=True),
+        ]
+        metrics = aggregate_buffer_cycle(results, 5, {}, {}, [])
+        assert metrics["compensation"]["evicted_recall_structured"] == 0.5
+        assert metrics["compensation"]["target_met"] is False
+
+    def test_partial_eviction_fraction_flags_weak_workload(self):
+        results = [
+            _result("q1", "evicted_recall", evidence_evicted=True),
+            _result("q2", "evicted_recall", evidence_evicted=False),
+        ]
+        metrics = aggregate_buffer_cycle(results, 5, {}, {}, [])
+        assert metrics["compensation"]["evidence_evicted_fraction"] == 0.5
+
+
+class TestDecisionsAudit:
+    def test_lost_decisions_listed(self):
+        block = aggregate_decisions(
+            [
+                DecisionAuditItem("Adopt Kafka", "2026-01-05", True),
+                DecisionAuditItem("Drop Neo4j", "2026-01-07", False),
+            ]
+        )
+        assert block == {
+            "expected": 2,
+            "found": 1,
+            "lost": 1,
+            "lost_decisions": ["[2026-01-07] Drop Neo4j"],
+            "zero_lost_met": False,
+        }
+
+    def test_empty_audit_passes(self):
+        assert aggregate_decisions([])["zero_lost_met"] is True
+
+
+class TestCrossAgentAggregate:
+    def test_orphans_and_target(self):
+        results = [
+            _result("q1", "cross_agent_propagation"),
+            _result("q2", "cross_agent_propagation", retrieved=("s9",)),
+        ]
+        artifacts = [
+            ArtifactAuditItem("report", "finance-agent", True, True),
+            ArtifactAuditItem("memo", "research-agent", True, False),
+        ]
+        metrics = aggregate_cross_agent(results, 5, artifacts)
+        assert metrics["propagation"]["recall@5"] == 0.5
+        assert metrics["propagation"]["target_met"] is False
+        assert metrics["artifacts"]["orphans"] == 1
+        assert metrics["artifacts"]["orphan_names"] == ["memo (research-agent)"]
+        assert metrics["artifacts"]["zero_orphans_met"] is False
+
+    def test_full_recall_meets_target(self):
+        results = [_result("q1", "cross_agent_propagation")]
+        metrics = aggregate_cross_agent(
+            results, 5, [ArtifactAuditItem("report", "finance-agent", True, True)]
+        )
+        assert metrics["propagation"]["target_met"] is True
+        assert metrics["artifacts"]["zero_orphans_met"] is True
+
+
+class TestFindLeaks:
+    CANARIES = {
+        "CANARY-000-1111AA": "seq_isolation_000",
+        "CANARY-001-2222BB": "seq_isolation_001",
+    }
+
+    def test_own_canary_is_not_a_leak(self):
+        leaks = find_leaks(
+            ["your locker code is CANARY-000-1111AA"],
+            ["seq_isolation_000_s001"],
+            "seq_isolation_000",
+            self.CANARIES,
+        )
+        assert leaks == []
+
+    def test_foreign_canary_is_a_leak(self):
+        leaks = find_leaks(
+            ["the code is canary-001-2222bb"],  # case-insensitive
+            [],
+            "seq_isolation_000",
+            self.CANARIES,
+        )
+        assert len(leaks) == 1
+        assert leaks[0]["kind"] == "foreign_canary"
+        assert leaks[0]["canary_owner"] == "seq_isolation_001"
+
+    def test_foreign_session_is_a_leak(self):
+        leaks = find_leaks(
+            [],
+            ["seq_isolation_001_s003"],
+            "seq_isolation_000",
+            self.CANARIES,
+        )
+        assert len(leaks) == 1
+        assert leaks[0]["kind"] == "foreign_session"
+
+
+class TestIsolationAggregate:
+    def test_clean_run_passes(self):
+        ops = [
+            IsolationOpResult("seq_isolation_000", "vector_search", "q"),
+            IsolationOpResult("seq_isolation_001", "graph", ""),
+        ]
+        metrics = aggregate_isolation(ops, users=2, target_ops=2)
+        assert metrics["passed"] is True
+        assert metrics["leaks"] == 0
+        assert metrics["by_op_kind"]["graph"]["operations"] == 1
+
+    def test_any_leak_fails(self):
+        ops = [
+            IsolationOpResult(
+                "seq_isolation_000",
+                "vector_search",
+                "q",
+                leaks=[{"kind": "foreign_canary", "canary_owner": "x", "detail": "C"}],
+            )
+        ]
+        metrics = aggregate_isolation(ops, users=1, target_ops=1)
+        assert metrics["passed"] is False
+        assert metrics["leaks"] == 1
+        assert metrics["leak_details"][0]["case_id"] == "seq_isolation_000"
+
+    def test_errored_ops_fail_the_audit(self):
+        ops = [IsolationOpResult("seq_isolation_000", "log", "", error="boom")]
+        metrics = aggregate_isolation(ops, users=1, target_ops=1)
+        assert metrics["passed"] is False
+        assert metrics["operations_errored"] == 1
+
+    def test_zero_ops_never_passes(self):
+        assert aggregate_isolation([], users=0, target_ops=0)["passed"] is False
+
+
+def _pair(detected=True, kind="conflicted", expected="conflicted", subject="Kai"):
+    return ContradictionPairAudit(
+        subject=subject,
+        predicate="works_at",
+        old_object="A",
+        new_object="B",
+        expected_detection=expected,
+        detected=detected,
+        detected_kind=kind if detected else None,
+    )
+
+
+class TestContradictionAggregate:
+    def test_precision_recall_and_kind_accuracy(self):
+        pairs = [
+            _pair(detected=True, kind="conflicted", expected="conflicted", subject="Kai"),
+            _pair(detected=True, kind="conflicted", expected="superseded", subject="Mara"),
+            _pair(detected=False, expected="conflicted", subject="Ravi"),
+        ]
+        false_positives = [("noor", "works_at", "a", "b")]
+        summary = summarize_contradiction_audit(pairs, false_positives)
+        assert summary["expected"] == 3
+        assert summary["true_positives"] == 2
+        assert summary["detected"] == 3
+        assert summary["precision"] == 2 / 3
+        assert summary["recall"] == 2 / 3
+        assert summary["detection_kind_accuracy"] == 0.5
+        assert summary["missed_pairs"] == ["Ravi works_at A -> B"]
+        assert len(summary["kind_mismatches"]) == 1
+
+    def test_targets_and_rebuild_consistency(self):
+        pairs = [_pair(subject=name) for name in ("Kai", "Mara", "Ravi")]
+        metrics = aggregate_contradiction(
+            pairs,
+            [],
+            events={"available": True, "events": 3, "matches_detections": True},
+            rebuild_pairs=pairs,
+            rebuild_false_positives=[],
+            rebuild_report={"events": 5, "applied": 5, "failed": 0},
+        )
+        assert metrics["targets"]["precision_met"] is True
+        assert metrics["targets"]["recall_met"] is True
+        assert metrics["rebuild"]["consistent_with_live"] is True
+
+    def test_rebuild_divergence_detected(self):
+        live = [_pair(subject=name) for name in ("Kai", "Mara")]
+        rebuilt = [
+            _pair(subject="Kai"),
+            _pair(detected=False, expected="conflicted", subject="Mara"),
+        ]
+        metrics = aggregate_contradiction(
+            live,
+            [],
+            events={"available": True, "events": 2, "matches_detections": True},
+            rebuild_pairs=rebuilt,
+        )
+        assert metrics["rebuild"]["consistent_with_live"] is False
+
+    def test_no_rebuild_block_when_unavailable(self):
+        metrics = aggregate_contradiction([_pair()], [], events={"available": False, "events": 0})
+        assert "rebuild" not in metrics
+
+
+class TestRendering:
+    def test_every_scenario_renders(self):
+        # Rendering must never crash on the aggregates it is fed.
+        buffer_metrics = aggregate_buffer_cycle(
+            [_result("q1", "evicted_recall", evidence_evicted=True)],
+            5,
+            {"ingested_turns": 10, "evicted_turns": 4, "max_memory_mb": 0.4},
+            {"hand_offs": 1, "items_handed": 5, "digest_enabled": False},
+            [DecisionAuditItem("d", "2026-01-01", True)],
+        )
+        cross_metrics = aggregate_cross_agent(
+            [_result("q1", "cross_agent_propagation")],
+            5,
+            [ArtifactAuditItem("report", "finance-agent", True, True)],
+        )
+        isolation_metrics = aggregate_isolation(
+            [IsolationOpResult("c", "graph", "")], users=1, target_ops=1
+        )
+        contradiction_metrics = aggregate_contradiction(
+            [_pair()],
+            [],
+            events={"available": True, "events": 1, "matches_detections": True},
+            rebuild_pairs=[_pair()],
+        )
+        for scenario, metrics in (
+            ("buffer_cycle", buffer_metrics),
+            ("cross_agent", cross_metrics),
+            ("isolation", isolation_metrics),
+            ("contradiction", contradiction_metrics),
+        ):
+            rendered = render_longitudinal_extras(scenario, metrics, 5)
+            assert rendered.strip(), scenario


### PR DESCRIPTION
Completes the memory-benchmarking PRD's **Tier 3 (Multi-Session Longitudinal)** in `bench/memory/`, on top of the Tier 1/2/4 harness (#220, #261). All four PRD scenarios run against a real formation — no mocks — with the harness conventions intact: cheap-model config ($0 retrieval-only runs), per-scenario failure isolation, reports always written, nonzero exit on incomplete runs.

## What's included

- **MemBench Generator** (`longitudinal_corpus.py`) — seeded, fully deterministic multi-session corpora (no LLM calls; byte-identical files per `(preset, seed)`), extending the Tier 2 generator's dated, agent-attributed session skeleton. Committed CI fixture (`fixtures/longitudinal_sample.json`) plus `--preset full` at the PRD's documented scale: 30-day corpora, 100 isolation users, 10,000 isolation retrieval operations.
- **Scenario A — buffer cycle compensation.** Raw turns replayed into the real working memory under a small `--buffer-max-mb` budget with the FIFO cleanup pass driven once per session — the exact path the pre-compaction flush (#260) guards. Flush hand-offs are counted end-to-end (opt-in `--flush-digest` runs the real silent-turn LLM digest); the persisted layers get the ground-truth manifest (Tier 2 style, isolating structured recall from extraction quality). Reports show evicted-fact recall through KG + Captain's Log vs the working-memory baseline, a `recent_recall` control group, an `evidence_evicted_fraction` validity check, and the PRD's zero-lost-decisions audit.
- **Scenario B — cross-agent knowledge propagation.** Four agents (research/finance/marketing/engineering per the PRD); every question's evidence lives in a different agent's sessions than the agent nominally asking (`question_meta` records the pair), plus the zero-artifact-orphans KG reachability audit.
- **Scenario C — multi-user isolation.** All users ingested side by side (working + persistent + KG + log, nothing cleared between users) with identical fact templates differing only in values — a scoping bug would make another user's near-identical turn the nearest neighbor. Vector, KG, and log retrieval operations are audited for foreign `CANARY-*` tokens and foreign session ids. Pass/fail per the PRD.
- **Scenario D — contradiction detection over time.** Manifests replayed per-session, in corpus order, through the live `store_extraction` path with per-fact confidences, so the storage layer's supersede/conflict detection and the substrate's `fact.contradicted` events (#259) fire exactly as in production. Measures precision/recall plus detection-kind accuracy (conflicted vs superseded) against injected pairs — with duplicate-fact and non-exclusive-predicate precision distractors that must NOT be flagged — tallies the substrate events, then rebuilds the knowledge-graph projection from the event log via the service layer (#259) and repeats the audit (`rebuild.consistent_with_live`). The PRD defines no separate cold-cold scenario; the rebuild re-audit inside Scenario D is where #259's replay determinism is exercised.
- **Runner** (`longitudinal_runner.py`) — one report per scenario under `results/`. `--scenario all` spawns one subprocess per scenario: the runtime's database manager is a process-level singleton, so two formations in one process would silently share the first run's (removed) SQLite path.
- **Tier 2 adapter fix** (bench code only): when several KG facts share a provenance turn (entity card + relationship stated by the same utterance), `_search_graph` now merges their renderings into the turn's retrieved text instead of dropping all but the first. Rankings are unchanged; the QA context is no longer starved of facts retrieval had already found. The Tier 2 structured fixture report is regenerated: retrieval metrics identical (R@5 100%), QA accuracy 53.3% -> 80.0%.

## Fixture results (committed under `bench/memory/results/`)

| Scenario | PRD target | Fixture result |
|----------|-----------|----------------|
| A `buffer_cycle` | evicted-fact R@5 >= 85% | **100%** structured vs **0%** working baseline (131/228 turns evicted, evidence evicted for 100% of evicted questions; 11 flush hand-offs / 131 items) — MET |
| A zero lost decisions | 0 lost | **1/1 findable** via Captain's Log — MET |
| A QA (`--qa`) | — | 100% (7/7) |
| B `cross_agent` | R@5 >= 80% | **100%** (n=24; QA 24/24; exact-string recall@5 100%) — MET |
| B artifact orphans | 0 | **0/8** — MET |
| C `isolation` | 0 leaks | **0 leaks across 600 ops / 6 users** (vector/graph/log; full preset: 10,000 ops / 100 users) — PASSED |
| D precision | >= 90% | **100%** (6/6 detected, 0 false positives) — MET |
| D recall | >= 80% | **100%** — MET |
| D detection-kind accuracy | — | 100% (conflicted vs superseded) |
| D substrate events | — | 6 `fact.contradicted` events, matches detections |
| D rebuild consistency | — | CONSISTENT (11/11 events replayed, 0 failed) |

Total fixture spend: ~$0.002 (QA answer/judge calls on gpt-4o-mini; retrieval-only runs are $0 with local ONNX embeddings).

## Tests

- `tests/unit/bench_memory/test_longitudinal_corpus.py` — generator determinism, scenario coverage, evidence integrity, canary uniqueness, confidence/detection-kind encoding, PRD full-preset scale.
- `tests/unit/bench_memory/test_longitudinal_scoring.py` — scenario aggregates (compensation, decisions audit, orphans, leak detection, contradiction precision/recall/kind accuracy, rebuild consistency), rendering.
- `tests/unit/bench_memory/test_longitudinal_dataset.py` — loader roundtrips, committed-fixture regenerability, error paths.
- Full unit suite: 3178 passed, 10 skipped.
- e2e regression: `cd e2e && uv run python run_random_tests.py 5` — **5/5 passed** (12_scheduling/test_12d1_error_scenarios, 19_api/test_19h1_users, 20_mcp_server/test_20e1_rest_parity, 2_memory/test_2k1_enhanced_prompt_integration, 7_orchestration/test_7b5_sop_synthesis_skip)

## Out of scope (documented)

- Work stays under `bench/` + `tests/unit/bench_memory/` + fixtures; `src/muxi/runtime` untouched.
- Full LLM-extraction replay (raw turns through `process_conversation_turn`) remains a documented non-goal — one LLM call per turn turns a $0 deterministic run into a multi-dollar nondeterministic one; Scenario D's per-session `store_extraction` replay is the same write path with the extraction supplied by the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
