### PR TITLE
fix: scope database managers by connection string instead of process singleton

### DIFF
--- a/bench/memory/longitudinal_runner.py
+++ b/bench/memory/longitudinal_runner.py
@@ -27,9 +27,9 @@ Runs the four PRD Tier 3 scenarios against a real MUXI formation
 Every scenario is failure-isolated and writes its own report; the
 process exits nonzero when any scenario was partial or errored.
 Each scenario boots its own formation, and ``--scenario all`` runs
-one subprocess per scenario: the runtime's database manager is a
-process-level singleton, so two formations in one process would
-silently share the first run's (already removed) SQLite path.
+one subprocess per scenario for failure isolation and fresh process
+state (the runtime's database managers are keyed by connection
+string, so DB isolation itself no longer requires subprocesses).
 
 Usage
 -----
@@ -684,13 +684,12 @@ async def _run_scenario_subprocess(args: argparse.Namespace, key: str) -> Tuple[
 async def _run_all_scenarios(args: argparse.Namespace) -> int:
     """Run every scenario in its own subprocess (fresh formation each).
 
-    One subprocess per scenario because the runtime's database manager
-    is a process-level singleton keyed to the first connection string
-    it sees — a second formation in the same process would reuse the
-    first scenario's (already removed) run-local SQLite path. The
-    subprocesses run CONCURRENTLY (each has its own temp run dir and
-    report file); output is buffered per scenario and printed whole as
-    each finishes, so summaries never interleave.
+    One subprocess per scenario keeps scenarios failure-isolated with
+    fresh process state (the runtime's database managers are keyed by
+    connection string, so DB isolation alone no longer requires
+    subprocesses). The subprocesses run CONCURRENTLY (each has its own
+    temp run dir and report file); output is buffered per scenario and
+    printed whole as each finishes, so summaries never interleave.
     """
     tasks = [asyncio.create_task(_run_scenario_subprocess(args, key)) for key in SCENARIOS]
     exit_code = 0

--- a/src/muxi/runtime/services/db.py
+++ b/src/muxi/runtime/services/db.py
@@ -30,6 +30,40 @@ from . import observability
 Base = declarative_base()
 
 
+def _resolve_connection_string(connection_string: Optional[str]) -> str:
+    """
+    Resolve a connection string to its canonical form.
+
+    Explicit strings are returned as-is, except bare SQLite file paths
+    (e.g. "memory/muxi.db") which are normalized to "sqlite:///" URLs so
+    equivalent spellings resolve to the same registry key. When no string
+    is provided, falls back to environment variables and finally to a
+    SQLite database in the memory directory.
+
+    Returns:
+        str: The resolved database connection string.
+    """
+    if connection_string:
+        if "://" not in connection_string and connection_string.endswith(".db"):
+            return f"sqlite:///{connection_string}"
+        return connection_string
+
+    # Try environment variables
+    postgres_url = os.getenv("POSTGRES_DATABASE_URL")
+    if postgres_url:
+        return postgres_url
+
+    # Try SQLite environment variable
+    sqlite_path = os.getenv("SQLITE_DATABASE_PATH")
+    if sqlite_path:
+        return f"sqlite:///{sqlite_path}"
+
+    # Default to SQLite in memory directory
+    memory_dir = get_memory_dir()
+    default_path = f"{memory_dir}/muxi.db"
+    return f"sqlite:///{default_path}"
+
+
 class AsyncModelMixin:
     """
     Mixin class to add common async query helpers to SQLAlchemy models.
@@ -220,23 +254,7 @@ class DatabaseManager:
         Returns:
             str: The resolved database connection string.
         """
-        if connection_string:
-            return connection_string
-
-        # Try environment variables
-        postgres_url = os.getenv("POSTGRES_DATABASE_URL")
-        if postgres_url:
-            return postgres_url
-
-        # Try SQLite environment variable
-        sqlite_path = os.getenv("SQLITE_DATABASE_PATH")
-        if sqlite_path:
-            return f"sqlite:///{sqlite_path}"
-
-        # Default to SQLite in memory directory
-        memory_dir = get_memory_dir()
-        default_path = f"{memory_dir}/muxi.db"
-        return f"sqlite:///{default_path}"
+        return _resolve_connection_string(connection_string)
 
     def _detect_database_type(self, connection_string: str) -> str:
         """
@@ -572,74 +590,73 @@ class DatabaseManager:
                 pass
 
 
-# Global database manager instance (initialized on first use)
-_db_manager: Optional[DatabaseManager] = None
+# Database managers keyed by resolved connection string (initialized on first use).
+# Each formation resolves its own connection string, so managers are formation-scoped:
+# two formations loaded in one process get independent engines/paths, while the
+# components of a single formation (memory, scheduler, credentials) share one
+# manager and its connection pool.
+_db_managers: Dict[str, DatabaseManager] = {}
 
 
 def get_database_manager(
     connection_string: Optional[str] = None, statement_timeout_seconds: int = 30
 ) -> DatabaseManager:
     """
-    Get the global database manager instance (SINGLETON).
+    Get the shared database manager for a connection string.
 
-    **Important**: This function uses a module-level singleton. The FIRST call's parameters
-    are authoritative and will be used to initialize the DatabaseManager. Subsequent calls
-    with different parameters will be IGNORED and will return the existing instance.
-    A warning will be logged if parameters differ from the existing instance.
+    Managers are cached per resolved connection string, so repeated calls with
+    the same string (or with None, which resolves via environment variables or
+    the default SQLite path) return the same instance and share its connection
+    pool, while different connection strings get independent managers.
+
+    **Important**: The FIRST call for a given connection string is authoritative
+    for the remaining parameters. Subsequent calls for the same connection string
+    with a different statement_timeout_seconds will be IGNORED and will return
+    the existing instance; a warning is logged.
 
     Args:
-        connection_string: Optional connection string for initialization (only used on first call)
-        statement_timeout_seconds: Maximum time for individual SQL queries (default: 30, only used on first call)
+        connection_string: Optional connection string (None resolves via
+            environment variables or the default SQLite path)
+        statement_timeout_seconds: Maximum time for individual SQL queries
+            (default: 30, only used when creating the manager)
 
     Returns:
-        DatabaseManager instance (singleton)
+        DatabaseManager instance shared across callers using the same connection string
 
     Note:
-        If you need multiple DatabaseManager instances with different configurations,
-        create them directly using DatabaseManager() instead of this singleton function.
+        If you need a private DatabaseManager instance (e.g. with a different
+        timeout for an already-registered connection string), create it directly
+        using DatabaseManager() instead of this function.
     """
-    global _db_manager
+    key = _resolve_connection_string(connection_string)
+    db_manager = _db_managers.get(key)
 
-    if _db_manager is None:
-        _db_manager = DatabaseManager(connection_string, statement_timeout_seconds)
-    else:
-        # Check if parameters differ from existing instance and log warning
-        params_differ = False
-        differences = []
+    if db_manager is None:
+        db_manager = DatabaseManager(key, statement_timeout_seconds)
+        _db_managers[key] = db_manager
+    elif statement_timeout_seconds != db_manager.statement_timeout_seconds:
+        import logging
 
-        if connection_string is not None and connection_string != _db_manager.connection_string:
-            params_differ = True
-            differences.append(
-                f"connection_string (provided: {connection_string!r}, existing: {_db_manager.connection_string!r})"
-            )
+        logger = logging.getLogger(__name__)
+        logger.warning(
+            "get_database_manager called with different parameters than the existing "
+            "instance for this connection string. Using existing instance and IGNORING "
+            "new parameters. Differences: statement_timeout_seconds (provided: %s, existing: %s)",
+            statement_timeout_seconds,
+            db_manager.statement_timeout_seconds,
+        )
 
-        if statement_timeout_seconds != _db_manager.statement_timeout_seconds:
-            params_differ = True
-            differences.append(
-                f"statement_timeout_seconds (provided: {statement_timeout_seconds}, "
-                f"existing: {_db_manager.statement_timeout_seconds})"
-            )
-
-        if params_differ:
-            import logging
-
-            logger = logging.getLogger(__name__)
-            logger.warning(
-                "get_database_manager called with different parameters than existing instance. "
-                "Using existing instance and IGNORING new parameters. "
-                "Differences: %s",
-                ", ".join(differences),
-            )
-
-    return _db_manager
+    return db_manager
 
 
 def set_database_manager(db_manager: DatabaseManager) -> None:
     """
-    Set the global database manager instance.
+    Register a database manager for its connection string.
+
+    Subsequent get_database_manager() calls that resolve to the same
+    connection string return this instance.
 
     Args:
-        db_manager: DatabaseManager instance to set as global
+        db_manager: DatabaseManager instance to register
     """
-    global _db_manager
-    _db_manager = db_manager
+    _db_managers[db_manager.connection_string] = db_manager

--- a/src/muxi/runtime/services/db.py
+++ b/src/muxi/runtime/services/db.py
@@ -15,6 +15,7 @@ Key Features:
 """
 
 import os
+import threading
 from contextlib import asynccontextmanager
 from typing import Any, Dict, Optional
 from urllib.parse import urlparse
@@ -551,10 +552,19 @@ class DatabaseManager:
             )
             raise
 
