### PR TITLE
feat: memory ingestion - tier heuristics, entity resolution, synthesis cadences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 ## [unreleased]
 
+### Memory ingestion maturation - tier heuristics, entity resolution, synthesis cadences
+
+Completes the memory-ingestion PRD's remaining scope on top of the
+shipped `/v1/memories` pipeline (#218) and the substrate's
+projections/rebuild machinery (#259):
+
+- Tier-escalation heuristics: a pure, deterministic decision per kept
+  item over Tier-0 regex signals (identities, dates, money,
+  commitments) plus the local classifier's category/margin. Personal/
+  work (and fail-open unknown) content escalates T1 -> T2 (LLM
+  extraction); flagged high-signal items and `metadata.priority: high`
+  escalate to T3 with an optionally configured frontier model
+  (`memory.ingestion.tiers.models`); per-source `tier` pins override.
+  Kept noise now rests at Tier 1 (verbatim event-sourced fact, no LLM
+  spent). Per-job budgets (`tiers.budget.t{2,3}_items_per_job`) demote
+  capped items instead of dropping them; every escalation is observable
+  (`memory.ingestion.tier_escalated` + tier/reason on the item report).
+- Entity resolution: probabilistic identity matching over the knowledge
+  graph (name/email/handle/role/relationship context). Auto-merge at or
+  above `entity_resolution.auto_merge_threshold` (0.85), flag below it
+  (event + `attributes.possible_duplicates` marker). Decisions ride the
+  event substrate as `entity.resolved` events with deterministic
+  per-pair idempotency keys, so re-ingestion can never duplicate or
+  re-merge differently; rebuilds replay recorded decisions verbatim,
+  and merged names redirect on upsert (duplicates never revive).
+- Pattern extraction + preference inference (v1): deterministic
+  aggregation only - activity schedule from event timestamps,
+  preference profile from `prefers`/`interested_in` edges, domain
+  expertise from reinforced topic entities - written as decaying
+  `fact.extracted` events keyed per (kind, ISO week).
+- Synthesis scheduling: hot (5min, resolution) / warm (hourly,
+  patterns) / cold (nightly, full pass) / cold-cold (weekly full
+  re-synthesis replaying the event log through the substrate rebuild)
+  cadences on the scheduler's existing periodic-task loop, each
+  individually disableable and interval-configurable, with durable
+  per-user cursors; failure-isolated everywhere and fully inert when
+  `memory.ingestion` is unconfigured (pinned by test).
+- Fail-fast config validation for the whole `memory.ingestion` block
+  through one shared parser (runtime service + formation validator).
+
 ### Memory benchmarking - Tier 2 structured recall + Tier 4 cost efficiency
 
 Extends the `bench/memory/` harness (memory-benchmarking PRD; Tier 1

--- a/e2e/tests/2_memory/formations/formation-ingestion-maturation/formation.yaml
+++ b/e2e/tests/2_memory/formations/formation-ingestion-maturation/formation.yaml
@@ -1,0 +1,73 @@
+schema: "1.0.0"
+id: ingestion-maturation-test
+description: "Formation for testing ingestion maturation: tier heuristics, entity resolution, synthesis cadences"
+auto_extract_user_info: true
+
+runtime:
+  built_in_mcps: false
+
+overlord:
+  clarification:
+    enabled: false
+
+llm:
+  settings:
+    temperature: 0.2
+    max_tokens: 1000
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+    - embedding: "openai/text-embedding-3-small"
+
+# Scheduler on so the synthesis cadences register as a periodic task
+# (the test drives passes directly for determinism; registration is the
+# assertion here).
+scheduler:
+  enabled: true
+
+memory:
+  buffer:
+    size: 50
+    multiplier: 10
+    vector_search: false
+
+  persistent:
+    provider: "sqlite"
+    connection_string: "ingestion_maturation_test.db"
+    embedding_model: "openai/text-embedding-3-small"
+
+  # Ingestion maturation surface: tier heuristics on (defaults), entity
+  # resolution with lowered thresholds so name+email/employer evidence
+  # from real LLM extraction reliably crosses the merge bar, and the
+  # synthesis cadence table (defaults, cold_cold weekly).
+  ingestion:
+    sources:
+      notes:
+        filter: lenient
+    tiers:
+      enabled: true
+    entity_resolution:
+      enabled: true
+      auto_merge_threshold: 0.45
+      flag_threshold: 0.3
+    synthesis:
+      enabled: true
+
+agents:
+  - id: assistant
+    name: "Maturation Test Assistant"
+    description: "A helpful assistant for testing matured ingestion recall"
+    system_message: "You are a helpful assistant. Be concise and direct. Answer from the provided context when possible."
+
+server:
+  enabled: true
+  port: 8275
+  api_keys:
+    admin_key: test-admin-key-2v2
+    client_key: test-client-key-2v2
+
+logging:
+  system:
+    level: "error"
+    destination: "stdout"

--- a/e2e/tests/2_memory/formations/formation-ingestion-maturation/secrets.enc
+++ b/e2e/tests/2_memory/formations/formation-ingestion-maturation/secrets.enc
@@ -1,0 +1,1 @@
+../formation-memory/secrets.enc

--- a/e2e/tests/2_memory/test_2v2_ingestion_maturation.py
+++ b/e2e/tests/2_memory/test_2v2_ingestion_maturation.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Test 2V2: Memory Ingestion Maturation (tiers, entity resolution, synthesis)
+
+This test validates the ingestion maturation scope end to end:
+
+1. Tier heuristics: ingested personal/work content escalates past Tier 1;
+   the item report carries tier + reason (observable escalation).
+2. Entity resolution: two ingested notes about the same person under two
+   names ("Ryan Leveille" / "Ryan", shared email + employer) resolve to
+   one identity -- an entity.resolved event with decision "merged", the
+   duplicate entity marked merged with an alias on the canonical row.
+3. Synthesis scheduling: the synthesis service is registered on the
+   scheduler's periodic-task loop; driving the hot cadence (the cheapest
+   observable pass) reports its work and the durable per-user cursor
+   skips settled users on the next pass.
+4. Idempotent maturation: replaying the resolution pass appends nothing
+   (deterministic per-pair idempotency keys).
+"""
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+
+import httpx
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent))
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from base_memory_test import BaseMemoryTest  # noqa: E402
+
+BASE_URL = "http://127.0.0.1:8275/v1"
+CLIENT_HEADERS = {
+    "X-Muxi-Client-Key": "test-client-key-2v2",
+    "X-Muxi-User-ID": "0",  # sqlite formation runs in single-user mode
+    "Content-Type": "application/json",
+}
+USER_ID = "0"
+
+NOTE_FULL_IDENTITY = (
+    "My colleague Ryan Leveille works at Nabo. His email is ryan@nabo.dev "
+    "and I usually reach him there about the hosting project."
+)
+NOTE_SHORT_IDENTITY = (
+    "Ryan from Nabo (ryan@nabo.dev) asked me about the hosting dispute "
+    "yesterday and wants an update this week."
+)
+
+
+async def poll_status(client, processing_id, timeout=180.0):
+    """Poll the ingestion status endpoint until a terminal status."""
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        r = await client.get(
+            f"{BASE_URL}/memories/ingestion/{processing_id}", headers=CLIENT_HEADERS
+        )
+        assert r.status_code == 200, f"status poll: {r.status_code} {r.text}"
+        last = r.json()["data"]
+        if last["status"] in ("completed", "failed"):
+            return last
+        await asyncio.sleep(2)
+    raise TimeoutError(f"Ingestion {processing_id} did not finish in {timeout}s: {last}")
+
+
+async def ingest(client, content, source_id):
+    r = await client.post(
+        f"{BASE_URL}/memories",
+        headers=CLIENT_HEADERS,
+        json={"content": content, "source": "notes", "source_id": source_id},
+    )
+    assert r.status_code == 202, f"ingest: {r.status_code} {r.text}"
+    return await poll_status(client, r.json()["data"]["processing_id"])
+
+
+class TestIngestionMaturation(BaseMemoryTest):
+    """Validate tier heuristics, entity resolution, and synthesis cadences."""
+
+    async def test_ingestion_maturation(self):
+        test_name = "2v2_ingestion_maturation"
+        self.print_test_header(
+            test_name,
+            "Ingestion maturation: tier escalation, duplicate identity merge, synthesis pass",
+        )
+
+        start_time = time.time()
+        checks_passed = []
+        transcript = []
+        all_passed = True
+
+        try:
+            # Fresh database for deterministic assertions.
+            for suffix in ("", "-wal", "-shm"):
+                stale = Path.cwd() / f"ingestion_maturation_test.db{suffix}"
+                if stale.exists():
+                    stale.unlink()
+
+            print("\n📝 Phase 1: Formation with scheduler + synthesis cadences...")
+            await self.setup_formation(
+                formation_path=Path(__file__).parent
+                / "formations"
+                / "formation-ingestion-maturation"
+            )
+            await self.formation.start_server(block=False)
+            await asyncio.sleep(2)
+
+            memory_events = getattr(self.overlord, "memory_events", None)
+            assert memory_events is not None, "memory event substrate missing"
+            synthesis = getattr(self.overlord, "memory_synthesis", None)
+            assert synthesis is not None, "memory synthesis service missing"
+            scheduler = getattr(self.overlord, "scheduler_service", None)
+            assert scheduler is not None, "scheduler missing"
+            assert synthesis in getattr(scheduler, "_periodic_tasks", []), (
+                "synthesis service must register on the scheduler's periodic-task loop"
+            )
+            print("  ✓ Synthesis service registered as a scheduler periodic task")
+            checks_passed.append("Synthesis cadences registered on scheduler loop")
+
+            print("\n📨 Phase 2: Ingest two notes about the same person...")
+            async with httpx.AsyncClient(timeout=90.0) as client:
+                first = await ingest(client, NOTE_FULL_IDENTITY, "note-a")
+                second = await ingest(client, NOTE_SHORT_IDENTITY, "note-b")
+
+            for label, status in (("note-a", first), ("note-b", second)):
+                assert status["status"] == "completed", status
+                item = status["items"][0]
+                assert item["disposition"] == "stored", (label, item)
+                assert "tier" in item and "tier_reason" in item, (label, item)
+                print(
+                    f"  ✓ {label}: stored at tier {item['tier']} "
+                    f"({item['tier_reason']}, category="
+                    f"{item['classification']['category']})"
+                )
+            checks_passed.append("Items stored with observable tier + reason")
+
+            tiers = {s["items"][0]["tier"] for s in (first, second)}
+            if tiers <= {2, 3} and tiers:
+                print("  ✓ Personal/work content escalated past Tier 1 (LLM extraction)")
+                checks_passed.append("Tier heuristics escalated synthesis-worthy content")
+            else:
+                print(f"  ✗ Expected tier 2/3 for personal notes, got {tiers}")
+                all_passed = False
+
+            print("\n🔗 Phase 3: Entity resolution merged the duplicate identity...")
+            knowledge_graph = self.overlord.knowledge_graph
+            person_entities = await knowledge_graph.storage.list_entities(
+                USER_ID, entity_type="person", status=None, limit=100
+            )
+            names = {e["name"].lower() for e in person_entities}
+            print(f"  Person entities extracted: {sorted(names)}")
+
+            # Determinism guard: LLM extraction occasionally normalizes
+            # both mentions to one name. If no short-name duplicate row
+            # exists, seed the classic duplicate (same email attribute)
+            # and let the REAL resolution machinery handle it via the
+            # synthesis pass below -- the merge path under test is
+            # identical either way.
+            resolver_input_seeded = False
+            if not any(n == "ryan" for n in names):
+                await knowledge_graph.storage.upsert_entity(
+                    USER_ID,
+                    "person",
+                    "Ryan",
+                    attributes={"email": "ryan@nabo.dev"},
+                    confidence=0.8,
+                )
+                resolver_input_seeded = True
+                print("  (seeded short-name duplicate: LLM unified the mentions itself)")
+
+            print("\n⚙️  Phase 4: Drive the hot synthesis cadence (cheapest pass)...")
+            report = await synthesis.run_cadence("hot")
+            print(f"  Hot cadence report: {report}")
+            assert report["cadence"] == "hot", report
+            assert report["failed"] == 0, report
+
+            resolved_events = await memory_events.list_events(
+                USER_ID, event_types=["entity.resolved"]
+            )
+            merged_events = [
+                e for e in resolved_events if e["payload"]["decision"] == "merged"
+            ]
+            assert merged_events, (
+                f"expected a merged entity.resolved event; got {resolved_events} "
+                f"(seeded={resolver_input_seeded})"
+            )
+            payload = merged_events[0]["payload"]
+            assert merged_events[0]["source"] == "synthesis", merged_events[0]
+            print(
+                f"  ✓ entity.resolved merged: {payload['duplicate_name']!r} -> "
+                f"{payload['canonical_name']!r} (score {payload.get('score')}, "
+                f"signals {payload.get('signals')})"
+            )
+            checks_passed.append("entity.resolved event recorded with decision merged")
+
+            duplicate = await knowledge_graph.storage.get_entity(
+                USER_ID, "person", payload["duplicate_name"]
+            )
+            canonical = await knowledge_graph.storage.get_entity(
+                USER_ID, "person", payload["canonical_name"]
+            )
+            assert duplicate["status"] == "merged", duplicate
+            assert duplicate["superseded_by"] == canonical["id"], duplicate
+            aliases = canonical["attributes"].get("aliases", [])
+            assert payload["duplicate_name"] in aliases, canonical
+            active_names = {
+                e["name"]
+                for e in await knowledge_graph.storage.list_entities(
+                    USER_ID, entity_type="person"
+                )
+            }
+            assert payload["duplicate_name"] not in active_names, active_names
+            print(
+                f"  ✓ Duplicate row merged -> canonical (alias recorded: {aliases}); "
+                f"active persons: {sorted(active_names)}"
+            )
+            checks_passed.append("Duplicate identity merged into canonical entity")
+
+            print("\n🔁 Phase 5: Cursor + idempotency on the next pass...")
+            second_report = await synthesis.run_cadence("hot")
+            assert second_report["users"] == 0, (
+                f"per-user cursor must skip settled users: {second_report}"
+            )
+            resolved_after = await memory_events.list_events(
+                USER_ID, event_types=["entity.resolved"]
+            )
+            assert len(resolved_after) == len(resolved_events), (
+                "replaying the pass must not append new resolution events"
+            )
+            print("  ✓ Second hot pass: 0 users (cursor respected), no new events")
+            checks_passed.append("Per-user cursor + idempotent re-resolution")
+
+            print("\n💬 Phase 6: Merged identity recallable in chat...")
+            recall_msg = "Where does Ryan work and what's his email?"
+            response = await self.overlord.chat(
+                recall_msg,
+                agent_name="assistant",
+                user_id=USER_ID,
+                use_async=False,
+                stream=False,
+            )
+            recall_text = response.content if hasattr(response, "content") else str(response)
+            transcript.append((recall_msg, recall_text))
+            print(f"  User: {recall_msg}")
+            print(f"  Assistant: {recall_text[:200]}")
+            if "nabo" in recall_text.lower():
+                print("  ✓ Chat recalled the merged identity's employer")
+                checks_passed.append("Merged identity recallable in chat")
+            else:
+                print("  ✗ Chat did not recall the merged identity")
+                all_passed = False
+
+        except Exception as e:
+            import traceback
+
+            print(f"  ✗ Test failed with error: {e}")
+            traceback.print_exc()
+            all_passed = False
+
+        finally:
+            await self.cleanup()
+
+        duration = time.time() - start_time
+        self.print_test_result(test_name, all_passed, checks_passed, transcript, duration)
+
+        return all_passed
+
+    async def run_test(self):
+        """Run all test cases."""
+        print("\n" + "=" * 60)
+        print("🧬 AREA 2V2: MEMORY INGESTION MATURATION")
+        print("=" * 60)
+
+        all_passed = await self.test_ingestion_maturation()
+
+        print("\n" + "=" * 60)
+        print(
+            f"🎯 OVERALL RESULT: {'✅ ALL TESTS PASSED' if all_passed else '❌ SOME TESTS FAILED'}"
+        )
+        print("=" * 60)
+
+        print("\n💡 KEY INSIGHTS:")
+        print("- Tier heuristics decide how much LLM an item earns; every escalation is observable")
+        print("- Entity resolution rides the event substrate: merged decisions are idempotent")
+        print("- Synthesis cadences run on the scheduler's loop with durable per-user cursors")
+        print("- The hot pass is cheap: local scoring over the graph, no LLM involved")
+
+        if all_passed:
+            print("SUCCESS", flush=True)
+        return all_passed
+
+
+def main():
+    """Main entry point."""
+    test = TestIngestionMaturation()
+    result = asyncio.run(test.run_test())
+    os._exit(0 if result else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/mental-model.md
+++ b/mental-model.md
@@ -1830,6 +1830,105 @@ backfill, GDPR). **E2E:** `2_memory/test_2s1_memory_event_substrate.py`
 `test_2s2_provenance_and_rebuild.py` (provenance chains on a real
 conversation, GDPR forget + rebuild, legacy backfill).
 
+### Memory Ingestion Maturation (2026-07-10): Tiers, Entity Resolution, Synthesis
+
+**Location:** `src/muxi/runtime/services/memory/ingest/` (tiers, config),
+`services/memory/graph/resolution.py`, `services/memory/synthesis.py`
+
+The maturation of the Phase 3a ingestion pipeline (memory-ingestion PRD):
+the shipped `POST /v1/memories` accept + classify/filter/extract pipeline
+gains escalation heuristics, the synthesis layer, and batched scheduling.
+Config all lives under `memory.ingestion`; `parse_ingestion_config`
+(`ingest/config.py`) is the single fail-fast parser, shared by
+`MemoryIngestionService.__init__` and the formation validator
+(`_validate_memory_ingestion_config`) so they can never disagree.
+
+**Tier heuristics (`ingest/tiers.py`):** per kept item, a PURE decision
+(no LLM decides whether to use an LLM):
+
+- Tier 0 = `content_signals()` regex counts (identities, dates, money,
+  commitments), Tier 1 = classify + verbatim event-sourced fact (no LLM),
+  Tier 2 = LLM extraction + KG link pass, Tier 3 = same with the
+  configured frontier model (`tiers.models.t3`, falls back to `t2`, then
+  the default extraction model).
+- Escalation order: per-source pin (`sources.<s>.tier`) > priority flag
+  (`metadata.priority: high` -> T3) > synthesis-worthy category
+  (personal/work/unknown -> T2) or ambiguous margin
+  (`tiers.ambiguity_margin`) > high-signal score
+  (`tiers.t3_signal_score` -> T3). Everything else rests at T1.
+- Per-JOB budgets (`tiers.budget.t{2,3}_items_per_job`) demote capped
+  items to the best affordable tier (never drop); the demotion is part
+  of the recorded reason. Every escalation is observable:
+  `memory.ingestion.tier_escalated` + `tier`/`tier_reason` on the item
+  report (returned verbatim by the status endpoint).
+- `tiers.enabled: false` restores the Phase 3a always-extract behavior.
+- BEHAVIOR CHANGE from 3a: kept noise (e.g. `filter: off` sources) now
+  rests at T1 -- stored verbatim, recallable, NO LLM extraction.
+
+**Entity resolution (`graph/resolution.py`):** probabilistic identity
+matching over kg_entities (name/email/handle/role/shared-neighbor
+context; weights are scorer mechanisms, thresholds are the config
+surface: `entity_resolution.auto_merge_threshold` 0.85 /
+`flag_threshold` 0.5). Runs at extraction time (after the ingestion KG
+link pass) and in synthesis cadences. Decisions are event-first:
+`entity.resolved` events (source `synthesis`) with a deterministic
+per-pair source_id `entity_resolution/<type>/<a>|<b>/<decision>` -- the
+substrate's idempotency index is what makes re-ingestion unable to merge
+twice or differently. `apply_entity_resolution` (graph service) is a
+pure function of the payload; the KnowledgeGraphProjector consumes
+`entity.resolved` alongside `graph.extracted`, so rebuilds replay
+recorded decisions verbatim (never re-scored). Merges re-point edges
+(collisions/self-loops become status `superseded`, retained), absorb
+attributes, record `aliases`; the duplicate row gets status `merged` +
+`superseded_by`, and `upsert_entity` REDIRECTS merged names to the
+canonical row (sticky -- re-mentions can never revive a duplicate).
+Flags stamp `attributes.possible_duplicates` on both rows; a flagged
+pair can still merge later on stronger evidence (distinct keys).
+
+**Pattern extraction (v1, in `synthesis.py`):** deterministic
+aggregation only, no LLM. `schedule` (event-timestamp histograms, needs
+`synthesis.patterns.min_events`), `preferences` (User's `prefers` /
+`interested_in` edges), `expertise` (most-reinforced topic entities).
+Written as `fact.extracted` events, source `synthesis`, decay_rate
+`decaying`, keyed `pattern/<kind>/<ISO week>` -- idempotent per week.
+
+**Synthesis scheduling (`MemorySynthesisService`):** registered via
+`scheduler_service.register_periodic_task` (the heartbeat/knowledge-sync
+extension point -- NO new loop); `tick()` gates per cadence and never
+raises; every per-user step is failure-isolated. Cadences (each
+`enabled` + `interval_seconds` configurable): hot 5min = entity
+resolution for users with new ingestion/graph events; warm hourly =
+preference/expertise patterns; cold nightly = schedule pattern + full
+resolution; cold_cold WEEKLY = full re-synthesis from the event log via
+`MemoryEventService.rebuild` per user, then the full pass -- this is how
+extraction-logic improvements become retroactive. hot/warm/cold keep
+durable per-user cursors in `projection_checkpoints` (names
+`synthesis_hot` etc. -- not registered projectors, so the applier and
+rebuild ignore them). Interval baselines stamp construction time
+(heartbeat convention: no startup stampede).
+
+**Wiring:** `Overlord._initialize_memory_synthesis` (after knowledge
+sync, needs the scheduler + substrate). INERT when `memory.ingestion`
+is unconfigured -- no service, no periodic task (pinned by unit test).
+Without a scheduler it degrades to manual `run_cadence` with an init
+warning, mirroring remote knowledge sync.
+
+**Gotchas:**
+1. **Resolution events always use source `synthesis`** even when
+   triggered from ingestion (caused_by still links the raw event) --
+   one deterministic idempotency key per pair, regardless of trigger.
+2. **`KnowledgeGraphProjector.apply` dispatches on `event_type`** with
+   `.get()` -- the legacy backfill path calls apply without that key
+   (graph.extracted implied).
+3. **The extractor accepts a per-call `model=` override** (tier
+   models); `knowledge_graph.process_conversation_turn` already did.
+
+**Unit tests:** `test_ingestion_tiers.py`, `test_entity_resolution.py`,
+`test_memory_synthesis.py` (+ updated `test_memory_ingestion.py`).
+**E2E:** `2_memory/test_2v2_ingestion_maturation.py` (tier-observable
+ingest, duplicate identity merged via the hot cadence, cursor + replay
+idempotency, merged identity recalled in chat).
+
 ---
 
 ## 4. LLM Layer

--- a/mental-model.md
+++ b/mental-model.md
@@ -1878,7 +1878,10 @@ twice or differently. `apply_entity_resolution` (graph service) is a
 pure function of the payload; the KnowledgeGraphProjector consumes
 `entity.resolved` alongside `graph.extracted`, so rebuilds replay
 recorded decisions verbatim (never re-scored). Merges re-point edges
-(collisions/self-loops become status `superseded`, retained), absorb
+(collisions with the canonical's ACTIVE copy of the same fact, and
+would-be self-loops, become status `superseded`, retained; non-active
+duplicate edges follow the re-point but never join collision handling,
+so an active fact can never be folded into superseded history), absorb
 attributes, record `aliases`; the duplicate row gets status `merged` +
 `superseded_by`, and `upsert_entity` REDIRECTS merged names to the
 canonical row (sticky -- re-mentions can never revive a duplicate).

--- a/src/muxi/runtime/datatypes/observability.py
+++ b/src/muxi/runtime/datatypes/observability.py
@@ -931,6 +931,28 @@ class ConversationEvents(Enum):
     MEMORY_INGESTION_FILTERED = "memory.ingestion.filtered"
     # When the noise gate drops an ingested item (disposition event recorded)
 
+    # Memory ingestion maturation (tier heuristics + synthesis layer)
+    MEMORY_INGESTION_TIER_ESCALATED = "memory.ingestion.tier_escalated"
+    # When an ingested item escalates past Tier 1 (tier + reason attached)
+
+    MEMORY_ENTITY_MERGED = "memory.entity.merged"
+    # When entity resolution auto-merges a duplicate identity
+
+    MEMORY_ENTITY_FLAGGED = "memory.entity.flagged"
+    # When entity resolution flags a possible duplicate below the merge threshold
+
+    MEMORY_PATTERN_EXTRACTED = "memory.pattern.extracted"
+    # When the synthesis layer derives a behavioral pattern / preference fact
+
+    MEMORY_SYNTHESIS_STARTED = "memory.synthesis.started"
+    # When a synthesis cadence pass (hot/warm/cold/cold_cold) starts
+
+    MEMORY_SYNTHESIS_COMPLETED = "memory.synthesis.completed"
+    # When a synthesis cadence pass completes (per-user counts attached)
+
+    MEMORY_SYNTHESIS_FAILED = "memory.synthesis.failed"
+    # When a synthesis pass or per-user step fails (isolated; never breaks chat)
+
     # Memory distillery intake (Memory Distillery Phase 3b)
     MEMORY_DISTILLED_ACCEPTED = "memory.distilled.accepted"
     # When POST /v1/memories/distilled accepts a signed batch

--- a/src/muxi/runtime/formation/config/validation.py
+++ b/src/muxi/runtime/formation/config/validation.py
@@ -2455,6 +2455,24 @@ class FormationValidator:
         if "lint" in memory_config:
             self._validate_memory_lint_config(memory_config["lint"])
 
+        # Validate ingestion configuration (Memory Ingestion maturation)
+        if "ingestion" in memory_config:
+            self._validate_memory_ingestion_config(memory_config["ingestion"])
+
+    def _validate_memory_ingestion_config(self, ingestion_config: Any) -> None:
+        """Validate memory.ingestion (tiers, entity resolution, synthesis).
+
+        Reuses the service-level parser so the validator and the runtime
+        can never disagree about what a valid ingestion block looks like
+        (the same pattern the artifacts/proactive/commands sections use).
+        """
+        from ...services.memory.ingest.config import parse_ingestion_config
+
+        try:
+            parse_ingestion_config(ingestion_config)
+        except ValueError as e:
+            self.result.add_error(str(e))
+
     def _validate_compaction_config(self, compaction_config: Any) -> None:
         """Validate memory.compaction (pre-compaction flush) configuration."""
         if not isinstance(compaction_config, dict):

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -893,6 +893,11 @@ class Overlord:
 
         self.memory_ingestion = MemoryIngestionService(self)
 
+        # Memory synthesis cadences (Memory Ingestion maturation): created
+        # in start_background_services only when memory.ingestion is
+        # configured -- inert otherwise (pinned by unit test).
+        self.memory_synthesis = None
+
         # Memory distillery intake (Memory Distillery Phase 3b): the
         # verify + accept service behind POST /v1/memories/distilled.
         # Construction is cheap (config parse only) and the service stays
@@ -1572,6 +1577,11 @@ class Overlord:
         # without url-based knowledge sources.
         self._initialize_knowledge_sync_service()
 
+        # Register the memory synthesis cadences (Memory Ingestion
+        # maturation) on the same scheduler loop. No-op for formations
+        # without a memory.ingestion block.
+        self._initialize_memory_synthesis()
+
         # Start the knowledge graph periodic extraction loop now that the
         # extraction/default model is resolved. The getter is evaluated per
         # run so the loop always uses the current capability model.
@@ -1746,6 +1756,64 @@ class Overlord:
                 f"heartbeat {'on' if self.heartbeat_service else 'off'}",
             )
         )
+
+    def _initialize_memory_synthesis(self) -> None:
+        """
+        Create the memory synthesis service (Memory Ingestion maturation).
+
+        Inert when ingestion is unconfigured: formations without a
+        ``memory.ingestion`` block get no synthesis service, no periodic
+        task, and never import the synthesis module (pinned by unit
+        test). When ingestion is configured, the cadences ride the
+        scheduler's worker loop through ``register_periodic_task`` -- the
+        same extension point the proactive heartbeat and remote knowledge
+        sync use. Without a running scheduler the service still exists
+        for manual passes (``run_cadence``) but nothing fires
+        periodically; that degradation is announced at init, never a
+        startup failure. The service also requires the memory event
+        substrate (synthesis reads and writes through it).
+        """
+        memory_config = (self.formation_config or {}).get("memory") or {}
+        ingestion_config = memory_config.get("ingestion")
+        if not isinstance(ingestion_config, dict) or not ingestion_config:
+            return
+
+        settings = getattr(self.memory_ingestion, "settings", None)
+        if settings is None or not settings.synthesis.enabled:
+            return
+
+        memory_events = getattr(self, "memory_events", None)
+        if memory_events is None or not getattr(memory_events, "enabled", False):
+            return
+
+        from ...datatypes.observability import InitEventFormatter
+        from ...services.memory.synthesis import CADENCES, MemorySynthesisService
+
+        self.memory_synthesis = MemorySynthesisService(
+            self, settings.synthesis, settings.entity_resolution
+        )
+
+        enabled_cadences = [
+            cadence for cadence in CADENCES if settings.synthesis.cadence(cadence).enabled
+        ]
+        if not enabled_cadences:
+            return
+        if self.scheduler_service:
+            self.scheduler_service.register_periodic_task(self.memory_synthesis)
+            print(
+                InitEventFormatter.format_ok(
+                    "Memory synthesis cadences active",
+                    ", ".join(enabled_cadences),
+                )
+            )
+        else:
+            print(
+                InitEventFormatter.format_warn(
+                    "Memory synthesis cadences require the scheduler",
+                    "manual passes only - enable 'scheduler.enabled: true' "
+                    "(requires persistent memory) for periodic synthesis",
+                )
+            )
 
     def _initialize_knowledge_sync_service(self) -> None:
         """

--- a/src/muxi/runtime/services/memory/events/__init__.py
+++ b/src/muxi/runtime/services/memory/events/__init__.py
@@ -11,6 +11,7 @@
 from .decay import DecaySettings
 from .models import (
     EVENT_ARTIFACT_SAVED,
+    EVENT_ENTITY_RESOLVED,
     EVENT_FACT_CONTRADICTED,
     EVENT_FACT_EXTRACTED,
     EVENT_GRAPH_EXTRACTED,
@@ -20,6 +21,7 @@ from .models import (
     EVENT_LOG_ENTRY,
     EVENT_MEMORY_INGESTED,
     EVENT_USER_DELETION,
+    SOURCE_SYNTHESIS,
     MemoryEvent,
     ProjectionCheckpoint,
     append_event_id,
@@ -36,6 +38,7 @@ from .storage import MemoryEventStorage
 
 __all__ = [
     "EVENT_ARTIFACT_SAVED",
+    "EVENT_ENTITY_RESOLVED",
     "EVENT_FACT_CONTRADICTED",
     "EVENT_FACT_EXTRACTED",
     "EVENT_GRAPH_EXTRACTED",
@@ -45,6 +48,7 @@ __all__ = [
     "EVENT_LOG_ENTRY",
     "EVENT_MEMORY_INGESTED",
     "EVENT_USER_DELETION",
+    "SOURCE_SYNTHESIS",
     "MemoryEvent",
     "ProjectionCheckpoint",
     "append_event_id",

--- a/src/muxi/runtime/services/memory/events/models.py
+++ b/src/muxi/runtime/services/memory/events/models.py
@@ -85,6 +85,16 @@ EVENT_INGESTION_FILTERED = "ingestion.filtered"
 # metadata; v1 events are reconstructed best-effort).
 EVENT_ARTIFACT_SAVED = "artifact.saved"
 
+# One entity-resolution decision (Memory Ingestion maturation): two graph
+# entities probabilistically matched as the same identity, either
+# auto-merged (score at/above the merge threshold) or flagged for review.
+# Applied by the knowledge-graph projector so a rebuild replays the exact
+# recorded decision (the scoring runs on the live path only; replay never
+# re-scores, so threshold changes cannot rewrite history). Idempotent via
+# a deterministic per-pair source_id, which is what makes re-ingestion
+# unable to re-merge differently.
+EVENT_ENTITY_RESOLVED = "entity.resolved"
+
 # One contradiction detected by the knowledge graph writer (Phase 2c):
 # a new fact on an exclusive predicate conflicted with (or superseded)
 # an existing fact. Audit/provenance only -- the conflict marking itself
@@ -179,6 +189,15 @@ EVENT_SCHEMAS: Dict[str, Dict[int, Dict[str, tuple]]] = {
             ),
         },
     },
+    EVENT_ENTITY_RESOLVED: {
+        1: {
+            # decision: 'merged' or 'flagged'. Names identify the rows by
+            # the graph's natural key (user, formation, type, name) so the
+            # apply is a pure function of the event on live and replay.
+            "required": ("decision", "entity_type", "canonical_name", "duplicate_name"),
+            "optional": ("score", "signals"),
+        }
+    },
     EVENT_FACT_CONTRADICTED: {
         1: {
             # detection: 'superseded' (new fact auto-replaced the old one)
@@ -203,6 +222,7 @@ _LIST_KEYS = {
     "relationships",
     "decisions",
     "projects",
+    "signals",
     "sources",
     "tags",
     "target_event_ids",
@@ -227,6 +247,7 @@ SOURCE_TOOL = "tool"  # the record_lesson agent tool
 SOURCE_USER_EDIT = "user_edit"  # user-initiated corrections/deletions
 SOURCE_ARTIFACT_MEMORY = "artifact_memory"  # artifact capture audit events
 SOURCE_LEGACY = "legacy"  # synthetic events backfilled for pre-event-log rows (Phase B)
+SOURCE_SYNTHESIS = "synthesis"  # synthesis layer (entity resolution, pattern extraction)
 
 # Scope shape recorded for forward compatibility with memory namespaces.
 from ..base import SCOPE_TYPE_USER  # noqa: E402 -- canonical scope constants

--- a/src/muxi/runtime/services/memory/events/projectors.py
+++ b/src/muxi/runtime/services/memory/events/projectors.py
@@ -38,6 +38,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from ..base import SCOPE_TYPE_USER
 from .models import (
     EVENT_ARTIFACT_SAVED,
+    EVENT_ENTITY_RESOLVED,
     EVENT_FACT_EXTRACTED,
     EVENT_GRAPH_EXTRACTED,
     EVENT_LESSON_RECORDED,
@@ -116,21 +117,30 @@ async def apply_fact_event(
 
 
 class KnowledgeGraphProjector:
-    """Rebuilds kg_entities / kg_relationships from graph.extracted events."""
+    """Rebuilds kg_entities / kg_relationships from graph.extracted and
+    entity.resolved events (extraction batches + identity merges replay
+    in append order, converging to the same merged graph)."""
 
     name = "knowledge_graph"
-    event_types = (EVENT_GRAPH_EXTRACTED,)
+    event_types = (EVENT_GRAPH_EXTRACTED, EVENT_ENTITY_RESOLVED)
 
     def __init__(self, knowledge_graph_service):
         self.service = knowledge_graph_service
 
     async def apply(self, event: Dict[str, Any]) -> Dict[str, Any]:
-        """Apply one extraction batch through the service's upsert path.
+        """Apply one extraction batch or resolution decision.
 
-        Returns the apply result (counts + detected contradictions) so
+        Extraction batches go through the service's upsert path and
+        return the apply result (counts + detected contradictions) so
         the live incremental path can record fact.contradicted audit
-        events; rebuild replay ignores the return value.
+        events; resolution decisions replay the recorded merge/flag
+        exactly (never re-scored). Rebuild replay ignores the return
+        value either way.
         """
+        if event.get("event_type") == EVENT_ENTITY_RESOLVED:
+            return await self.service.apply_entity_resolution(
+                event["user_id"], event["payload"], event_id=event["id"]
+            )
         return await self.service.apply_extraction(
             event["user_id"], event["payload"], event_id=event["id"]
         )

--- a/src/muxi/runtime/services/memory/extractor.py
+++ b/src/muxi/runtime/services/memory/extractor.py
@@ -108,6 +108,7 @@ class MemoryExtractor:
         message_count=1,
         caused_by_event_id=None,
         event_source=None,
+        model=None,
     ):
         """
         Process a conversation turn and extract information if needed.
@@ -128,6 +129,10 @@ class MemoryExtractor:
                 (default: interaction). The ingestion pipeline passes the
                 developer's source ("gmail", ...) so derived facts carry
                 their true origin.
+            model: Optional extraction LLM override for this turn. The
+                ingestion tier heuristics pass the resolved tier model
+                (T2 mid / T3 frontier); None keeps the instance's
+                extraction model / overlord default resolution.
         """
         if not self.auto_extract:
             return
@@ -163,7 +168,7 @@ class MemoryExtractor:
             conversation = f"User: {user_message}\n(Note: Extract from user's statement alone, agent hasn't responded yet)"
 
         # Extract information
-        extraction_results = await self._extract_user_information(conversation)
+        extraction_results = await self._extract_user_information(conversation, model=model)
 
         # Process and store results if confidence threshold is met
         await self._process_extraction_results(
@@ -247,7 +252,7 @@ class MemoryExtractor:
 
         return True
 
-    async def _extract_user_information(self, conversation):
+    async def _extract_user_information(self, conversation, model=None):
         """
         Extract user information using the specified LLM.
 
@@ -256,12 +261,14 @@ class MemoryExtractor:
 
         Args:
             conversation: The conversation text to analyze
+            model: Optional per-call LLM override (ingestion tier models)
 
         Returns:
             A dictionary of extracted information with confidence scores
         """
-        # Use the specified extraction model if available, otherwise use overlord's default
-        model = self.extraction_model or self.overlord.default_model
+        # Per-call override first (ingestion tiers), then the configured
+        # extraction model, then the overlord's default.
+        model = model or self.extraction_model or self.overlord.default_model
 
         # Create extraction prompt
         prompt = self._create_extraction_prompt(conversation)

--- a/src/muxi/runtime/services/memory/graph/models.py
+++ b/src/muxi/runtime/services/memory/graph/models.py
@@ -66,6 +66,12 @@ STATUS_ACTIVE = "active"
 STATUS_CONFLICTED = "conflicted"
 STATUS_SUPERSEDED = "superseded"
 
+# Entity resolved as a duplicate identity (Memory Ingestion maturation,
+# PRD "Entity resolution"). The row is retained with ``superseded_by``
+# pointing at the canonical entity; upserts by the merged name redirect
+# to the canonical row so the duplicate never silently revives.
+STATUS_MERGED = "merged"
+
 # Confidence delta above which a new fact auto-supersedes a conflicting old
 # fact instead of flagging both as conflicted (PRD: ">0.3 delta").
 SUPERSEDE_CONFIDENCE_DELTA = 0.3

--- a/src/muxi/runtime/services/memory/graph/resolution.py
+++ b/src/muxi/runtime/services/memory/graph/resolution.py
@@ -1,0 +1,383 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Entity Resolution - Probabilistic Identity Matching
+# Description:  Detects and merges duplicate identities in the knowledge graph
+# Role:         Scores entity pairs; auto-merges or flags via entity.resolved
+# Usage:        Driven by the ingestion pipeline (extraction time) and the
+#               synthesis cadences (hot/cold passes)
+# Author:       Muxi Framework Team
+#
+# Memory Ingestion maturation (PRD "Entity resolution"): "Ryan from this
+# email" = "Ryan Leveille" from LinkedIn = the same person. Matching is
+# probabilistic over name / email / handle / role / relationship context,
+# but the SCORING IS PURE STRING AND SET LOGIC -- deterministic given the
+# same two entities, so the same content always resolves the same way.
+#
+# Decisions ride the event substrate:
+# - score >= auto_merge_threshold  -> decision "merged"
+# - flag_threshold <= score < auto -> decision "flagged" (event + stored
+#   attributes.possible_duplicates marker; a later pass with stronger
+#   evidence can still merge the pair -- merged and flagged use distinct
+#   idempotency keys)
+#
+# Determinism and idempotency contract:
+# - Every decision is appended as an entity.resolved event BEFORE it is
+#   applied, keyed by a deterministic per-pair source_id
+#   (entity_resolution/<type>/<nameA>|<nameB>/<decision>, names sorted).
+#   Re-ingestion re-derives the same pair, hits the substrate's
+#   (source, source_id) unique index, and is skipped -- it can neither
+#   duplicate the merge nor re-merge differently.
+# - The apply is a pure function of the event payload (names, decision):
+#   rebuild replays the recorded decisions in append order and converges
+#   to the same merged graph, even if thresholds changed since.
+# - Merged names stay sticky: the graph upsert path redirects them to the
+#   canonical entity, so later mentions of the duplicate cannot revive it.
+# =============================================================================
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
+
+from ... import observability
+from ..events.models import EVENT_ENTITY_RESOLVED, SOURCE_SYNTHESIS
+from .extractor import USER_ENTITY_NAME
+from .models import STATUS_ACTIVE
+
+if TYPE_CHECKING:  # imported lazily at runtime (the ingest package pulls
+    # in the request tracker; keep graph modules import-light)
+    from ..ingest.config import ResolutionSettings
+
+DECISION_MERGED = "merged"
+DECISION_FLAGGED = "flagged"
+
+# Signal weights (PRD matching dimensions). The exact values are a
+# mechanism dial baked into the scorer; the THRESHOLDS are the formation
+# author's policy surface (memory.ingestion.entity_resolution).
+WEIGHT_EMAIL = 0.6
+WEIGHT_HANDLE = 0.4
+WEIGHT_NAME_MATCH = 0.5
+WEIGHT_NAME_SUBSET = 0.35
+WEIGHT_FIRST_NAME = 0.15
+WEIGHT_ROLE = 0.15
+WEIGHT_SHARED_CONTEXT = 0.2
+
+# Attribute keys mined for identity signals (values may be str or list).
+EMAIL_KEYS = ("email", "emails", "email_address", "contact_email")
+HANDLE_KEYS = ("handle", "handles", "username", "github", "twitter", "x", "linkedin", "slack")
+ROLE_KEYS = ("role", "title", "job_title", "user_role", "position")
+
+_EMAIL_RE = re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b")
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _attribute_values(attributes: Dict[str, Any], keys: Tuple[str, ...]) -> Set[str]:
+    """Normalized string values under the given attribute keys."""
+    values: Set[str] = set()
+    for key in keys:
+        raw = attributes.get(key)
+        if raw is None:
+            continue
+        items = raw if isinstance(raw, list) else [raw]
+        for item in items:
+            if isinstance(item, str) and item.strip():
+                values.add(item.strip().lower().lstrip("@"))
+    return values
+
+
+def _emails(entity: Dict[str, Any]) -> Set[str]:
+    """Emails from the email attribute keys plus any attribute string value."""
+    attributes = entity.get("attributes") or {}
+    found = _attribute_values(attributes, EMAIL_KEYS)
+    for value in attributes.values():
+        items = value if isinstance(value, list) else [value]
+        for item in items:
+            if isinstance(item, str):
+                found.update(match.lower() for match in _EMAIL_RE.findall(item))
+    return {value for value in found if "@" in value}
+
+
+def _name_tokens(name: str) -> Tuple[str, ...]:
+    """Lowercased alphanumeric name tokens in order."""
+    return tuple(_TOKEN_RE.findall(name.lower()))
+
+
+def score_identity_match(
+    a: Dict[str, Any],
+    b: Dict[str, Any],
+    shared_neighbors: int = 0,
+) -> Tuple[float, List[str]]:
+    """
+    Score two entities as the same identity (0.0 - 1.0, deterministic).
+
+    Args:
+        a, b: Entity dicts (graph storage shape: name + attributes).
+        shared_neighbors: Count of graph entities both are related to
+            (relationship context, e.g. both ``works_at`` the same
+            company).
+
+    Returns:
+        (score, signals) -- signals is the sorted list of contributing
+        signal names, recorded on the entity.resolved event.
+    """
+    score = 0.0
+    signals: List[str] = []
+
+    if _emails(a) & _emails(b):
+        score += WEIGHT_EMAIL
+        signals.append("email_match")
+
+    handles_a = _attribute_values(a.get("attributes") or {}, HANDLE_KEYS)
+    handles_b = _attribute_values(b.get("attributes") or {}, HANDLE_KEYS)
+    if handles_a & handles_b:
+        score += WEIGHT_HANDLE
+        signals.append("handle_match")
+
+    tokens_a = set(_name_tokens(a.get("name") or ""))
+    tokens_b = set(_name_tokens(b.get("name") or ""))
+    if tokens_a and tokens_b:
+        if tokens_a == tokens_b:
+            score += WEIGHT_NAME_MATCH
+            signals.append("name_match")
+        elif tokens_a < tokens_b or tokens_b < tokens_a:
+            score += WEIGHT_NAME_SUBSET
+            signals.append("name_subset")
+        else:
+            first_a = _name_tokens(a.get("name") or "")[0]
+            first_b = _name_tokens(b.get("name") or "")[0]
+            if first_a == first_b:
+                score += WEIGHT_FIRST_NAME
+                signals.append("first_name_match")
+
+    roles_a = _attribute_values(a.get("attributes") or {}, ROLE_KEYS)
+    roles_b = _attribute_values(b.get("attributes") or {}, ROLE_KEYS)
+    if roles_a & roles_b:
+        score += WEIGHT_ROLE
+        signals.append("role_match")
+
+    if shared_neighbors > 0:
+        score += WEIGHT_SHARED_CONTEXT
+        signals.append("shared_context")
+
+    return min(score, 1.0), sorted(signals)
+
+
+def pick_canonical(a: Dict[str, Any], b: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Deterministically pick (canonical, duplicate) for a matched pair.
+
+    The fuller name wins (more tokens); ties fall to higher confidence,
+    then to the older row (lower id -- replay recreates rows in the same
+    relative order, so this is stable across rebuilds).
+    """
+    key_a = (len(_name_tokens(a.get("name") or "")), a.get("confidence") or 0.0, -(a["id"]))
+    key_b = (len(_name_tokens(b.get("name") or "")), b.get("confidence") or 0.0, -(b["id"]))
+    return (a, b) if key_a >= key_b else (b, a)
+
+
+def pair_source_id(entity_type: str, name_a: str, name_b: str, decision: str) -> str:
+    """Deterministic idempotency key for one resolution decision."""
+    low, high = sorted((name_a.strip().lower(), name_b.strip().lower()))
+    return f"entity_resolution/{entity_type}/{low}|{high}/{decision}"
+
+
+class EntityResolver:
+    """Runs resolution passes over a user's graph; never raises."""
+
+    def __init__(self, knowledge_graph, memory_events, settings: "ResolutionSettings"):
+        """
+        Args:
+            knowledge_graph: KnowledgeGraphService (storage + apply path).
+            memory_events: MemoryEventService (event-first decisions).
+            settings: Validated ResolutionSettings.
+        """
+        self.knowledge_graph = knowledge_graph
+        self.memory_events = memory_events
+        self.settings = settings
+
+    async def resolve_user(
+        self,
+        user_id: Any,
+        caused_by: Optional[int] = None,
+    ) -> Dict[str, int]:
+        """
+        Run one resolution pass for a user. Failure-isolated: any error is
+        observed and an empty result returned -- resolution can never
+        break ingestion or a synthesis cadence.
+
+        Returns:
+            {"merged": n, "flagged": n} decision counts for this pass.
+        """
+        try:
+            return await self._resolve(str(user_id), caused_by)
+        except Exception as e:
+            observability.observe(
+                event_type=observability.ConversationEvents.MEMORY_SYNTHESIS_FAILED,
+                level=observability.EventLevel.WARNING,
+                data={
+                    "user_id": str(user_id),
+                    "pass": "entity_resolution",
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                },
+                description=f"Entity resolution failed (isolated): {e}",
+            )
+            return {"merged": 0, "flagged": 0}
+
+    async def _resolve(self, user_id: str, caused_by: Optional[int]) -> Dict[str, int]:
+        if (
+            not self.settings.enabled
+            or self.knowledge_graph is None
+            or self.memory_events is None
+            or not getattr(self.memory_events, "enabled", False)
+        ):
+            return {"merged": 0, "flagged": 0}
+
+        storage = self.knowledge_graph.storage
+        neighbors = await self._neighbor_map(storage, user_id)
+        counts = {"merged": 0, "flagged": 0}
+
+        for entity_type in self.settings.entity_types:
+            entities = await storage.list_entities(
+                user_id,
+                entity_type=entity_type,
+                status=STATUS_ACTIVE,
+                limit=self.settings.max_entities,
+            )
+            # The user's canonical self node is never a merge candidate:
+            # every self-referential fact hangs off it, so a false match
+            # would fold a contact into the user themselves.
+            entities = [
+                entity
+                for entity in entities
+                if entity["name"].strip().lower() != USER_ENTITY_NAME.lower()
+            ]
+            entities.sort(key=lambda entity: entity["id"])
+            resolved_away: Set[int] = set()
+
+            for i, a in enumerate(entities):
+                if a["id"] in resolved_away:
+                    continue
+                for b in entities[i + 1 :]:
+                    if b["id"] in resolved_away or a["id"] in resolved_away:
+                        continue
+                    shared = len(
+                        (neighbors.get(a["id"], set()) - {b["id"]})
+                        & (neighbors.get(b["id"], set()) - {a["id"]})
+                    )
+                    score, signals = score_identity_match(a, b, shared_neighbors=shared)
+                    if score >= self.settings.auto_merge_threshold:
+                        decision = DECISION_MERGED
+                    elif score >= self.settings.flag_threshold:
+                        decision = DECISION_FLAGGED
+                    else:
+                        continue
+
+                    canonical, duplicate = pick_canonical(a, b)
+                    applied = await self._record_and_apply(
+                        user_id,
+                        entity_type,
+                        canonical,
+                        duplicate,
+                        decision,
+                        score,
+                        signals,
+                        caused_by,
+                    )
+                    if applied:
+                        counts[decision] += 1
+                        if decision == DECISION_MERGED:
+                            resolved_away.add(duplicate["id"])
+        return counts
+
+    async def _neighbor_map(self, storage, user_id: str) -> Dict[int, Set[int]]:
+        """Undirected adjacency sets over the user's active edges."""
+        neighbors: Dict[int, Set[int]] = {}
+        for edge in await storage.iter_edges(user_id):
+            neighbors.setdefault(edge["from_entity_id"], set()).add(edge["to_entity_id"])
+            neighbors.setdefault(edge["to_entity_id"], set()).add(edge["from_entity_id"])
+        return neighbors
+
+    async def _record_and_apply(
+        self,
+        user_id: str,
+        entity_type: str,
+        canonical: Dict[str, Any],
+        duplicate: Dict[str, Any],
+        decision: str,
+        score: float,
+        signals: List[str],
+        caused_by: Optional[int],
+    ) -> bool:
+        """Append the decision event (idempotent) and apply it once.
+
+        Returns True when a NEW decision was recorded and applied; False
+        for pairs already resolved (duplicate source_id) or when the
+        substrate rejected the append.
+        """
+        payload = {
+            "decision": decision,
+            "entity_type": entity_type,
+            "canonical_name": canonical["name"],
+            "duplicate_name": duplicate["name"],
+            "score": round(score, 4),
+            "signals": signals,
+        }
+        source_id = pair_source_id(entity_type, canonical["name"], duplicate["name"], decision)
+        try:
+            event, created = await self.memory_events.storage.append(
+                user_id=user_id,
+                event_type=EVENT_ENTITY_RESOLVED,
+                payload=payload,
+                source=SOURCE_SYNTHESIS,
+                source_id=source_id,
+                caused_by=caused_by,
+            )
+        except Exception as e:
+            observability.observe(
+                event_type=observability.ConversationEvents.MEMORY_EVENT_APPEND_FAILED,
+                level=observability.EventLevel.WARNING,
+                data={
+                    "user_id": user_id,
+                    "memory_event_type": EVENT_ENTITY_RESOLVED,
+                    "source": SOURCE_SYNTHESIS,
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                },
+                description=f"Entity resolution event append failed: {e}",
+            )
+            return False
+        if not created:
+            # Already decided (this run or a previous ingestion): the
+            # substrate's idempotency key guarantees one merge per pair.
+            return False
+
+        if getattr(self.memory_events, "event_first", False):
+            await self.memory_events.apply_event(event)
+        else:
+            await self.knowledge_graph.apply_entity_resolution(
+                user_id, payload, event_id=event["id"]
+            )
+
+        observability.observe(
+            event_type=(
+                observability.ConversationEvents.MEMORY_ENTITY_MERGED
+                if decision == DECISION_MERGED
+                else observability.ConversationEvents.MEMORY_ENTITY_FLAGGED
+            ),
+            level=observability.EventLevel.INFO,
+            data={
+                "user_id": user_id,
+                "entity_type": entity_type,
+                "canonical_name": canonical["name"],
+                "duplicate_name": duplicate["name"],
+                "score": payload["score"],
+                "signals": signals,
+                "memory_event_id": event["id"],
+            },
+            description=(
+                f"Entity resolution {decision}: {duplicate['name']!r} -> "
+                f"{canonical['name']!r} (score {payload['score']})"
+            ),
+        )
+        return True

--- a/src/muxi/runtime/services/memory/graph/service.py
+++ b/src/muxi/runtime/services/memory/graph/service.py
@@ -328,6 +328,47 @@ class KnowledgeGraphService:
             result_counts["contradictions"] = contradictions
         return result_counts
 
+    async def apply_entity_resolution(
+        self,
+        user_id: Any,
+        payload: Dict[str, Any],
+        event_id: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Apply one entity.resolved decision (live path and replay).
+
+        A pure function of the payload (Memory Ingestion maturation):
+        entities are addressed by their (type, name) natural key, so
+        replaying the recorded decision on a rebuilt graph converges to
+        the same merged state. Missing entities (e.g. their source events
+        were forgotten) make the apply a no-op rather than an error.
+        """
+        user_id = str(user_id)
+        from .resolution import DECISION_MERGED
+
+        entity_type = normalize_type(payload["entity_type"])
+        canonical = await self.storage.get_entity(user_id, entity_type, payload["canonical_name"])
+        duplicate = await self.storage.get_entity(user_id, entity_type, payload["duplicate_name"])
+        if canonical is None or duplicate is None or canonical["id"] == duplicate["id"]:
+            return {"applied": False}
+
+        if payload["decision"] == DECISION_MERGED:
+            result = await self.storage.merge_entities(
+                user_id, canonical["id"], duplicate["id"], event_id=event_id
+            )
+            self.algorithms.invalidate(user_id)
+            return {"applied": True, "decision": payload["decision"], **result}
+
+        flagged_canonical = await self.storage.mark_possible_duplicate(
+            canonical["id"], duplicate["name"], event_id=event_id
+        )
+        flagged_duplicate = await self.storage.mark_possible_duplicate(
+            duplicate["id"], canonical["name"], event_id=event_id
+        )
+        return {
+            "applied": flagged_canonical or flagged_duplicate,
+            "decision": payload["decision"],
+        }
+
     async def _resolve_endpoint(
         self,
         user_id: str,

--- a/src/muxi/runtime/services/memory/graph/storage.py
+++ b/src/muxi/runtime/services/memory/graph/storage.py
@@ -32,11 +32,16 @@ from .models import (
     EXCLUSIVE_RELATIONSHIP_TYPES,
     STATUS_ACTIVE,
     STATUS_CONFLICTED,
+    STATUS_MERGED,
     STATUS_SUPERSEDED,
     SUPERSEDE_CONFIDENCE_DELTA,
     KGEntity,
     KGRelationship,
 )
+
+# Bound on merge-chain hops followed by the upsert redirect (defensive;
+# chains longer than this indicate corrupted bookkeeping).
+MAX_MERGE_CHAIN_DEPTH = 10
 
 
 class KnowledgeGraphStorage:
@@ -73,6 +78,11 @@ class KnowledgeGraphStorage:
         keep the highest confidence seen. When ``event_id`` is provided it
         is appended to the row's provenance list (idempotently).
 
+        Sticky entity resolution: a name previously merged away by entity
+        resolution redirects to its canonical entity (following the
+        ``superseded_by`` merge chain), so re-mentions of the duplicate
+        name enrich the canonical row instead of reviving the duplicate.
+
         Returns:
             Dict representation of the stored entity.
         """
@@ -88,6 +98,9 @@ class KnowledgeGraphStorage:
                 name=name,
             )
             existing = (await session.execute(stmt)).scalar_one_or_none()
+
+            if existing is not None and existing.status == STATUS_MERGED:
+                existing = await self._follow_merge_chain(session, existing)
 
             if existing is not None:
                 merged = dict(existing.attributes or {})
@@ -116,6 +129,26 @@ class KnowledgeGraphStorage:
             session.add(entity)
             await session.flush()
             return entity.to_dict()
+
+    @staticmethod
+    async def _follow_merge_chain(session, entity: KGEntity) -> KGEntity:
+        """Resolve a merged entity to its canonical row (bounded chain).
+
+        Returns the last resolvable row: the canonical entity in the
+        normal case, or the input row itself when the chain is broken
+        (defensive -- never returns None, so the caller's upsert can
+        always merge into an existing row instead of violating the
+        (user, formation, type, name) unique constraint).
+        """
+        current = entity
+        for _ in range(MAX_MERGE_CHAIN_DEPTH):
+            if current.status != STATUS_MERGED or current.superseded_by is None:
+                return current
+            target = await session.get(KGEntity, current.superseded_by)
+            if target is None:
+                return current
+            current = target
+        return current
 
     async def get_entity(
         self, user_id: str, entity_type: str, name: str
@@ -355,6 +388,142 @@ class KnowledgeGraphStorage:
                 stmt = stmt.filter(KGRelationship.type.in_([normalize_type(t) for t in rel_types]))
             rows = (await session.execute(stmt)).scalars().all()
             return [row.to_dict() for row in rows]
+
+    # ------------------------------------------------------------------
+    # Entity resolution (Memory Ingestion maturation)
+    # ------------------------------------------------------------------
+
+    async def merge_entities(
+        self,
+        user_id: str,
+        canonical_id: int,
+        duplicate_id: int,
+        event_id: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """
+        Merge a duplicate identity into its canonical entity.
+
+        Deterministic and idempotent: relationships are re-pointed from
+        the duplicate to the canonical entity (an edge that would collide
+        with an existing canonical edge, or become a self-loop, is marked
+        superseded instead -- facts are retained, never deleted); the
+        canonical row absorbs the duplicate's attributes (canonical values
+        win on conflict), keeps the max confidence, and records the
+        duplicate's name under ``attributes.aliases``. The duplicate row
+        is marked ``merged`` with ``superseded_by`` -> canonical, which
+        the upsert path treats as a redirect.
+
+        Returns:
+            {"repointed": n, "superseded": n} edge counts (both zero when
+            either entity is missing or the merge already happened).
+        """
+        user_id = str(user_id)
+        async with self.db_manager.get_async_session() as session:
+            canonical = await session.get(KGEntity, canonical_id)
+            duplicate = await session.get(KGEntity, duplicate_id)
+            if (
+                canonical is None
+                or duplicate is None
+                or canonical.id == duplicate.id
+                or canonical.user_id != user_id
+                or duplicate.user_id != user_id
+                or duplicate.status == STATUS_MERGED
+            ):
+                return {"repointed": 0, "superseded": 0}
+
+            # Existing canonical edge index for collision detection.
+            stmt = select(KGRelationship).filter_by(user_id=user_id, formation_id=self.formation_id)
+            edges = (await session.execute(stmt)).scalars().all()
+            canonical_edges: Dict[tuple, KGRelationship] = {}
+            duplicate_edges = []
+            for edge in edges:
+                touches_duplicate = duplicate.id in (edge.from_entity_id, edge.to_entity_id)
+                if touches_duplicate:
+                    duplicate_edges.append(edge)
+                elif canonical.id in (edge.from_entity_id, edge.to_entity_id):
+                    canonical_edges[(edge.from_entity_id, edge.to_entity_id, edge.type)] = edge
+
+            repointed = superseded = 0
+            for edge in duplicate_edges:
+                new_from = (
+                    canonical.id if edge.from_entity_id == duplicate.id else edge.from_entity_id
+                )
+                new_to = canonical.id if edge.to_entity_id == duplicate.id else edge.to_entity_id
+                collision = canonical_edges.get((new_from, new_to, edge.type))
+                if new_from == new_to:
+                    # Would become a self-loop (e.g. duplicate -> canonical
+                    # "knows" edge): retain as a superseded fact.
+                    edge.status = STATUS_SUPERSEDED
+                    edge.derived_from_event_ids = append_event_id(
+                        edge.derived_from_event_ids, event_id
+                    )
+                    superseded += 1
+                elif collision is not None:
+                    collision.confidence = max(collision.confidence or 0.0, edge.confidence or 0.0)
+                    merged_attrs = dict(edge.attributes or {})
+                    merged_attrs.update(collision.attributes or {})
+                    collision.attributes = merged_attrs
+                    collision.derived_from_event_ids = append_event_id(
+                        collision.derived_from_event_ids, event_id
+                    )
+                    edge.status = STATUS_SUPERSEDED
+                    edge.superseded_by = collision.id
+                    superseded += 1
+                else:
+                    edge.from_entity_id = new_from
+                    edge.to_entity_id = new_to
+                    edge.derived_from_event_ids = append_event_id(
+                        edge.derived_from_event_ids, event_id
+                    )
+                    canonical_edges[(new_from, new_to, edge.type)] = edge
+                    repointed += 1
+
+            # Canonical absorbs the duplicate (canonical attributes win).
+            merged_attrs = dict(duplicate.attributes or {})
+            merged_attrs.update(canonical.attributes or {})
+            aliases = set(merged_attrs.get("aliases") or [])
+            aliases.update((duplicate.attributes or {}).get("aliases") or [])
+            aliases.add(duplicate.name)
+            aliases.discard(canonical.name)
+            merged_attrs["aliases"] = sorted(aliases)
+            canonical.attributes = merged_attrs
+            canonical.confidence = max(canonical.confidence or 0.0, duplicate.confidence or 0.0)
+            canonical.derived_from_event_ids = append_event_id(
+                canonical.derived_from_event_ids, event_id
+            )
+
+            duplicate.status = STATUS_MERGED
+            duplicate.superseded_by = canonical.id
+            duplicate.derived_from_event_ids = append_event_id(
+                duplicate.derived_from_event_ids, event_id
+            )
+            await session.flush()
+            return {"repointed": repointed, "superseded": superseded}
+
+    async def mark_possible_duplicate(
+        self, entity_id: int, other_name: str, event_id: Optional[int] = None
+    ) -> bool:
+        """
+        Stamp a below-threshold resolution match on an entity.
+
+        The stored marker is ``attributes.possible_duplicates`` (a sorted,
+        de-duplicated name list), so flagged pairs are reviewable without
+        a schema change and re-application is idempotent.
+        """
+        async with self.db_manager.get_async_session() as session:
+            entity = await session.get(KGEntity, entity_id)
+            if entity is None:
+                return False
+            attributes = dict(entity.attributes or {})
+            flagged = set(attributes.get("possible_duplicates") or [])
+            if other_name in flagged:
+                return False
+            flagged.add(other_name)
+            attributes["possible_duplicates"] = sorted(flagged)
+            entity.attributes = attributes
+            entity.derived_from_event_ids = append_event_id(entity.derived_from_event_ids, event_id)
+            await session.flush()
+            return True
 
     # ------------------------------------------------------------------
     # Rebuild support (Memory Event Substrate)

--- a/src/muxi/runtime/services/memory/graph/storage.py
+++ b/src/muxi/runtime/services/memory/graph/storage.py
@@ -432,6 +432,10 @@ class KnowledgeGraphStorage:
                 return {"repointed": 0, "superseded": 0}
 
             # Existing canonical edge index for collision detection.
+            # ACTIVE edges only: an active duplicate fact must never be
+            # folded into a superseded/conflicted canonical row (that
+            # would silently drop it from the active graph); non-active
+            # rows are retained history, not collision targets.
             stmt = select(KGRelationship).filter_by(user_id=user_id, formation_id=self.formation_id)
             edges = (await session.execute(stmt)).scalars().all()
             canonical_edges: Dict[tuple, KGRelationship] = {}
@@ -440,7 +444,10 @@ class KnowledgeGraphStorage:
                 touches_duplicate = duplicate.id in (edge.from_entity_id, edge.to_entity_id)
                 if touches_duplicate:
                     duplicate_edges.append(edge)
-                elif canonical.id in (edge.from_entity_id, edge.to_entity_id):
+                elif edge.status == STATUS_ACTIVE and canonical.id in (
+                    edge.from_entity_id,
+                    edge.to_entity_id,
+                ):
                     canonical_edges[(edge.from_entity_id, edge.to_entity_id, edge.type)] = edge
 
             repointed = superseded = 0
@@ -449,6 +456,17 @@ class KnowledgeGraphStorage:
                     canonical.id if edge.from_entity_id == duplicate.id else edge.from_entity_id
                 )
                 new_to = canonical.id if edge.to_entity_id == duplicate.id else edge.to_entity_id
+                if edge.status != STATUS_ACTIVE:
+                    # Retained non-active facts follow the merge (their
+                    # endpoints stay coherent with the surviving entity)
+                    # but never participate in collision handling.
+                    edge.from_entity_id = new_from
+                    edge.to_entity_id = new_to
+                    edge.derived_from_event_ids = append_event_id(
+                        edge.derived_from_event_ids, event_id
+                    )
+                    repointed += 1
+                    continue
                 collision = canonical_edges.get((new_from, new_to, edge.type))
                 if new_from == new_to:
                     # Would become a self-loop (e.g. duplicate -> canonical

--- a/src/muxi/runtime/services/memory/ingest/__init__.py
+++ b/src/muxi/runtime/services/memory/ingest/__init__.py
@@ -19,6 +19,16 @@ from .classification import (
     classify_content,
     is_filtered,
 )
+from .config import (
+    TIER_FRONTIER,
+    TIER_LOCAL,
+    TIER_STANDARD,
+    IngestionSettings,
+    ResolutionSettings,
+    SynthesisSettings,
+    TierSettings,
+    parse_ingestion_config,
+)
 from .service import (
     DISPOSITION_FAILED,
     DISPOSITION_FILTERED,
@@ -32,6 +42,7 @@ from .service import (
     MemoryIngestionService,
     validate_item,
 )
+from .tiers import TierBudget, content_signals, decide_tier, signal_score
 
 __all__ = [
     "CATEGORY_SPECS",
@@ -43,6 +54,14 @@ __all__ = [
     "build_category_specs",
     "classify_content",
     "is_filtered",
+    "TIER_FRONTIER",
+    "TIER_LOCAL",
+    "TIER_STANDARD",
+    "IngestionSettings",
+    "ResolutionSettings",
+    "SynthesisSettings",
+    "TierSettings",
+    "parse_ingestion_config",
     "DISPOSITION_FAILED",
     "DISPOSITION_FILTERED",
     "DISPOSITION_STORED",
@@ -54,4 +73,8 @@ __all__ = [
     "IngestItem",
     "MemoryIngestionService",
     "validate_item",
+    "TierBudget",
+    "content_signals",
+    "decide_tier",
+    "signal_score",
 ]

--- a/src/muxi/runtime/services/memory/ingest/config.py
+++ b/src/muxi/runtime/services/memory/ingest/config.py
@@ -1,0 +1,380 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Memory Ingestion Settings - Fail-Fast Configuration Parsing
+# Description:  Validated settings for tiers, entity resolution, and synthesis
+# Role:         Single source of truth for the memory.ingestion config shape
+# Usage:        parse_ingestion_config() from MemoryIngestionService and the
+#               formation validator (both parse the same way, by construction)
+# Author:       Muxi Framework Team
+#
+# Memory Ingestion maturation (tier heuristics + entity resolution +
+# synthesis cadences). One parser, shared by the runtime service and the
+# formation config validator, so the two can never disagree about what a
+# valid ``memory.ingestion`` block looks like. Every error message carries
+# the full config path (fail-fast policy).
+#
+#   memory:
+#     ingestion:
+#       max_in_flight_per_user: 4        # pre-existing (lenient fallback)
+#       sources:
+#         gmail:
+#           filter: strict|lenient|off   # pre-existing noise gate
+#           tier: 1|2|3                  # optional per-source tier pin
+#       tiers:                           # escalation heuristics (T1->T2->T3)
+#         enabled: true
+#         ambiguity_margin: 0.05         # classify margin below -> escalate T2
+#         t3_signal_score: 5             # T0 signal score at/above -> T3
+#         models:
+#           t2: "openai/gpt-4o-mini"     # optional; default extraction model
+#           t3: "anthropic/claude-..."   # optional; falls back to t2 model
+#         budget:
+#           t2_items_per_job: 100        # LLM-extraction cap per processing job
+#           t3_items_per_job: 10         # frontier cap per processing job
+#       entity_resolution:
+#         enabled: true
+#         auto_merge_threshold: 0.85     # score at/above -> auto-merge
+#         flag_threshold: 0.5            # score at/above (below merge) -> flag
+#         entity_types: [person]
+#         max_entities: 200              # per-user scan bound per pass
+#       synthesis:
+#         enabled: true
+#         hot:       { enabled: true, interval_seconds: 300 }
+#         warm:      { enabled: true, interval_seconds: 3600 }
+#         cold:      { enabled: true, interval_seconds: 86400 }
+#         cold_cold: { enabled: true, interval_seconds: 604800 }
+#         patterns:
+#           enabled: true
+#           min_events: 20               # schedule pattern needs this many events
+#           top_k: 3                     # items per rendered pattern fact
+# =============================================================================
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Tuple
+
+# Tier vocabulary (PRD "Processing Pipeline" stage 3). Tier 0 (regex +
+# heuristics) is not a resting tier: it computes the escalation signals.
+TIER_LOCAL = 1  # small local processing only (classify + verbatim store)
+TIER_STANDARD = 2  # mid-size LLM extraction (the default extraction model)
+TIER_FRONTIER = 3  # frontier LLM extraction, flagged high-signal items only
+TIERS = (TIER_LOCAL, TIER_STANDARD, TIER_FRONTIER)
+
+DEFAULT_AMBIGUITY_MARGIN = 0.05
+DEFAULT_T3_SIGNAL_SCORE = 5
+DEFAULT_T2_ITEMS_PER_JOB = 100
+DEFAULT_T3_ITEMS_PER_JOB = 10
+
+DEFAULT_AUTO_MERGE_THRESHOLD = 0.85
+DEFAULT_FLAG_THRESHOLD = 0.5
+DEFAULT_RESOLUTION_ENTITY_TYPES = ("person",)
+DEFAULT_RESOLUTION_MAX_ENTITIES = 200
+
+# PRD "Synthesis Scheduling" cadence table.
+DEFAULT_CADENCE_INTERVALS = {
+    "hot": 300.0,  # 5 minutes
+    "warm": 3600.0,  # hourly
+    "cold": 86400.0,  # nightly
+    "cold_cold": 604800.0,  # weekly full re-synthesis
+}
+
+DEFAULT_PATTERN_MIN_EVENTS = 20
+DEFAULT_PATTERN_TOP_K = 3
+
+
+@dataclass(frozen=True)
+class TierSettings:
+    """Validated ``memory.ingestion.tiers`` (escalation heuristics)."""
+
+    enabled: bool = True
+    ambiguity_margin: float = DEFAULT_AMBIGUITY_MARGIN
+    t3_signal_score: int = DEFAULT_T3_SIGNAL_SCORE
+    t2_model: Optional[str] = None
+    t3_model: Optional[str] = None
+    t2_items_per_job: int = DEFAULT_T2_ITEMS_PER_JOB
+    t3_items_per_job: int = DEFAULT_T3_ITEMS_PER_JOB
+
+
+@dataclass(frozen=True)
+class ResolutionSettings:
+    """Validated ``memory.ingestion.entity_resolution``."""
+
+    enabled: bool = True
+    auto_merge_threshold: float = DEFAULT_AUTO_MERGE_THRESHOLD
+    flag_threshold: float = DEFAULT_FLAG_THRESHOLD
+    entity_types: Tuple[str, ...] = DEFAULT_RESOLUTION_ENTITY_TYPES
+    max_entities: int = DEFAULT_RESOLUTION_MAX_ENTITIES
+
+
+@dataclass(frozen=True)
+class CadenceSettings:
+    """One synthesis cadence: individually disableable, interval in seconds."""
+
+    enabled: bool = True
+    interval_seconds: float = 0.0
+
+
+@dataclass(frozen=True)
+class PatternSettings:
+    """Validated ``memory.ingestion.synthesis.patterns`` (v1 mechanisms)."""
+
+    enabled: bool = True
+    min_events: int = DEFAULT_PATTERN_MIN_EVENTS
+    top_k: int = DEFAULT_PATTERN_TOP_K
+
+
+@dataclass(frozen=True)
+class SynthesisSettings:
+    """Validated ``memory.ingestion.synthesis`` (cadence table)."""
+
+    enabled: bool = True
+    hot: CadenceSettings = field(
+        default_factory=lambda: CadenceSettings(True, DEFAULT_CADENCE_INTERVALS["hot"])
+    )
+    warm: CadenceSettings = field(
+        default_factory=lambda: CadenceSettings(True, DEFAULT_CADENCE_INTERVALS["warm"])
+    )
+    cold: CadenceSettings = field(
+        default_factory=lambda: CadenceSettings(True, DEFAULT_CADENCE_INTERVALS["cold"])
+    )
+    cold_cold: CadenceSettings = field(
+        default_factory=lambda: CadenceSettings(True, DEFAULT_CADENCE_INTERVALS["cold_cold"])
+    )
+    patterns: PatternSettings = field(default_factory=PatternSettings)
+
+    def cadence(self, name: str) -> CadenceSettings:
+        """The settings for one cadence name (hot/warm/cold/cold_cold)."""
+        return getattr(self, name)
+
+
+@dataclass(frozen=True)
+class IngestionSettings:
+    """The validated ``memory.ingestion`` maturation sections.
+
+    The pre-existing keys (``sources`` filter levels and
+    ``max_in_flight_per_user``) keep their shipped lenient-fallback
+    semantics in MemoryIngestionService; this object owns the strict
+    (fail-fast) sections plus the per-source tier pins.
+    """
+
+    tiers: TierSettings = field(default_factory=TierSettings)
+    entity_resolution: ResolutionSettings = field(default_factory=ResolutionSettings)
+    synthesis: SynthesisSettings = field(default_factory=SynthesisSettings)
+    source_tiers: Dict[str, int] = field(default_factory=dict)
+
+
+def parse_ingestion_config(config: Any) -> IngestionSettings:
+    """
+    Parse and validate a ``memory.ingestion`` config block.
+
+    Args:
+        config: The raw config section (None means "not configured";
+            defaults apply).
+
+    Returns:
+        IngestionSettings with every maturation section validated.
+
+    Raises:
+        ValueError: On any invalid value, with the full config path in
+            the message (fail-fast policy; the formation validator
+            surfaces the same message at load time).
+    """
+    if config is None:
+        config = {}
+    if not isinstance(config, dict):
+        raise ValueError("memory.ingestion must be a dictionary")
+
+    return IngestionSettings(
+        tiers=_parse_tiers(config.get("tiers")),
+        entity_resolution=_parse_resolution(config.get("entity_resolution")),
+        synthesis=_parse_synthesis(config.get("synthesis")),
+        source_tiers=_parse_source_tiers(config.get("sources")),
+    )
+
+
+def _parse_tiers(section: Any) -> TierSettings:
+    section = _section(section, "memory.ingestion.tiers")
+    models = _section(section.get("models"), "memory.ingestion.tiers.models")
+    budget = _section(section.get("budget"), "memory.ingestion.tiers.budget")
+    return TierSettings(
+        enabled=_boolean(section.get("enabled", True), "memory.ingestion.tiers.enabled"),
+        ambiguity_margin=_number_in_range(
+            section.get("ambiguity_margin", DEFAULT_AMBIGUITY_MARGIN),
+            "memory.ingestion.tiers.ambiguity_margin",
+            low=0.0,
+            high=1.0,
+        ),
+        t3_signal_score=_positive_int(
+            section.get("t3_signal_score", DEFAULT_T3_SIGNAL_SCORE),
+            "memory.ingestion.tiers.t3_signal_score",
+        ),
+        t2_model=_optional_model(models.get("t2"), "memory.ingestion.tiers.models.t2"),
+        t3_model=_optional_model(models.get("t3"), "memory.ingestion.tiers.models.t3"),
+        t2_items_per_job=_positive_int(
+            budget.get("t2_items_per_job", DEFAULT_T2_ITEMS_PER_JOB),
+            "memory.ingestion.tiers.budget.t2_items_per_job",
+        ),
+        t3_items_per_job=_positive_int(
+            budget.get("t3_items_per_job", DEFAULT_T3_ITEMS_PER_JOB),
+            "memory.ingestion.tiers.budget.t3_items_per_job",
+        ),
+    )
+
+
+def _parse_resolution(section: Any) -> ResolutionSettings:
+    section = _section(section, "memory.ingestion.entity_resolution")
+    auto_merge = _number_in_range(
+        section.get("auto_merge_threshold", DEFAULT_AUTO_MERGE_THRESHOLD),
+        "memory.ingestion.entity_resolution.auto_merge_threshold",
+        low=0.0,
+        high=1.0,
+    )
+    flag = _number_in_range(
+        section.get("flag_threshold", DEFAULT_FLAG_THRESHOLD),
+        "memory.ingestion.entity_resolution.flag_threshold",
+        low=0.0,
+        high=1.0,
+    )
+    if flag > auto_merge:
+        raise ValueError(
+            "memory.ingestion.entity_resolution.flag_threshold must not exceed "
+            "auto_merge_threshold"
+        )
+    entity_types = section.get("entity_types", list(DEFAULT_RESOLUTION_ENTITY_TYPES))
+    if not isinstance(entity_types, list) or not entity_types:
+        raise ValueError("memory.ingestion.entity_resolution.entity_types must be a non-empty list")
+    normalized = []
+    for value in entity_types:
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(
+                "memory.ingestion.entity_resolution.entity_types entries must be "
+                "non-empty strings"
+            )
+        normalized.append(value.strip().lower())
+    return ResolutionSettings(
+        enabled=_boolean(
+            section.get("enabled", True), "memory.ingestion.entity_resolution.enabled"
+        ),
+        auto_merge_threshold=auto_merge,
+        flag_threshold=flag,
+        entity_types=tuple(normalized),
+        max_entities=_positive_int(
+            section.get("max_entities", DEFAULT_RESOLUTION_MAX_ENTITIES),
+            "memory.ingestion.entity_resolution.max_entities",
+        ),
+    )
+
+
+def _parse_synthesis(section: Any) -> SynthesisSettings:
+    section = _section(section, "memory.ingestion.synthesis")
+    cadences = {}
+    for name, default_interval in DEFAULT_CADENCE_INTERVALS.items():
+        cadence_section = _section(section.get(name), f"memory.ingestion.synthesis.{name}")
+        cadences[name] = CadenceSettings(
+            enabled=_boolean(
+                cadence_section.get("enabled", True),
+                f"memory.ingestion.synthesis.{name}.enabled",
+            ),
+            interval_seconds=_positive_number(
+                cadence_section.get("interval_seconds", default_interval),
+                f"memory.ingestion.synthesis.{name}.interval_seconds",
+            ),
+        )
+    patterns_section = _section(section.get("patterns"), "memory.ingestion.synthesis.patterns")
+    patterns = PatternSettings(
+        enabled=_boolean(
+            patterns_section.get("enabled", True),
+            "memory.ingestion.synthesis.patterns.enabled",
+        ),
+        min_events=_positive_int(
+            patterns_section.get("min_events", DEFAULT_PATTERN_MIN_EVENTS),
+            "memory.ingestion.synthesis.patterns.min_events",
+        ),
+        top_k=_positive_int(
+            patterns_section.get("top_k", DEFAULT_PATTERN_TOP_K),
+            "memory.ingestion.synthesis.patterns.top_k",
+        ),
+    )
+    return SynthesisSettings(
+        enabled=_boolean(section.get("enabled", True), "memory.ingestion.synthesis.enabled"),
+        hot=cadences["hot"],
+        warm=cadences["warm"],
+        cold=cadences["cold"],
+        cold_cold=cadences["cold_cold"],
+        patterns=patterns,
+    )
+
+
+def _parse_source_tiers(sources: Any) -> Dict[str, int]:
+    """Per-source tier pins (``sources.<source>.tier``), validated strictly.
+
+    The pre-existing ``filter`` key keeps its lenient fallback in the
+    service; only the new ``tier`` key is validated here.
+    """
+    if sources is None:
+        return {}
+    if not isinstance(sources, dict):
+        raise ValueError("memory.ingestion.sources must be a dictionary")
+    pins: Dict[str, int] = {}
+    for source, source_config in sources.items():
+        if not isinstance(source_config, dict):
+            continue  # shipped lenient posture for per-source blocks
+        if "tier" not in source_config:
+            continue
+        tier = source_config["tier"]
+        if isinstance(tier, bool) or not isinstance(tier, int) or tier not in TIERS:
+            raise ValueError(
+                f"memory.ingestion.sources.{source}.tier must be one of {list(TIERS)}, "
+                f"got {tier!r}"
+            )
+        pins[str(source)] = tier
+    return pins
+
+
+# ---------------------------------------------------------------------------
+# Primitive validators (full-path error messages)
+# ---------------------------------------------------------------------------
+
+
+def _section(value: Any, label: str) -> Dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a dictionary")
+    return value
+
+
+def _boolean(value: Any, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{label} must be a boolean, got {value!r}")
+    return value
+
+
+def _positive_int(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{label} must be a positive integer, got {value!r}")
+    return value
+
+
+def _positive_number(value: Any, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+        raise ValueError(f"{label} must be a positive number, got {value!r}")
+    return float(value)
+
+
+def _number_in_range(value: Any, label: str, low: float, high: float) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{label} must be a number between {low} and {high}, got {value!r}")
+    number = float(value)
+    if number < low or number > high:
+        raise ValueError(f"{label} must be between {low} and {high}, got {value!r}")
+    return number
+
+
+def _optional_model(value: Any, label: str) -> Optional[str]:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a non-empty model string when provided")
+    return value.strip()

--- a/src/muxi/runtime/services/memory/ingest/service.py
+++ b/src/muxi/runtime/services/memory/ingest/service.py
@@ -59,6 +59,8 @@ from .classification import (
     classify_content,
     is_filtered,
 )
+from .config import TIER_LOCAL, parse_ingestion_config
+from .tiers import TierBudget, content_signals, decide_tier
 
 # Fallback ceiling on concurrently processing ingestion jobs per user.
 # One job may carry a whole batch, so this caps background work, not
@@ -245,8 +247,14 @@ class MemoryIngestionService:
         except (TypeError, ValueError):
             self.max_in_flight = DEFAULT_MAX_IN_FLIGHT_PER_USER
 
+        # Maturation settings (tiers / entity resolution / synthesis):
+        # fail-fast on invalid values (the formation validator surfaces
+        # the same parser's message at load time).
+        self.settings = parse_ingestion_config(config)
+
         self._in_flight: Dict[str, int] = {}
         self._in_flight_lock = asyncio.Lock()
+        self._entity_resolver = None
 
     # ------------------------------------------------------------------
     # Configuration surface
@@ -470,9 +478,13 @@ class MemoryIngestionService:
 
         try:
             await tracker.update_request(processing_id, RequestStatus.PROCESSING)
+            # One escalation budget per job (PRD "Cost Management"): caps
+            # how many items may run T2/T3 extraction; capped items demote
+            # to the best affordable tier, never drop.
+            budget = TierBudget.from_settings(self.settings.tiers)
             reports: List[Dict[str, Any]] = []
             for index, item, event in items:
-                report = await self._process_item(user_id, item, event)
+                report = await self._process_item(user_id, item, event, budget)
                 report["index"] = index
                 report["event_id"] = event["public_id"]
                 reports.append(report)
@@ -523,9 +535,13 @@ class MemoryIngestionService:
             await self._release_slot(user_id)
 
     async def _process_item(
-        self, user_id: str, item: IngestItem, event: Dict[str, Any]
+        self,
+        user_id: str,
+        item: IngestItem,
+        event: Dict[str, Any],
+        budget: Optional[TierBudget] = None,
     ) -> Dict[str, Any]:
-        """Run classify -> filter -> extract/store for one item.
+        """Run classify -> filter -> tier -> extract/store for one item.
 
         Per-item failures are contained: the job continues and the item
         reports disposition "failed" with the error.
@@ -550,15 +566,73 @@ class MemoryIngestionService:
                 report["disposition"] = DISPOSITION_FILTERED
                 return report
 
+            # Stage 3 gate: tier decision (Tier 0 signals + heuristics,
+            # budget-capped per job). Shared-scope items bypass tiering:
+            # they are stored verbatim by policy (#215), never extracted.
+            tier = TIER_LOCAL
+            if item.scope is None:
+                decision = self._decide_item_tier(user_id, item, event, category, margin, budget)
+                tier = decision["tier"]
+                report["tier"] = decision["tier"]
+                report["tier_reason"] = decision["reason"]
+
             # Stages 3-6: extract -> embed -> link -> store, all riding
             # the existing extraction machinery.
-            report.update(await self._store_item(user_id, item, event))
+            report.update(await self._store_item(user_id, item, event, tier))
             report["disposition"] = DISPOSITION_STORED
             return report
         except Exception as exc:
             report["disposition"] = DISPOSITION_FAILED
             report["error"] = str(exc)
             return report
+
+    def _decide_item_tier(
+        self,
+        user_id: str,
+        item: IngestItem,
+        event: Dict[str, Any],
+        category: str,
+        margin: float,
+        budget: Optional[TierBudget],
+    ) -> Dict[str, Any]:
+        """Heuristic tier decision + budget admission for one kept item.
+
+        Every escalation past Tier 1 is observable: the tier, the
+        heuristic reason, and any budget demotion are emitted as a
+        memory.ingestion.tier_escalated event and recorded on the item
+        report (which the status endpoint returns verbatim).
+        """
+        signals = content_signals(item.content_text)
+        priority = item.metadata.get("priority") if item.metadata else None
+        requested, reason = decide_tier(
+            category,
+            margin,
+            signals,
+            self.settings.tiers,
+            source_tier=self.settings.source_tiers.get(item.source),
+            priority=priority,
+        )
+        granted, capped = (requested, False) if budget is None else budget.admit(requested)
+        if capped:
+            reason = f"{reason};budget_capped_from_t{requested}"
+
+        if granted > TIER_LOCAL or capped:
+            observability.observe(
+                event_type=observability.ConversationEvents.MEMORY_INGESTION_TIER_ESCALATED,
+                level=observability.EventLevel.DEBUG,
+                data={
+                    "user_id": user_id,
+                    "source": item.source,
+                    "source_id": item.source_id,
+                    "tier": granted,
+                    "requested_tier": requested,
+                    "reason": reason,
+                    "signals": {k: v for k, v in signals.items() if v},
+                    "memory_event_id": event["id"],
+                },
+                description=f"Ingested item escalated to tier {granted} ({reason})",
+            )
+        return {"tier": granted, "reason": reason}
 
     async def _get_classifier(self):
         """The shared LocalClassifier (overlord-warmed when available)."""
@@ -603,19 +677,28 @@ class MemoryIngestionService:
         )
 
     async def _store_item(
-        self, user_id: str, item: IngestItem, event: Dict[str, Any]
+        self, user_id: str, item: IngestItem, event: Dict[str, Any], tier: int = TIER_LOCAL
     ) -> Dict[str, Any]:
-        """Extract/embed/link/store one kept item through existing paths."""
+        """Extract/embed/link/store one kept item through existing paths.
+
+        ``tier`` is the granted extraction tier: Tier 1 stores the content
+        verbatim as an event-sourced fact (small local processing only --
+        classified, embedded on write, recallable); Tiers 2/3 run the LLM
+        extraction + knowledge-graph link pass, with the tier's model when
+        one is configured (memory.ingestion.tiers.models).
+        """
         if item.scope is not None:
             return await self._store_shared(user_id, item, event)
 
         extractor = getattr(self.overlord, "extractor", None)
-        if extractor is None:
-            # No extractor configured (auto extraction disabled): store the
-            # content verbatim as an event-sourced user-scope fact so the
-            # item is still recallable.
+        if extractor is None or tier <= TIER_LOCAL:
+            # Tier 1 (or auto extraction disabled): store the content
+            # verbatim as an event-sourced user-scope fact so the item is
+            # still recallable. The raw event stays replayable through
+            # deeper tiers later (weekly re-synthesis / rebuild).
             return await self._store_fact(user_id, item, event, scope=None)
 
+        tier_model = await self._tier_model(tier)
         await extractor.process_conversation_turn(
             user_message=item.content_text,
             agent_response="",
@@ -623,28 +706,85 @@ class MemoryIngestionService:
             message_count=extractor.extraction_interval,  # always run for ingestion
             caused_by_event_id=event["id"],
             event_source=item.source,
+            model=tier_model,
         )
 
-        # Link pass: the knowledge graph's real-time extraction (entity
-        # resolution + relationships) with provenance back to the raw event.
+        # Link pass: the knowledge graph's real-time extraction (entities
+        # + relationships) with provenance back to the raw event.
         knowledge_graph = getattr(self.overlord, "knowledge_graph", None)
         if knowledge_graph is not None:
             await knowledge_graph.process_conversation_turn(
                 user_message=item.content_text,
                 agent_response="",
                 user_id=user_id,
-                model=getattr(self.overlord, "default_model", None),
+                model=tier_model or getattr(self.overlord, "default_model", None),
                 caused_by_event_id=event["id"],
                 event_source=item.source,
             )
 
         derived = await self._derived_events(user_id, event)
-        return {
+        report = {
             "facts_extracted": sum(1 for d in derived if d["event_type"] == EVENT_FACT_EXTRACTED),
             "graph_extractions": sum(
                 1 for d in derived if d["event_type"] == EVENT_GRAPH_EXTRACTED
             ),
         }
+
+        # Entity resolution at extraction time (PRD "Synthesis layer"):
+        # probabilistic identity matching over the user's graph, event-
+        # first and failure-isolated -- a resolution error never fails
+        # the item.
+        resolver = self.entity_resolver
+        if resolver is not None and knowledge_graph is not None:
+            resolution = await resolver.resolve_user(user_id, caused_by=event["id"])
+            if resolution.get("merged") or resolution.get("flagged"):
+                report["entity_resolution"] = resolution
+        return report
+
+    @property
+    def entity_resolver(self):
+        """The lazily constructed EntityResolver (None when unavailable)."""
+        if not self.settings.entity_resolution.enabled:
+            return None
+        knowledge_graph = getattr(self.overlord, "knowledge_graph", None)
+        memory_events = self.memory_events
+        if knowledge_graph is None or memory_events is None:
+            return None
+        if self._entity_resolver is None:
+            from ..graph.resolution import EntityResolver
+
+            self._entity_resolver = EntityResolver(
+                knowledge_graph, memory_events, self.settings.entity_resolution
+            )
+        return self._entity_resolver
+
+    async def _tier_model(self, tier: int):
+        """Resolve the configured LLM for a tier (None = extractor default).
+
+        Tier 3 without a configured frontier model falls back to the Tier
+        2 model; resolution failures degrade to the default extraction
+        model with a warning rather than failing the item.
+        """
+        name = None
+        if tier >= 3:
+            name = self.settings.tiers.t3_model or self.settings.tiers.t2_model
+        elif tier == 2:
+            name = self.settings.tiers.t2_model
+        if not name:
+            return None
+        getter = getattr(self.overlord, "_get_or_create_model", None)
+        if getter is None:
+            return None
+        try:
+            return await getter({"model": name}, cache_scope=f"ingestion:t{tier}")
+        except Exception as exc:
+            observability.observe(
+                event_type=observability.ErrorEvents.WARNING,
+                level=observability.EventLevel.WARNING,
+                data={"tier": tier, "model": name, "error": str(exc)},
+                description=f"Ingestion tier {tier} model {name!r} unavailable: {exc}",
+            )
+            return None
 
     async def _store_shared(
         self, user_id: str, item: IngestItem, event: Dict[str, Any]

--- a/src/muxi/runtime/services/memory/ingest/tiers.py
+++ b/src/muxi/runtime/services/memory/ingest/tiers.py
@@ -1,0 +1,194 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Ingestion Tier Heuristics - T1 -> T2 -> T3 Escalation
+# Description:  Deterministic escalation decisions for the extraction stage
+# Role:         Decides how much LLM an ingested item earns (PRD tier table)
+# Usage:        Used by MemoryIngestionService per kept item, budget-capped
+# Author:       Muxi Framework Team
+#
+# Memory Ingestion maturation, PRD "Processing Pipeline" stage 3:
+#
+#   Tier 0 (free):      regex + heuristics       -> content_signals()
+#   Tier 1 (cheap):     small local processing    -> classify + verbatim store
+#   Tier 2 (moderate):  mid-size model            -> LLM extraction pass
+#   Tier 3 (expensive): frontier model            -> flagged high-signal items
+#
+# "Most items never leave Tier 1. Frontier LLM use is deliberate, not
+# default." The decision is a PURE function of the classification result,
+# the Tier-0 signals, and validated settings -- no LLM is consulted to
+# decide whether to consult an LLM. Escalation criteria, in order:
+#
+#   1. Per-source pin (sources.<source>.tier) -- the developer's dial wins.
+#   2. Explicit priority flag (metadata.priority: high) -> Tier 3.
+#   3. Synthesis-worthy category (personal/work; unknown fails open) or an
+#      ambiguous classification (margin below tiers.ambiguity_margin)
+#      -> Tier 2.
+#   4. High-signal Tier-2 items (Tier-0 signal score at/above
+#      tiers.t3_signal_score: commitments, dates, money, identity
+#      mentions) -> Tier 3.
+#   5. Everything else rests at Tier 1.
+#
+# Budgets (tiers.budget.t{2,3}_items_per_job) cap escalations per
+# processing job; a capped item is demoted to the best affordable tier and
+# the demotion is part of the recorded reason -- never a dropped item.
+# =============================================================================
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+from .classification import CATEGORY_PERSONAL, CATEGORY_UNKNOWN, CATEGORY_WORK
+from .config import TIER_FRONTIER, TIER_LOCAL, TIER_STANDARD, TierSettings
+
+# Categories whose content is synthesis-worthy by default (PRD: "mid-size
+# model for synthesis-worthy items"). Unknown is included so a broken
+# classifier degrades extraction quality upward, never downward.
+SYNTHESIS_WORTHY_CATEGORIES = frozenset({CATEGORY_PERSONAL, CATEGORY_WORK, CATEGORY_UNKNOWN})
+
+# ---------------------------------------------------------------------------
+# Tier 0: regex + heuristics (free signal extraction)
+# ---------------------------------------------------------------------------
+
+_EMAIL_RE = re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b")
+_HANDLE_RE = re.compile(r"(?<![\w@])@[A-Za-z][\w-]{2,}\b")
+_MONEY_RE = re.compile(
+    r"(?:[$€£]\s?\d[\d,]*(?:\.\d+)?)|(?:\b\d[\d,]*(?:\.\d+)?\s?(?:USD|EUR|GBP)\b)"
+)
+_DATE_RE = re.compile(
+    r"(?:\b\d{4}-\d{2}-\d{2}\b)"
+    r"|(?:\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2}\b)"
+    r"|(?:\b\d{1,2}(?:st|nd|rd|th)?\s+(?:of\s+)?"
+    r"(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\b)"
+    r"|(?:\bnext\s+(?:week|month|quarter)\b)"
+    r"|(?:\bend\s+of\s+Q[1-4]\b)",
+    re.IGNORECASE,
+)
+_COMMITMENT_RE = re.compile(
+    r"\b(?:deadline|due(?:\s+(?:on|by|date))?|agreed(?:\s+to)?|commit(?:ment|ted|s)?"
+    r"|promised?|action\s+items?|deliverables?|contract|signed?\s+off"
+    r"|must\s+(?:ship|deliver|finish|complete)"
+    r"|will\s+(?:send|deliver|ship|finish|complete)|by\s+(?:eod|eow|end\s+of\s+day))\b",
+    re.IGNORECASE,
+)
+# Capitalized bigrams ("Ryan Leveille") as a cheap proper-name proxy.
+_NAME_RE = re.compile(r"\b[A-Z][a-z]+\s+[A-Z][a-z]+\b")
+
+# Per-signal contribution caps so one signal class cannot dominate the score.
+_SIGNAL_CAPS = {"identities": 3, "dates": 2, "money": 2, "commitments": 3}
+
+
+def content_signals(text: str) -> Dict[str, int]:
+    """Tier-0 signal counts for one content string (pure regex, no LLM).
+
+    ``identities`` counts identity mentions (emails, @handles, proper
+    names) -- the entity-density proxy; the rest map one-to-one onto the
+    PRD's high-signal markers (commitments, dates, money).
+    """
+    if not text:
+        return {"identities": 0, "dates": 0, "money": 0, "commitments": 0}
+    return {
+        "identities": len(_EMAIL_RE.findall(text))
+        + len(_HANDLE_RE.findall(text))
+        + len(_NAME_RE.findall(text)),
+        "dates": len(_DATE_RE.findall(text)),
+        "money": len(_MONEY_RE.findall(text)),
+        "commitments": len(_COMMITMENT_RE.findall(text)),
+    }
+
+
+def signal_score(signals: Dict[str, int]) -> int:
+    """Aggregate signal score with per-signal caps (deterministic)."""
+    return sum(min(signals.get(name, 0), cap) for name, cap in _SIGNAL_CAPS.items())
+
+
+# ---------------------------------------------------------------------------
+# Escalation decision (pure function of triage + signals + settings)
+# ---------------------------------------------------------------------------
+
+
+def decide_tier(
+    category: str,
+    margin: float,
+    signals: Dict[str, int],
+    settings: TierSettings,
+    source_tier: Optional[int] = None,
+    priority: Optional[str] = None,
+) -> Tuple[int, str]:
+    """
+    Decide the extraction tier for one kept item.
+
+    Args:
+        category: The triage category from the local classifier.
+        margin: The winning category's classification margin.
+        signals: Tier-0 signal counts (content_signals()).
+        settings: Validated TierSettings.
+        source_tier: Optional per-source pin (sources.<source>.tier).
+        priority: The item's ``metadata.priority`` value, if any.
+
+    Returns:
+        (tier, reason) -- reason is a stable, machine-parsable string
+        recorded on the escalation event and the item report.
+    """
+    if not settings.enabled:
+        # Heuristics off: the shipped Phase 3a behavior (every kept item
+        # runs the standard extraction pass).
+        return TIER_STANDARD, "tiers_disabled"
+
+    if source_tier is not None:
+        return source_tier, f"source_pin:{source_tier}"
+
+    if isinstance(priority, str) and priority.strip().lower() == "high":
+        return TIER_FRONTIER, "priority_flag"
+
+    if category in SYNTHESIS_WORTHY_CATEGORIES:
+        tier, reason = TIER_STANDARD, f"category:{category}"
+    elif margin < settings.ambiguity_margin:
+        tier, reason = TIER_STANDARD, f"ambiguous_classification:margin={margin:.4f}"
+    else:
+        return TIER_LOCAL, f"low_signal_category:{category}"
+
+    score = signal_score(signals)
+    if score >= settings.t3_signal_score:
+        rendered = ",".join(f"{k}={v}" for k, v in sorted(signals.items()) if v)
+        return TIER_FRONTIER, f"high_signal:score={score}({rendered})"
+    return tier, reason
+
+
+@dataclass
+class TierBudget:
+    """Per-job escalation budget (PRD "Cost Management": tiered budgets).
+
+    One instance per processing job. ``admit`` consumes budget for the
+    requested tier and demotes to the best affordable tier when the cap
+    is reached -- items are never dropped for budget reasons.
+    """
+
+    t2_remaining: int
+    t3_remaining: int
+
+    @classmethod
+    def from_settings(cls, settings: TierSettings) -> "TierBudget":
+        return cls(
+            t2_remaining=settings.t2_items_per_job,
+            t3_remaining=settings.t3_items_per_job,
+        )
+
+    def admit(self, tier: int) -> Tuple[int, bool]:
+        """Admit an item at ``tier``; returns (granted tier, capped?)."""
+        if tier == TIER_FRONTIER:
+            if self.t3_remaining > 0:
+                self.t3_remaining -= 1
+                return TIER_FRONTIER, False
+            tier = TIER_STANDARD  # demote and fall through to the T2 budget
+            capped = True
+        else:
+            capped = False
+        if tier == TIER_STANDARD:
+            if self.t2_remaining > 0:
+                self.t2_remaining -= 1
+                return TIER_STANDARD, capped
+            return TIER_LOCAL, True
+        return TIER_LOCAL, capped

--- a/src/muxi/runtime/services/memory/synthesis.py
+++ b/src/muxi/runtime/services/memory/synthesis.py
@@ -61,6 +61,7 @@ from .events.models import (
     SOURCE_SYNTHESIS,
 )
 from .events.projectors import apply_fact_event
+from .graph.extractor import USER_ENTITY_NAME, USER_ENTITY_TYPE
 from .ingest.config import ResolutionSettings, SynthesisSettings
 
 CADENCE_HOT = "hot"
@@ -373,7 +374,7 @@ class MemorySynthesisService:
         if knowledge_graph is None:
             return None
         storage = knowledge_graph.storage
-        user_entity = await storage.get_entity(user_id, "person", "User")
+        user_entity = await storage.get_entity(user_id, USER_ENTITY_TYPE, USER_ENTITY_NAME)
         if user_entity is None:
             return None
         top_k = self.settings.patterns.top_k

--- a/src/muxi/runtime/services/memory/synthesis.py
+++ b/src/muxi/runtime/services/memory/synthesis.py
@@ -1,0 +1,484 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Memory Synthesis Service - Hot/Warm/Cold Cadences
+# Description:  Batched synthesis over the event substrate (PRD cadence table)
+# Role:         Entity resolution, pattern extraction, weekly re-synthesis
+# Usage:        Registered with SchedulerService.register_periodic_task by the
+#               Overlord when memory.ingestion is configured
+# Author:       Muxi Framework Team
+#
+# Memory Ingestion maturation, PRD "Synthesis Scheduling": synthesis is
+# never real-time -- it runs batched at hot/warm/cold intervals on the
+# scheduler's existing worker loop (the same register_periodic_task
+# extension point the proactive heartbeat and remote knowledge sync use;
+# no new loop). ``tick()`` applies per-cadence interval gating and never
+# raises; every per-user step is failure-isolated, so synthesis can never
+# break chat or ingestion.
+#
+#   hot (5 min):      entity resolution for users with new ingestion /
+#                     graph events since the hot cursor
+#   warm (hourly):    preference + domain-expertise pattern facts for
+#                     users with new events since the warm cursor
+#   cold (nightly):   full pass -- schedule pattern + entity resolution
+#                     over the whole graph
+#   cold_cold (weekly): full re-synthesis FROM THE EVENT LOG -- per-user
+#                     projection rebuild (reset -> replay -> checkpoint via
+#                     MemoryEventService.rebuild, the substrate machinery
+#                     from the projections/rebuild phase), then the full
+#                     synthesis pass. This is what makes extraction-logic
+#                     improvements retroactive: replay re-derives history,
+#                     recorded entity.resolved decisions replay verbatim.
+#
+# Cursors: hot/warm/cold keep durable per-user cursors in the substrate's
+# projection_checkpoints table (names "synthesis_hot" etc.), so restarts
+# never reprocess settled history; the checkpoint names are not registered
+# projectors, so the incremental applier and rebuild never touch them.
+# Interval gating is in-memory and initialized to "now" at construction
+# (heartbeat convention: a restart must not fire a burst of passes).
+#
+# Pattern extraction (v1, PRD "basic"): deterministic aggregation only, no
+# LLM. Derived pattern facts ride the substrate as fact.extracted events
+# (source "synthesis", decay_rate "decaying") keyed per (kind, ISO week),
+# so re-running a cadence within the same week is a no-op -- idempotent by
+# the same (source, source_id) index every other writer leans on.
+# =============================================================================
+
+from __future__ import annotations
+
+import calendar
+from collections import Counter
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from .. import observability
+from .events.models import (
+    DECAY_DECAYING,
+    EVENT_FACT_EXTRACTED,
+    EVENT_GRAPH_EXTRACTED,
+    EVENT_INTERACTION_TURN,
+    EVENT_MEMORY_INGESTED,
+    SOURCE_SYNTHESIS,
+)
+from .events.projectors import apply_fact_event
+from .ingest.config import ResolutionSettings, SynthesisSettings
+
+CADENCE_HOT = "hot"
+CADENCE_WARM = "warm"
+CADENCE_COLD = "cold"
+CADENCE_COLD_COLD = "cold_cold"
+CADENCES = (CADENCE_HOT, CADENCE_WARM, CADENCE_COLD, CADENCE_COLD_COLD)
+
+# Durable per-user cursor names (projection_checkpoints.projection_name).
+CURSOR_NAMES = {
+    CADENCE_HOT: "synthesis_hot",
+    CADENCE_WARM: "synthesis_warm",
+    CADENCE_COLD: "synthesis_cold",
+}
+
+# Pattern kinds (v1). Each maps to one deterministic builder.
+PATTERN_SCHEDULE = "schedule"
+PATTERN_PREFERENCES = "preferences"
+PATTERN_EXPERTISE = "expertise"
+
+# Cap on events aggregated per user for the schedule pattern.
+SCHEDULE_EVENT_LIMIT = 5000
+
+# Event types that gate the hot cadence (new high-priority events).
+HOT_TRIGGER_EVENT_TYPES = [EVENT_MEMORY_INGESTED, EVENT_GRAPH_EXTRACTED]
+
+
+class MemorySynthesisService:
+    """Owns the synthesis cadences; registered as a scheduler periodic task."""
+
+    def __init__(
+        self,
+        overlord,
+        settings: SynthesisSettings,
+        resolution_settings: ResolutionSettings,
+    ):
+        """
+        Args:
+            overlord: The formation overlord (memory services resolved
+                lazily so late-initialized services are picked up).
+            settings: Validated SynthesisSettings (cadence table).
+            resolution_settings: Validated ResolutionSettings for the
+                resolution passes this service drives.
+        """
+        self.overlord = overlord
+        self.settings = settings
+        self.resolution_settings = resolution_settings
+        # First run fires one full interval after startup (heartbeat
+        # convention): a frequently restarting formation must not turn
+        # synthesis into a startup stampede -- cold_cold especially.
+        now = datetime.now(timezone.utc)
+        self._last_run: Dict[str, datetime] = {cadence: now for cadence in CADENCES}
+        self._running = False
+        self._resolver = None
+
+    # ------------------------------------------------------------------
+    # Service resolution (lazy; the overlord wires services after init)
+    # ------------------------------------------------------------------
+
+    @property
+    def memory_events(self):
+        return getattr(self.overlord, "memory_events", None)
+
+    @property
+    def knowledge_graph(self):
+        return getattr(self.overlord, "knowledge_graph", None)
+
+    @property
+    def entity_resolver(self):
+        if self._resolver is None:
+            memory_events = self.memory_events
+            knowledge_graph = self.knowledge_graph
+            if memory_events is None or knowledge_graph is None:
+                return None
+            from .graph.resolution import EntityResolver
+
+            self._resolver = EntityResolver(
+                knowledge_graph, memory_events, self.resolution_settings
+            )
+        return self._resolver
+
+    # ------------------------------------------------------------------
+    # Scheduler hook
+    # ------------------------------------------------------------------
+
+    async def tick(self, now: Optional[datetime] = None) -> None:
+        """
+        Scheduler-cycle hook: run every cadence whose interval elapsed.
+
+        Never raises; cadences run coarsest-first so a due cold_cold
+        re-synthesis is not preceded by redundant hot/warm work in the
+        same cycle.
+        """
+        try:
+            now = now or datetime.now(timezone.utc)
+            if self._running or not self.settings.enabled:
+                return
+            self._running = True
+            try:
+                for cadence in reversed(CADENCES):
+                    cadence_settings = self.settings.cadence(cadence)
+                    if not cadence_settings.enabled:
+                        continue
+                    elapsed = (now - self._last_run[cadence]).total_seconds()
+                    if elapsed < cadence_settings.interval_seconds:
+                        continue
+                    self._last_run[cadence] = now
+                    await self.run_cadence(cadence, now=now)
+            finally:
+                self._running = False
+        except Exception as e:
+            observability.observe(
+                event_type=observability.ConversationEvents.MEMORY_SYNTHESIS_FAILED,
+                level=observability.EventLevel.WARNING,
+                data={"error": str(e), "error_type": type(e).__name__, "phase": "tick"},
+                description=f"Memory synthesis tick failed (isolated): {e}",
+            )
+
+    # ------------------------------------------------------------------
+    # Cadence passes
+    # ------------------------------------------------------------------
+
+    async def run_cadence(self, cadence: str, now: Optional[datetime] = None) -> Dict[str, Any]:
+        """
+        Run one cadence pass over every eligible user, bypassing interval
+        gating (used by tick(), tests, and operational drivers).
+
+        Per-user failures are isolated; the pass always returns a report:
+        {"cadence", "users", "merged", "flagged", "patterns", "rebuilt",
+        "failed"}.
+        """
+        if cadence not in CADENCES:
+            raise ValueError(f"Unknown synthesis cadence {cadence!r}; expected one of {CADENCES}")
+        now = now or datetime.now(timezone.utc)
+        report: Dict[str, Any] = {
+            "cadence": cadence,
+            "users": 0,
+            "merged": 0,
+            "flagged": 0,
+            "patterns": 0,
+            "rebuilt": 0,
+            "failed": 0,
+        }
+        memory_events = self.memory_events
+        if memory_events is None or not getattr(memory_events, "enabled", False):
+            return report  # inert without the substrate
+
+        observability.observe(
+            event_type=observability.ConversationEvents.MEMORY_SYNTHESIS_STARTED,
+            level=observability.EventLevel.DEBUG,
+            data={"cadence": cadence},
+            description=f"Memory synthesis {cadence} pass started",
+        )
+        try:
+            for user_id in await memory_events.storage.list_event_user_ids():
+                try:
+                    user_report = await self._run_user(cadence, user_id, now)
+                    if user_report is None:
+                        continue  # nothing new for this user (cursor gate)
+                    report["users"] += 1
+                    for key in ("merged", "flagged", "patterns", "rebuilt"):
+                        report[key] += user_report.get(key, 0)
+                except Exception as e:
+                    report["failed"] += 1
+                    observability.observe(
+                        event_type=observability.ConversationEvents.MEMORY_SYNTHESIS_FAILED,
+                        level=observability.EventLevel.WARNING,
+                        data={
+                            "cadence": cadence,
+                            "user_id": user_id,
+                            "error": str(e),
+                            "error_type": type(e).__name__,
+                        },
+                        description=f"Memory synthesis {cadence} failed for user (isolated): {e}",
+                    )
+        except Exception as e:
+            report["failed"] += 1
+            observability.observe(
+                event_type=observability.ConversationEvents.MEMORY_SYNTHESIS_FAILED,
+                level=observability.EventLevel.WARNING,
+                data={"cadence": cadence, "error": str(e), "error_type": type(e).__name__},
+                description=f"Memory synthesis {cadence} pass failed (isolated): {e}",
+            )
+        observability.observe(
+            event_type=observability.ConversationEvents.MEMORY_SYNTHESIS_COMPLETED,
+            level=(
+                observability.EventLevel.INFO if report["users"] else observability.EventLevel.DEBUG
+            ),
+            data=dict(report),
+            description=(
+                f"Memory synthesis {cadence} pass completed "
+                f"({report['users']} user(s), {report['failed']} failure(s))"
+            ),
+        )
+        return report
+
+    async def _run_user(
+        self, cadence: str, user_id: str, now: datetime
+    ) -> Optional[Dict[str, int]]:
+        """One cadence pass for one user; None when the cursor gate skips.
+
+        The hot/warm/cold cursor is only advanced after the pass succeeds,
+        so a failed pass is retried on the next interval.
+        """
+        memory_events = self.memory_events
+        cursor_name = CURSOR_NAMES.get(cadence)
+        tail = None
+        if cursor_name is not None:
+            checkpoint = await memory_events.storage.get_checkpoint(cursor_name, user_id)
+            after_id = checkpoint["last_event_id"] if checkpoint else None
+            trigger_types = HOT_TRIGGER_EVENT_TYPES if cadence == CADENCE_HOT else None
+            pending = await memory_events.storage.list_events(
+                user_id, event_types=trigger_types, after_id=after_id, limit=1
+            )
+            if not pending:
+                return None
+            tail = await memory_events.storage.max_event_id(user_id)
+
+        result = {"merged": 0, "flagged": 0, "patterns": 0, "rebuilt": 0}
+
+        if cadence == CADENCE_COLD_COLD:
+            # Weekly full re-synthesis: replay the event log through the
+            # substrate's rebuild machinery (reset -> replay -> checkpoint,
+            # per-user cursors handled inside), then synthesize on the
+            # freshly rebuilt projections.
+            await memory_events.rebuild(user_id)
+            result["rebuilt"] = 1
+
+        if cadence in (CADENCE_HOT, CADENCE_COLD, CADENCE_COLD_COLD):
+            resolver = self.entity_resolver
+            if resolver is not None:
+                resolution = await resolver.resolve_user(user_id)
+                result["merged"] = resolution.get("merged", 0)
+                result["flagged"] = resolution.get("flagged", 0)
+
+        if self.settings.patterns.enabled:
+            if cadence == CADENCE_WARM:
+                kinds = [PATTERN_PREFERENCES, PATTERN_EXPERTISE]
+            elif cadence in (CADENCE_COLD, CADENCE_COLD_COLD):
+                kinds = [PATTERN_SCHEDULE, PATTERN_PREFERENCES, PATTERN_EXPERTISE]
+            else:
+                kinds = []
+            for kind in kinds:
+                if await self._extract_pattern(user_id, kind, now):
+                    result["patterns"] += 1
+
+        if cursor_name is not None and tail is not None:
+            await memory_events.storage.set_checkpoint(cursor_name, user_id, last_event_id=tail)
+        return result
+
+    # ------------------------------------------------------------------
+    # Pattern extraction (v1: deterministic aggregation, no LLM)
+    # ------------------------------------------------------------------
+
+    async def _extract_pattern(self, user_id: str, kind: str, now: datetime) -> bool:
+        """Derive and record one pattern fact; returns True when written."""
+        if kind == PATTERN_SCHEDULE:
+            rendered = await self._schedule_pattern(user_id)
+            collection = "activities"
+        elif kind == PATTERN_PREFERENCES:
+            rendered = await self._preference_pattern(user_id)
+            collection = "preferences"
+        elif kind == PATTERN_EXPERTISE:
+            rendered = await self._expertise_pattern(user_id)
+            collection = "context"
+        else:
+            return False
+        if not rendered:
+            return False
+        return await self._record_pattern(user_id, kind, rendered, collection, now)
+
+    async def _schedule_pattern(self, user_id: str) -> Optional[str]:
+        """Behavioral schedule from aggregated event timestamps (UTC)."""
+        events = await self.memory_events.storage.list_events(
+            user_id,
+            event_types=[EVENT_INTERACTION_TURN, EVENT_MEMORY_INGESTED],
+            limit=SCHEDULE_EVENT_LIMIT,
+        )
+        if len(events) < self.settings.patterns.min_events:
+            return None
+        hours: Counter = Counter()
+        days: Counter = Counter()
+        for event in events:
+            occurred_at = event.get("occurred_at")
+            if isinstance(occurred_at, str):
+                try:
+                    occurred_at = datetime.fromisoformat(occurred_at)
+                except ValueError:
+                    continue
+            if not isinstance(occurred_at, datetime):
+                continue
+            hours[occurred_at.hour] += 1
+            days[calendar.day_name[occurred_at.weekday()]] += 1
+        if not hours:
+            return None
+        # Deterministic ordering: count desc, then hour/day ascending.
+        top_hours = sorted(hours.items(), key=lambda kv: (-kv[1], kv[0]))[:3]
+        day_order = {name: i for i, name in enumerate(calendar.day_name)}
+        top_days = sorted(days.items(), key=lambda kv: (-kv[1], day_order[kv[0]]))[:2]
+        hours_text = ", ".join(f"{hour:02d}:00" for hour, _ in sorted(top_hours))
+        days_text = " and ".join(day for day, _ in top_days)
+        return (
+            f"Typically active around {hours_text} UTC, most often on {days_text} "
+            f"(observed across {len(events)} events)"
+        )
+
+    async def _preference_pattern(self, user_id: str) -> Optional[str]:
+        """Preference profile from the user's graph (prefers/interested_in)."""
+        knowledge_graph = self.knowledge_graph
+        if knowledge_graph is None:
+            return None
+        storage = knowledge_graph.storage
+        user_entity = await storage.get_entity(user_id, "person", "User")
+        if user_entity is None:
+            return None
+        top_k = self.settings.patterns.top_k
+        prefers = await self._related_names(storage, user_id, user_entity["id"], "prefers", top_k)
+        interests = await self._related_names(
+            storage, user_id, user_entity["id"], "interested_in", top_k
+        )
+        parts = []
+        if prefers:
+            parts.append(f"prefers {', '.join(prefers)}")
+        if interests:
+            parts.append(f"is interested in {', '.join(interests)}")
+        if not parts:
+            return None
+        return f"Preference profile (synthesized): the user {'; '.join(parts)}"
+
+    async def _expertise_pattern(self, user_id: str) -> Optional[str]:
+        """Domain expertise proxy: the most-reinforced topic entities."""
+        knowledge_graph = self.knowledge_graph
+        if knowledge_graph is None:
+            return None
+        topics = await knowledge_graph.storage.list_entities(
+            user_id, entity_type="topic", limit=100
+        )
+        if not topics:
+            return None
+        # Reinforcement proxy: provenance count (how many events touched
+        # the topic), then confidence, then name for determinism.
+        topics.sort(
+            key=lambda t: (
+                -len(t.get("derived_from_event_ids") or []),
+                -(t.get("confidence") or 0.0),
+                t["name"].lower(),
+            )
+        )
+        names = [topic["name"] for topic in topics[: self.settings.patterns.top_k]]
+        return f"Frequently engaged topics (synthesized): {', '.join(names)}"
+
+    @staticmethod
+    async def _related_names(storage, user_id, from_entity_id, rel_type, top_k) -> List[str]:
+        """Target entity names for one relationship type, strongest first."""
+        relationships = await storage.list_relationships(
+            user_id, rel_type=rel_type, from_entity_id=from_entity_id, limit=top_k
+        )
+        if not relationships:
+            return []
+        entities = await storage.get_entities_by_ids([rel["to_entity_id"] for rel in relationships])
+        names_by_id = {entity["id"]: entity["name"] for entity in entities}
+        return [
+            names_by_id[rel["to_entity_id"]]
+            for rel in relationships
+            if rel["to_entity_id"] in names_by_id
+        ]
+
+    async def _record_pattern(
+        self, user_id: str, kind: str, rendered: str, collection: str, now: datetime
+    ) -> bool:
+        """Write one pattern fact event-first, keyed per (kind, ISO week).
+
+        Idempotent within the period through the substrate's
+        (source, source_id) index; pattern facts decay (decay_rate
+        "decaying") so a stale week's synthesis sinks without deletion.
+        """
+        memory_events = self.memory_events
+        iso = now.isocalendar()
+        period = f"{iso[0]}-W{iso[1]:02d}"
+        source_id = f"pattern/{kind}/{period}"
+        existing = await memory_events.storage.find_by_source_id(
+            user_id, SOURCE_SYNTHESIS, source_id
+        )
+        if existing is not None:
+            return False
+
+        payload = {
+            "memory": rendered,
+            "collection": collection,
+            "metadata": {"source": SOURCE_SYNTHESIS, "pattern": kind, "period": period},
+        }
+        event = await memory_events.record(
+            user_id=user_id,
+            event_type=EVENT_FACT_EXTRACTED,
+            payload=payload,
+            source=SOURCE_SYNTHESIS,
+            source_id=source_id,
+            decay_rate=DECAY_DECAYING,
+        )
+        if event is None:
+            return False
+        if getattr(memory_events, "event_first", False):
+            await memory_events.apply_event(event)
+        else:
+            long_term_memory = getattr(self.overlord, "long_term_memory", None)
+            if long_term_memory is None:
+                return False
+            await apply_fact_event(long_term_memory, user_id, payload, event_id=event["id"])
+        observability.observe(
+            event_type=observability.ConversationEvents.MEMORY_PATTERN_EXTRACTED,
+            level=observability.EventLevel.INFO,
+            data={
+                "user_id": user_id,
+                "pattern": kind,
+                "period": period,
+                "collection": collection,
+                "memory_event_id": event["id"],
+            },
+            description=f"Synthesized {kind} pattern for period {period}",
+        )
+        return True

--- a/tests/unit/test_entity_resolution.py
+++ b/tests/unit/test_entity_resolution.py
@@ -1,0 +1,410 @@
+"""Unit tests for entity resolution (Memory Ingestion maturation).
+
+Covers:
+
+  * Probabilistic scoring per PRD dimension (name / email / handle /
+    role / relationship context), deterministic and pure.
+  * Auto-merge at/above the high-confidence threshold; flag (event +
+    stored attributes.possible_duplicates marker) below it.
+  * Merge mechanics: relationship re-pointing (collisions and would-be
+    self-loops superseded, never deleted), attribute absorption,
+    aliases, and the merged-name upsert redirect (sticky merges).
+  * Determinism + idempotency: re-running resolution appends nothing
+    (per-pair source_id rides the substrate's idempotency index) and a
+    full projection rebuild replays the recorded decisions to the same
+    merged graph.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.events import MemoryEventService
+from muxi.runtime.services.memory.events.models import EVENT_ENTITY_RESOLVED, SOURCE_SYNTHESIS
+from muxi.runtime.services.memory.events.projectors import KnowledgeGraphProjector
+from muxi.runtime.services.memory.graph.models import (
+    STATUS_ACTIVE,
+    STATUS_MERGED,
+    STATUS_SUPERSEDED,
+)
+from muxi.runtime.services.memory.graph.resolution import (
+    DECISION_FLAGGED,
+    DECISION_MERGED,
+    EntityResolver,
+    pair_source_id,
+    pick_canonical,
+    score_identity_match,
+)
+from muxi.runtime.services.memory.graph.service import KnowledgeGraphService
+from muxi.runtime.services.memory.ingest.config import parse_ingestion_config
+
+FORMATION_ID = "resolution-test-formation"
+
+USER = "u1"
+
+
+def entity(name, entity_id=1, confidence=0.9, **attributes):
+    return {"id": entity_id, "name": name, "confidence": confidence, "attributes": attributes}
+
+
+def resolution_settings(**overrides):
+    return parse_ingestion_config({"entity_resolution": overrides}).entity_resolution
+
+
+@pytest.fixture
+def graph_env(tmp_path):
+    """Real graph service + event substrate over one SQLite database."""
+    db_manager = DatabaseManager(f"sqlite:///{tmp_path}/resolution.db")
+    db_manager.create_tables(Base.metadata)
+    events = MemoryEventService(db_manager, FORMATION_ID, config={"enabled": True})
+    graph = KnowledgeGraphService(db_manager, FORMATION_ID, config={}, event_log=events)
+    events.register_projector(KnowledgeGraphProjector(graph))
+    yield graph, events
+    db_manager.engine.dispose()
+
+
+# ----------------------------------------------------------------------
+# Scoring per PRD dimension
+# ----------------------------------------------------------------------
+
+
+class TestScoring:
+    def test_email_match(self):
+        score, signals = score_identity_match(
+            entity("Ryan", email="ryan@nabo.dev"),
+            entity("Ryan Leveille", 2, email="RYAN@nabo.dev"),
+        )
+        assert "email_match" in signals and "name_subset" in signals
+        assert score == pytest.approx(0.95)
+
+    def test_email_found_in_any_attribute_value(self):
+        score, signals = score_identity_match(
+            entity("Ryan", note="contact: ryan@nabo.dev"),
+            entity("Rian", 2, emails=["ryan@nabo.dev"]),
+        )
+        assert "email_match" in signals
+        assert score >= 0.6
+
+    def test_handle_match(self):
+        score, signals = score_identity_match(
+            entity("Ryan Leveille", github="@rleveille"),
+            entity("Ryan", 2, handle="rleveille"),
+        )
+        assert "handle_match" in signals
+        assert score == pytest.approx(0.4 + 0.35)
+
+    def test_name_exact_tokens(self):
+        score, signals = score_identity_match(entity("ryan leveille"), entity("Leveille, Ryan", 2))
+        assert signals == ["name_match"]
+        assert score == pytest.approx(0.5)
+
+    def test_first_name_only(self):
+        score, signals = score_identity_match(entity("Ryan Smith"), entity("Ryan Jones", 2))
+        assert signals == ["first_name_match"]
+        assert score == pytest.approx(0.15)
+
+    def test_role_match(self):
+        _, signals = score_identity_match(
+            entity("Ryan", role="CTO"), entity("Ryan Leveille", 2, title="cto")
+        )
+        assert "role_match" in signals
+
+    def test_shared_context(self):
+        score, signals = score_identity_match(
+            entity("Ryan"), entity("Ryan Leveille", 2), shared_neighbors=1
+        )
+        assert "shared_context" in signals
+        assert score == pytest.approx(0.35 + 0.2)
+
+    def test_unrelated_entities_score_low(self):
+        score, signals = score_identity_match(entity("Ryan"), entity("Sarah", 2))
+        assert score == 0.0
+        assert signals == []
+
+    def test_pick_canonical_prefers_fuller_name(self):
+        canonical, duplicate = pick_canonical(entity("Ryan", 5), entity("Ryan Leveille", 9))
+        assert canonical["name"] == "Ryan Leveille"
+        assert duplicate["name"] == "Ryan"
+
+    def test_pick_canonical_tie_falls_to_older_row(self):
+        canonical, _ = pick_canonical(entity("Ryan A", 5), entity("Ryan B", 9))
+        assert canonical["id"] == 5  # same token count + confidence -> lower id
+
+    def test_pair_source_id_is_order_independent(self):
+        assert pair_source_id("person", "Ryan", "Ryan Leveille", "merged") == pair_source_id(
+            "person", "Ryan Leveille", "Ryan", "merged"
+        )
+
+
+# ----------------------------------------------------------------------
+# Resolver: merge / flag decisions over a real graph
+# ----------------------------------------------------------------------
+
+
+async def seed_duplicate_identities(graph, *, email=True):
+    """Two person entities + edges: the classic 'Ryan' duplicate."""
+    attributes = {"email": "ryan@nabo.dev"} if email else {}
+    full = await graph.storage.upsert_entity(
+        USER, "person", "Ryan Leveille", attributes=attributes, confidence=0.9
+    )
+    short = await graph.storage.upsert_entity(
+        USER, "person", "Ryan", attributes=attributes, confidence=0.8
+    )
+    company = await graph.storage.upsert_entity(USER, "company", "Nabo", confidence=0.9)
+    await graph.storage.upsert_relationship(
+        USER, full["id"], company["id"], "works_at", confidence=0.9
+    )
+    await graph.storage.upsert_relationship(
+        USER, short["id"], company["id"], "works_at", confidence=0.8
+    )
+    return full, short, company
+
+
+class TestResolver:
+    async def test_auto_merge_above_threshold(self, graph_env):
+        graph, events = graph_env
+        full, short, company = await seed_duplicate_identities(graph)
+        resolver = EntityResolver(graph, events, resolution_settings())
+
+        counts = await resolver.resolve_user(USER)
+        assert counts == {"merged": 1, "flagged": 0}
+
+        # Decision recorded as an entity.resolved event (source synthesis,
+        # deterministic per-pair key).
+        recorded = await events.list_events(USER, event_types=[EVENT_ENTITY_RESOLVED])
+        assert len(recorded) == 1
+        payload = recorded[0]["payload"]
+        assert payload["decision"] == DECISION_MERGED
+        assert payload["canonical_name"] == "Ryan Leveille"
+        assert payload["duplicate_name"] == "Ryan"
+        assert "email_match" in payload["signals"]
+        assert recorded[0]["source"] == SOURCE_SYNTHESIS
+
+        # Duplicate marked merged -> canonical; canonical carries alias.
+        merged = await graph.storage.get_entity(USER, "person", "Ryan")
+        assert merged["status"] == STATUS_MERGED
+        assert merged["superseded_by"] == full["id"]
+        canonical = await graph.storage.get_entity(USER, "person", "Ryan Leveille")
+        assert canonical["attributes"]["aliases"] == ["Ryan"]
+
+        # The duplicate's works_at edge collided with the canonical's:
+        # superseded (retained), never deleted; one active edge remains.
+        active = await graph.storage.list_relationships(USER, rel_type="works_at")
+        assert len(active) == 1
+        assert active[0]["from_entity_id"] == full["id"]
+        superseded = await graph.storage.list_relationships(
+            USER, rel_type="works_at", status=STATUS_SUPERSEDED
+        )
+        assert len(superseded) == 1
+
+        # Merged entities disappear from the active listing.
+        names = {e["name"] for e in await graph.storage.list_entities(USER, entity_type="person")}
+        assert names == {"Ryan Leveille"}
+
+    async def test_repoints_unique_edges_to_canonical(self, graph_env):
+        graph, events = graph_env
+        full, short, _ = await seed_duplicate_identities(graph)
+        project = await graph.storage.upsert_entity(USER, "project", "Atlas", confidence=0.9)
+        await graph.storage.upsert_relationship(
+            USER, short["id"], project["id"], "building", confidence=0.8
+        )
+
+        resolver = EntityResolver(graph, events, resolution_settings())
+        await resolver.resolve_user(USER)
+
+        building = await graph.storage.list_relationships(USER, rel_type="building")
+        assert len(building) == 1
+        assert building[0]["from_entity_id"] == full["id"]
+
+    async def test_flag_below_merge_threshold(self, graph_env):
+        graph, events = graph_env
+        # Name subset + shared employer = 0.55: above the flag threshold,
+        # below the merge threshold.
+        await seed_duplicate_identities(graph, email=False)
+        resolver = EntityResolver(graph, events, resolution_settings())
+
+        counts = await resolver.resolve_user(USER)
+        assert counts == {"merged": 0, "flagged": 1}
+
+        recorded = await events.list_events(USER, event_types=[EVENT_ENTITY_RESOLVED])
+        assert recorded[0]["payload"]["decision"] == DECISION_FLAGGED
+
+        # Stored marker on both rows; both stay active.
+        full = await graph.storage.get_entity(USER, "person", "Ryan Leveille")
+        short = await graph.storage.get_entity(USER, "person", "Ryan")
+        assert full["attributes"]["possible_duplicates"] == ["Ryan"]
+        assert short["attributes"]["possible_duplicates"] == ["Ryan Leveille"]
+        assert full["status"] == short["status"] == STATUS_ACTIVE
+
+    async def test_flagged_pair_can_merge_on_new_evidence(self, graph_env):
+        graph, events = graph_env
+        full, short, _ = await seed_duplicate_identities(graph, email=False)
+        resolver = EntityResolver(graph, events, resolution_settings())
+        assert (await resolver.resolve_user(USER))["flagged"] == 1
+
+        # New evidence lands (shared email attribute): the pair now
+        # crosses the merge threshold; merged/flagged keys are distinct
+        # so the earlier flag does not block the merge.
+        await graph.storage.upsert_entity(
+            USER, "person", "Ryan Leveille", attributes={"email": "ryan@nabo.dev"}
+        )
+        await graph.storage.upsert_entity(
+            USER, "person", "Ryan", attributes={"email": "ryan@nabo.dev"}
+        )
+        counts = await resolver.resolve_user(USER)
+        assert counts["merged"] == 1
+        merged = await graph.storage.get_entity(USER, "person", "Ryan")
+        assert merged["status"] == STATUS_MERGED
+
+    async def test_resolution_is_idempotent(self, graph_env):
+        graph, events = graph_env
+        await seed_duplicate_identities(graph)
+        resolver = EntityResolver(graph, events, resolution_settings())
+
+        assert (await resolver.resolve_user(USER))["merged"] == 1
+        # Re-running (same content, e.g. re-ingestion) appends nothing
+        # and merges nothing new.
+        assert await resolver.resolve_user(USER) == {"merged": 0, "flagged": 0}
+        recorded = await events.list_events(USER, event_types=[EVENT_ENTITY_RESOLVED])
+        assert len(recorded) == 1
+
+    async def test_merged_name_upsert_redirects_to_canonical(self, graph_env):
+        graph, events = graph_env
+        full, _, _ = await seed_duplicate_identities(graph)
+        resolver = EntityResolver(graph, events, resolution_settings())
+        await resolver.resolve_user(USER)
+
+        # A later mention of the duplicate name (re-ingestion, new email)
+        # enriches the canonical row instead of reviving the duplicate.
+        redirected = await graph.storage.upsert_entity(
+            USER, "person", "Ryan", attributes={"phone_style": "signal"}, confidence=0.7
+        )
+        assert redirected["id"] == full["id"]
+        assert redirected["attributes"]["phone_style"] == "signal"
+        merged = await graph.storage.get_entity(USER, "person", "Ryan")
+        assert merged["status"] == STATUS_MERGED  # never revived
+
+    async def test_disabled_resolution_is_inert(self, graph_env):
+        graph, events = graph_env
+        await seed_duplicate_identities(graph)
+        resolver = EntityResolver(graph, events, resolution_settings(enabled=False))
+        assert await resolver.resolve_user(USER) == {"merged": 0, "flagged": 0}
+        assert await events.list_events(USER, event_types=[EVENT_ENTITY_RESOLVED]) == []
+
+    async def test_resolver_never_raises(self, graph_env):
+        graph, events = graph_env
+
+        class Boom:
+            def __getattr__(self, name):
+                raise RuntimeError("storage down")
+
+        broken = EntityResolver(Boom(), events, resolution_settings())
+        assert await broken.resolve_user(USER) == {"merged": 0, "flagged": 0}
+
+
+# ----------------------------------------------------------------------
+# Rebuild determinism (replay reproduces the merged graph)
+# ----------------------------------------------------------------------
+
+
+def graph_snapshot(entities, relationships):
+    return (
+        sorted(
+            (
+                e["type"],
+                e["name"],
+                e["status"],
+                e["superseded_by"] is not None,
+                tuple(sorted((e["attributes"] or {}).get("aliases", []))),
+            )
+            for e in entities
+        ),
+        sorted(
+            (r["type"], r["from_entity_id"], r["to_entity_id"], r["status"]) for r in relationships
+        ),
+    )
+
+
+class TestRebuildDeterminism:
+    async def test_rebuild_replays_recorded_decisions(self, graph_env):
+        graph, events = graph_env
+
+        # Live flow: extractions recorded as graph.extracted events (the
+        # dual-write path), then resolution merges the duplicate.
+        await graph.store_extraction(
+            USER,
+            {
+                "entities": [
+                    {
+                        "name": "Ryan Leveille",
+                        "type": "person",
+                        "attributes": {"email": "ryan@nabo.dev"},
+                        "confidence": 0.9,
+                    },
+                    {"name": "Nabo", "type": "company", "attributes": {}, "confidence": 0.9},
+                ],
+                "relationships": [
+                    {
+                        "from": "Ryan Leveille",
+                        "from_type": "person",
+                        "to": "Nabo",
+                        "to_type": "company",
+                        "type": "works_at",
+                        "confidence": 0.9,
+                    }
+                ],
+            },
+        )
+        await graph.store_extraction(
+            USER,
+            {
+                "entities": [
+                    {
+                        "name": "Ryan",
+                        "type": "person",
+                        "attributes": {"email": "ryan@nabo.dev"},
+                        "confidence": 0.8,
+                    }
+                ],
+                "relationships": [],
+            },
+        )
+        resolver = EntityResolver(graph, events, resolution_settings())
+        assert (await resolver.resolve_user(USER))["merged"] == 1
+
+        entities = await graph.storage.list_entities(USER, status=None, limit=100)
+        relationships = await graph.storage.list_relationships(USER, status=None, limit=100)
+        before = graph_snapshot(entities, relationships)
+
+        # Wipe-and-replay through the substrate's rebuild machinery.
+        report = await events.rebuild(USER, projection="knowledge_graph")
+        assert report["knowledge_graph"]["failed"] == 0
+        # graph.extracted x2 + entity.resolved x1 replayed in append order.
+        assert report["knowledge_graph"]["events"] == 3
+
+        entities = await graph.storage.list_entities(USER, status=None, limit=100)
+        relationships = await graph.storage.list_relationships(USER, status=None, limit=100)
+        assert graph_snapshot(entities, relationships) == before
+
+        # And a second rebuild converges again (idempotent replay).
+        await events.rebuild(USER, projection="knowledge_graph")
+        entities = await graph.storage.list_entities(USER, status=None, limit=100)
+        relationships = await graph.storage.list_relationships(USER, status=None, limit=100)
+        assert graph_snapshot(entities, relationships) == before
+
+    async def test_replay_never_rescores(self, graph_env):
+        # Threshold changes after the fact must not rewrite history: the
+        # projector applies the recorded decision payload verbatim.
+        graph, events = graph_env
+        await seed_duplicate_identities(graph)
+        resolver = EntityResolver(graph, events, resolution_settings())
+        await resolver.resolve_user(USER)
+
+        (event,) = await events.list_events(USER, event_types=[EVENT_ENTITY_RESOLVED])
+        projector = KnowledgeGraphProjector(graph)
+        result = await projector.apply(event)
+        # Re-applying the merged decision is a no-op (already merged).
+        assert result["applied"] is True
+        merged = await graph.storage.get_entity(USER, "person", "Ryan")
+        assert merged["status"] == STATUS_MERGED

--- a/tests/unit/test_entity_resolution.py
+++ b/tests/unit/test_entity_resolution.py
@@ -304,6 +304,102 @@ class TestResolver:
 
 
 # ----------------------------------------------------------------------
+# Merge edge handling (collision map is ACTIVE-only)
+# ----------------------------------------------------------------------
+
+
+class TestMergeEdgeCollisions:
+    async def test_both_entities_share_the_same_active_edge(self, graph_env):
+        # Both rows carry an ACTIVE works_at edge to the same company:
+        # the duplicate's copy folds into the canonical's (max confidence,
+        # merged attributes) and is retained as superseded.
+        graph, _ = graph_env
+        storage = graph.storage
+        full = await storage.upsert_entity(USER, "person", "Ryan Leveille", confidence=0.9)
+        short = await storage.upsert_entity(USER, "person", "Ryan", confidence=0.8)
+        company = await storage.upsert_entity(USER, "company", "Nabo", confidence=0.9)
+        kept = await storage.upsert_relationship(
+            USER, full["id"], company["id"], "works_at", confidence=0.7
+        )
+        await storage.upsert_relationship(
+            USER, short["id"], company["id"], "works_at", confidence=0.95
+        )
+
+        result = await storage.merge_entities(USER, full["id"], short["id"])
+        assert result == {"repointed": 0, "superseded": 1}
+
+        active = await storage.list_relationships(USER, rel_type="works_at")
+        assert len(active) == 1
+        assert active[0]["id"] == kept["id"]
+        assert active[0]["confidence"] == 0.95  # absorbed the duplicate's max
+        folded = await storage.list_relationships(
+            USER, rel_type="works_at", status=STATUS_SUPERSEDED
+        )
+        assert len(folded) == 1
+        assert folded[0]["superseded_by"] == kept["id"]
+
+    async def test_active_duplicate_edge_survives_superseded_canonical_copy(self, graph_env):
+        # The canonical's copy of the fact is SUPERSEDED history; the
+        # duplicate's copy is ACTIVE. The active fact must be re-pointed
+        # and stay active -- never folded into the superseded row (which
+        # would silently drop it from the active graph).
+        graph, _ = graph_env
+        storage = graph.storage
+        full = await storage.upsert_entity(USER, "person", "Ryan Leveille", confidence=0.9)
+        short = await storage.upsert_entity(USER, "person", "Ryan", confidence=0.8)
+        old_co = await storage.upsert_entity(USER, "company", "Nabo", confidence=0.9)
+        new_co = await storage.upsert_entity(USER, "company", "Acme", confidence=0.9)
+        # works_at is exclusive: the Acme fact supersedes the canonical's
+        # Nabo fact (confidence delta > 0.3), leaving a SUPERSEDED
+        # canonical works_at row pointing at Nabo.
+        await storage.upsert_relationship(
+            USER, full["id"], old_co["id"], "works_at", confidence=0.5
+        )
+        await storage.upsert_relationship(
+            USER, full["id"], new_co["id"], "works_at", confidence=0.9
+        )
+        live = await storage.upsert_relationship(
+            USER, short["id"], old_co["id"], "works_at", confidence=0.85
+        )
+
+        await storage.merge_entities(USER, full["id"], short["id"])
+
+        refreshed = await storage.get_relationship_by_id(live["id"])
+        assert refreshed["status"] == STATUS_ACTIVE
+        assert refreshed["from_entity_id"] == full["id"]  # re-pointed, not folded
+
+    async def test_superseded_duplicate_edge_follows_merge_without_collision(self, graph_env):
+        # A retained non-active duplicate fact is re-pointed to the
+        # canonical entity (coherent history) but never merges into or
+        # displaces the canonical's ACTIVE copy of the same fact.
+        graph, _ = graph_env
+        storage = graph.storage
+        full = await storage.upsert_entity(USER, "person", "Ryan Leveille", confidence=0.9)
+        short = await storage.upsert_entity(USER, "person", "Ryan", confidence=0.8)
+        old_co = await storage.upsert_entity(USER, "company", "Nabo", confidence=0.9)
+        new_co = await storage.upsert_entity(USER, "company", "Acme", confidence=0.9)
+        active_canonical = await storage.upsert_relationship(
+            USER, full["id"], old_co["id"], "works_at", confidence=0.9
+        )
+        # Duplicate's Nabo fact got superseded by its Acme fact.
+        stale = await storage.upsert_relationship(
+            USER, short["id"], old_co["id"], "works_at", confidence=0.5
+        )
+        await storage.upsert_relationship(
+            USER, short["id"], new_co["id"], "works_at", confidence=0.9
+        )
+
+        await storage.merge_entities(USER, full["id"], short["id"])
+
+        refreshed_stale = await storage.get_relationship_by_id(stale["id"])
+        assert refreshed_stale["status"] == STATUS_SUPERSEDED
+        assert refreshed_stale["from_entity_id"] == full["id"]  # follows the merge
+        refreshed_active = await storage.get_relationship_by_id(active_canonical["id"])
+        assert refreshed_active["status"] == STATUS_ACTIVE
+        assert refreshed_active["confidence"] == 0.9  # untouched by the stale copy
+
+
+# ----------------------------------------------------------------------
 # Rebuild determinism (replay reproduces the merged graph)
 # ----------------------------------------------------------------------
 

--- a/tests/unit/test_ingestion_tiers.py
+++ b/tests/unit/test_ingestion_tiers.py
@@ -1,0 +1,439 @@
+"""Unit tests for the ingestion tier-escalation heuristics (maturation).
+
+Covers, per PRD criterion:
+
+  * Tier-0 signal extraction: identities (emails/handles/proper names),
+    dates, money, commitment language -- pure regex, deterministic.
+  * decide_tier(): per-source pins, priority flags, synthesis-worthy
+    categories (personal/work/unknown), ambiguous classification,
+    high-signal T3 escalation, and the T1 rest state.
+  * TierBudget: per-job caps demote T3 -> T2 -> T1 (never drop).
+  * Fail-fast config validation of memory.ingestion (tiers /
+    entity_resolution / synthesis / source tier pins), and that the
+    formation validator reuses the same parser.
+  * Service integration: tier + reason on the item report, escalation
+    observability, Tier-1 verbatim store, tier-model resolution for
+    T2/T3, and legacy behavior with tiers disabled.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from muxi.runtime.formation.background.request_tracker import RequestTracker
+from muxi.runtime.formation.config.validation import FormationValidator
+from muxi.runtime.formation.overlord.input_validation import InputLimits, InputValidator
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.events import MemoryEventService
+from muxi.runtime.services.memory.events.models import MemoryEvent, ProjectionCheckpoint
+from muxi.runtime.services.memory.ingest import (
+    TIER_FRONTIER,
+    TIER_LOCAL,
+    TIER_STANDARD,
+    MemoryIngestionService,
+    parse_ingestion_config,
+    validate_item,
+)
+from muxi.runtime.services.memory.ingest.classification import (
+    CATEGORY_AUTOMATED,
+    CATEGORY_PERSONAL,
+    CATEGORY_TRANSACTIONAL,
+    CATEGORY_UNKNOWN,
+    CATEGORY_WORK,
+    INTENT_PREFIX,
+)
+from muxi.runtime.services.memory.ingest.tiers import (
+    TierBudget,
+    content_signals,
+    decide_tier,
+    signal_score,
+)
+
+FORMATION_ID = "tiers-test-formation"
+EVENT_TABLES = [MemoryEvent.__table__, ProjectionCheckpoint.__table__]
+
+HIGH_SIGNAL_TEXT = (
+    "Agreed with Ryan Leveille (ryan@nabo.dev): the contract deadline is "
+    "2026-08-01, deliverables due by EOD, budget $12,000."
+)
+
+
+def settings(**overrides):
+    config = {"tiers": overrides} if overrides else {}
+    return parse_ingestion_config(config).tiers
+
+
+# ----------------------------------------------------------------------
+# Tier 0: signal extraction
+# ----------------------------------------------------------------------
+
+
+class TestContentSignals:
+    def test_identity_mentions(self):
+        signals = content_signals("Email ryan@nabo.dev or ping @rleveille; ask Ryan Leveille")
+        assert signals["identities"] == 3
+
+    def test_dates(self):
+        signals = content_signals("Ship on 2026-08-01, review next week, close by end of Q3")
+        assert signals["dates"] == 3
+
+    def test_money(self):
+        signals = content_signals("Invoice for $1,200.50 plus 300 EUR")
+        assert signals["money"] == 2
+
+    def test_commitments(self):
+        signals = content_signals("The deadline was agreed; I will deliver the action items")
+        assert signals["commitments"] >= 2
+
+    def test_empty_content(self):
+        assert signal_score(content_signals("")) == 0
+
+    def test_score_caps_per_signal_class(self):
+        text = " ".join(f"user{i}@example.com" for i in range(10))
+        assert signal_score(content_signals(text)) == 3  # identities capped at 3
+
+    def test_high_signal_text_crosses_default_threshold(self):
+        assert signal_score(content_signals(HIGH_SIGNAL_TEXT)) >= 5
+
+
+# ----------------------------------------------------------------------
+# Escalation decision per criterion
+# ----------------------------------------------------------------------
+
+
+class TestDecideTier:
+    def test_synthesis_worthy_categories_escalate_to_t2(self):
+        no_signal = content_signals("hello")
+        for category in (CATEGORY_PERSONAL, CATEGORY_WORK, CATEGORY_UNKNOWN):
+            tier, reason = decide_tier(category, 0.4, no_signal, settings())
+            assert tier == TIER_STANDARD, category
+            assert reason == f"category:{category}"
+
+    def test_noise_categories_rest_at_t1(self):
+        no_signal = content_signals("hello")
+        for category in (CATEGORY_AUTOMATED, CATEGORY_TRANSACTIONAL):
+            tier, reason = decide_tier(category, 0.4, no_signal, settings())
+            assert tier == TIER_LOCAL, category
+            assert reason == f"low_signal_category:{category}"
+
+    def test_ambiguous_classification_escalates_to_t2(self):
+        tier, reason = decide_tier(CATEGORY_AUTOMATED, 0.01, content_signals("hello"), settings())
+        assert tier == TIER_STANDARD
+        assert reason.startswith("ambiguous_classification:")
+
+    def test_high_signal_t2_item_escalates_to_t3(self):
+        tier, reason = decide_tier(
+            CATEGORY_WORK, 0.4, content_signals(HIGH_SIGNAL_TEXT), settings()
+        )
+        assert tier == TIER_FRONTIER
+        assert reason.startswith("high_signal:score=")
+
+    def test_high_signal_noise_stays_t1(self):
+        # High-signal escalation applies to synthesis-worthy items only:
+        # a promotional blast full of prices is still noise.
+        tier, _ = decide_tier(
+            CATEGORY_TRANSACTIONAL, 0.4, content_signals(HIGH_SIGNAL_TEXT), settings()
+        )
+        assert tier == TIER_LOCAL
+
+    def test_priority_flag_escalates_to_t3(self):
+        tier, reason = decide_tier(
+            CATEGORY_AUTOMATED, 0.4, content_signals("hello"), settings(), priority="HIGH"
+        )
+        assert tier == TIER_FRONTIER
+        assert reason == "priority_flag"
+
+    def test_source_pin_wins(self):
+        tier, reason = decide_tier(
+            CATEGORY_PERSONAL,
+            0.4,
+            content_signals(HIGH_SIGNAL_TEXT),
+            settings(),
+            source_tier=1,
+        )
+        assert tier == TIER_LOCAL
+        assert reason == "source_pin:1"
+
+    def test_t3_signal_score_is_configurable(self):
+        strict = settings(t3_signal_score=100)
+        tier, _ = decide_tier(CATEGORY_WORK, 0.4, content_signals(HIGH_SIGNAL_TEXT), strict)
+        assert tier == TIER_STANDARD
+
+    def test_tiers_disabled_restores_legacy_always_extract(self):
+        tier, reason = decide_tier(
+            CATEGORY_AUTOMATED, 0.4, content_signals("hello"), settings(enabled=False)
+        )
+        assert tier == TIER_STANDARD
+        assert reason == "tiers_disabled"
+
+
+# ----------------------------------------------------------------------
+# Budget caps
+# ----------------------------------------------------------------------
+
+
+class TestTierBudget:
+    def test_t3_budget_demotes_to_t2_then_t1(self):
+        budget = TierBudget(t2_remaining=1, t3_remaining=1)
+        assert budget.admit(TIER_FRONTIER) == (TIER_FRONTIER, False)
+        # T3 exhausted: demote into the T2 budget.
+        assert budget.admit(TIER_FRONTIER) == (TIER_STANDARD, True)
+        # Both exhausted: rest at T1 (never dropped).
+        assert budget.admit(TIER_FRONTIER) == (TIER_LOCAL, True)
+
+    def test_t2_budget_demotes_to_t1(self):
+        budget = TierBudget(t2_remaining=1, t3_remaining=0)
+        assert budget.admit(TIER_STANDARD) == (TIER_STANDARD, False)
+        assert budget.admit(TIER_STANDARD) == (TIER_LOCAL, True)
+
+    def test_t1_is_never_budgeted(self):
+        budget = TierBudget(t2_remaining=0, t3_remaining=0)
+        for _ in range(5):
+            assert budget.admit(TIER_LOCAL) == (TIER_LOCAL, False)
+
+
+# ----------------------------------------------------------------------
+# Fail-fast config validation
+# ----------------------------------------------------------------------
+
+
+class TestConfigValidation:
+    def test_defaults_parse(self):
+        parsed = parse_ingestion_config(None)
+        assert parsed.tiers.enabled is True
+        assert parsed.synthesis.hot.interval_seconds == 300.0
+        assert parsed.synthesis.cold_cold.interval_seconds == 604800.0
+        assert parsed.entity_resolution.auto_merge_threshold == 0.85
+
+    def test_non_dict_rejected(self):
+        with pytest.raises(ValueError, match="memory.ingestion must be a dictionary"):
+            parse_ingestion_config("yes")
+
+    def test_bad_ambiguity_margin(self):
+        with pytest.raises(ValueError, match="tiers.ambiguity_margin"):
+            parse_ingestion_config({"tiers": {"ambiguity_margin": 2}})
+
+    def test_bad_budget(self):
+        with pytest.raises(ValueError, match="t3_items_per_job"):
+            parse_ingestion_config({"tiers": {"budget": {"t3_items_per_job": 0}}})
+
+    def test_bad_source_tier_pin(self):
+        with pytest.raises(ValueError, match=r"sources.crm.tier"):
+            parse_ingestion_config({"sources": {"crm": {"tier": 4}}})
+
+    def test_flag_threshold_must_not_exceed_merge_threshold(self):
+        with pytest.raises(ValueError, match="flag_threshold"):
+            parse_ingestion_config(
+                {"entity_resolution": {"auto_merge_threshold": 0.5, "flag_threshold": 0.9}}
+            )
+
+    def test_bad_cadence_interval(self):
+        with pytest.raises(ValueError, match=r"synthesis.warm.interval_seconds"):
+            parse_ingestion_config({"synthesis": {"warm": {"interval_seconds": -5}}})
+
+    def test_bad_cadence_enabled_type(self):
+        with pytest.raises(ValueError, match=r"synthesis.cold.enabled"):
+            parse_ingestion_config({"synthesis": {"cold": {"enabled": "yes"}}})
+
+    def test_formation_validator_reuses_parser(self):
+        validator = FormationValidator()
+        validator._validate_memory_config({"ingestion": {"tiers": {"t3_signal_score": "many"}}})
+        assert any("t3_signal_score" in e for e in validator.result.errors)
+
+    def test_formation_validator_accepts_valid_block(self):
+        validator = FormationValidator()
+        validator._validate_memory_config(
+            {
+                "ingestion": {
+                    "sources": {"gmail": {"filter": "lenient", "tier": 3}},
+                    "tiers": {"models": {"t3": "openai/gpt-5"}},
+                    "entity_resolution": {"auto_merge_threshold": 0.9},
+                    "synthesis": {"cold_cold": {"enabled": False}},
+                }
+            }
+        )
+        assert not [e for e in validator.result.errors if "ingestion" in e]
+
+
+# ----------------------------------------------------------------------
+# Service integration (tier drives the pipeline)
+# ----------------------------------------------------------------------
+
+
+class StubClassifier:
+    def __init__(self, margins=None):
+        self.margins = margins or {}
+
+    async def register(self, spec):
+        pass
+
+    async def classify_binary(self, name, text):
+        margin = self.margins.get(name, -0.5)
+        return margin > 0, margin
+
+
+class RecordingLTM:
+    def __init__(self):
+        self.rows = []
+
+    async def add(self, content, metadata=None, user_id=None, collection=None, scope=None):
+        self.rows.append({"content": content, "collection": collection, "scope": scope})
+        return f"m{len(self.rows)}"
+
+
+class RecordingExtractor:
+    extraction_interval = 1
+
+    def __init__(self):
+        self.calls = []
+
+    async def process_conversation_turn(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+def make_overlord(memory_events, *, classifier_category=CATEGORY_PERSONAL, ingestion_config=None):
+    extractor = RecordingExtractor()
+    overlord = SimpleNamespace(
+        formation_config={"memory": {"ingestion": ingestion_config or {}}},
+        formation_id=FORMATION_ID,
+        memory_events=memory_events,
+        request_tracker=RequestTracker(),
+        long_term_memory=RecordingLTM(),
+        extractor=extractor,
+        knowledge_graph=None,
+        default_model=None,
+        is_multi_user=False,
+        input_validator=InputValidator(InputLimits()),
+    )
+    classifier = StubClassifier({f"{INTENT_PREFIX}{classifier_category}": 0.4})
+
+    async def _get_local_classifier():
+        return classifier
+
+    overlord._get_local_classifier = _get_local_classifier
+    return overlord
+
+
+@pytest.fixture
+def memory_events(tmp_path):
+    db_manager = DatabaseManager(f"sqlite:///{tmp_path}/events.db")
+    db_manager.create_tables(Base.metadata, tables=EVENT_TABLES)
+    service = MemoryEventService(db_manager, FORMATION_ID, config={"enabled": True})
+    yield service
+    db_manager.engine.dispose()
+
+
+def make_item(**overrides):
+    payload = {"content": "I moved to London last month", "source": "gmail", "source_id": "m-1"}
+    payload.update(overrides)
+    item, error = validate_item(payload)
+    assert error is None, error
+    return item
+
+
+async def run_one(overlord, item):
+    service = MemoryIngestionService(overlord)
+    outcome = await service.submit("alice", [(0, item)])
+    state = await overlord.request_tracker.get_request(outcome["processing_id"])
+    await state.task_ref
+    state = await overlord.request_tracker.get_request(outcome["processing_id"])
+    return state.result["items"][0]
+
+
+class TestServiceIntegration:
+    async def test_t2_report_and_extractor_default_model(self, memory_events):
+        overlord = make_overlord(memory_events)
+        report = await run_one(overlord, make_item())
+        assert report["tier"] == TIER_STANDARD
+        assert report["tier_reason"] == f"category:{CATEGORY_PERSONAL}"
+        (call,) = overlord.extractor.calls
+        assert call["model"] is None  # default extraction model
+
+    async def test_t1_stores_verbatim_without_extractor(self, memory_events):
+        overlord = make_overlord(
+            memory_events,
+            classifier_category=CATEGORY_TRANSACTIONAL,
+            ingestion_config={"sources": {"gmail": {"filter": "off"}}},
+        )
+        report = await run_one(overlord, make_item(content="Order #4521 shipped, $42 paid"))
+        assert report["tier"] == TIER_LOCAL
+        assert report["disposition"] == "stored"
+        assert overlord.extractor.calls == []
+        assert len(overlord.long_term_memory.rows) == 1
+
+    async def test_t3_resolves_configured_frontier_model(self, memory_events):
+        overlord = make_overlord(
+            memory_events,
+            classifier_category=CATEGORY_WORK,
+            ingestion_config={"tiers": {"models": {"t3": "openai/gpt-5"}}},
+        )
+        resolved = []
+
+        async def _get_or_create_model(model_config, cache_scope):
+            resolved.append((model_config["model"], cache_scope))
+            return f"llm:{model_config['model']}"
+
+        overlord._get_or_create_model = _get_or_create_model
+        report = await run_one(overlord, make_item(content=HIGH_SIGNAL_TEXT))
+        assert report["tier"] == TIER_FRONTIER
+        assert report["tier_reason"].startswith("high_signal:")
+        assert resolved == [("openai/gpt-5", "ingestion:t3")]
+        (call,) = overlord.extractor.calls
+        assert call["model"] == "llm:openai/gpt-5"
+
+    async def test_budget_cap_demotes_and_records_reason(self, memory_events):
+        overlord = make_overlord(
+            memory_events,
+            ingestion_config={"tiers": {"budget": {"t2_items_per_job": 1}}},
+        )
+        service = MemoryIngestionService(overlord)
+        items = [
+            (0, make_item(source_id="m-1", content="I love hiking in Wales")),
+            (1, make_item(source_id="m-2", content="My sister lives in Boston")),
+        ]
+        outcome = await service.submit("alice", items)
+        state = await overlord.request_tracker.get_request(outcome["processing_id"])
+        await state.task_ref
+        state = await overlord.request_tracker.get_request(outcome["processing_id"])
+        by_index = {r["index"]: r for r in state.result["items"]}
+        assert by_index[0]["tier"] == TIER_STANDARD
+        assert by_index[1]["tier"] == TIER_LOCAL
+        assert "budget_capped_from_t2" in by_index[1]["tier_reason"]
+        # Only the admitted item spent LLM extraction.
+        assert len(overlord.extractor.calls) == 1
+
+    async def test_budget_resets_per_job(self, memory_events):
+        overlord = make_overlord(
+            memory_events,
+            ingestion_config={"tiers": {"budget": {"t2_items_per_job": 1}}},
+        )
+        first = await run_one(overlord, make_item(source_id="m-1"))
+        second = await run_one(overlord, make_item(source_id="m-2"))
+        assert first["tier"] == second["tier"] == TIER_STANDARD
+
+    async def test_source_pin_via_config(self, memory_events):
+        overlord = make_overlord(
+            memory_events,
+            classifier_category=CATEGORY_PERSONAL,
+            ingestion_config={"sources": {"gmail": {"tier": 1}}},
+        )
+        report = await run_one(overlord, make_item())
+        assert report["tier"] == TIER_LOCAL
+        assert report["tier_reason"] == "source_pin:1"
+        assert overlord.extractor.calls == []
+
+    async def test_tiers_disabled_keeps_legacy_pipeline(self, memory_events):
+        overlord = make_overlord(
+            memory_events,
+            classifier_category=CATEGORY_AUTOMATED,
+            ingestion_config={
+                "tiers": {"enabled": False},
+                "sources": {"gmail": {"filter": "off"}},
+            },
+        )
+        report = await run_one(overlord, make_item(content="Build #8841 passed"))
+        assert report["tier"] == TIER_STANDARD
+        assert report["tier_reason"] == "tiers_disabled"
+        assert len(overlord.extractor.calls) == 1

--- a/tests/unit/test_memory_ingestion.py
+++ b/tests/unit/test_memory_ingestion.py
@@ -518,19 +518,29 @@ class TestPipeline:
         assert filtered[0]["payload"]["filter_level"] == "strict"
         assert filtered[0]["source"] == "gmail"
 
-    async def test_filter_off_keeps_noise(self, memory_events):
+    async def test_filter_off_keeps_noise_at_tier_1(self, memory_events):
+        # Kept noise (automated content surviving filter: off) rests at
+        # Tier 1 under the escalation heuristics: stored verbatim as an
+        # event-sourced fact, no LLM extraction spent on it.
+        ltm = RecordingLTM()
         extractor = StubExtractor(memory_events)
         overlord = make_overlord(
             memory_events,
             extractor=extractor,
-            classifier=StubClassifier(margins_for(CATEGORY_AUTOMATED)),
+            long_term_memory=ltm,
+            classifier=StubClassifier({f"{INTENT_PREFIX}{CATEGORY_AUTOMATED}": 0.4}),
             ingestion_config={"sources": {"gmail": {"filter": "off"}}},
         )
         service = MemoryIngestionService(overlord)
         outcome = await service.submit("alice", [(0, make_item())])
         state = await finish_job(overlord, outcome["processing_id"])
-        assert state.result["items"][0]["disposition"] == DISPOSITION_STORED
-        assert len(extractor.calls) == 1
+        report = state.result["items"][0]
+        assert report["disposition"] == DISPOSITION_STORED
+        assert report["tier"] == 1
+        assert report["tier_reason"].startswith("low_signal_category:")
+        # Tier 1 = small local processing only: verbatim fact, no extractor.
+        assert extractor.calls == []
+        assert len(ltm.rows) == 1
 
     async def test_classifier_failure_fails_open(self, memory_events):
         extractor = StubExtractor(memory_events)

--- a/tests/unit/test_memory_synthesis.py
+++ b/tests/unit/test_memory_synthesis.py
@@ -1,0 +1,488 @@
+"""Unit tests for the memory synthesis cadences (Memory Ingestion maturation).
+
+Covers:
+
+  * Overlord wiring: inert when memory.ingestion is unconfigured (pin),
+    service created + registered as a scheduler periodic task when
+    configured, degradation without a scheduler, and the master
+    synthesis.enabled switch.
+  * tick() interval gating per cadence, individually disableable.
+  * Hot cadence: entity resolution for users with new events; the
+    durable per-user cursor gates re-processing.
+  * Warm/cold cadences: deterministic pattern extraction (preferences,
+    domain expertise, schedule) written event-first with per-(kind,
+    ISO week) idempotency keys and decaying decay_rate.
+  * Cold-cold: per-user rebuild from the event log (the substrate's
+    replay machinery), deterministic across replays, failure-isolated
+    per user.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from muxi.runtime.formation.overlord.overlord import Overlord
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.events import MemoryEventService
+from muxi.runtime.services.memory.events.models import (
+    EVENT_FACT_EXTRACTED,
+    EVENT_INTERACTION_TURN,
+    EVENT_MEMORY_INGESTED,
+    SOURCE_INTERACTION,
+    SOURCE_SYNTHESIS,
+)
+from muxi.runtime.services.memory.events.projectors import KnowledgeGraphProjector
+from muxi.runtime.services.memory.graph.models import STATUS_MERGED
+from muxi.runtime.services.memory.graph.service import KnowledgeGraphService
+from muxi.runtime.services.memory.ingest.config import parse_ingestion_config
+from muxi.runtime.services.memory.synthesis import (
+    CADENCE_COLD,
+    CADENCE_COLD_COLD,
+    CADENCE_HOT,
+    CADENCE_WARM,
+    CADENCES,
+    MemorySynthesisService,
+)
+
+FORMATION_ID = "synthesis-test-formation"
+USER = "u1"
+
+NOW = datetime(2026, 7, 8, 12, 0, 0, tzinfo=timezone.utc)  # a Wednesday
+
+
+class RecordingLTM:
+    def __init__(self):
+        self.rows = []
+
+    async def add(self, content, metadata=None, user_id=None, collection=None, scope=None):
+        self.rows.append(
+            {"content": content, "metadata": dict(metadata or {}), "collection": collection}
+        )
+        return f"m{len(self.rows)}"
+
+
+def make_settings(**synthesis_overrides):
+    return parse_ingestion_config({"synthesis": synthesis_overrides})
+
+
+@pytest.fixture
+def env(tmp_path):
+    """Real substrate + graph + a minimal overlord namespace."""
+    db_manager = DatabaseManager(f"sqlite:///{tmp_path}/synthesis.db")
+    db_manager.create_tables(Base.metadata)
+    events = MemoryEventService(db_manager, FORMATION_ID, config={"enabled": True})
+    graph = KnowledgeGraphService(db_manager, FORMATION_ID, config={}, event_log=events)
+    events.register_projector(KnowledgeGraphProjector(graph))
+    overlord = SimpleNamespace(
+        memory_events=events,
+        knowledge_graph=graph,
+        long_term_memory=RecordingLTM(),
+    )
+    yield overlord, events, graph
+    db_manager.engine.dispose()
+
+
+def make_service(overlord, *, baseline=None, **synthesis_overrides):
+    parsed = make_settings(**synthesis_overrides)
+    service = MemorySynthesisService(overlord, parsed.synthesis, parsed.entity_resolution)
+    if baseline is not None:
+        # Freeze the startup baseline for deterministic gating tests
+        # (construction stamps the real clock).
+        service._last_run = {cadence: baseline for cadence in CADENCES}
+    return service
+
+
+async def seed_ingestion_event(events, source_id="m-1"):
+    return await events.record(
+        user_id=USER,
+        event_type=EVENT_MEMORY_INGESTED,
+        payload={"content": "hello"},
+        source="gmail",
+        source_id=source_id,
+    )
+
+
+async def seed_duplicate_identities(graph):
+    full = await graph.storage.upsert_entity(
+        USER, "person", "Ryan Leveille", attributes={"email": "ryan@nabo.dev"}, confidence=0.9
+    )
+    await graph.storage.upsert_entity(
+        USER, "person", "Ryan", attributes={"email": "ryan@nabo.dev"}, confidence=0.8
+    )
+    return full
+
+
+# ----------------------------------------------------------------------
+# Overlord wiring (inertness pin + registration)
+# ----------------------------------------------------------------------
+
+
+class FakeScheduler:
+    def __init__(self):
+        self.periodic_tasks = []
+
+    def register_periodic_task(self, task):
+        self.periodic_tasks.append(task)
+
+
+def overlord_stub(memory_config, *, scheduler=True, memory_events=None):
+    ingestion_config = (memory_config or {}).get("ingestion")
+    settings = (
+        parse_ingestion_config(ingestion_config)
+        if isinstance(ingestion_config, dict)
+        else parse_ingestion_config(None)
+    )
+    return SimpleNamespace(
+        formation_config={"memory": memory_config or {}},
+        memory_ingestion=SimpleNamespace(settings=settings),
+        memory_synthesis=None,
+        memory_events=memory_events or SimpleNamespace(enabled=True),
+        knowledge_graph=None,
+        scheduler_service=FakeScheduler() if scheduler else None,
+    )
+
+
+class TestOverlordWiring:
+    def test_inert_when_ingestion_unconfigured(self):
+        stub = overlord_stub({})
+        Overlord._initialize_memory_synthesis(stub)
+        assert stub.memory_synthesis is None
+        assert stub.scheduler_service.periodic_tasks == []
+
+    def test_registered_when_ingestion_configured(self):
+        stub = overlord_stub({"ingestion": {"sources": {"gmail": {"filter": "lenient"}}}})
+        Overlord._initialize_memory_synthesis(stub)
+        assert stub.memory_synthesis is not None
+        assert stub.scheduler_service.periodic_tasks == [stub.memory_synthesis]
+
+    def test_synthesis_master_switch_disables(self):
+        stub = overlord_stub({"ingestion": {"synthesis": {"enabled": False}}})
+        Overlord._initialize_memory_synthesis(stub)
+        assert stub.memory_synthesis is None
+
+    def test_all_cadences_disabled_registers_nothing(self):
+        stub = overlord_stub(
+            {
+                "ingestion": {
+                    "synthesis": {
+                        "hot": {"enabled": False},
+                        "warm": {"enabled": False},
+                        "cold": {"enabled": False},
+                        "cold_cold": {"enabled": False},
+                    }
+                }
+            }
+        )
+        Overlord._initialize_memory_synthesis(stub)
+        # Service exists for manual passes, but no periodic task fires.
+        assert stub.memory_synthesis is not None
+        assert stub.scheduler_service.periodic_tasks == []
+
+    def test_no_scheduler_degrades_to_manual(self, capsys):
+        stub = overlord_stub({"ingestion": {}}, scheduler=False)
+        stub.formation_config = {"memory": {"ingestion": {"tiers": {}}}}
+        stub.memory_ingestion = SimpleNamespace(settings=parse_ingestion_config({"tiers": {}}))
+        Overlord._initialize_memory_synthesis(stub)
+        assert stub.memory_synthesis is not None
+        assert "require the scheduler" in capsys.readouterr().out
+
+    def test_requires_event_substrate(self):
+        stub = overlord_stub(
+            {"ingestion": {"tiers": {}}},
+            memory_events=SimpleNamespace(enabled=False),
+        )
+        Overlord._initialize_memory_synthesis(stub)
+        assert stub.memory_synthesis is None
+
+
+# ----------------------------------------------------------------------
+# tick() interval gating
+# ----------------------------------------------------------------------
+
+
+class TestTickGating:
+    async def test_cadence_fires_only_after_interval(self, env):
+        overlord, events, _ = env
+        service = make_service(overlord, baseline=NOW)
+        ran = []
+
+        async def record_cadence(cadence, now=None):
+            ran.append(cadence)
+            return {}
+
+        service.run_cadence = record_cadence
+
+        await service.tick(NOW + timedelta(seconds=60))
+        assert ran == []  # nothing due yet (first fire is one interval in)
+
+        await service.tick(NOW + timedelta(seconds=301))
+        assert ran == [CADENCE_HOT]
+
+        await service.tick(NOW + timedelta(seconds=3901))
+        assert CADENCE_WARM in ran and ran.count(CADENCE_HOT) == 2
+
+    async def test_disabled_cadence_never_fires(self, env):
+        overlord, _, _ = env
+        service = make_service(overlord, baseline=NOW, hot={"enabled": False})
+        ran = []
+
+        async def record_cadence(cadence, now=None):
+            ran.append(cadence)
+            return {}
+
+        service.run_cadence = record_cadence
+        await service.tick(NOW + timedelta(days=30))
+        assert CADENCE_HOT not in ran
+        assert {CADENCE_WARM, CADENCE_COLD, CADENCE_COLD_COLD} <= set(ran)
+
+    async def test_custom_interval_respected(self, env):
+        overlord, _, _ = env
+        service = make_service(overlord, baseline=NOW, hot={"interval_seconds": 10})
+        ran = []
+
+        async def record_cadence(cadence, now=None):
+            ran.append(cadence)
+            return {}
+
+        service.run_cadence = record_cadence
+        await service.tick(NOW + timedelta(seconds=11))
+        assert ran == [CADENCE_HOT]
+
+    async def test_tick_never_raises(self, env):
+        overlord, _, _ = env
+        service = make_service(overlord, baseline=NOW)
+
+        async def boom(cadence, now=None):
+            raise RuntimeError("pass exploded")
+
+        service.run_cadence = boom
+        await service.tick(NOW + timedelta(days=1))  # must not raise
+
+
+# ----------------------------------------------------------------------
+# Hot cadence: resolution + durable cursors
+# ----------------------------------------------------------------------
+
+
+class TestHotCadence:
+    async def test_hot_resolves_users_with_new_events(self, env):
+        overlord, events, graph = env
+        await seed_duplicate_identities(graph)
+        await seed_ingestion_event(events)
+        service = make_service(overlord)
+
+        report = await service.run_cadence(CADENCE_HOT)
+        assert report["users"] == 1
+        assert report["merged"] == 1
+
+        merged = await graph.storage.get_entity(USER, "person", "Ryan")
+        assert merged["status"] == STATUS_MERGED
+
+    async def test_hot_cursor_skips_settled_users(self, env):
+        overlord, events, graph = env
+        await seed_duplicate_identities(graph)
+        await seed_ingestion_event(events)
+        service = make_service(overlord)
+
+        first = await service.run_cadence(CADENCE_HOT)
+        assert first["users"] == 1
+        # No new events since the cursor advanced: the user is skipped.
+        second = await service.run_cadence(CADENCE_HOT)
+        assert second["users"] == 0
+
+        # A new ingestion event makes the user eligible again.
+        await seed_ingestion_event(events, source_id="m-2")
+        third = await service.run_cadence(CADENCE_HOT)
+        assert third["users"] == 1
+
+    async def test_inert_without_substrate(self):
+        overlord = SimpleNamespace(memory_events=None, knowledge_graph=None, long_term_memory=None)
+        service = make_service(overlord)
+        report = await service.run_cadence(CADENCE_HOT)
+        assert report["users"] == 0
+
+
+# ----------------------------------------------------------------------
+# Warm/cold cadences: pattern extraction
+# ----------------------------------------------------------------------
+
+
+async def seed_graph_preferences(graph):
+    user = await graph.storage.upsert_entity(USER, "person", "User", confidence=0.95)
+    tea = await graph.storage.upsert_entity(USER, "preference", "Earl Grey tea", confidence=0.9)
+    bouldering = await graph.storage.upsert_entity(USER, "topic", "bouldering", confidence=0.9)
+    python = await graph.storage.upsert_entity(USER, "topic", "Python", confidence=0.8)
+    await graph.storage.upsert_relationship(USER, user["id"], tea["id"], "prefers", confidence=0.9)
+    await graph.storage.upsert_relationship(
+        USER, user["id"], bouldering["id"], "interested_in", confidence=0.9
+    )
+    return python
+
+
+async def seed_turns(events, count, start=NOW):
+    for i in range(count):
+        occurred = (start + timedelta(days=i % 2, hours=(i % 3) - 1)).replace(tzinfo=None)
+        await events.record(
+            user_id=USER,
+            event_type=EVENT_INTERACTION_TURN,
+            payload={"user_message": f"turn {i}"},
+            source=SOURCE_INTERACTION,
+            occurred_at=occurred,
+        )
+
+
+class TestPatternExtraction:
+    async def test_warm_writes_preference_and_expertise_patterns(self, env):
+        overlord, events, graph = env
+        await seed_graph_preferences(graph)
+        await seed_ingestion_event(events)
+        service = make_service(overlord)
+
+        report = await service.run_cadence(CADENCE_WARM, now=NOW)
+        assert report["patterns"] == 2
+
+        facts = await events.list_events(USER, event_types=[EVENT_FACT_EXTRACTED])
+        by_kind = {e["payload"]["metadata"]["pattern"]: e for e in facts}
+        assert set(by_kind) == {"preferences", "expertise"}
+        assert "Earl Grey tea" in by_kind["preferences"]["payload"]["memory"]
+        assert by_kind["preferences"]["payload"]["collection"] == "preferences"
+        assert by_kind["preferences"]["source"] == SOURCE_SYNTHESIS
+        assert by_kind["preferences"]["decay_rate"] == "decaying"
+        assert by_kind["preferences"]["source_id"] == "pattern/preferences/2026-W28"
+
+        # The flat-fact projection received the pattern rows.
+        contents = [row["content"] for row in overlord.long_term_memory.rows]
+        assert any("Earl Grey tea" in content for content in contents)
+
+    async def test_patterns_idempotent_within_period(self, env):
+        overlord, events, graph = env
+        await seed_graph_preferences(graph)
+        await seed_ingestion_event(events)
+        service = make_service(overlord)
+
+        assert (await service.run_cadence(CADENCE_WARM, now=NOW))["patterns"] == 2
+        await seed_ingestion_event(events, source_id="m-2")  # re-arm the cursor
+        assert (await service.run_cadence(CADENCE_WARM, now=NOW))["patterns"] == 0
+        assert len(overlord.long_term_memory.rows) == 2
+
+        # A new period re-derives.
+        await seed_ingestion_event(events, source_id="m-3")
+        next_week = NOW + timedelta(days=7)
+        assert (await service.run_cadence(CADENCE_WARM, now=next_week))["patterns"] == 2
+
+    async def test_cold_writes_schedule_pattern(self, env):
+        overlord, events, graph = env
+        await seed_turns(events, 24)
+        service = make_service(overlord)
+
+        report = await service.run_cadence(CADENCE_COLD, now=NOW)
+        assert report["patterns"] == 1
+        facts = await events.list_events(USER, event_types=[EVENT_FACT_EXTRACTED])
+        (schedule,) = facts
+        assert schedule["payload"]["metadata"]["pattern"] == "schedule"
+        assert schedule["payload"]["collection"] == "activities"
+        assert "Typically active around" in schedule["payload"]["memory"]
+        assert "Wednesday" in schedule["payload"]["memory"]
+
+    async def test_schedule_needs_min_events(self, env):
+        overlord, events, _ = env
+        await seed_turns(events, 5)  # below the default min_events=20
+        service = make_service(overlord)
+        report = await service.run_cadence(CADENCE_COLD, now=NOW)
+        assert report["patterns"] == 0
+
+    async def test_min_events_configurable(self, env):
+        overlord, events, _ = env
+        await seed_turns(events, 5)
+        service = make_service(overlord, patterns={"min_events": 3})
+        report = await service.run_cadence(CADENCE_COLD, now=NOW)
+        assert report["patterns"] == 1
+
+    async def test_patterns_disableable(self, env):
+        overlord, events, graph = env
+        await seed_graph_preferences(graph)
+        await seed_ingestion_event(events)
+        service = make_service(overlord, patterns={"enabled": False})
+        report = await service.run_cadence(CADENCE_WARM, now=NOW)
+        assert report["patterns"] == 0
+
+
+# ----------------------------------------------------------------------
+# Cold-cold: weekly re-synthesis from the event log
+# ----------------------------------------------------------------------
+
+
+class TestColdCold:
+    async def test_cold_cold_rebuilds_then_synthesizes(self, env):
+        overlord, events, graph = env
+
+        # History lives in the event log (dual-write), so the rebuild's
+        # wipe-and-replay recreates it; the duplicate pair merges after.
+        await graph.store_extraction(
+            USER,
+            {
+                "entities": [
+                    {
+                        "name": "Ryan Leveille",
+                        "type": "person",
+                        "attributes": {"email": "ryan@nabo.dev"},
+                        "confidence": 0.9,
+                    },
+                    {
+                        "name": "Ryan",
+                        "type": "person",
+                        "attributes": {"email": "ryan@nabo.dev"},
+                        "confidence": 0.8,
+                    },
+                ],
+                "relationships": [],
+            },
+        )
+        service = make_service(overlord)
+        report = await service.run_cadence(CADENCE_COLD_COLD, now=NOW)
+        assert report["rebuilt"] == 1
+        assert report["merged"] == 1
+
+        merged = await graph.storage.get_entity(USER, "person", "Ryan")
+        assert merged["status"] == STATUS_MERGED
+
+        # Replay determinism: a second full re-synthesis converges to the
+        # same merged graph and derives nothing new.
+        second = await service.run_cadence(CADENCE_COLD_COLD, now=NOW)
+        assert second["rebuilt"] == 1
+        assert second["merged"] == 0
+        merged = await graph.storage.get_entity(USER, "person", "Ryan")
+        assert merged["status"] == STATUS_MERGED
+        names = {e["name"] for e in await graph.storage.list_entities(USER, entity_type="person")}
+        assert names == {"Ryan Leveille"}
+
+    async def test_rebuild_failure_is_isolated(self, env):
+        overlord, events, graph = env
+        await seed_ingestion_event(events)
+        await events.record(
+            user_id="u2",
+            event_type=EVENT_MEMORY_INGESTED,
+            payload={"content": "other user"},
+            source="gmail",
+            source_id="m-9",
+        )
+        service = make_service(overlord)
+
+        original_rebuild = events.rebuild
+        calls = []
+
+        async def flaky_rebuild(user_id, *args, **kwargs):
+            calls.append(str(user_id))
+            if str(user_id) == USER:
+                raise RuntimeError("replay exploded")
+            return await original_rebuild(user_id, *args, **kwargs)
+
+        events.rebuild = flaky_rebuild
+        report = await service.run_cadence(CADENCE_COLD_COLD, now=NOW)
+        # The failing user is isolated; the other user still rebuilt.
+        assert sorted(calls) == [USER, "u2"]
+        assert report["failed"] == 1
+        assert report["rebuilt"] == 1


### PR DESCRIPTION
Completes the memory-ingestion PRD's remaining maturation scope on top of the shipped `/v1/memories` pipeline (#218) and the substrate's projections/rebuild machinery (#259).

## Tier-escalation heuristics

- Pure, deterministic decision per kept item: Tier-0 regex signals (identities, dates, money, commitments) + the local classifier's category/margin. No LLM decides whether to use an LLM.
- Personal/work (and fail-open unknown) content escalates T1 -> T2 (LLM extraction + KG link pass); flagged high-signal items and `metadata.priority: high` escalate to T3 with an optionally configured frontier model (`memory.ingestion.tiers.models.t3`, falls back to t2, then the default extraction model); per-source `sources.<s>.tier` pins override everything.
- Kept noise now rests at Tier 1: stored verbatim as an event-sourced fact (classified, embedded, recallable) with **no LLM spent** - the PRD's "most items never leave Tier 1". `tiers.enabled: false` restores the shipped always-extract behavior.
- Per-job budgets (`tiers.budget.t{2,3}_items_per_job`) demote capped items to the best affordable tier, never drop. Every escalation is observable: `memory.ingestion.tier_escalated` events (tier + reason + signals) and `tier`/`tier_reason` on the item report returned by the status endpoint.

## Entity resolution

- Probabilistic identity matching over kg_entities on name / email / handle / role / relationship context; scoring is pure string+set logic (deterministic given the same rows). Auto-merge at/above `entity_resolution.auto_merge_threshold` (0.85), flag below it (event + `attributes.possible_duplicates` stored marker). Runs at extraction time after the ingestion link pass, and in the synthesis cadences.
- Decisions are event-first: `entity.resolved` events with a deterministic per-pair `source_id` riding the substrate's idempotency index - re-ingestion can never duplicate a merge or re-merge differently, and rebuilds replay recorded decisions verbatim (never re-scored, so threshold changes cannot rewrite history).
- Merges re-point edges (collisions / would-be self-loops become `superseded`, retained, never deleted), absorb attributes, record `aliases`; the duplicate row is marked `merged` and the graph upsert path redirects merged names to the canonical entity, so re-mentions can never revive a duplicate. Flagged pairs can still merge later on stronger evidence.

## Pattern extraction + preference inference (v1)

Deterministic aggregation only (no LLM): activity schedule from event-timestamp histograms, preference profile from the user's `prefers`/`interested_in` edges, domain expertise from the most-reinforced topic entities. Written as `fact.extracted` events (source `synthesis`, decay_rate `decaying`) keyed per `(kind, ISO week)` - idempotent within the period. `synthesis.patterns.{enabled,min_events,top_k}` are the dials; policies stay out.

## Synthesis scheduling

- Hot (5 min: entity resolution for users with new ingestion/graph events) / warm (hourly: preference + expertise patterns) / cold (nightly: schedule pattern + full resolution) cadences on the SchedulerService's existing `register_periodic_task` loop - the same extension point the heartbeat and knowledge sync use; no new loop.
- Cold-cold WEEKLY full re-synthesis replays the event log through the substrate's rebuild machinery (`MemoryEventService.rebuild` per user, background, failure-isolated per user) and then re-synthesizes - extraction-logic improvements become retroactive without re-ingestion.
- All cadences individually disableable + interval-configurable; hot/warm/cold keep durable per-user cursors in `projection_checkpoints`; everything is failure-isolated (synthesis can never break chat or ingestion); and the whole service is **inert when `memory.ingestion` is unconfigured** (pinned by unit test).

## Config + validation

One fail-fast parser (`ingest/config.py::parse_ingestion_config`) shared by `MemoryIngestionService` and the formation validator, so runtime and load-time validation can never disagree about the `memory.ingestion` shape. `validate_events.py`: 100%.

## Tests

- Unit (+78 new): `test_ingestion_tiers.py` (36 - signals per criterion, escalation decisions per PRD criterion, budgets, config fail-fast, service integration incl. tier-model resolution), `test_entity_resolution.py` (21 - scoring per PRD dimension, merge/flag thresholds, sticky redirects, idempotent re-resolution, rebuild determinism incl. a never-re-score pin), `test_memory_synthesis.py` (21 - wiring/inertness pins, tick gating, cursors, pattern idempotency, cold-cold rebuild + failure isolation), plus an updated pin in `test_memory_ingestion.py` (kept noise rests at T1). Full unit suite: 2972 passed, 10 skipped.
- E2E: new `2_memory/test_2v2_ingestion_maturation.py` - ingest via `/v1/memories`, tier + reason observable on the report, duplicate identity ("Ryan" -> "Ryan Leveille") merged with an `entity.resolved` event + alias, hot synthesis cadence driven (registered on the scheduler loop; a second pass proves the per-user cursor + idempotency), merged identity recalled in chat. Existing `test_2v1_memory_ingestion.py` re-run green.
- Regression: `run_random_tests.py 5` - 5/5 passed (12_scheduling, 16_caching, 17_multiple_identities, 2_memory, 6_knowledge).

## Behavior change from Phase 3a

Kept noise (e.g. `filter: off` sources) no longer runs LLM extraction - it is stored verbatim at Tier 1 and remains replayable through deeper tiers via the weekly re-synthesis. Set `tiers.enabled: false` to restore the old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
