### PR TITLE
fix: harden substrate admin paths — chunked locks, async forget, backfill resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [unreleased]
 
+### Fixes
+
+- Hardened the memory event substrate's operational paths (#259 review
+  follow-ups): `project_pending` now applies events in bounded chunks
+  (`memory.projections.batch_size`, default 500) per projection-lock
+  acquisition, releasing the lock between chunks so long catch-up
+  batches never stall concurrent event-first writers (checkpoint per
+  chunk; no event skipped or re-applied across chunk boundaries, crash
+  between chunks resumes at the last boundary); the GDPR
+  `POST /memory/forget` endpoint now runs its projection rebuild as a
+  tracked background job by default (202 + `job_id` pollable at
+  `GET /memory/forget/{job_id}`; the soft delete still runs inline,
+  `background: false` or `?sync=true` keeps the blocking behavior); and
+  the legacy backfill's silent 100,000-row ceiling became a documented
+  per-pass bound with persisted resume cursors - tables of any size
+  backfill across multiple passes, and the report now returns
+  `{"synthesized": n, "complete": bool}` per projection so operators
+  know when another pass is needed.
+
 ### Memory ingestion maturation - tier heuristics, entity resolution, synthesis cadences
 
 Completes the memory-ingestion PRD's remaining scope on top of the

--- a/e2e/tests/2_memory/test_2s2_provenance_and_rebuild.py
+++ b/e2e/tests/2_memory/test_2s2_provenance_and_rebuild.py
@@ -223,14 +223,16 @@ class TestMemoryProvenanceAndRebuild(BaseMemoryTest):
                 effective_user_id, "company", "LegacyCorp"
             )
             legacy_events = await memory_events.list_events(effective_user_id, source="legacy")
+            kg_backfill = backfill_report.get("knowledge_graph") or {}
             if (
-                backfill_report.get("knowledge_graph", 0) >= 1
+                kg_backfill.get("synthesized", 0) >= 1
+                and kg_backfill.get("complete") is True
                 and stamped["derived_from_event_ids"]
                 and legacy_events
             ):
                 print(
-                    f"  ✓ Backfill synthesized {backfill_report['knowledge_graph']} legacy "
-                    "event(s) and stamped provenance in place"
+                    f"  ✓ Backfill synthesized {kg_backfill['synthesized']} legacy "
+                    "event(s) (complete pass) and stamped provenance in place"
                 )
                 checks_passed.append("Backfill synthesizes legacy events")
             else:

--- a/src/muxi/runtime/formation/server/routes/admin/memory.py
+++ b/src/muxi/runtime/formation/server/routes/admin/memory.py
@@ -68,17 +68,22 @@ class MemoryForgetRequest(BaseModel):
 
     Soft-deletes every live memory event from ``source`` for the user and
     records the user.deletion audit event. With ``rebuild`` (default
-    True) the projections are recomputed immediately, so derived state
-    reflects the forgetting; otherwise the events stay excluded from any
-    later rebuild. Soft-deleted events are reversible until the
-    retention grace period elapses and the hard-purge worker removes
-    them.
+    True) the projections are recomputed so derived state reflects the
+    forgetting; otherwise the events stay excluded from any later
+    rebuild. ``background`` (default True) runs that rebuild as a
+    tracked background job (202 + ``job_id`` pollable at GET
+    /memory/forget/{job_id}) so large users never block the admin call;
+    ``background: false`` -- or the ``?sync=true`` query escape hatch --
+    blocks until the rebuild finishes and returns the report inline.
+    Soft-deleted events are reversible until the retention grace period
+    elapses and the hard-purge worker removes them.
     """
 
     user_id: str
     source: str
     reason: str = "user_request"
     rebuild: bool = True
+    background: bool = True
 
 
 @router.get("/memory", response_model=APIResponse)
@@ -207,6 +212,70 @@ async def _run_memory_job(memory_events, job: MemoryRebuildRequest) -> Dict[str,
     return data
 
 
+async def _start_tracked_job(overlord, prefix: str, user_id: str, runner) -> str:
+    """Track and launch one background admin job; returns its job id.
+
+    ``runner`` is an argless coroutine function producing the job's
+    result dict. The job is registered with the overlord's request
+    tracker (the same lifecycle chat requests use), so it survives for
+    polling after completion and its task can be cancelled on shutdown.
+    """
+    import asyncio
+    import time
+
+    from .....utils.id_generator import get_default_nanoid
+    from ....background.request_tracker import RequestState, RequestStatus
+
+    job_id = f"{prefix}_{get_default_nanoid()}"
+    tracker = overlord.request_tracker
+    state = RequestState(
+        id=job_id,
+        status=RequestStatus.PROCESSING,
+        start_time=time.time(),
+        user_id=user_id,
+    )
+    await tracker.track_request(job_id, state)
+
+    async def _job():
+        try:
+            result = await runner()
+            await tracker.update_request(job_id, status=RequestStatus.COMPLETED, result=result)
+        except Exception as e:
+            await tracker.update_request(job_id, status=RequestStatus.FAILED, error=str(e))
+
+    state.task_ref = asyncio.create_task(_job())
+    return job_id
+
+
+async def _job_status_response(request: Request, job_id: str, kind: str) -> JSONResponse:
+    """Shared poll handler for background memory jobs (rebuild / forget)."""
+    request_id = getattr(request.state, "request_id", None)
+    formation = request.app.state.formation
+    overlord = getattr(formation, "_overlord", None)
+    if overlord is None:
+        response = create_error_response(
+            "SERVICE_UNAVAILABLE", "Overlord service is not available", None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=503)
+
+    state = await overlord.request_tracker.get_request(job_id)
+    if state is None:
+        response = create_error_response(
+            "NOT_FOUND", f"Unknown or expired {kind} job '{job_id}'", None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=404)
+
+    data: Dict[str, Any] = {"job_id": job_id, "status": state.status.value}
+    if state.error:
+        data["error"] = state.error
+    if isinstance(state.result, dict):
+        data.update(state.result)
+    response = create_success_response(
+        APIObjectType.MEMORY, APIEventType.MEMORY_RETRIEVED, data, request_id
+    )
+    return JSONResponse(content=response.model_dump(), status_code=200)
+
+
 @router.post("/memory/rebuild", response_model=APIResponse, operation_id="rebuild_memory")
 async def rebuild_memory_projections(
     request: Request, rebuild: MemoryRebuildRequest
@@ -240,30 +309,11 @@ async def rebuild_memory_projections(
         return JSONResponse(content=response.model_dump(), status_code=422)
 
     if rebuild.background and not rebuild.dry_run:
-        import asyncio
-        import time
 
-        from .....utils.id_generator import get_default_nanoid
-        from ....background.request_tracker import RequestState, RequestStatus
+        async def _runner():
+            return await _run_memory_job(memory_events, rebuild)
 
-        job_id = f"rebuild_{get_default_nanoid()}"
-        tracker = overlord.request_tracker
-        state = RequestState(
-            id=job_id,
-            status=RequestStatus.PROCESSING,
-            start_time=time.time(),
-            user_id=rebuild.user_id,
-        )
-        await tracker.track_request(job_id, state)
-
-        async def _job():
-            try:
-                result = await _run_memory_job(memory_events, rebuild)
-                await tracker.update_request(job_id, status=RequestStatus.COMPLETED, result=result)
-            except Exception as e:
-                await tracker.update_request(job_id, status=RequestStatus.FAILED, error=str(e))
-
-        state.task_ref = asyncio.create_task(_job())
+        job_id = await _start_tracked_job(overlord, "rebuild", rebuild.user_id, _runner)
         data = {
             "user_id": rebuild.user_id,
             "job_id": job_id,
@@ -345,31 +395,17 @@ async def lint_memory(request: Request, lint: MemoryLintRequest) -> JSONResponse
 )
 async def get_memory_rebuild_status(request: Request, job_id: str) -> JSONResponse:
     """Poll a background memory rebuild job (completed reports attached)."""
-    request_id = getattr(request.state, "request_id", None)
-    formation = request.app.state.formation
-    overlord = getattr(formation, "_overlord", None)
-    if overlord is None:
-        response = create_error_response(
-            "SERVICE_UNAVAILABLE", "Overlord service is not available", None, request_id
-        )
-        return JSONResponse(content=response.model_dump(), status_code=503)
+    return await _job_status_response(request, job_id, "rebuild")
 
-    state = await overlord.request_tracker.get_request(job_id)
-    if state is None:
-        response = create_error_response(
-            "NOT_FOUND", f"Unknown or expired rebuild job '{job_id}'", None, request_id
-        )
-        return JSONResponse(content=response.model_dump(), status_code=404)
 
-    data: Dict[str, Any] = {"job_id": job_id, "status": state.status.value}
-    if state.error:
-        data["error"] = state.error
-    if isinstance(state.result, dict):
-        data.update(state.result)
-    response = create_success_response(
-        APIObjectType.MEMORY, APIEventType.MEMORY_RETRIEVED, data, request_id
-    )
-    return JSONResponse(content=response.model_dump(), status_code=200)
+@router.get(
+    "/memory/forget/{job_id}",
+    response_model=APIResponse,
+    operation_id="get_memory_forget_status",
+)
+async def get_memory_forget_status(request: Request, job_id: str) -> JSONResponse:
+    """Poll a background memory forget job (rebuild report attached)."""
+    return await _job_status_response(request, job_id, "forget")
 
 
 @router.post("/memory/backfill", response_model=APIResponse, operation_id="backfill_memory")
@@ -383,6 +419,12 @@ async def backfill_memory_events(request: Request, backfill: MemoryBackfillReque
     stamped in place; flat-fact rows become provenance-complete on the
     next rebuild (POST /memory/rebuild with ``backfill: true`` does both
     in one call).
+
+    BOUNDED PER PASS: each projection scans at most
+    BACKFILL_MAX_ROWS_PER_PASS rows per table per call, persisting a
+    resume cursor between passes. A projection reporting ``complete:
+    false`` still has unscanned rows -- call again until every
+    projection reports ``complete: true``.
     """
     request_id = getattr(request.state, "request_id", None)
     memory_events, _overlord, error_response = _memory_events_or_error(request, request_id)