+    def _evict_from_registry(self) -> None:
+        # A closed manager must not be served to future get_database_manager
+        # callers (its engines are disposed); evict only if the registry entry
+        # is this exact instance -- private managers are never registered.
+        with _db_managers_lock:
+            if _db_managers.get(self.connection_string) is self:
+                del _db_managers[self.connection_string]
+
     async def close_async(self) -> None:
         """
         Asynchronously disposes of the async database engine and releases associated resources.
         """
+        self._evict_from_registry()
         if self._async_engine is not None:
             await self._async_engine.dispose()
 
@@ -566,6 +576,7 @@ class DatabaseManager:
         based on the event loop state. In production, prefer using `close_async()`
         for asynchronous cleanup.
         """
+        self._evict_from_registry()
         if hasattr(self, "engine"):
             self.engine.dispose()
         if self._async_engine is not None:
@@ -596,6 +607,11 @@ class DatabaseManager:
 # components of a single formation (memory, scheduler, credentials) share one
 # manager and its connection pool.
 _db_managers: Dict[str, DatabaseManager] = {}
+
+# Guards the check-create-store sequence below: concurrent boot paths (e.g. two
+# formations loading on different threads) must not construct two managers for
+# the same connection string.
+_db_managers_lock = threading.Lock()
 
 
 def get_database_manager(
@@ -629,12 +645,14 @@ def get_database_manager(
         using DatabaseManager() instead of this function.
     """
     key = _resolve_connection_string(connection_string)
