### PR TITLE
test: deflake background-forget job lifecycle polling

### DIFF
--- a/tests/unit/test_memory_forget_route.py
+++ b/tests/unit/test_memory_forget_route.py
@@ -13,6 +13,7 @@ job polling, and the substrate-unavailable 503.
 from __future__ import annotations
 
 import asyncio
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -75,15 +76,22 @@ async def seed_two_sources(graph):
     await graph.store_extraction(USER, extraction("MailCorp"), source="gmail")
 
 
-def poll_until_terminal(client, job_id, attempts=50):
-    """Poll the forget job until it leaves 'processing' (each request
-    gives the shared test event loop cycles to run the job task)."""
-    for _ in range(attempts):
+def poll_until_terminal(client, job_id, deadline_seconds=30.0):
+    """Poll the forget job until it leaves 'processing'.
+
+    The job task runs on the TestClient portal loop (a separate thread),
+    so sleeping here does not starve it -- it gives the background rebuild
+    real wall-time. Sleep-less polling raced the job on loaded CI runners
+    and flaked with "never reached a terminal status".
+    """
+    deadline = time.monotonic() + deadline_seconds
+    while time.monotonic() < deadline:
         response = client.get(f"/memory/forget/{job_id}")
         assert response.status_code == 200
         data = response.json()["data"]
         if data["status"] != "processing":
             return data
+        time.sleep(0.05)
     raise AssertionError("forget job never reached a terminal status")
 
 


### PR DESCRIPTION
poll_until_terminal did 50 sleep-less HTTP polls and raced the background rebuild on loaded CI runners (failed twice on #269's CI, which touches only e2e/ files). Now deadline-based (30s) with a 50ms sleep between polls — the job task runs on the TestClient portal loop in a separate thread, so sleeping gives it real wall-time. Verified stable across 15 consecutive local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)