@@ -408,7 +450,9 @@ async def backfill_memory_events(request: Request, backfill: MemoryBackfillReque
 
 
 @router.post("/memory/forget", response_model=APIResponse, operation_id="forget_memory_source")
-async def forget_memory_source(request: Request, forget: MemoryForgetRequest) -> JSONResponse:
+async def forget_memory_source(
+    request: Request, forget: MemoryForgetRequest, sync: bool = False
+) -> JSONResponse:
     """
     Forget every memory derived from a source (GDPR / selective forgetting).
 
@@ -417,9 +461,16 @@ async def forget_memory_source(request: Request, forget: MemoryForgetRequest) ->
     removes them permanently), records the user.deletion audit event,
     and -- unless ``rebuild: false`` -- recomputes the projections so
     derived state reflects a world where the source was never imported.
+
+    The soft delete itself always runs inline (the response carries
+    ``deleted_events``). The rebuild runs as a tracked background job by
+    default (202 + ``job_id`` pollable at GET /memory/forget/{job_id})
+    so large users never block the admin call; ``background: false`` in
+    the body or ``?sync=true`` on the query blocks until the rebuild
+    finishes and returns the projection report inline.
     """
     request_id = getattr(request.state, "request_id", None)
-    memory_events, _overlord, error_response = _memory_events_or_error(request, request_id)
+    memory_events, overlord, error_response = _memory_events_or_error(request, request_id)
     if error_response:
         return error_response
 
@@ -433,10 +484,27 @@ async def forget_memory_source(request: Request, forget: MemoryForgetRequest) ->
             "deleted_events": result["deleted_events"],
             "grace_period_days": memory_events.grace_period_days,
         }
-        if forget.rebuild:
-            data["projections"] = await memory_events.rebuild(forget.user_id)
-        else:
+        if not forget.rebuild:
             data["rebuild_required"] = result["rebuild_required"]
+        elif forget.background and not sync:
+
+            async def _runner():
+                return {"projections": await memory_events.rebuild(forget.user_id)}
+
+            job_id = await _start_tracked_job(overlord, "forget", forget.user_id, _runner)
+            data.update(
+                {
+                    "job_id": job_id,
+                    "status": "processing",
+                    "status_url": f"/memory/forget/{job_id}",
+                }
+            )
+            response = create_success_response(
+                APIObjectType.MEMORY, APIEventType.MEMORY_DELETED, data, request_id
+            )
+            return JSONResponse(content=response.model_dump(), status_code=202)
+        else:
+            data["projections"] = await memory_events.rebuild(forget.user_id)
     except ValueError as e:
         response = create_error_response("INVALID_PARAMS", str(e), None, request_id)
         return JSONResponse(content=response.model_dump(), status_code=422)

--- a/src/muxi/runtime/formation/server/routes/admin/memory.py
+++ b/src/muxi/runtime/formation/server/routes/admin/memory.py
@@ -5,6 +5,8 @@ These endpoints provide memory configuration and buffer management,
 requiring admin API key authentication.
 """
 
+import asyncio
+import time
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Request
@@ -13,6 +15,8 @@ from pydantic import BaseModel
 
 from .....datatypes.api import APIEventType, APIObjectType
 from .....services import observability
+from .....utils.id_generator import get_default_nanoid
+from ....background.request_tracker import RequestState, RequestStatus
 from ...responses import (
     APIResponse,
     create_error_response,
@@ -218,14 +222,11 @@ async def _start_tracked_job(overlord, prefix: str, user_id: str, runner) -> str
     ``runner`` is an argless coroutine function producing the job's
     result dict. The job is registered with the overlord's request
     tracker (the same lifecycle chat requests use), so it survives for
-    polling after completion and its task can be cancelled on shutdown.
+    polling after completion and its task can be cancelled on shutdown
+    -- cancellation marks the job CANCELLED (terminal) before
+    re-raising, so a graceful shutdown never strands a poller on a job
+    stuck at PROCESSING.
     """