-    db_manager = _db_managers.get(key)
+    with _db_managers_lock:
+        db_manager = _db_managers.get(key)
+        if db_manager is None:
+            db_manager = DatabaseManager(key, statement_timeout_seconds)
+            _db_managers[key] = db_manager
+            return db_manager
 
-    if db_manager is None:
-        db_manager = DatabaseManager(key, statement_timeout_seconds)
-        _db_managers[key] = db_manager
-    elif statement_timeout_seconds != db_manager.statement_timeout_seconds:
+    if statement_timeout_seconds != db_manager.statement_timeout_seconds:
         import logging
 
         logger = logging.getLogger(__name__)
@@ -659,4 +677,5 @@ def set_database_manager(db_manager: DatabaseManager) -> None:
     Args:
         db_manager: DatabaseManager instance to register
     """
-    _db_managers[db_manager.connection_string] = db_manager
+    with _db_managers_lock:
+        _db_managers[db_manager.connection_string] = db_manager

--- a/tests/unit/test_db_manager_registry.py
+++ b/tests/unit/test_db_manager_registry.py
@@ -1,0 +1,85 @@
+"""Tests for the connection-string-keyed database manager registry.
+
+The database manager used to be a process-level singleton: the first
+get_database_manager() call pinned the connection string for the whole
+process, so a second formation loaded in the same process silently
+shared the first formation's SQLite path. The registry keys managers by
+resolved connection string, so formations get isolated databases while
+callers sharing a connection string still share one engine and pool.
+"""
+
+import pytest
+from sqlalchemy import text
+
+from muxi.runtime.services import db as db_module
+from muxi.runtime.services.db import (
+    DatabaseManager,
+    get_database_manager,
+    set_database_manager,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_registry(monkeypatch):
+    """Isolate each test's registry and DB-related environment."""
+    monkeypatch.setattr(db_module, "_db_managers", {})
+    monkeypatch.delenv("POSTGRES_DATABASE_URL", raising=False)
+    monkeypatch.delenv("SQLITE_DATABASE_PATH", raising=False)
+
+
+class TestFormationScopedManagers:
+    def test_two_formations_get_isolated_databases(self, tmp_path):
+        """Two formations loaded in one process must not share a database."""
+        first = get_database_manager(f"sqlite:///{tmp_path}/formation_a.db")
+        second = get_database_manager(f"sqlite:///{tmp_path}/formation_b.db")
+
+        assert first is not second
+        assert first.connection_string != second.connection_string
+
+        with first.engine.connect() as conn:
+            conn.execute(text("CREATE TABLE marker (id INTEGER PRIMARY KEY)"))
+            conn.execute(text("INSERT INTO marker (id) VALUES (1)"))
+            conn.commit()
+
+        with second.engine.connect() as conn:
+            tables = conn.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table' AND name='marker'")
+            ).fetchall()
+        assert tables == []
+
+    def test_same_connection_string_shares_manager(self, tmp_path):
+        """Repeated calls for one connection string share the engine/pool."""
+        connection_string = f"sqlite:///{tmp_path}/formation.db"
+        assert get_database_manager(connection_string) is get_database_manager(connection_string)
+
+    def test_bare_db_path_normalized_to_sqlite_url(self, tmp_path):
+        """A bare .db path and its sqlite:/// spelling resolve to one manager."""
+        path = f"{tmp_path}/formation.db"
+        prefixed = get_database_manager(f"sqlite:///{path}")
+        bare = get_database_manager(path)
+        assert bare is prefixed
+
+    def test_default_resolution_is_stable(self, tmp_path, monkeypatch):
+        """No-arg calls (env/default resolution) keep returning one manager."""
+        monkeypatch.setenv("SQLITE_DATABASE_PATH", f"{tmp_path}/default.db")
+        assert get_database_manager() is get_database_manager()
+
+    def test_default_and_explicit_same_path_share_manager(self, tmp_path, monkeypatch):
+        """Env-resolved and explicit connection strings share one manager."""
+        monkeypatch.setenv("SQLITE_DATABASE_PATH", f"{tmp_path}/default.db")
+        explicit = get_database_manager(f"sqlite:///{tmp_path}/default.db")
+        assert get_database_manager() is explicit
+
+    def test_timeout_ignored_for_existing_manager(self, tmp_path):
+        """First call's timeout is authoritative for a connection string."""
+        connection_string = f"sqlite:///{tmp_path}/formation.db"
+        first = get_database_manager(connection_string, statement_timeout_seconds=30)
+        second = get_database_manager(connection_string, statement_timeout_seconds=60)
+        assert second is first
+        assert second.statement_timeout_seconds == 30
+
+    def test_set_database_manager_registers_by_connection_string(self, tmp_path):
+        connection_string = f"sqlite:///{tmp_path}/formation.db"
+        manager = DatabaseManager(connection_string)
+        set_database_manager(manager)
+        assert get_database_manager(connection_string) is manager

