### PR TITLE
fix: deadline-based polling in forget-route job lifecycle tests

### DIFF
--- a/tests/unit/test_memory_forget_route.py
+++ b/tests/unit/test_memory_forget_route.py
@@ -13,6 +13,7 @@ job polling, and the substrate-unavailable 503.
 from __future__ import annotations
 
 import asyncio
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -75,16 +76,25 @@ async def seed_two_sources(graph):
     await graph.store_extraction(USER, extraction("MailCorp"), source="gmail")
 
 
-def poll_until_terminal(client, job_id, attempts=50):
-    """Poll the forget job until it leaves 'processing' (each request
-    gives the shared test event loop cycles to run the job task)."""
-    for _ in range(attempts):
+def poll_until_terminal(client, job_id, timeout=30.0, interval=0.02):
+    """Poll the forget job until it leaves 'processing'.
+
+    The job task runs on the TestClient portal loop in a background
+    thread, so it needs wall-clock time -- not request count -- to
+    finish; a deadline with short sleeps between polls keeps this
+    stable under CI load where the rebuild's thread-pool DB work can
+    outlast any fixed number of back-to-back requests.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
         response = client.get(f"/memory/forget/{job_id}")
         assert response.status_code == 200
         data = response.json()["data"]
         if data["status"] != "processing":
             return data
-    raise AssertionError("forget job never reached a terminal status")
+        if time.monotonic() >= deadline:
+            raise AssertionError(f"forget job never reached a terminal status within {timeout}s")
+        time.sleep(interval)
 
 
 class TestBackgroundForget:


### PR DESCRIPTION
## Why

`tests/unit/test_memory_forget_route.py::TestBackgroundForget::test_background_job_lifecycle` failed on an unrelated PR's CI run (which touched only `e2e/` files) with `AssertionError: forget job never reached a terminal status`, while passing locally and on its own gate — a timing flake, not a product bug.

## Root cause

`poll_until_terminal` used a request counter as its wait budget: 50 back-to-back GETs with no pause between them. The tracked forget/rebuild job (started via `_start_tracked_job` from #270) runs on the TestClient portal loop in a background thread, so it needs wall-clock time — not request count — to finish. 50 rapid polls complete in tens of milliseconds; under CI load the job's thread-pool SQLite work outlasts that window and the helper gives up while the job is still legitimately `processing`.

## Fix

Replace the attempt counter with a monotonic deadline (30s, well inside the 60s unit-test timeout) and a short 20ms sleep between polls. The helper still returns as soon as the job goes terminal (normal runs finish in a poll or two), but the wait budget is now elapsed time, so CI load can't shrink it. Both callers (`test_background_job_lifecycle` and `test_failed_job_reports_error`) get the fix. The sibling cancellation tests already synchronize deterministically (`asyncio.Event` + awaiting the task handle) and needed no change.

## Verification

- `uv run --extra dev python -m pytest tests/unit/test_memory_forget_route.py -q` run 20 consecutive times: 20/20 green (9 passed each run)
- Full unit suite: 3398 passed, 10 skipped
- black / isort (profile=black) / ruff: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)