-    import asyncio
-    import time
-
-    from .....utils.id_generator import get_default_nanoid
-    from ....background.request_tracker import RequestState, RequestStatus
-
     job_id = f"{prefix}_{get_default_nanoid()}"
     tracker = overlord.request_tracker
     state = RequestState(
@@ -240,6 +241,11 @@ async def _start_tracked_job(overlord, prefix: str, user_id: str, runner) -> str
         try:
             result = await runner()
             await tracker.update_request(job_id, status=RequestStatus.COMPLETED, result=result)
+        except asyncio.CancelledError:
+            await tracker.update_request(
+                job_id, status=RequestStatus.CANCELLED, error="job cancelled"
+            )
+            raise
         except Exception as e:
             await tracker.update_request(job_id, status=RequestStatus.FAILED, error=str(e))
 
@@ -317,7 +323,7 @@ async def rebuild_memory_projections(
         data = {
             "user_id": rebuild.user_id,
             "job_id": job_id,
-            "status": "processing",
+            "status": RequestStatus.PROCESSING.value,
             "status_url": f"/memory/rebuild/{job_id}",
         }
         response = create_success_response(
@@ -495,7 +501,7 @@ async def forget_memory_source(
             data.update(
                 {
                     "job_id": job_id,
-                    "status": "processing",
+                    "status": RequestStatus.PROCESSING.value,
                     "status_url": f"/memory/forget/{job_id}",
                 }
             )

--- a/src/muxi/runtime/services/memory/artifacts/storage.py
+++ b/src/muxi/runtime/services/memory/artifacts/storage.py
@@ -264,12 +264,16 @@ class ArtifactMemoryStorage:
         include_deleted: bool = False,
         limit: Optional[int] = None,
         order_by_last_accessed: bool = False,
+        after_id: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """List a user's artifacts, newest first.
 
         ``order_by_last_accessed`` switches to the manifest ordering
         (PRD 2.1: ``last_accessed_at DESC``); ``limit`` caps the fetch so
         the manifest never pulls a user's entire artifact history.
+        ``after_id`` switches to keyset pagination -- rows with id greater
+        than the cursor, oldest first (the legacy backfill's stable
+        multi-pass scan ordering).
         """
         async with self.db_manager.get_async_session() as session:
             stmt = select(Artifact).filter_by(user_id=str(user_id), formation_id=self.formation_id)
@@ -279,7 +283,9 @@ class ArtifactMemoryStorage:
                 stmt = stmt.filter_by(is_latest=True)
             if not include_deleted:
                 stmt = stmt.filter(Artifact.deleted_at.is_(None))
-            if order_by_last_accessed:
+            if after_id is not None:
+                stmt = stmt.filter(Artifact.id > after_id).order_by(Artifact.id.asc())
+            elif order_by_last_accessed:
                 stmt = stmt.order_by(Artifact.last_accessed_at.desc(), Artifact.id.desc())
             else:
                 stmt = stmt.order_by(Artifact.id.desc())

--- a/src/muxi/runtime/services/memory/events/projectors.py
+++ b/src/muxi/runtime/services/memory/events/projectors.py
@@ -27,6 +27,14 @@
 # events carry source='legacy' with a per-row source_id, so the backfill is
 # idempotent through the substrate's own (source, source_id) key.
 #
+# BACKFILL IS BOUNDED PER PASS: each backfill call scans at most
+# ``BACKFILL_MAX_ROWS_PER_PASS`` rows per table and persists a resume
+# cursor (a ``projection_checkpoints`` row named ``backfill/...``) when it
+# stops short. Legacy tables larger than the bound need multiple passes:
+# keep calling ``backfill_user`` until every projection reports
+# ``complete: true``. A completed pass clears its cursors so a later
+# re-run scans from the start again (idempotent through per-row keys).
+#
 # Extensibility: adding a projection (e.g. the deferred Knowledge Index) is
 # a new class with these members plus a service.register_projector call --
 # no schema changes to the event log.
@@ -51,6 +59,42 @@ from .models import (
 # (the provenance bridge for the vector projection, which has no dedicated
 # derived_from column -- metadata is its extension point).
 FACT_EVENT_METADATA_KEY = "derived_from_event_id"
+
+# ---------------------------------------------------------------------------
+# LOUD BOUND: legacy backfill scans at most this many rows PER TABLE PER
+# PASS. One ``backfill_user`` call is NOT guaranteed to cover a legacy
+# table larger than this -- it persists a resume cursor and reports
+# ``complete: false``; run additional passes until ``complete: true``.
+# Overridable per projector instance via ``backfill_batch_rows`` (tests).
+# ---------------------------------------------------------------------------
+BACKFILL_MAX_ROWS_PER_PASS = 100_000
+
+
+async def _backfill_cursor(event_service, cursor_name: str, user_id: str) -> int:
+    """Read a persisted backfill resume cursor (0 = scan from the start).
+
+    Backfill cursors reuse the ``projection_checkpoints`` table exactly
+    like projection cursors, under reserved ``backfill/...`` names;
+    ``last_event_id`` holds the scan position (a projection row id, or a
+    row offset for the flat-fact projection) rather than an event id.
+    """
+    checkpoint = await event_service.storage.get_checkpoint(cursor_name, user_id)
+    return checkpoint["last_event_id"] if checkpoint else 0
+
+
+async def _save_backfill_cursor(
+    event_service, cursor_name: str, user_id: str, position: int, complete: bool
+) -> None:
+    """Persist (or, on a completed scan, clear) a backfill resume cursor.
+
+    Clearing on completion restores the historical semantics for small
+    tables: a later backfill run re-scans everything and skips rows that
+    already carry provenance or an idempotent (source, source_id) event.
+    """
+    if complete:
+        await event_service.storage.reset_checkpoint(cursor_name, user_id)
+    else:
+        await event_service.storage.set_checkpoint(cursor_name, user_id, last_event_id=position)
 
 
 def event_scope(event: Dict[str, Any]) -> Optional[Tuple[str, str]]:
@@ -150,7 +194,9 @@ class KnowledgeGraphProjector:
         await self.service.storage.delete_all_for_user(user_id)
         self.service.algorithms.invalidate(str(user_id))
 
-    async def backfill(self, user_id: str, event_service) -> int:
+    backfill_batch_rows = BACKFILL_MAX_ROWS_PER_PASS
+
+    async def backfill(self, user_id: str, event_service) -> Dict[str, Any]:
         """Synthesize graph.extracted events for pre-event-log rows.
 
         One event per entity/relationship without provenance, keyed
@@ -158,14 +204,20 @@ class KnowledgeGraphProjector:
         dated to the row's creation. Each synthetic event is applied
         immediately: the upsert merges into the existing row (a no-op for
         content) and stamps its ``derived_from_event_ids`` bridge.
-        Returns the number of events synthesized.
+
+        Bounded per pass (BACKFILL_MAX_ROWS_PER_PASS rows per table);
+        resume cursors persist under ``backfill/knowledge_graph/*``.
+        Returns {"synthesized": n, "complete": bool}.
         """
         user_id = str(user_id)
         storage = self.service.storage
+        limit = self.backfill_batch_rows
         synthesized = 0
 
-        entities = await storage.list_entities(user_id, status=None, limit=100000)
-        names = {entity["id"]: entity for entity in entities}
+        entity_cursor_name = "backfill/knowledge_graph/entities"
+        cursor = await _backfill_cursor(event_service, entity_cursor_name, user_id)
+        entities = await storage.list_entities(user_id, status=None, limit=limit, after_id=cursor)
+        entities_complete = len(entities) < limit
         for entity in entities:
             if entity["derived_from_event_ids"]:
                 continue
@@ -191,8 +243,24 @@ class KnowledgeGraphProjector:
                 continue
             await self.apply({"user_id": user_id, "id": event["id"], "payload": event["payload"]})
             synthesized += 1
+        await _save_backfill_cursor(
+            event_service,
+            entity_cursor_name,
+            user_id,
+            entities[-1]["id"] if entities else cursor,
+            entities_complete,
+        )
 
-        for rel in await storage.list_relationships(user_id, status=None, limit=100000):
+        rel_cursor_name = "backfill/knowledge_graph/relationships"
+        cursor = await _backfill_cursor(event_service, rel_cursor_name, user_id)
+        relationships = await storage.list_relationships(
+            user_id, status=None, limit=limit, after_id=cursor
+        )
+        relationships_complete = len(relationships) < limit
+        endpoint_ids = {rel["from_entity_id"] for rel in relationships}
+        endpoint_ids.update(rel["to_entity_id"] for rel in relationships)
+        names = {entity["id"]: entity for entity in await storage.get_entities_by_ids(endpoint_ids)}
+        for rel in relationships:
             if rel["derived_from_event_ids"]:
                 continue
             from_entity = names.get(rel["from_entity_id"])
@@ -224,7 +292,17 @@ class KnowledgeGraphProjector:
                 continue
             await self.apply({"user_id": user_id, "id": event["id"], "payload": event["payload"]})
             synthesized += 1
-        return synthesized
+        await _save_backfill_cursor(
+            event_service,
+            rel_cursor_name,
+            user_id,
+            relationships[-1]["id"] if relationships else cursor,
+            relationships_complete,
+        )
+        return {
+            "synthesized": synthesized,
+            "complete": entities_complete and relationships_complete,
+        }
 
 
 class CaptainsLogProjector:
@@ -261,20 +339,28 @@ class CaptainsLogProjector:
         await self.service.lessons.delete_all_for_user(user_id)
         await self.service.storage.delete_all_for_user(user_id)
 
-    async def backfill(self, user_id: str, event_service) -> int:
+    backfill_batch_rows = BACKFILL_MAX_ROWS_PER_PASS
+
+    async def backfill(self, user_id: str, event_service) -> Dict[str, Any]:
         """Synthesize log.entry / lesson.recorded events for legacy rows.
 
         Entries are keyed ``legacy/captains_log/<public_id>``, lessons
         ``legacy/lesson/<public_id>``; both dated to the row's creation
-        and applied immediately to stamp provenance. Returns the number
-        of events synthesized.
+        and applied immediately to stamp provenance.
+
+        Bounded per pass (BACKFILL_MAX_ROWS_PER_PASS rows per table);
+        resume cursors persist under ``backfill/captains_log/*``.
+        Returns {"synthesized": n, "complete": bool}.
         """
         user_id = str(user_id)
+        limit = self.backfill_batch_rows
         synthesized = 0
 
-        entries = await self.service.storage.list_entries(user_id, limit=100000)
+        entry_cursor_name = "backfill/captains_log/entries"
+        cursor = await _backfill_cursor(event_service, entry_cursor_name, user_id)
+        entries = await self.service.storage.list_entries(user_id, limit=limit, after_id=cursor)
+        entries_complete = len(entries) < limit
         sources = await self.service.storage.get_sources_for_logs([e["id"] for e in entries])
-        dates_by_id = {entry["id"]: entry["date"] for entry in entries}
         for entry in entries:
             if entry["derived_from_event_ids"]:
                 continue
@@ -307,8 +393,24 @@ class CaptainsLogProjector:
                 }
             )
             synthesized += 1
+        await _save_backfill_cursor(
+            event_service,
+            entry_cursor_name,
+            user_id,
+            entries[-1]["id"] if entries else cursor,
+            entries_complete,
+        )
 
-        for lesson in await self.service.lessons.list_all_for_user(user_id):
+        lesson_cursor_name = "backfill/captains_log/lessons"
+        cursor = await _backfill_cursor(event_service, lesson_cursor_name, user_id)
+        lessons = await self.service.lessons.list_all_for_user(
+            user_id, limit=limit, after_id=cursor
+        )
+        lessons_complete = len(lessons) < limit
+        dates_by_id = await self.service.storage.get_entry_dates(
+            {lesson["source_log_id"] for lesson in lessons}
+        )
+        for lesson in lessons:
             if lesson["derived_from_event_ids"]:
                 continue
             event = await event_service.record(
@@ -336,7 +438,14 @@ class CaptainsLogProjector:
                 }
             )
             synthesized += 1
-        return synthesized
+        await _save_backfill_cursor(
+            event_service,
+            lesson_cursor_name,
+            user_id,
+            lessons[-1]["id"] if lessons else cursor,
+            lessons_complete,
+        )
+        return {"synthesized": synthesized, "complete": entries_complete and lessons_complete}
 
 
 class FlatFactProjector:
@@ -376,7 +485,9 @@ class FlatFactProjector:
         """
         return await self.long_term_memory.delete_extracted_memories(str(user_id))
 
-    async def backfill(self, user_id: str, event_service) -> int:
+    backfill_batch_rows = BACKFILL_MAX_ROWS_PER_PASS
+
+    async def backfill(self, user_id: str, event_service) -> Dict[str, Any]:
         """Synthesize fact.extracted events for pre-event-log extraction rows.
 
         Keyed ``legacy/memory/<row id>``, dated to the row's creation. The
@@ -384,11 +495,23 @@ class FlatFactProjector:
         does not upsert, so applying would duplicate them); the provenance
         bridge lands on the next rebuild, whose reset already wipes
         extraction rows and whose replay recreates them from these events.
-        Returns the number of events synthesized.
+
+        Bounded per pass (BACKFILL_MAX_ROWS_PER_PASS rows). Because the
+        rows stay orphaned until the next rebuild, the resume cursor is a
+        row OFFSET into the stable orphan listing, persisted under
+        ``backfill/flat_facts/memories``.
+        Returns {"synthesized": n, "complete": bool}.
         """
         user_id = str(user_id)
+        limit = self.backfill_batch_rows
+        cursor_name = "backfill/flat_facts/memories"
+        offset = await _backfill_cursor(event_service, cursor_name, user_id)
+        rows = await self.long_term_memory.list_extracted_orphan_memories(
+            user_id, limit=limit, offset=offset
+        )
+        complete = len(rows) < limit
         synthesized = 0
-        for row in await self.long_term_memory.list_extracted_orphan_memories(user_id):
+        for row in rows:
             source_id = f"legacy/memory/{row['id']}"
             # The row stays orphaned until the next rebuild stamps it, so
             # a re-run sees it again -- the per-row idempotency key keeps
@@ -417,7 +540,10 @@ class FlatFactProjector:
             )
             if event is not None:
                 synthesized += 1
-        return synthesized
+        await _save_backfill_cursor(
+            event_service, cursor_name, user_id, offset + len(rows), complete
+        )
+        return {"synthesized": synthesized, "complete": complete}
 
 
 class ArtifactMetadataProjector:
@@ -489,19 +615,30 @@ class ArtifactMetadataProjector:
         """
         return await self.service.storage.delete_event_sourced_for_user(str(user_id))
 
-    async def backfill(self, user_id: str, event_service) -> int:
+    backfill_batch_rows = BACKFILL_MAX_ROWS_PER_PASS
+
+    async def backfill(self, user_id: str, event_service) -> Dict[str, Any]:
         """Synthesize artifact.saved events for pre-substrate metadata rows.
 
         Uses the live capture path's ``artifact/<public_id>`` idempotency
         key, so rows that already have an audit event reuse it instead of
         duplicating; either way the row is stamped with its provenance
-        bridge. Returns the number of rows stamped.
+        bridge.
+
+        Bounded per pass (BACKFILL_MAX_ROWS_PER_PASS rows); the resume
+        cursor persists under ``backfill/artifact_metadata/artifacts``.
+        Returns {"synthesized": n, "complete": bool} (synthesized counts
+        rows stamped).
         """
         user_id = str(user_id)
+        limit = self.backfill_batch_rows
+        cursor_name = "backfill/artifact_metadata/artifacts"
+        cursor = await _backfill_cursor(event_service, cursor_name, user_id)
         stamped = 0
         rows = await self.service.storage.list_artifacts(
-            user_id, latest_only=False, include_deleted=True
+            user_id, latest_only=False, include_deleted=True, limit=limit, after_id=cursor
         )
+        complete = len(rows) < limit
         for row in rows:
             if row.get("derived_from_event_id") is not None:
                 continue
@@ -532,7 +669,10 @@ class ArtifactMetadataProjector:
                 continue
             await self.service.storage.set_derived_event(row["id"], event["id"])
             stamped += 1
-        return stamped
+        await _save_backfill_cursor(
+            event_service, cursor_name, user_id, rows[-1]["id"] if rows else cursor, complete
+        )
+        return {"synthesized": stamped, "complete": complete}
 
 
 def _parse_iso(value):

--- a/src/muxi/runtime/services/memory/events/service.py
+++ b/src/muxi/runtime/services/memory/events/service.py
@@ -40,7 +40,9 @@
 #    period, and raises the per-user event-log size-cap alert.
 # 8. Legacy backfill (Phase B): ``backfill_user`` asks each projector to
 #    synthesize ``source='legacy'`` events for pre-event-log rows so old
-#    data becomes replayable and provenance-complete.
+#    data becomes replayable and provenance-complete. Bounded per pass
+#    (BACKFILL_MAX_ROWS_PER_PASS in projectors.py) with persisted resume
+#    cursors -- large legacy tables need multiple passes.
 # =============================================================================
 
 import asyncio
@@ -64,6 +66,14 @@ MAINTENANCE_INTERVAL_SECONDS = 3600.0
 # Incremental applier defaults (memory.projections in the formation YAML).
 DEFAULT_APPLY_INTERVAL_SECONDS = 5.0
 DEFAULT_LAG_ALERT_THRESHOLD_SECONDS = 300.0
+# Max events applied per lock acquisition in ``project_pending``. The
+# projection lock is released and reacquired between chunks so a long
+# catch-up batch never starves concurrent event-first writers
+# (``apply_event`` shares the same lock). Cursor correctness across the
+# release: each chunk re-reads its checkpoint under the lock before
+# listing events, so work done by an interleaved apply_event is never
+# re-applied and no event is skipped.
+DEFAULT_PROJECT_BATCH_SIZE = 500
 
 
 class MemoryEventService:
@@ -114,6 +124,10 @@ class MemoryEventService:
                 "lag_alert_threshold_seconds", DEFAULT_LAG_ALERT_THRESHOLD_SECONDS
             ),
             "memory.projections.lag_alert_threshold_seconds",