--- a/tests/unit/test_db_manager_registry.py
+++ b/tests/unit/test_db_manager_registry.py
@@ -83,3 +83,54 @@ class TestFormationScopedManagers:
         manager = DatabaseManager(connection_string)
         set_database_manager(manager)
         assert get_database_manager(connection_string) is manager
+
+
+class TestRegistryHardening:
+    """Review follow-ups: lock around check-create-store, eviction on close."""
+
+    def test_concurrent_get_returns_single_instance(self, tmp_path):
+        import threading as _t
+
+        from muxi.runtime.services import db as db_mod
+
+        conn = f"sqlite:///{tmp_path}/reg.db"
+        results = []
+        barrier = _t.Barrier(8)
+
+        def grab():
+            barrier.wait()
+            results.append(db_mod.get_database_manager(conn))
+
+        threads = [_t.Thread(target=grab) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        try:
+            assert len({id(m) for m in results}) == 1
+        finally:
+            results[0].close()
+
+    def test_close_evicts_from_registry(self, tmp_path):
+        from muxi.runtime.services import db as db_mod
+
+        conn = f"sqlite:///{tmp_path}/evict.db"
+        first = db_mod.get_database_manager(conn)
+        first.close()
+        second = db_mod.get_database_manager(conn)
+        try:
+            assert second is not first
+        finally:
+            second.close()
+
+    def test_close_does_not_evict_foreign_instance(self, tmp_path):
+        from muxi.runtime.services import db as db_mod
+
+        conn = f"sqlite:///{tmp_path}/foreign.db"
+        registered = db_mod.get_database_manager(conn)
+        private = db_mod.DatabaseManager(registered.connection_string, 30)
+        private.close()
+        try:
+            assert db_mod.get_database_manager(conn) is registered
+        finally:
+            registered.close()


### PR DESCRIPTION
## Summary

`get_database_manager()` was a process-level singleton: the first call pinned the connection string for the whole process, so a second formation loaded in the same process silently shared the first formation's SQLite path/connection (discovered by `bench/memory/longitudinal_runner.py`, which worked around it by spawning one subprocess per scenario).

This PR makes managers formation-scoped by caching `DatabaseManager` instances per **resolved connection string**:

- Two formations in one process now get isolated databases — the legitimate embedded/framework pattern of loading multiple formations per process works, and test isolation improves.
- Single-formation behavior is preserved: all components of one formation (memory, scheduler, credentials) resolve to the same connection string and share one manager and its connection pool. Repeated no-arg calls (env/default resolution) keep returning the same instance.
- Bare `.db` paths are normalized to `sqlite:///` URLs so equivalent spellings (the formation-level and overlord-level init paths spell them differently) resolve to one manager.
- The first call for a given connection string stays authoritative for `statement_timeout_seconds`; differing later calls log a warning, as before.
- `set_database_manager()` now registers by the manager's connection string.
- Updated the longitudinal bench runner comments that documented the singleton (subprocess-per-scenario is kept for failure isolation and concurrency).

## Testing

- New unit tests in `tests/unit/test_db_manager_registry.py`: two formations in one process get isolated DBs (cross-manager write visibility checked), same-connection-string sharing, bare-path normalization, stable default resolution, timeout-ignored warning path, and `set_database_manager` registration.
- Full unit suite: 3364 passed, 10 skipped.
- e2e: `run_random_tests.py 5` — 4/5 passed; the one failure (`19_api/test_19x2_group_permissions.py`) was missing gitignored `.key` provisioning in a fresh worktree (fails inside SecretsManager before any DB code runs) and passes after linking the formation keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)