### PR TITLE
docs: changelog entries for #257, #258

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -630,7 +630,20 @@ sandbox. No inner LLM loop, no orchestration, no new execution paths.
   ``failure_kind`` breakdown. Disable via ``skills.disable_builtin``;
   degrades like any scripted skill when no RCE is configured.
 
-### Fixes (#229, #231, #234, #235, #240, #241, #249)
+### Performance: local embeddings on macOS (#258)
+
+The CoreML execution provider is now off by default on macOS for the
+local ONNX embedding models -- partition negotiation cost far more than
+it saved (observed: e2e p50 retrieval latency dropped ~27%) -- and the
+classifier warmup halves its embed calls. Set
+``ONELLM_COREML_DISABLED=false`` to opt back in.
+
+### Fixes (#229, #231, #234, #235, #240, #241, #249, #257)
+
+- Pytest-based e2e tests no longer inherit the unit-test 60-second
+  pytest-timeout through rootdir discovery: ``e2e/pytest.ini`` now owns
+  e2e ceilings (360s, thread method) -- this was the real cause of the
+  "ONNX load timeout" failures in area 15 (#257).
 
 - Scheduler due-job queries are scoped to the owning formation:
   formations sharing one database no longer execute each other's


### PR DESCRIPTION
Adds the two entries that chip sessions skipped: the CoreML-off perf change (#258) and the e2e pytest-timeout root-cause fix (#257). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)