+        )
+        self.project_batch_size = _positive_int(
+            projections_config.get("batch_size", DEFAULT_PROJECT_BATCH_SIZE),
+            "memory.projections.batch_size",
         )
         self.decay = decay if decay is not None else DecaySettings()
 
@@ -313,6 +327,15 @@ class MemoryEventService:
         (the cursor still advances; a rebuild reconciles), keeping one
         poison event from wedging the projection forever.
 
+        Lock hold discipline: events are applied in chunks of at most
+        ``memory.projections.batch_size`` per lock acquisition, with the
+        checkpoint advanced at the end of every chunk. The lock is
+        released between chunks so a long catch-up batch never stalls
+        concurrent event-first writers, and a crash between chunks
+        resumes from the last checkpointed chunk boundary -- every chunk
+        re-reads its cursor under the lock, so no event is skipped or
+        re-applied across the boundary.
+
         Returns {projection: {user: {"events": n, "applied": n, "failed": n}}}.
         """
         users = [str(user_id)] if user_id is not None else await self.storage.list_event_user_ids()
@@ -321,43 +344,63 @@ class MemoryEventService:
             projector = self.projectors[name]
             per_user: Dict[str, Any] = {}
             for uid in users:
-                async with self._projection_lock:
-                    checkpoint = await self.storage.get_checkpoint(name, uid)
-                    after_id = checkpoint["last_event_id"] if checkpoint else None
-                    events = await self.storage.list_events(
-                        uid, event_types=list(projector.event_types), after_id=after_id
-                    )
-                    applied = failed = 0
-                    for event in events:
-                        try:
-                            result = await projector.apply(event)
-                            applied += 1
-                        except Exception as e:
-                            failed += 1
-                            result = None
-                            observability.observe(
-                                event_type=(
-                                    observability.ConversationEvents.MEMORY_PROJECTION_FAILED
-                                ),
-                                level=observability.EventLevel.WARNING,
-                                data={
-                                    "user_id": uid,
-                                    "projection": name,
-                                    "memory_event_id": event["id"],
-                                    "error": str(e),
-                                    "error_type": type(e).__name__,
-                                },
-                                description=f"Applying event {event['id']} to {name} failed: {e}",
-                            )
-                        if result:
-                            await self.record_contradictions(event, result)
-                    if events:
-                        await self.storage.set_checkpoint(name, uid, last_event_id=events[-1]["id"])
-                if events:
-                    per_user[uid] = {"events": len(events), "applied": applied, "failed": failed}
+                totals = {"events": 0, "applied": 0, "failed": 0}
+                while True:
+                    chunk_size = await self._project_pending_chunk(name, projector, uid, totals)
+                    if chunk_size < self.project_batch_size:
+                        break
+                if totals["events"]:
+                    per_user[uid] = totals
             if per_user:
                 report[name] = per_user
         return report
+
+    async def _project_pending_chunk(
+        self, name: str, projector, uid: str, totals: Dict[str, int]
+    ) -> int:
+        """Apply one bounded chunk of pending events under the lock.
+
+        Reads the cursor, applies at most ``project_batch_size`` events
+        past it, and checkpoints the chunk tail -- all while holding the
+        projection lock, which is released when this returns so writers
+        can interleave between chunks. Returns the number of events the
+        chunk contained (a short chunk means the cursor reached the log
+        tail).
+        """
+        async with self._projection_lock:
+            checkpoint = await self.storage.get_checkpoint(name, uid)
+            after_id = checkpoint["last_event_id"] if checkpoint else None
+            events = await self.storage.list_events(
+                uid,
+                event_types=list(projector.event_types),
+                after_id=after_id,
+                limit=self.project_batch_size,
+            )
+            for event in events:
+                try:
+                    result = await projector.apply(event)
+                    totals["applied"] += 1
+                except Exception as e:
+                    totals["failed"] += 1
+                    result = None
+                    observability.observe(
+                        event_type=observability.ConversationEvents.MEMORY_PROJECTION_FAILED,
+                        level=observability.EventLevel.WARNING,
+                        data={
+                            "user_id": uid,
+                            "projection": name,
+                            "memory_event_id": event["id"],
+                            "error": str(e),
+                            "error_type": type(e).__name__,
+                        },
+                        description=f"Applying event {event['id']} to {name} failed: {e}",
+                    )
+                if result:
+                    await self.record_contradictions(event, result)
+            if events:
+                await self.storage.set_checkpoint(name, uid, last_event_id=events[-1]["id"])
+        totals["events"] += len(events)
+        return len(events)
 
     async def record_contradictions(
         self, event: Dict[str, Any], result: Optional[Dict[str, Any]]
@@ -576,7 +619,7 @@ class MemoryEventService:
     # Legacy backfill (Phase B: synthetic events for pre-event-log rows)
     # ------------------------------------------------------------------
 
-    async def backfill_user(self, user_id: Any) -> Dict[str, int]:
+    async def backfill_user(self, user_id: Any) -> Dict[str, Dict[str, Any]]:
         """
         Synthesize legacy events for a user's pre-event-log projection rows.
 
@@ -587,7 +630,14 @@ class MemoryEventService:
         provenance-complete on the next rebuild (their write path inserts
         rather than upserts).
 
-        Returns {projection_name: synthesized_event_count}.
+        BOUNDED PER PASS: each projector scans at most
+        ``BACKFILL_MAX_ROWS_PER_PASS`` rows per table per call (see
+        projectors.py), persisting a resume cursor in
+        ``projection_checkpoints``. A projection whose report says
+        ``complete: false`` still has unscanned rows -- call again until
+        every projection reports ``complete: true``.
+
+        Returns {projection_name: {"synthesized": n, "complete": bool}}.
 
         Raises:
             ValueError: When the substrate is disabled.
@@ -601,18 +651,30 @@ class MemoryEventService:
             data={"user_id": user_id, "projections": sorted(self.projectors)},
             description=f"Legacy memory backfill started for user {user_id}",
         )
-        report: Dict[str, int] = {}
+        report: Dict[str, Dict[str, Any]] = {}
         for name in sorted(self.projectors):
             backfill = getattr(self.projectors[name], "backfill", None)
             if backfill is None:
                 continue
             report[name] = await backfill(user_id, self)
-        observability.observe(
-            event_type=observability.ConversationEvents.MEMORY_BACKFILL_COMPLETED,
-            level=observability.EventLevel.INFO,
-            data={"user_id": user_id, "report": report},
-            description=f"Legacy memory backfill completed for user {user_id}",
-        )
+        incomplete = sorted(name for name, entry in report.items() if not entry["complete"])
+        if incomplete:
+            observability.observe(
+                event_type=observability.ConversationEvents.MEMORY_BACKFILL_COMPLETED,
+                level=observability.EventLevel.WARNING,
+                data={"user_id": user_id, "report": report, "incomplete": incomplete},
+                description=(
+                    f"Legacy memory backfill pass hit its per-pass row bound for "
+                    f"{', '.join(incomplete)}; run another pass to continue"
+                ),
+            )
+        else:
+            observability.observe(
+                event_type=observability.ConversationEvents.MEMORY_BACKFILL_COMPLETED,
+                level=observability.EventLevel.INFO,
+                data={"user_id": user_id, "report": report},
+                description=f"Legacy memory backfill completed for user {user_id}",
+            )
         return report
 
     # ------------------------------------------------------------------
@@ -815,6 +877,17 @@ def _optional_positive_int(value: Any, label: str) -> Optional[int]:
         raise ValueError(f"{label} must be a positive integer or null, got {value!r}")
     if number <= 0:
         raise ValueError(f"{label} must be a positive integer or null, got {value!r}")
+    return number
+
+
+def _positive_int(value: Any, label: str) -> int:
+    """Coerce a config value to a positive integer, failing fast otherwise."""
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{label} must be a positive integer, got {value!r}")
+    if number <= 0:
+        raise ValueError(f"{label} must be a positive integer, got {value!r}")
     return number
 
 

--- a/src/muxi/runtime/services/memory/graph/storage.py
+++ b/src/muxi/runtime/services/memory/graph/storage.py
@@ -190,15 +190,25 @@ class KnowledgeGraphStorage:
         entity_type: Optional[str] = None,
         status: Optional[str] = STATUS_ACTIVE,
         limit: int = 100,
+        after_id: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
-        """List entities for a user, newest first."""
+        """List entities for a user, newest first.
+
+        ``after_id`` switches to keyset pagination: rows with id greater
+        than the cursor, oldest first (the legacy backfill's stable
+        multi-pass scan ordering).
+        """
         async with self.db_manager.get_async_session() as session:
             stmt = select(KGEntity).filter_by(user_id=str(user_id), formation_id=self.formation_id)
             if entity_type:
                 stmt = stmt.filter_by(type=normalize_type(entity_type))
             if status:
                 stmt = stmt.filter_by(status=status)
-            stmt = stmt.order_by(KGEntity.id.desc()).limit(limit)
+            if after_id is not None:
+                stmt = stmt.filter(KGEntity.id > after_id).order_by(KGEntity.id.asc())
+            else:
+                stmt = stmt.order_by(KGEntity.id.desc())
+            stmt = stmt.limit(limit)
             rows = (await session.execute(stmt)).scalars().all()
             return [row.to_dict() for row in rows]
 
@@ -349,8 +359,14 @@ class KnowledgeGraphStorage:
         to_entity_id: Optional[int] = None,
         status: Optional[str] = STATUS_ACTIVE,
         limit: int = 200,
+        after_id: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
-        """List relationships for a user, highest confidence first."""
+        """List relationships for a user, highest confidence first.
+
+        ``after_id`` switches to keyset pagination: rows with id greater
+        than the cursor, oldest first (the legacy backfill's stable
+        multi-pass scan ordering).
+        """
         async with self.db_manager.get_async_session() as session:
             stmt = select(KGRelationship).filter_by(
                 user_id=str(user_id), formation_id=self.formation_id
@@ -363,7 +379,10 @@ class KnowledgeGraphStorage:
                 stmt = stmt.filter_by(to_entity_id=to_entity_id)
             if status:
                 stmt = stmt.filter_by(status=status)
-            stmt = stmt.order_by(KGRelationship.confidence.desc(), KGRelationship.id.desc())
+            if after_id is not None:
+                stmt = stmt.filter(KGRelationship.id > after_id).order_by(KGRelationship.id.asc())
+            else:
+                stmt = stmt.order_by(KGRelationship.confidence.desc(), KGRelationship.id.desc())
             stmt = stmt.limit(limit)
             rows = (await session.execute(stmt)).scalars().all()
             return [row.to_dict() for row in rows]

--- a/src/muxi/runtime/services/memory/log/storage.py
+++ b/src/muxi/runtime/services/memory/log/storage.py
@@ -144,8 +144,14 @@ class CaptainsLogStorage:
         limit: int = 10,
         date_from: Optional[date_type] = None,
         date_to: Optional[date_type] = None,
+        after_id: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
-        """List entries for a user, newest date first."""
+        """List entries for a user, newest date first.
+
+        ``after_id`` switches to keyset pagination: rows with id greater
+        than the cursor, oldest first (the legacy backfill's stable
+        multi-pass scan ordering).
+        """
         async with self.db_manager.get_async_session() as session:
             stmt = select(CaptainsLogEntry).filter_by(
                 user_id=str(user_id), formation_id=self.formation_id
@@ -154,9 +160,29 @@ class CaptainsLogStorage:
                 stmt = stmt.filter(CaptainsLogEntry.date >= date_from)
             if date_to is not None:
                 stmt = stmt.filter(CaptainsLogEntry.date <= date_to)
-            stmt = stmt.order_by(CaptainsLogEntry.date.desc()).limit(limit)
+            if after_id is not None:
+                stmt = stmt.filter(CaptainsLogEntry.id > after_id)
+                stmt = stmt.order_by(CaptainsLogEntry.id.asc()).limit(limit)
+            else:
+                stmt = stmt.order_by(CaptainsLogEntry.date.desc()).limit(limit)
             rows = (await session.execute(stmt)).scalars().all()
             return [row.to_dict() for row in rows]
+
+    async def get_entry_dates(self, log_ids) -> Dict[int, Optional[str]]:
+        """Return {entry id: ISO date} for many entries in one query.
+
+        Batched lookup for the lesson backfill, whose paginated lesson
+        pages may reference entries outside the current entry page.
+        """
+        ids = [log_id for log_id in log_ids if log_id is not None]
+        if not ids:
+            return {}
+        async with self.db_manager.get_async_session() as session:
+            stmt = select(CaptainsLogEntry.id, CaptainsLogEntry.date).filter(
+                CaptainsLogEntry.id.in_(ids)
+            )
+            rows = (await session.execute(stmt)).all()
+            return {int(row[0]): row[1].isoformat() if row[1] else None for row in rows}
 
     # ------------------------------------------------------------------
     # Source lineage (evidence trail + derivation DAG)
@@ -384,19 +410,27 @@ class LessonStorage:
             await session.flush()
             return lesson.to_dict(), True
 
-    async def list_all_for_user(self, user_id: str) -> List[Dict[str, Any]]:
+    async def list_all_for_user(
+        self,
+        user_id: str,
+        limit: Optional[int] = None,
+        after_id: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
         """Every lesson for a user (any archived state), oldest first.
 
         Legacy backfill support (Memory Substrate Phase 2d): the backfill
         scans the full projection for rows without event provenance, so
         archived lessons are included -- replay must reproduce them too.
+        ``after_id`` / ``limit`` support the backfill's bounded multi-pass
+        keyset scan.
         """
         async with self.db_manager.get_async_session() as session:
-            stmt = (
-                select(Lesson)
-                .filter_by(user_id=str(user_id), formation_id=self.formation_id)
-                .order_by(Lesson.id.asc())
-            )
+            stmt = select(Lesson).filter_by(user_id=str(user_id), formation_id=self.formation_id)
+            if after_id is not None:
+                stmt = stmt.filter(Lesson.id > after_id)
+            stmt = stmt.order_by(Lesson.id.asc())
+            if limit is not None:
+                stmt = stmt.limit(limit)
             rows = (await session.execute(stmt)).scalars().all()
             return [row.to_dict() for row in rows]
 

--- a/src/muxi/runtime/services/memory/long_term.py
+++ b/src/muxi/runtime/services/memory/long_term.py
@@ -1637,7 +1637,10 @@ class LongTermMemory:
             ]
 
     async def list_extracted_orphan_memories(
-        self, external_user_id: Optional[str] = None
+        self,
+        external_user_id: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """
         Extraction rows without event provenance (legacy backfill support).
@@ -1646,6 +1649,8 @@ class LongTermMemory:
         ``derived_from_event_id`` predate the memory event substrate; the
         backfill synthesizes fact.extracted events for exactly these so a
         rebuild can recreate them. Non-extraction rows are never listed.
+        ``limit`` / ``offset`` page the stable (created_at, id) ordering
+        for the backfill's bounded multi-pass scan.
         """
         internal_user_id = await self._resolve_user_id_async(external_user_id)
         source_marker = type_coerce(self.MemoryModel.meta_data, JSON)["source"].as_string()
@@ -1660,6 +1665,10 @@ class LongTermMemory:
                 .where(event_marker.is_(None))
                 .order_by(self.MemoryModel.created_at, self.MemoryModel.id)
             )
+            if offset:
+                query = query.offset(offset)
+            if limit is not None:
+                query = query.limit(limit)
             rows = (await session.execute(query)).scalars().all()
             return [
                 {

--- a/src/muxi/runtime/services/memory/memobase.py
+++ b/src/muxi/runtime/services/memory/memobase.py
@@ -536,20 +536,26 @@ class Memobase:
         return await self.long_term_memory.delete_extracted_memories(external_user_id)
 
     async def list_extracted_orphan_memories(
-        self, external_user_id: Optional[str] = None
+        self,
+        external_user_id: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """
         Extraction rows without event provenance (legacy backfill support).
 
-        Delegates to the wrapped LongTermMemory. Anonymous users store
-        nothing, so the call returns [] for them.
+        Delegates to the wrapped LongTermMemory (``limit`` / ``offset``
+        page the backfill's bounded multi-pass scan). Anonymous users
+        store nothing, so the call returns [] for them.
         """
         external_user_id = (
             external_user_id if external_user_id is not None else self.default_external_user_id
         )
         if external_user_id in ["default", "anonymous", "0"]:
             return []
-        return await self.long_term_memory.list_extracted_orphan_memories(external_user_id)
+        return await self.long_term_memory.list_extracted_orphan_memories(
+            external_user_id, limit=limit, offset=offset
+        )
 
     def clear_user_memory(self, external_user_id: Optional[str] = None) -> None:
         """

--- a/src/muxi/runtime/services/memory/sqlite.py
+++ b/src/muxi/runtime/services/memory/sqlite.py
@@ -648,7 +648,10 @@ class SQLiteMemory(BaseMemory):
         return memory_id
 
     async def list_extracted_orphan_memories(
-        self, user_id: Optional[str] = None
+        self,
+        user_id: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """
         Extraction rows without event provenance (legacy backfill support).
@@ -658,13 +661,25 @@ class SQLiteMemory(BaseMemory):
         backfill synthesizes fact.extracted events for exactly these so a
         rebuild can recreate them. Non-extraction rows (conversations,
         manual user memories, knowledge uploads) are not event-sourced and
-        are never listed.
+        are never listed. ``limit`` / ``offset`` page the stable
+        (created_at, id) ordering for the backfill's bounded multi-pass
+        scan.
         """
         await self._ensure_dim()
         if user_id:
             internal_user_id = await self.get_or_create_user(str(user_id))
         else:
             internal_user_id = self.default_user_id
+        paging = ""
+        params: list = [internal_user_id]
+        if limit is not None:
+            paging += " LIMIT ?"
+            params.append(limit)
+        if offset:
+            if limit is None:
+                paging += " LIMIT -1"
+            paging += " OFFSET ?"
+            params.append(offset)
         rows = self.conn.execute(
             f"""
             SELECT id, text, collection, metadata, created_at
@@ -673,8 +688,9 @@ class SQLiteMemory(BaseMemory):
               AND json_extract(metadata, '$.source') = 'extraction'
               AND json_extract(metadata, '$.derived_from_event_id') IS NULL
             ORDER BY created_at, id
+            {paging}
             """,
-            (internal_user_id,),
+            tuple(params),
         ).fetchall()
         return [
             {

--- a/tests/unit/test_memory_events_backfill.py
+++ b/tests/unit/test_memory_events_backfill.py
@@ -4,8 +4,9 @@ Pre-event-log rows (created before the substrate shipped, so without any
 ``derived_from_event_ids`` provenance) get synthetic ``source='legacy'``
 events keyed per row. Covers: synthesis + in-place provenance stamping
 for graph/log rows, event synthesis for orphan flat facts, idempotent
-re-runs, and the rebuild-after-backfill path that makes legacy data
-replayable.
+re-runs, the rebuild-after-backfill path that makes legacy data
+replayable, and the bounded multi-pass scan (per-pass row bound with a
+persisted resume cursor, crash-safe re-runs without duplicates).
 """
 
 from __future__ import annotations
@@ -62,14 +63,17 @@ class FakeLongTermMemory:
             del self.rows[memory_id]
         return len(doomed)
 
-    async def list_extracted_orphan_memories(self, user_id):
-        return [
+    async def list_extracted_orphan_memories(self, user_id, limit=None, offset=None):
+        orphans = [
             dict(row)
             for row in self.rows.values()
             if row["user_id"] == str(user_id)
             and row["metadata"].get("source") == "extraction"
             and row["metadata"].get("derived_from_event_id") is None
         ]
+        start = offset or 0
+        end = start + limit if limit is not None else None
+        return orphans[start:end]
 
 
 @pytest.fixture
@@ -104,7 +108,8 @@ class TestKnowledgeGraphBackfill:
         events.register_projector(KnowledgeGraphProjector(graph))
 
         report = await events.backfill_user(USER)
-        assert report["knowledge_graph"] == 3  # 2 entities + 1 relationship
+        # 2 entities + 1 relationship, all scanned in one pass.
+        assert report["knowledge_graph"] == {"synthesized": 3, "complete": True}
 
         legacy = await events.list_events(USER, source=SOURCE_LEGACY)
         assert len(legacy) == 3
@@ -123,8 +128,10 @@ class TestKnowledgeGraphBackfill:
 
         first = await events.backfill_user(USER)
         second = await events.backfill_user(USER)
-        assert first["knowledge_graph"] == 3
-        assert second["knowledge_graph"] == 0  # everything already stamped
+        assert first["knowledge_graph"]["synthesized"] == 3
+        # Everything already stamped on the re-run (cursors were cleared
+        # by the completed pass, so the re-run scanned from the start).
+        assert second["knowledge_graph"] == {"synthesized": 0, "complete": True}
         assert len(await events.list_events(USER, source=SOURCE_LEGACY)) == 3
 
     async def test_rebuild_after_backfill_reproduces_legacy_rows(self, db_manager, events):
@@ -178,7 +185,8 @@ class TestCaptainsLogBackfill:
         events.register_projector(CaptainsLogProjector(log))
 
         report = await events.backfill_user(USER)
-        assert report["captains_log"] == 2  # 1 entry + 1 lesson
+        # 1 entry + 1 lesson.
+        assert report["captains_log"] == {"synthesized": 2, "complete": True}
 
         entries = await log.storage.list_entries(USER)
         assert entries[0]["derived_from_event_ids"]
@@ -189,7 +197,8 @@ class TestCaptainsLogBackfill:
         # set and lineage are unchanged.
         assert lessons[0]["rule"] == "Prefer reportlab over fpdf"
 
-        assert await events.backfill_user(USER) == {"captains_log": 0}
+        rerun = await events.backfill_user(USER)
+        assert rerun == {"captains_log": {"synthesized": 0, "complete": True}}
 
     async def test_rebuild_after_backfill_reproduces_entries(self, db_manager, events):
         log = await self.seed_legacy_log(db_manager)
@@ -227,14 +236,15 @@ class TestFlatFactBackfill:
         )
 
         report = await events.backfill_user(USER)
-        assert report["flat_facts"] == 1
+        assert report["flat_facts"] == {"synthesized": 1, "complete": True}
         legacy = await events.list_events(USER, source=SOURCE_LEGACY)
         assert len(legacy) == 1
         assert legacy[0]["payload"]["memory"] == "Likes tea"
 
-        assert await events.backfill_user(USER) == {"flat_facts": 0}  # idempotent? no:
+        rerun = await events.backfill_user(USER)  # idempotent? no:
         # the row is still orphaned (stamping happens on rebuild), but the
         # per-row legacy source_id makes the re-run an idempotent skip.
+        assert rerun == {"flat_facts": {"synthesized": 0, "complete": True}}
 
     async def test_rebuild_after_backfill_stamps_provenance(self, events):
         long_term = FakeLongTermMemory()
@@ -254,4 +264,131 @@ class TestFlatFactBackfill:
         assert rows[0]["text"] == "Likes tea"
         assert rows[0]["metadata"]["derived_from_event_id"] is not None
         # Now provenance-complete: nothing left to backfill.
-        assert await events.backfill_user(USER) == {"flat_facts": 0}
+        rerun = await events.backfill_user(USER)
+        assert rerun == {"flat_facts": {"synthesized": 0, "complete": True}}
+
+
+class TestMultiPassBackfill:
+    """The per-pass row bound with a persisted resume cursor.
+
+    Legacy tables larger than BACKFILL_MAX_ROWS_PER_PASS backfill across
+    multiple ``backfill_user`` calls: an incomplete pass persists its
+    scan cursor in projection_checkpoints (``backfill/...`` names) and
+    reports ``complete: false``; the next pass resumes past it. No row
+    is skipped and no legacy event is duplicated across passes.
+    """
+
+    async def seed_entities(self, db_manager, count):
+        graph = KnowledgeGraphService(db_manager, FORMATION_ID, event_log=None)
+        for index in range(count):
+            await graph.storage.upsert_entity(USER, "company", f"Corp{index}", confidence=0.9)
+        return graph
+
+    async def test_kg_backfill_resumes_across_passes(self, db_manager, events):
+        graph = await self.seed_entities(db_manager, 5)
+        projector = KnowledgeGraphProjector(graph)
+        projector.backfill_batch_rows = 2  # shrink the per-pass bound
+        events.register_projector(projector)
+
+        synthesized = []
+        for _ in range(2):
+            report = await events.backfill_user(USER)
+            assert report["knowledge_graph"]["complete"] is False
+            synthesized.append(report["knowledge_graph"]["synthesized"])
+            # The resume cursor persisted like a projection cursor.
+            checkpoint = await events.storage.get_checkpoint(
+                "backfill/knowledge_graph/entities", USER
+            )
+            assert checkpoint is not None
+
+        final = await events.backfill_user(USER)
+        assert final["knowledge_graph"]["complete"] is True
+        synthesized.append(final["knowledge_graph"]["synthesized"])
+
+        # Every entity synthesized exactly once across the passes.
+        assert sum(synthesized) == 5
+        legacy = await events.list_events(USER, source=SOURCE_LEGACY)
+        assert len(legacy) == 5
+        assert len({e["source_id"] for e in legacy}) == 5
+        entities = await graph.storage.list_entities(USER, status=None)
+        assert all(e["derived_from_event_ids"] for e in entities)
+        # The completed pass cleared its cursors.
+        assert await events.storage.get_checkpoint("backfill/knowledge_graph/entities", USER) is (
+            None
+        )
+
+    async def test_kg_crash_between_passes_never_duplicates(self, db_manager, events):
+        """A re-run after an interrupted pass re-scans that pass's rows;
+        the per-row (source, source_id) key keeps events unique."""
+        graph = await self.seed_entities(db_manager, 4)
+        projector = KnowledgeGraphProjector(graph)
+        projector.backfill_batch_rows = 2
+        events.register_projector(projector)
+
+        await events.backfill_user(USER)  # pass 1 (rows 1-2), cursor persisted
+
+        # Simulate a crash before pass 2 persisted anything: wipe the
+        # cursor so the next run re-scans from the start.
+        await events.storage.reset_checkpoint("backfill/knowledge_graph/entities", USER)
+        await events.storage.reset_checkpoint("backfill/knowledge_graph/relationships", USER)
+
+        report = await events.backfill_user(USER)  # re-scans rows 1-2
+        assert report["knowledge_graph"] == {"synthesized": 0, "complete": False}
+        final = await events.backfill_user(USER)  # rows 3-4
+        assert final["knowledge_graph"]["synthesized"] == 2
+
+        legacy = await events.list_events(USER, source=SOURCE_LEGACY)
+        assert len(legacy) == 4  # no duplicates despite the re-scan
+        assert len({e["source_id"] for e in legacy}) == 4
+
+    async def test_flat_fact_offset_cursor_resumes(self, events):
+        long_term = FakeLongTermMemory()
+        projector = FlatFactProjector(long_term)
+        projector.backfill_batch_rows = 2
+        events.register_projector(projector)
+        for index in range(5):
+            await long_term.add(
+                content=f"Fact {index}",
+                metadata={"source": "extraction"},
+                user_id=USER,
+                collection="preferences",
+            )
+
+        first = await events.backfill_user(USER)
+        assert first["flat_facts"] == {"synthesized": 2, "complete": False}
+        second = await events.backfill_user(USER)
+        assert second["flat_facts"] == {"synthesized": 2, "complete": False}
+        third = await events.backfill_user(USER)
+        assert third["flat_facts"] == {"synthesized": 1, "complete": True}
+
+        legacy = await events.list_events(USER, source=SOURCE_LEGACY)
+        assert sorted(e["payload"]["memory"] for e in legacy) == [
+            f"Fact {index}" for index in range(5)
+        ]
+        # Completed pass cleared the offset cursor.
+        assert await events.storage.get_checkpoint("backfill/flat_facts/memories", USER) is None
+
+    async def test_lessons_resolve_entry_dates_across_pages(self, db_manager, events):
+        """A paginated lesson page still resolves its source entry's date
+        even when that entry was scanned in an earlier page."""
+        from datetime import date
+
+        log = CaptainsLogService(db_manager, FORMATION_ID, event_log=None)
+        entry = await log.storage.upsert_entry(USER, date(2025, 6, 1), summary="Day one.")
+        await log.lessons.upsert_lesson(
+            user_id=USER, agent_id="overlord", rule="Rule A", source_log_id=entry["id"]
+        )
+        projector = CaptainsLogProjector(log)
+        projector.backfill_batch_rows = 1  # entry page and lesson page split
+        events.register_projector(projector)
+
+        reports = []
+        for _ in range(3):
+            reports.append(await events.backfill_user(USER))
+            if reports[-1]["captains_log"]["complete"]:
+                break
+        assert reports[-1]["captains_log"]["complete"] is True
+
+        lesson_events = await events.list_events(USER, event_types=["lesson.recorded"])
+        assert len(lesson_events) == 1
+        assert lesson_events[0]["payload"]["source_log_date"] == "2025-06-01"

--- a/tests/unit/test_memory_events_projection.py
+++ b/tests/unit/test_memory_events_projection.py
@@ -156,6 +156,111 @@ class TestProjectPending:
         assert checkpoint["last_event_id"] == good["id"]  # not wedged
 
 
+class TestChunkedProjectPending:
+    """Bounded lock holds: project_pending applies events in chunks of
+    ``memory.projections.batch_size`` per lock acquisition, checkpointing
+    every chunk. No event is skipped or duplicated across chunk
+    boundaries, and a crash between chunks resumes from the last
+    checkpointed boundary."""
+
+    @pytest.fixture
+    def chunked_events(self, db_manager):
+        return MemoryEventService(db_manager, FORMATION_ID, projections_config={"batch_size": 2})
+
+    async def test_all_events_applied_exactly_once_across_chunks(self, chunked_events):
+        events = chunked_events
+        long_term = FakeLongTermMemory()
+        events.register_projector(FlatFactProjector(long_term))
+        recorded = [await record_fact(events, f"Fact {index}") for index in range(5)]
+
+        report = await events.project_pending(USER)
+        assert report["flat_facts"][USER] == {"events": 5, "applied": 5, "failed": 0}
+        # Exactly once each: 5 rows, 5 distinct contents.
+        assert sorted(row["content"] for row in long_term.rows.values()) == [
+            f"Fact {index}" for index in range(5)
+        ]
+        checkpoint = await events.storage.get_checkpoint("flat_facts", USER)
+        assert checkpoint["last_event_id"] == recorded[-1]["id"]
+
+        # Nothing pending on a second pass.
+        assert await events.project_pending(USER) == {}
+
+    async def test_crash_between_chunks_resumes_without_skip_or_duplicate(
+        self, chunked_events, monkeypatch
+    ):
+        events = chunked_events
+        long_term = FakeLongTermMemory()
+        events.register_projector(FlatFactProjector(long_term))
+        recorded = [await record_fact(events, f"Fact {index}") for index in range(5)]
+
+        # Crash the pass at the second chunk's read -- AFTER chunk one
+        # was applied and checkpointed, BEFORE chunk two touched anything.
+        original_list_events = events.storage.list_events
+        calls = {"count": 0}
+
+        async def crashing_list_events(*args, **kwargs):
+            calls["count"] += 1
+            if calls["count"] == 2:
+                raise RuntimeError("process died between chunks")
+            return await original_list_events(*args, **kwargs)
+
+        monkeypatch.setattr(events.storage, "list_events", crashing_list_events)
+        with pytest.raises(RuntimeError, match="between chunks"):
+            await events.project_pending(USER)
+
+        # Chunk one landed and was checkpointed at the chunk boundary.
+        assert len(long_term.rows) == 2
+        checkpoint = await events.storage.get_checkpoint("flat_facts", USER)
+        assert checkpoint["last_event_id"] == recorded[1]["id"]
+
+        # Recovery pass: only the remaining events apply -- none skipped,
+        # none re-applied.
+        monkeypatch.undo()
+        report = await events.project_pending(USER)
+        assert report["flat_facts"][USER] == {"events": 3, "applied": 3, "failed": 0}
+        assert sorted(row["content"] for row in long_term.rows.values()) == [
+            f"Fact {index}" for index in range(5)
+        ]
+
+    async def test_lock_released_between_chunks(self, chunked_events):
+        """The projection lock is free between chunks, so a concurrent
+        writer acquires it mid-batch instead of waiting for the tail."""
+        events = chunked_events
+        long_term = FakeLongTermMemory()
+        projector = FlatFactProjector(long_term)
+        events.register_projector(projector)
+        for index in range(6):
+            await record_fact(events, f"Fact {index}")
+
+        import asyncio
+
+        rows_seen_under_lock = []
+
+        async def contender():
+            # Queued behind the running pass; asyncio.Lock is FIFO, so
+            # this wakes at the first chunk boundary -- mid-batch --
+            # rather than after the whole batch (the old monolithic hold).
+            async with events._projection_lock:
+                rows_seen_under_lock.append(len(long_term.rows))
+
+        pending_task = asyncio.create_task(events.project_pending(USER))
+        await asyncio.sleep(0)  # let the pass take the lock first
+        contender_task = asyncio.create_task(contender())
+        await asyncio.wait_for(asyncio.gather(pending_task, contender_task), timeout=5.0)
+
+        assert len(long_term.rows) == 6
+        # The contender got the lock while the batch was still running.
+        assert 0 < rows_seen_under_lock[0] < 6
+
+    async def test_batch_size_config_validation(self, db_manager):
+        with pytest.raises(ValueError, match="memory.projections.batch_size"):
+            MemoryEventService(db_manager, FORMATION_ID, projections_config={"batch_size": 0})
+        with pytest.raises(ValueError, match="memory.projections.batch_size"):
+            MemoryEventService(db_manager, FORMATION_ID, projections_config={"batch_size": "lots"})
+        service = MemoryEventService(db_manager, FORMATION_ID)
+        assert service.project_batch_size == 500  # documented default
+
+
 class TestApplyEvent:
     async def test_apply_event_projects_and_checkpoints(self, events):
         long_term = FakeLongTermMemory()

--- a/tests/unit/test_memory_forget_route.py
+++ b/tests/unit/test_memory_forget_route.py
@@ -12,14 +12,15 @@ job polling, and the substrate-unavailable 503.
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from muxi.runtime.formation.background.request_tracker import RequestTracker
-from muxi.runtime.formation.server.routes.admin.memory import router
+from muxi.runtime.formation.background.request_tracker import RequestStatus, RequestTracker
+from muxi.runtime.formation.server.routes.admin.memory import _start_tracked_job, router
 from muxi.runtime.services.db import Base, DatabaseManager
 from muxi.runtime.services.memory.events import KnowledgeGraphProjector, MemoryEventService
 from muxi.runtime.services.memory.graph.service import KnowledgeGraphService
@@ -178,3 +179,49 @@ class TestUnavailableSubstrate:
         with TestClient(make_app(None)) as client:
             response = client.post("/memory/forget", json={"user_id": USER, "source": "gmail"})
             assert response.status_code == 503
+
+
+class TestJobCancellation:
+    """Graceful-shutdown cancellation marks tracked jobs terminal.
+
+    ``except Exception`` alone would miss asyncio.CancelledError and
+    strand the tracker entry at PROCESSING forever; the shared
+    ``_start_tracked_job`` helper (rebuild AND forget paths) must mark
+    the job CANCELLED and re-raise so the task cancels cleanly.
+    """
+
+    async def test_cancelled_job_marked_terminal_and_reraises(self):
+        tracker = RequestTracker()
+        overlord = SimpleNamespace(request_tracker=tracker)
+        started = asyncio.Event()
+
+        async def runner():
+            started.set()
+            await asyncio.sleep(3600)  # a long rebuild, interrupted by shutdown
+
+        job_id = await _start_tracked_job(overlord, "forget", USER, runner)
+        await asyncio.wait_for(started.wait(), timeout=5.0)
+
+        state = await tracker.get_request(job_id)
+        assert state.status is RequestStatus.PROCESSING
+        state.task_ref.cancel()
+        with pytest.raises(asyncio.CancelledError):  # cancellation propagates
+            await state.task_ref
+
+        final = await tracker.get_request(job_id)
+        assert final.status is RequestStatus.CANCELLED  # terminal, not stuck
+        assert final.error == "job cancelled"
+
+    async def test_completed_job_still_reports_completed(self):
+        """The cancellation guard does not disturb the happy path."""
+        tracker = RequestTracker()
+        overlord = SimpleNamespace(request_tracker=tracker)
+
+        async def runner():
+            return {"projections": {}}
+
+        job_id = await _start_tracked_job(overlord, "rebuild", USER, runner)
+        state = await tracker.get_request(job_id)
+        await state.task_ref
+        final = await tracker.get_request(job_id)
+        assert final.status is RequestStatus.COMPLETED

--- a/tests/unit/test_memory_forget_route.py
+++ b/tests/unit/test_memory_forget_route.py
@@ -1,0 +1,180 @@
+"""GDPR forget endpoint job lifecycle tests (substrate admin hardening).
+
+POST /memory/forget soft-deletes inline (the response always carries
+``deleted_events``) but runs the projection rebuild as a tracked
+background job by default, so large users never block the admin call:
+202 + ``job_id`` pollable at GET /memory/forget/{job_id}. Covers the
+full job lifecycle (spawn, poll to completion, rebuild report attached,
+derived state actually removed), the ``?sync=true`` and ``background:
+false`` inline escape hatches, the ``rebuild: false`` posture, unknown
+job polling, and the substrate-unavailable 503.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from muxi.runtime.formation.background.request_tracker import RequestTracker
+from muxi.runtime.formation.server.routes.admin.memory import router
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.events import KnowledgeGraphProjector, MemoryEventService
+from muxi.runtime.services.memory.graph.service import KnowledgeGraphService
+
+FORMATION_ID = "forget-route-test"
+USER = "u1"
+
+
+@pytest.fixture
+def db_manager(tmp_path):
+    manager = DatabaseManager(f"sqlite:///{tmp_path}/forget_route.db")
+    manager.create_tables(Base.metadata)
+    yield manager
+    manager.engine.dispose()
+
+
+@pytest.fixture
+def events(db_manager):
+    return MemoryEventService(db_manager, FORMATION_ID)
+
+
+@pytest.fixture
+def graph(db_manager, events):
+    service = KnowledgeGraphService(db_manager, FORMATION_ID, event_log=events)
+    events.register_projector(KnowledgeGraphProjector(service))
+    return service
+
+
+def make_app(memory_events) -> FastAPI:
+    """The admin memory router wired the way the runtime serves it."""
+    app = FastAPI()
+    app.include_router(router)
+    overlord = (
+        SimpleNamespace(memory_events=memory_events, request_tracker=RequestTracker())
+        if memory_events is not None
+        else None
+    )
+    app.state.formation = SimpleNamespace(_overlord=overlord, formation_id=FORMATION_ID)
+    return app
+
+
+def extraction(company):
+    return {
+        "entities": [{"name": company, "type": "company", "confidence": 0.9}],
+        "relationships": [],
+    }
+
+
+async def seed_two_sources(graph):
+    """Facts from a chat turn and from an imported source (gmail)."""
+    await graph.store_extraction(USER, extraction("Acme"), source="interaction")
+    await graph.store_extraction(USER, extraction("MailCorp"), source="gmail")
+
+
+def poll_until_terminal(client, job_id, attempts=50):
+    """Poll the forget job until it leaves 'processing' (each request
+    gives the shared test event loop cycles to run the job task)."""
+    for _ in range(attempts):
+        response = client.get(f"/memory/forget/{job_id}")
+        assert response.status_code == 200
+        data = response.json()["data"]
+        if data["status"] != "processing":
+            return data
+    raise AssertionError("forget job never reached a terminal status")
+
+
+class TestBackgroundForget:
+    async def test_background_job_lifecycle(self, events, graph):
+        await seed_two_sources(graph)
+        assert await graph.storage.get_entity(USER, "company", "MailCorp") is not None
+
+        with TestClient(make_app(events)) as client:
+            response = client.post(
+                "/memory/forget",
+                json={"user_id": USER, "source": "gmail", "reason": "gdpr"},
+            )
+            assert response.status_code == 202
+            data = response.json()["data"]
+            # The soft delete ran inline; only the rebuild went background.
+            assert data["deleted_events"] == 1
+            assert data["status"] == "processing"
+            assert data["job_id"].startswith("forget_")
+            assert data["status_url"] == f"/memory/forget/{data['job_id']}"
+            assert "projections" not in data
+
+            final = poll_until_terminal(client, data["job_id"])
+            assert final["status"] == "completed"
+            assert final["projections"]["knowledge_graph"]["failed"] == 0
+
+        # Derived state reflects the forgetting.
+        assert await graph.storage.get_entity(USER, "company", "MailCorp") is None
+        assert await graph.storage.get_entity(USER, "company", "Acme") is not None
+
+    async def test_failed_job_reports_error(self, events, graph, monkeypatch):
+        await seed_two_sources(graph)
+
+        async def broken_rebuild(*args, **kwargs):
+            raise RuntimeError("rebuild exploded")
+
+        monkeypatch.setattr(events, "rebuild", broken_rebuild)
+        with TestClient(make_app(events)) as client:
+            response = client.post("/memory/forget", json={"user_id": USER, "source": "gmail"})
+            assert response.status_code == 202
+            final = poll_until_terminal(client, response.json()["data"]["job_id"])
+            assert final["status"] == "failed"
+            assert "rebuild exploded" in final["error"]
+
+    def test_unknown_job_returns_404(self, events):
+        with TestClient(make_app(events)) as client:
+            response = client.get("/memory/forget/forget_nope")
+            assert response.status_code == 404
+
+
+class TestSyncEscapeHatches:
+    async def test_sync_query_param_blocks_inline(self, events, graph):
+        await seed_two_sources(graph)
+        with TestClient(make_app(events)) as client:
+            response = client.post(
+                "/memory/forget?sync=true",
+                json={"user_id": USER, "source": "gmail", "reason": "gdpr"},
+            )
+            assert response.status_code == 200
+            data = response.json()["data"]
+            assert data["deleted_events"] == 1
+            assert data["projections"]["knowledge_graph"]["failed"] == 0
+            assert "job_id" not in data
+        assert await graph.storage.get_entity(USER, "company", "MailCorp") is None
+
+    async def test_background_false_body_blocks_inline(self, events, graph):
+        await seed_two_sources(graph)
+        with TestClient(make_app(events)) as client:
+            response = client.post(
+                "/memory/forget",
+                json={"user_id": USER, "source": "gmail", "background": False},
+            )
+            assert response.status_code == 200
+            assert "projections" in response.json()["data"]
+
+    async def test_rebuild_false_skips_rebuild_entirely(self, events, graph):
+        await seed_two_sources(graph)
+        with TestClient(make_app(events)) as client:
+            response = client.post(
+                "/memory/forget",
+                json={"user_id": USER, "source": "gmail", "rebuild": False},
+            )
+            assert response.status_code == 200
+            data = response.json()["data"]
+            assert data["rebuild_required"] == ["knowledge_graph"]
+            assert "job_id" not in data
+        # No rebuild ran: the projection still shows the forgotten fact.
+        assert await graph.storage.get_entity(USER, "company", "MailCorp") is not None
+
+
+class TestUnavailableSubstrate:
+    def test_missing_substrate_returns_503(self):
+        with TestClient(make_app(None)) as client:
+            response = client.post("/memory/forget", json={"user_id": USER, "source": "gmail"})
+            assert response.status_code == 503


### PR DESCRIPTION
## Summary

Three operational hardenings flagged by review on #259 (event substrate projections/provenance/rebuild). None are correctness bugs; all are long-tail operational risks on large users. Checked against #266's synthesis cadences: the weekly cold-cold pass calls `memory_events.rebuild(user_id)`, whose signature and semantics are unchanged.

### 1. Bounded projection-lock holds (`project_pending`)

`project_pending` used to hold `_projection_lock` for an entire catch-up batch, stalling concurrent event-first writers (`apply_event` shares the lock) for the duration. It now applies events in chunks of `memory.projections.batch_size` (default 500, validated fail-fast) per lock acquisition:

- The lock is **released and reacquired between chunks**, so writers interleave mid-batch.
- Each chunk **re-reads its cursor under the lock** before listing events and **checkpoints its own tail**, so work done by an interleaved `apply_event` is never re-applied and no event is skipped — exactly-once across chunk boundaries.
- A crash between chunks resumes from the last checkpointed boundary.

### 2. Background-by-default GDPR forget (`POST /memory/forget`)

The forget endpoint ran the full projection rebuild synchronously in-request; large users blocked the admin call. It now mirrors the rebuild endpoint's job pattern:

- The **soft delete + audit event still run inline** — the response always carries `deleted_events`.
- The rebuild runs as a tracked background job: **202 + `job_id`**, pollable at `GET /memory/forget/{job_id}` (shared status helper with the rebuild poller, same request tracker lifecycle).
- Escape hatches: `background: false` in the body or `?sync=true` on the query keep the old blocking behavior; `rebuild: false` is unchanged.

### 3. Legacy backfill pagination + resume (100,000-row ceiling)

Projector backfills capped their scans at a silent `limit=100000` — rows past the ceiling were never backfilled. Now:

- `BACKFILL_MAX_ROWS_PER_PASS` (100,000) is a **loudly documented per-table, per-pass bound** in `projectors.py`.
- Each pass persists a resume cursor in `projection_checkpoints` under reserved `backfill/...` names (keyset `after_id` cursors for KG entities/relationships, log entries, lessons, artifacts; a row-offset cursor for the stable flat-fact orphan listing). A completed pass clears its cursors so re-runs re-scan idempotently, preserving prior semantics for small tables.
- `backfill_user` now reports `{"synthesized": n, "complete": bool}` per projection (was a bare count) and emits a WARNING observation when a pass stops at the bound, so operators know to run another pass.
- Storage listings gained opt-in `after_id`/`limit`/`offset` pagination; default orderings and existing callers are untouched. Relationship pages resolve endpoint entities via the batched `get_entities_by_ids`; lesson pages resolve entry dates via a new `get_entry_dates` batch helper (cross-page safe).

## Decisions

- `backfill_user`'s report shape changed (int → dict per projection). In-repo consumers (admin routes, unit tests, e2e 2s2) updated; this is the honest API since operators must know whether another pass is needed.
- Backfill scan order flipped to id-ascending under the cursor, which also makes backfilled artifact events replay in capture order.
- Forget's soft delete stays inline (it is one bounded pass) — only the rebuild goes background.

## Testing

- New unit coverage: chunked projection exactly-once semantics incl. crash-between-chunks resume and a mid-batch lock-acquisition proof; background forget job lifecycle (spawn, poll to completion, failure report, sync escape hatches, 404/503); multi-pass backfill resume (keyset + offset cursors, crash re-scan without duplicate legacy events, cross-page lesson date resolution).
- Full unit suite: **3372 passed, 10 skipped**.
- Substrate e2e `2_memory` test_2s1 + test_2s2: **PASS** (2s2 updated for the new backfill report shape).
- Regression `run_random_tests.py 5`: **5/5 pass** (19x3 required restoring the gitignored `.key` symlink for `formation-api-enforcement`, which is missing in local envs — environmental, unrelated to this change).
- black 100 / isort / ruff clean on touched files; `validate_events` 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)