### PR TITLE
feat(coding): opencode + pi adapter templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,35 @@ delegation PRD, plus the droid adapter pulled forward):
   remotes, real agent runs). Developer guide:
   `contributing/coding-delegation.md`.
 
+### Coding-agent delegation - opencode + pi adapter templates
+
+Phase 2a of the coding-agent delegation PRD: the two remaining bundled
+adapter templates, both on the captured-session path (the tool assigns
+the session id; MUXI parses it from output and replays it on
+`continue_job_id`):
+
+- `opencode` template, verified against opencode 1.14.46 with real
+  runs: `opencode run --format json` (JSONL events), result from the
+  final `text` event (`$.part.text`), session id from the events'
+  top-level `sessionID`, `--session` confirmed resume-only (a fresh id
+  fails), `--dir` on the forbidden list (MUXI sets the cwd).
+- `pi` template (@mariozechner/pi-coding-agent), verified against a
+  local pi 0.73.1 install: `pi --print --mode json` (JSONL), session
+  id from the real session-header event (`$.id`), `--session`
+  confirmed resume-only with global id lookup. The successful-run
+  result selector (`$.messages[-1].content[-1].text`) derives from
+  that version's bundled docs (no credentialed run was available) and
+  is marked `[verify]` in the template.
+- Delegation subprocesses now get `PWD` rewritten to the delegation
+  directory (POSIX-shell hygiene): opencode resolves its working
+  directory from `PWD` rather than the real cwd, and the inherited
+  runtime value made it operate on the wrong tree.
+- E2e: three real-run opencode tests (ad-hoc, new-project,
+  existing-project - hermetic local file:// bare remotes) and a pi
+  fixture-CLI test (real event shapes; exercises the bundled
+  template's selectors and captured-session continuation end to end).
+  Developer guide gained paste-ready `coding:` blocks for both tools.
+
 ### Fixes
 
 - Knowledge graph entity ATTRIBUTES now render in the graph context

--- a/contributing/coding-delegation.md
+++ b/contributing/coding-delegation.md
@@ -28,9 +28,8 @@ MUXI ships the mechanism only:
 ## Ready-to-paste formation blocks
 
 Each block below is complete and working -- copy it into `formation.yaml`
-and edit. Bundled templates today: `claude-code` and `droid`. (`opencode`
-and `pi` templates ship in a later phase; their blocks will slot into this
-list the same way.)
+and edit. Bundled templates today: `claude-code`, `droid`, `opencode`,
+and `pi`.
 
 ### claude-code
 
@@ -83,6 +82,57 @@ coding:
     FACTORY_API_KEY: "${{ secrets.FACTORY_API_KEY }}"
 ```
 
+### opencode
+
+Prerequisite: install the opencode CLI and authenticate a provider
+(`opencode auth login` or a provider API-key env var) -- your
+responsibility, MUXI only checks the binary exists.
+
+```yaml
+coding:
+  client: opencode               # bundled adapter template
+  model: anthropic/claude-sonnet-4-5   # provider/model namespace
+  workdirs: ["./workspace"]
+  cleanup: delete
+  timeout: 30m
+  max_concurrent: 3
+  groups: []
+  extra_args:
+    # opencode prompts for tool permission by default; auto-approve
+    # anything not explicitly denied ONLY in a sandboxed environment:
+    - "--dangerously-skip-permissions"
+    # also useful: --agent <name>, --title <title>
+  env:
+    # The ONLY place ${{ secrets.* }} resolves (argv is ps-visible; env is not).
+    ANTHROPIC_API_KEY: "${{ secrets.ANTHROPIC_API_KEY }}"
+```
+
+### pi
+
+Prerequisite: install the pi coding agent
+(`npm install -g @mariozechner/pi-coding-agent`) and provide a provider
+API key -- your responsibility, MUXI only checks the binary exists.
+
+```yaml
+coding:
+  client: pi                     # bundled adapter template
+  model: anthropic/claude-sonnet-4-5   # provider/id; optional :<thinking> suffix
+  workdirs: ["./workspace"]
+  cleanup: delete
+  timeout: 30m
+  max_concurrent: 3
+  groups: []
+  extra_args:
+    # pi's built-in tools (read, bash, edit, write) run unattended in
+    # headless mode -- rely on YOUR sandbox, or restrict the tool set:
+    - "--tools"
+    - "read,bash"
+    # also useful: --thinking <off|minimal|low|medium|high>, --no-skills
+  env:
+    # pi reads provider keys from the standard env vars.
+    ANTHROPIC_API_KEY: "${{ secrets.ANTHROPIC_API_KEY }}"
+```
+
 ## How it behaves
 
 ### The tool
@@ -111,8 +161,8 @@ flags) in `extra_args`; MUXI sets the cwd and rejects those flags at load.
 ### Sessions and continuation
 
 The vendor session id is persisted on the tracked job (MUXI-generated for
-claude-code and droid; captured from output for tools that assign their
-own). To continue a task -- including answering a question a run ended
+claude-code and droid; captured from output for opencode and pi, which
+assign their own). To continue a task -- including answering a question a run ended
 with -- call `delegate_coding` again with `continue_job_id: <job id>`;
 MUXI replays the stored session id. Agents never see vendor session ids.
 

--- a/e2e/tests/24_coding/formation-opencode/formation.yaml
+++ b/e2e/tests/24_coding/formation-opencode/formation.yaml
@@ -1,0 +1,63 @@
+schema: "1.0.0"
+id: formation-coding-opencode
+description: E2E formation delegating coding tasks to the opencode CLI adapter
+
+llm:
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+
+# Coding-agent delegation via the bundled opencode adapter template.
+# --dangerously-skip-permissions because the tests exercise file writes,
+# git commits, and git push (opencode prompts for permission otherwise).
+# The model is pinned to opencode's built-in zen model so the run does
+# not depend on which providers the local install has configured.
+# cleanup: keep so the tests can assert on the delegation directory
+# contents after the run.
+coding:
+  client: opencode
+  model: opencode/big-pickle
+  workdirs: ["./workspace"]
+  cleanup: keep
+  extra_args: ["--dangerously-skip-permissions"]
+  timeout: 10m
+  max_concurrent: 2
+
+agents:
+  - id: assistant
+    name: Assistant
+    description: Coding delegation test assistant
+    system_message: |
+      You are a test assistant with a delegate_coding tool that hands
+      coding tasks to a background coding agent. When the user asks you to
+      delegate a coding task, ALWAYS call the delegate_coding tool exactly
+      once, passing the user's task text VERBATIM as the prompt (keep any
+      quoted text, URLs, and file paths exactly as written). After the
+      tool returns, reply with only the job id it gave you. Keep responses
+      under 40 words.
+    default: true
+
+overlord:
+  workflow:
+    auto_decomposition: true
+    complexity_threshold: 9.0
+    plan_approval_threshold: 10
+  response:
+    streaming: false
+    widgets: false
+
+server:
+  host: 0.0.0.0
+  port: 18243
+  access_log: false
+  api_keys:
+    admin_key: "testing-api-key"
+    client_key: "testing-api-key"
+
+logging:
+  system:
+    level: "error"
+    destination: "stdout"
+  conversation:
+    enabled: false

--- a/e2e/tests/24_coding/formation-opencode/secrets.enc
+++ b/e2e/tests/24_coding/formation-opencode/secrets.enc
@@ -1,0 +1,1 @@
+../../../assets/secrets.enc

--- a/e2e/tests/24_coding/formation-opencode/workspace/.gitignore
+++ b/e2e/tests/24_coding/formation-opencode/workspace/.gitignore
@@ -1,0 +1,4 @@
+# Delegation directories are disposable runtime output (cleanup: keep in
+# this fixture so tests can assert on them); never commit them.
+*
+!.gitignore

--- a/e2e/tests/24_coding/formation-pi/formation.yaml
+++ b/e2e/tests/24_coding/formation-pi/formation.yaml
@@ -1,0 +1,61 @@
+schema: "1.0.0"
+id: formation-coding-pi
+description: E2E formation delegating coding tasks to the pi CLI adapter (fixture binary)
+
+llm:
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+
+# Coding-agent delegation via the bundled pi adapter template. The pi CLI
+# is not installed in the e2e environment; test 24A10 provisions a
+# fixture `pi` binary on PATH that emits the REAL pi 0.73.1 JSONL shapes
+# (session header verified against the actual tool; agent_end from that
+# version's bundled docs/json.md), so the bundled template's parse
+# selectors and captured-session wiring are still exercised end to end.
+# cleanup: keep so the test can inspect the delegation directory.
+coding:
+  client: pi
+  workdirs: ["./workspace"]
+  cleanup: keep
+  timeout: 2m
+  max_concurrent: 2
+
+agents:
+  - id: assistant
+    name: Assistant
+    description: Coding delegation test assistant
+    system_message: |
+      You are a test assistant with a delegate_coding tool that hands
+      coding tasks to a background coding agent. When the user asks you to
+      delegate a coding task, ALWAYS call the delegate_coding tool exactly
+      once, passing the user's task text VERBATIM as the prompt (keep any
+      quoted text, URLs, and file paths exactly as written). After the
+      tool returns, reply with only the job id it gave you. Keep responses
+      under 40 words.
+    default: true
+
+overlord:
+  workflow:
+    auto_decomposition: true
+    complexity_threshold: 9.0
+    plan_approval_threshold: 10
+  response:
+    streaming: false
+    widgets: false
+
+server:
+  host: 0.0.0.0
+  port: 18244
+  access_log: false
+  api_keys:
+    admin_key: "testing-api-key"
+    client_key: "testing-api-key"
+
+logging:
+  system:
+    level: "error"
+    destination: "stdout"
+  conversation:
+    enabled: false

--- a/e2e/tests/24_coding/formation-pi/secrets.enc
+++ b/e2e/tests/24_coding/formation-pi/secrets.enc
@@ -1,0 +1,1 @@
+../../../assets/secrets.enc

--- a/e2e/tests/24_coding/formation-pi/workspace/.gitignore
+++ b/e2e/tests/24_coding/formation-pi/workspace/.gitignore
@@ -1,0 +1,4 @@
+# Delegation directories are disposable runtime output (cleanup: keep in
+# this fixture so tests can assert on them); never commit them.
+*
+!.gitignore

--- a/e2e/tests/24_coding/test_24a10_pi_fixture.py
+++ b/e2e/tests/24_coding/test_24a10_pi_fixture.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Test 24A10: Coding delegation, pi adapter, fixture CLI.
+
+The pi CLI is not installed (and needs provider credentials), so this
+test provisions a fixture `pi` binary on PATH -- the PRD's fixture-CLI
+approach -- emitting the REAL pi 0.73.1 JSONL shapes: the session header
+line was verified against the actual tool (a credential-less run emits
+it before failing), the agent_end event comes from that version's
+bundled docs/json.md. The BUNDLED pi template is what resolves, so its
+parse selectors ($.messages[-1].content[-1].text / $.id) and the
+captured-session wiring are exercised end to end:
+
+chat turn -> delegate_coding -> fixture `pi --print --mode json <prompt>`
+-> session id captured from the header -> continuation replays it via
+`--session <id>` -> the fixture proves it received the id.
+"""
+
+import asyncio
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+from coding_common import (
+    assert_cross_user_isolation,
+    delegate_via_chat,
+    load_formation,
+    teardown,
+    wait_for_completion,
+    wait_for_reentry,
+)
+
+TASK = "List the files in the current directory."
+
+# The fixed id lets the test assert MUXI replayed the CAPTURED id on
+# resume (vendor session ids never leak through the public surface).
+FIXTURE_SESSION_ID = "0199aaaa-bbbb-7ccc-8ddd-eeeeffff0001"
+
+# Emits the pi 0.73.1 --mode json line shapes. Resume runs (--session)
+# echo the received id in the final text so the test can prove the
+# captured id round-tripped.
+FIXTURE_PI = f"""#!{sys.executable}
+import json, sys
+
+args = sys.argv[1:]
+assert args[:3] == ["--print", "--mode", "json"], f"unexpected base args: {{args}}"
+session_id = None
+if "--session" in args:
+    session_id = args[args.index("--session") + 1]
+prompt = args[-1]
+
+sid = session_id or "{FIXTURE_SESSION_ID}"
+reply = (
+    "resumed:" + sid + ":follow-up handled"
+    if session_id
+    else "fixture-pi-done: " + prompt
+)
+final = {{
+    "role": "assistant",
+    "content": [
+        {{"type": "thinking", "thinking": "planning"}},
+        {{"type": "text", "text": reply}},
+    ],
+    "stopReason": "stop",
+}}
+print(json.dumps({{"type": "session", "version": 3, "id": sid, "cwd": "."}}))
+print(json.dumps({{"type": "agent_start"}}))
+print(json.dumps({{"type": "turn_start"}}))
+print(json.dumps({{"type": "message_end", "message": final}}))
+print(json.dumps({{"type": "turn_end", "message": final, "toolResults": []}}))
+print(json.dumps({{
+    "type": "agent_end",
+    "messages": [
+        {{"role": "user", "content": [{{"type": "text", "text": prompt}}]}},
+        final,
+    ],
+}}))
+"""
+
+
+def provision_fixture_pi(bin_dir: Path) -> None:
+    """A fake `pi` on PATH so formation load (binary check) succeeds."""
+    script = bin_dir / "pi"
+    script.write_text(FIXTURE_PI)
+    script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    os.environ["PATH"] = str(bin_dir) + os.pathsep + os.environ.get("PATH", "")
+
+
+async def main():
+    print("MUXI Runtime - Test 24A10: pi fixture-CLI delegation")
+    print("=" * 60)
+
+    formation = None
+    bin_dir = Path(tempfile.mkdtemp(prefix="muxi-coding-24a10-"))
+    try:
+        provision_fixture_pi(bin_dir)
+        print(f"Fixture pi provisioned at {bin_dir}/pi")
+
+        formation, overlord = await load_formation("formation-pi")
+        print(f"Formation loaded: {formation.formation_id}")
+
+        # --- First delegation: captured-id path -------------------------
+        reply, job, user = await delegate_via_chat(overlord, TASK)
+        finished = await wait_for_completion(overlord, job["id"], user)
+
+        assert finished.status == "completed", f"delegation failed: {finished.error}"
+        # The template's result selector must have extracted the final
+        # assistant text (not thinking, not raw JSONL). The prompt tail is
+        # not asserted verbatim -- the delegating LLM owns that fidelity.
+        assert (finished.result or "").startswith(
+            "fixture-pi-done: "
+        ), f"parse.result selector extracted the wrong value: {finished.result!r}"
+        assert "files" in finished.result, f"prompt did not reach the CLI: {finished.result!r}"
+        # The session header's id must have been captured.
+        assert (
+            finished.vendor_session_id == FIXTURE_SESSION_ID
+        ), "session id was not captured from the pi session header"
+        print(f"Result extracted via template selectors: {finished.result!r}")
+        print("Session id captured from the session header event")
+
+        await wait_for_reentry(overlord, job["id"], user)
+        mine = await overlord.delegation_service.list_user_jobs(user)
+        assert mine[0]["resumable"] is True, "captured-session job must read as resumable"
+
+        # --- Continuation: MUXI replays the captured id via --session ---
+        continued = await overlord.delegation_service.delegate(
+            user_id=user,
+            prompt="Now also count them.",
+            continue_job_id=job["id"],
+        )
+        assert continued["success"], f"continuation rejected: {continued}"
+        second = await wait_for_completion(overlord, continued["job_id"], user)
+        assert second.status == "completed", f"continuation failed: {second.error}"
+        assert (
+            second.result == f"resumed:{FIXTURE_SESSION_ID}:follow-up handled"
+        ), f"the captured session id did not round-trip on resume: {second.result!r}"
+        print(f"Continuation replayed the captured id: {second.result!r}")
+
+        assert_cross_user_isolation(overlord, job["id"])
+
+        print("\n" + "=" * 40)
+        print("\n### Test Result:")
+        print("  SUCCESS: pi delegation works end-to-end against the fixture CLI")
+        print("  - the bundled pi template resolved and drove the subprocess")
+        print("  - result extracted via $.messages[-1].content[-1].text")
+        print("  - session id captured from the real-shape session header ($.id)")
+        print("  - continuation replayed the captured id via --session")
+        print("\n" + "=" * 40)
+        print("\n### Chat transcript:")
+        print(f'\nUser: Please delegate this coding task: "{TASK}"')
+        print(f"System: {reply}")
+
+        print("\nTest 24A10 PASSED")
+        return True
+
+    except Exception as e:
+        print(f"\nTest failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+    finally:
+        if formation is not None:
+            await teardown(formation)
+        import shutil
+
+        shutil.rmtree(bin_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0 if success else 1)

--- a/e2e/tests/24_coding/test_24a7_opencode_adhoc.py
+++ b/e2e/tests/24_coding/test_24a7_opencode_adhoc.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+Test 24A7: Coding delegation, opencode adapter, ad-hoc task.
+
+Chat turn -> delegate_coding tool -> REAL `opencode run` subprocess ->
+tracked job completes -> result re-enters the conversation
+(route_class: delegation) and stays retrievable by the calling user.
+opencode is a captured-session adapter: the first run carries no session
+flag and the tool-assigned id is parsed from output, so the finished job
+must read as resumable.
+"""
+
+import asyncio
+import os
+import sys
+
+from coding_common import (
+    assert_cross_user_isolation,
+    delegate_via_chat,
+    load_formation,
+    teardown,
+    wait_for_completion,
+    wait_for_reentry,
+)
+
+TASK = "Compute 17*23 and reply with only the resulting number."
+
+
+async def main():
+    print("MUXI Runtime - Test 24A7: opencode ad-hoc delegation")
+    print("=" * 60)
+
+    formation = None
+    try:
+        formation, overlord = await load_formation("formation-opencode")
+        print(f"Formation loaded: {formation.formation_id}")
+
+        reply, job, user = await delegate_via_chat(overlord, TASK)
+        finished = await wait_for_completion(overlord, job["id"], user)
+
+        assert finished.status == "completed", f"delegation failed: {finished.error}"
+        assert "391" in (finished.result or ""), f"unexpected result: {finished.result!r}"
+        print(f"Result carries the computation: {finished.result[:120]!r}")
+
+        # Captured-id path: the tool-assigned session id must have been
+        # parsed from output, making the job resumable.
+        assert finished.vendor_session_id, "tool-assigned session id was not captured"
+        print("Tool-assigned session id captured (resumable job)")
+
+        await wait_for_reentry(overlord, job["id"], user)
+        mine = await overlord.delegation_service.list_user_jobs(user)
+        assert any(entry["id"] == job["id"] for entry in mine)
+        assert mine[0]["result_preview"], "result missing from the user's tracked record"
+        assert mine[0]["resumable"] is True, "captured-session job must read as resumable"
+        assert_cross_user_isolation(overlord, job["id"])
+
+        print("\n" + "=" * 40)
+        print("\n### Test Result:")
+        print("  SUCCESS: opencode ad-hoc delegation works end-to-end")
+        print("  - delegate_coding returned immediately with a job id")
+        print("  - the real opencode run completed and produced 391")
+        print("  - the tool-assigned session id was captured from output")
+        print("  - completion re-entered the conversation (route_class: delegation)")
+        print("  - result retrievable by the calling user only")
+        print("\n" + "=" * 40)
+        print("\n### Chat transcript:")
+        print(f'\nUser: Please delegate this coding task: "{TASK}"')
+        print(f"System: {reply}")
+
+        print("\nTest 24A7 PASSED")
+        return True
+
+    except Exception as e:
+        print(f"\nTest failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+    finally:
+        if formation is not None:
+            await teardown(formation)
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0 if success else 1)

--- a/e2e/tests/24_coding/test_24a8_opencode_new_project.py
+++ b/e2e/tests/24_coding/test_24a8_opencode_new_project.py
@@ -48,7 +48,8 @@ async def main():
 
         hello = os.path.join(workdir, "hello.txt")
         assert os.path.isfile(hello), "hello.txt was not created"
-        assert "hello muxi" in open(hello).read(), "hello.txt content wrong"
+        with open(hello) as f:
+            assert "hello muxi" in f.read(), "hello.txt content wrong"
 
         log = git(["log", "--oneline", "-5"], cwd=workdir).stdout
         assert "init muxi project" in log, f"expected commit missing from log: {log!r}"

--- a/e2e/tests/24_coding/test_24a8_opencode_new_project.py
+++ b/e2e/tests/24_coding/test_24a8_opencode_new_project.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Test 24A8: Coding delegation, opencode adapter, new-project task.
+
+The delegated agent git-inits a fresh project inside its disposable
+delegation directory. The fixture formation uses cleanup: keep, so the
+test asserts the repository + commit exist in the workdir afterwards.
+"""
+
+import asyncio
+import os
+import sys
+
+from coding_common import (
+    delegate_via_chat,
+    git,
+    load_formation,
+    teardown,
+    wait_for_completion,
+    wait_for_reentry,
+)
+
+TASK = (
+    "Initialize a new git repository in the current directory. Create a "
+    "file named hello.txt containing exactly the text: hello muxi. Commit "
+    "it with the commit message: init muxi project. Use relative paths "
+    "only; do not change directories."
+)
+
+
+async def main():
+    print("MUXI Runtime - Test 24A8: opencode new-project delegation")
+    print("=" * 60)
+
+    formation = None
+    try:
+        formation, overlord = await load_formation("formation-opencode")
+        print(f"Formation loaded: {formation.formation_id}")
+
+        reply, job, user = await delegate_via_chat(overlord, TASK)
+        finished = await wait_for_completion(overlord, job["id"], user)
+        assert finished.status == "completed", f"delegation failed: {finished.error}"
+
+        # cleanup: keep -- the delegation dir must still exist with the repo.
+        workdir = finished.delegation_dir
+        assert workdir and os.path.isdir(workdir), f"delegation dir missing: {workdir}"
+        assert os.path.isdir(os.path.join(workdir, ".git")), "no git repository was created"
+
+        hello = os.path.join(workdir, "hello.txt")
+        assert os.path.isfile(hello), "hello.txt was not created"
+        assert "hello muxi" in open(hello).read(), "hello.txt content wrong"
+
+        log = git(["log", "--oneline", "-5"], cwd=workdir).stdout
+        assert "init muxi project" in log, f"expected commit missing from log: {log!r}"
+        print(f"Repository created at {workdir}")
+        print(f"Git log: {log.strip()}")
+
+        await wait_for_reentry(overlord, job["id"], user)
+
+        print("\n" + "=" * 40)
+        print("\n### Test Result:")
+        print("  SUCCESS: opencode new-project delegation works end-to-end")
+        print("  - the real opencode run git-inited a project in its delegation dir")
+        print("  - hello.txt + the 'init muxi project' commit exist pre-cleanup")
+        print("  - completion re-entered the conversation")
+        print("\n" + "=" * 40)
+        print("\n### Chat transcript:")
+        print(f'\nUser: Please delegate this coding task: "{TASK}"')
+        print(f"System: {reply}")
+
+        print("\nTest 24A8 PASSED")
+        return True
+
+    except Exception as e:
+        print(f"\nTest failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+    finally:
+        if formation is not None:
+            await teardown(formation)
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0 if success else 1)

--- a/e2e/tests/24_coding/test_24a9_opencode_existing_project.py
+++ b/e2e/tests/24_coding/test_24a9_opencode_existing_project.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Test 24A9: Coding delegation, opencode adapter, existing-project task.
+
+Hermetic: a LOCAL bare git repository (file:// remote) stands in for the
+project host. The delegated agent clones it, makes a specific change,
+commits, and pushes a branch; the test asserts the branch + commit
+arrived in the bare remote. No GitHub, no network.
+"""
+
+import asyncio
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+from coding_common import (
+    delegate_via_chat,
+    git,
+    load_formation,
+    make_bare_remote,
+    teardown,
+    wait_for_completion,
+    wait_for_reentry,
+)
+
+
+async def main():
+    print("MUXI Runtime - Test 24A9: opencode existing-project delegation")
+    print("=" * 60)
+
+    formation = None
+    fixture_dir = Path(tempfile.mkdtemp(prefix="muxi-coding-24a9-"))
+    try:
+        remote_url = make_bare_remote(fixture_dir)
+        print(f"Local bare remote seeded: {remote_url}")
+
+        task = (
+            f"Clone the git repository at {remote_url} into a directory named "
+            "repo. Inside that repo, create a branch named muxi-update, append "
+            "the line: updated by muxi, to the end of notes.txt, commit with "
+            "the message: muxi update, and push the muxi-update branch to origin."
+        )
+
+        formation, overlord = await load_formation("formation-opencode")
+        print(f"Formation loaded: {formation.formation_id}")
+
+        reply, job, user = await delegate_via_chat(overlord, task)
+        finished = await wait_for_completion(overlord, job["id"], user)
+        assert finished.status == "completed", f"delegation failed: {finished.error}"
+
+        # The branch + commit must have arrived in the bare remote.
+        bare = str(fixture_dir / "remote.git")
+        branch = git(["--git-dir", bare, "rev-parse", "muxi-update"], check=False)
+        assert branch.returncode == 0, "branch muxi-update was not pushed to the remote"
+        notes = git(["--git-dir", bare, "show", "muxi-update:notes.txt"]).stdout
+        assert "updated by muxi" in notes, f"pushed notes.txt missing the change: {notes!r}"
+        subject = git(["--git-dir", bare, "log", "-1", "--format=%s", "muxi-update"]).stdout.strip()
+        print(f"Remote received branch muxi-update, HEAD commit: {subject!r}")
+        print(f"notes.txt on the remote branch:\n{notes.strip()}")
+
+        await wait_for_reentry(overlord, job["id"], user)
+
+        print("\n" + "=" * 40)
+        print("\n### Test Result:")
+        print("  SUCCESS: opencode existing-project delegation works end-to-end")
+        print("  - the real opencode run cloned the local file:// remote")
+        print("  - the change was committed and pushed as branch muxi-update")
+        print("  - the bare remote received the branch + commit (git is the persistence layer)")
+        print("\n" + "=" * 40)
+        print("\n### Chat transcript:")
+        print(f'\nUser: Please delegate this coding task: "{task}"')
+        print(f"System: {reply}")
+
+        print("\nTest 24A9 PASSED")
+        return True
+
+    except Exception as e:
+        print(f"\nTest failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+    finally:
+        if formation is not None:
+            await teardown(formation)
+        shutil.rmtree(fixture_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0 if success else 1)

--- a/src/muxi/runtime/formation/background/builtin/coding/opencode.yaml
+++ b/src/muxi/runtime/formation/background/builtin/coding/opencode.yaml
@@ -1,0 +1,40 @@
+# Bundled coding adapter template: opencode (dormant until referenced).
+#
+# Activate with `coding.client: opencode`; shadow by placing a
+# coding/opencode.yaml file in the formation directory. Installation and
+# authentication (`opencode auth login` or provider API-key env vars) are
+# the developer's business -- MUXI only verifies the binary is present at
+# formation load.
+#
+# Tested against: opencode 1.14.46 (flags verified 2026-07-10 against the
+# installed binary with real runs):
+# - `opencode run [message..]` -- positional prompt confirmed.
+# - `--format json` -- raw JSON events, one per line (JSONL): step_start,
+#   tool_use, step_finish, text -- maps to the stream-json parser. Every
+#   event carries a top-level "sessionID"; text events carry the complete
+#   part text at "part.text", so the last text event is the final
+#   assistant message (last non-empty extraction wins).
+# - `--session <id>` -- resume ONLY: passing a fresh id fails with
+#   "Session not found" (exit 1, verified empirically), so the template
+#   uses the captured-id path: the first run gets NO session flag and the
+#   tool-assigned id is parsed from output.
+# - `--model <provider/model>` -- opaque vendor namespace.
+#
+# Vendor permission/safety surface goes through coding.extra_args
+# (passthrough only): --dangerously-skip-permissions (auto-approve
+# anything not explicitly denied -- sandboxed environments only),
+# --agent <name>, --title <title>.
+name: opencode
+command: opencode
+args:
+  base: ["run", "--format", "json"]
+  prompt: ["{prompt}"]
+  session_resume: ["--session", "{id}"]
+  model: ["--model", "{model}"]
+output: stream-json
+parse:
+  result: "$.part.text"
+  session_id: "$.sessionID"
+# MUXI sets the subprocess cwd (fresh <root>/<user_id>/<request_id> dir);
+# flags that would move it are rejected at load.
+forbidden_extra_args: ["--dir"]

--- a/src/muxi/runtime/formation/background/builtin/coding/pi.yaml
+++ b/src/muxi/runtime/formation/background/builtin/coding/pi.yaml
@@ -1,0 +1,48 @@
+# Bundled coding adapter template: pi (@mariozechner/pi-coding-agent;
+# dormant until referenced).
+#
+# Activate with `coding.client: pi`; shadow by placing a coding/pi.yaml
+# file in the formation directory. Installation
+# (`npm install -g @mariozechner/pi-coding-agent`) and credentials
+# (provider API-key env vars such as ANTHROPIC_API_KEY, via coding.env)
+# are the developer's business -- MUXI only verifies the binary is
+# present at formation load.
+#
+# Tested against: pi 0.73.1 (flags verified 2026-07-10 against a local
+# install; the verification runs were credential-less, so everything a
+# run emits BEFORE the LLM call is real-verified and the successful-run
+# event schema comes from that version's bundled docs/json.md):
+# - `pi --print --mode json [messages..]` -- headless JSONL events;
+#   positional prompt confirmed.
+# - The first output line is the session header
+#   {"type":"session","version":3,"id":"<uuid>","timestamp":...,"cwd":...}
+#   (real output) -- the only event with a top-level "id", so
+#   parse.session_id captures it.
+# - `--session <path|id>` -- resume ONLY: a fresh id fails with "No
+#   session found matching" (exit 1, verified empirically), so the
+#   template uses the captured-id path. Id lookup falls back to a global
+#   search across project session dirs (source-verified), so resuming
+#   from a fresh delegation directory works.
+# - `--model <provider/id>` -- opaque; optional ":<thinking>" suffix
+#   (e.g. anthropic/claude-sonnet-4-5:high).
+#
+# Useful coding.extra_args (passthrough only): --thinking <level>,
+# --tools <allowlist>, --no-extensions, --no-skills.
+name: pi
+command: pi
+args:
+  base: ["--print", "--mode", "json"]
+  prompt: ["{prompt}"]
+  session_resume: ["--session", "{id}"]
+  model: ["--model", "{model}"]
+output: stream-json
+parse:
+  # [verify] Selector derived from docs/json.md (no credentialed run was
+  # available): the terminal "agent_end" event carries every message; the
+  # last message is the final assistant one and its last content block is
+  # its text (thinking blocks precede text blocks).
+  result: "$.messages[-1].content[-1].text"
+  session_id: "$.id"
+# pi exposes no cwd/worktree flag (sessions live under ~/.pi, looked up
+# globally); MUXI sets the subprocess cwd itself. Nothing to forbid.
+forbidden_extra_args: []

--- a/src/muxi/runtime/formation/background/builtin/coding/pi.yaml
+++ b/src/muxi/runtime/formation/background/builtin/coding/pi.yaml
@@ -16,8 +16,9 @@
 #   positional prompt confirmed.
 # - The first output line is the session header
 #   {"type":"session","version":3,"id":"<uuid>","timestamp":...,"cwd":...}
-#   (real output) -- the only event with a top-level "id", so
-#   parse.session_id captures it.
+#   (real output). Session-id capture is first-match, so the header wins
+#   even if some later event in a credentialed run carries an unrelated
+#   root-level "id" (never observed; guarded regardless).
 # - `--session <path|id>` -- resume ONLY: a fresh id fails with "No
 #   session found matching" (exit 1, verified empirically), so the
 #   template uses the captured-id path. Id lookup falls back to a global

--- a/src/muxi/runtime/services/coding/adapter.py
+++ b/src/muxi/runtime/services/coding/adapter.py
@@ -100,12 +100,18 @@ def _extract_cost(document: Dict[str, Any]) -> Optional[float]:
 
 
 def _apply_selectors(adapter: AdapterConfig, document: Dict[str, Any], parsed: ParsedOutput):
-    """Apply the adapter's parse selectors to one JSON document (last wins)."""
+    """Apply the adapter's parse selectors to one JSON document.
+
+    Result: last non-empty extraction wins (the terminal event carries
+    the final result). Session id: FIRST match wins -- a session id never
+    changes mid-run, and a later event may carry an unrelated root-level
+    field of the same name (a tool-call id, say) that must not clobber it.
+    """
     if adapter.parse_result:
         value = extract_path(document, adapter.parse_result)
         if value is not None:
             parsed.result = value if isinstance(value, str) else json.dumps(value)
-    if adapter.parse_session_id:
+    if adapter.parse_session_id and parsed.session_id is None:
         value = extract_path(document, adapter.parse_session_id)
         if isinstance(value, str) and value.strip():
             parsed.session_id = value.strip()
@@ -132,8 +138,9 @@ def parse_output(adapter: AdapterConfig, stdout: str) -> ParsedOutput:
 
     - ``stream-json``: JSONL -- every parseable event is retained (the
       service also observes them incrementally as DELEGATION_PROGRESS);
-      selectors apply to each event, last non-empty extraction wins (the
-      terminal event carries the result).
+      selectors apply to each event: the result takes the last non-empty
+      extraction (the terminal event carries it), the session id the
+      first (it never changes mid-run).
     - ``json``: a single document on exit; selectors apply to it. Defensive
       fallback: when the whole stdout is not one document, the last
       parseable line wins (some CLIs prepend informational lines).

--- a/src/muxi/runtime/services/coding/service.py
+++ b/src/muxi/runtime/services/coding/service.py
@@ -420,6 +420,12 @@ class DelegationService:
             # secrets resolve). Argv never carries a secret.
             env = dict(os.environ)
             env.update(self.config.env)
+            # POSIX-shell hygiene: PWD must match the child's cwd (shells
+            # rewrite it on every cd; a plain environ inherit leaks the
+            # runtime's). opencode 1.14.46 resolves its working directory
+            # from PWD (verified 2026-07-10) -- with a stale value it
+            # operates on the wrong tree.
+            env["PWD"] = job.delegation_dir
 
             proc = await asyncio.create_subprocess_exec(
                 *argv,

--- a/tests/unit/coding/test_coding_config.py
+++ b/tests/unit/coding/test_coding_config.py
@@ -318,6 +318,8 @@ class TestTemplateResolution:
         names = list_bundled_adapters()
         assert "claude-code" in names
         assert "droid" in names
+        assert "opencode" in names
+        assert "pi" in names
 
     def test_bundled_claude_code_shape(self):
         adapter = resolve_adapter_template("claude-code", None)
@@ -343,11 +345,50 @@ class TestTemplateResolution:
         assert adapter.generates_session_id is True
         assert "--cwd" in adapter.forbidden_extra_args
 
+    def test_bundled_opencode_shape(self):
+        adapter = resolve_adapter_template("opencode", None)
+        assert adapter.command == "opencode"
+        assert adapter.prompt == ["{prompt}"]
+        assert adapter.output == "stream-json"
+        # Verified 2026-07-10 against opencode 1.14.46: --session with a
+        # fresh id fails ("Session not found"), so the template uses the
+        # captured-id path -- no session flag on the first run, the
+        # tool-assigned id parsed from output.
+        assert adapter.session is None
+        assert adapter.session_new is None
+        assert adapter.session_resume == ["--session", "{id}"]
+        assert adapter.captures_session_id is True
+        assert adapter.generates_session_id is False
+        assert adapter.supports_resume is True
+        assert adapter.parse_result == "$.part.text"
+        assert adapter.parse_session_id == "$.sessionID"
+        assert "--dir" in adapter.forbidden_extra_args
+
+    def test_bundled_pi_shape(self):
+        adapter = resolve_adapter_template("pi", None)
+        assert adapter.command == "pi"
+        assert adapter.prompt == ["{prompt}"]
+        assert adapter.output == "stream-json"
+        # Verified 2026-07-10 against pi 0.73.1: --session with a fresh
+        # id fails ("No session found matching"), so pi also uses the
+        # captured-id path (the session header event carries the id).
+        assert adapter.session is None
+        assert adapter.session_new is None
+        assert adapter.session_resume == ["--session", "{id}"]
+        assert adapter.captures_session_id is True
+        assert adapter.generates_session_id is False
+        assert adapter.supports_resume is True
+        assert adapter.parse_result == "$.messages[-1].content[-1].text"
+        assert adapter.parse_session_id == "$.id"
+        assert adapter.forbidden_extra_args == []
+
     def test_unknown_client_lists_bundled(self):
         with pytest.raises(CodingConfigError) as excinfo:
             parse_coding_config({"client": "nope", "workdirs": ["./ws"]})
         assert "claude-code" in str(excinfo.value)
         assert "droid" in str(excinfo.value)
+        assert "opencode" in str(excinfo.value)
+        assert "pi" in str(excinfo.value)
 
     def test_client_name_pattern(self):
         with pytest.raises(CodingConfigError, match="template name"):

--- a/tests/unit/coding/test_delegation_service.py
+++ b/tests/unit/coding/test_delegation_service.py
@@ -65,6 +65,14 @@ elif mode == "argv":
     }))
 elif mode == "pwd":
     print(json.dumps({"type": "result", "result": os.getcwd(), "session_id": "vend-pwd"}))
+elif mode == "envpwd":
+    # Some CLIs (opencode) resolve their working directory from the PWD
+    # environment variable rather than the real cwd.
+    print(json.dumps({
+        "type": "result",
+        "result": os.environ.get("PWD", ""),
+        "session_id": "vend-envpwd",
+    }))
 elif mode == "stream":
     prompt = sys.stdin.read()
     print(json.dumps({"type": "system", "subtype": "init", "session_id": "ignored"}))
@@ -443,6 +451,15 @@ class TestWorkdirs:
         assert os.path.realpath(job.result) == os.path.realpath(expected)
         assert os.path.isdir(expected)  # keep: directory survives
 
+    async def test_env_pwd_matches_delegation_dir(self, tmp_path, fixture_cli):
+        """PWD is rewritten to the delegation dir (POSIX-shell hygiene):
+        CLIs that trust PWD over the real cwd (opencode) must not see the
+        runtime's own directory."""
+        service = make_service(tmp_path, fixture_cli, mode_args=["envpwd"], cleanup="keep")
+        result = await service.delegate(user_id="u1", prompt="where does PWD say")
+        job = await wait_terminal(service, result["job_id"])
+        assert os.path.realpath(job.result) == os.path.realpath(job.delegation_dir)
+
     async def test_workdir_param_selects_root(self, tmp_path, fixture_cli):
         service = make_service(
             tmp_path, fixture_cli, mode_args=["pwd"], workdirs=["ws", "alt"], cleanup="keep"
@@ -797,3 +814,86 @@ class TestParsers:
         adapter = self._adapter("json")
         parsed = parse_output(adapter, json.dumps({"result": {"files": 3}}))
         assert json.loads(parsed.result) == {"files": 3}
+
+    def test_opencode_template_selectors_on_real_shape(self):
+        """The bundled opencode template's selectors against the real
+        event shapes (captured from opencode 1.14.46, 2026-07-10)."""
+        from muxi.runtime.services.coding.config import resolve_adapter_template
+
+        adapter = resolve_adapter_template("opencode", None)
+        stdout = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "step_start",
+                        "sessionID": "ses_abc123",
+                        "part": {"type": "step-start"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "tool_use",
+                        "sessionID": "ses_abc123",
+                        "part": {"type": "tool", "tool": "write", "state": {"output": "ok"}},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "step_finish",
+                        "sessionID": "ses_abc123",
+                        "part": {"type": "step-finish", "cost": 0},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "text",
+                        "sessionID": "ses_abc123",
+                        "part": {"type": "text", "text": "I created the file."},
+                    }
+                ),
+            ]
+        )
+        parsed = parse_output(adapter, stdout)
+        assert parsed.result == "I created the file."
+        assert parsed.session_id == "ses_abc123"
+
+    def test_pi_template_selectors_on_documented_shape(self):
+        """The bundled pi template's selectors: session header (real shape,
+        pi 0.73.1) + agent_end (docs/json.md shape), negative indices."""
+        from muxi.runtime.services.coding.config import resolve_adapter_template
+
+        adapter = resolve_adapter_template("pi", None)
+        final = {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "hmm"},
+                {"type": "text", "text": "All done."},
+            ],
+            "stopReason": "stop",
+        }
+        stdout = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "session",
+                        "version": 3,
+                        "id": "0199aaaa-bbbb-7ccc-8ddd-eeeeffff0001",
+                        "cwd": "/tmp/x",
+                    }
+                ),
+                json.dumps({"type": "agent_start"}),
+                json.dumps({"type": "message_end", "message": final}),
+                json.dumps(
+                    {
+                        "type": "agent_end",
+                        "messages": [
+                            {"role": "user", "content": [{"type": "text", "text": "task"}]},
+                            final,
+                        ],
+                    }
+                ),
+            ]
+        )
+        parsed = parse_output(adapter, stdout)
+        assert parsed.result == "All done."
+        assert parsed.session_id == "0199aaaa-bbbb-7ccc-8ddd-eeeeffff0001"

--- a/tests/unit/coding/test_delegation_service.py
+++ b/tests/unit/coding/test_delegation_service.py
@@ -75,12 +75,14 @@ elif mode == "envpwd":
     }))
 elif mode == "stream":
     prompt = sys.stdin.read()
-    print(json.dumps({"type": "system", "subtype": "init", "session_id": "ignored"}))
+    # Session-id capture is FIRST-match (the init event wins); the
+    # terminal event's differing value must not clobber it.
+    print(json.dumps({"type": "system", "subtype": "init", "session_id": "vend-stream"}))
     print(json.dumps({"type": "assistant", "text": "working"}))
     print(json.dumps({
         "type": "result",
         "result": "stream-done: " + prompt.strip(),
-        "session_id": "vend-stream",
+        "session_id": "later-value-must-not-clobber",
         "total_cost_usd": 0.042,
     }))
 elif mode == "sleep":
@@ -247,6 +249,8 @@ class TestCompletionAndReentry:
         job = await wait_terminal(service, result["job_id"])
         assert job.status == STATUS_COMPLETED
         assert job.result == "stream-done: via stdin"
+        # First-match capture: the init event's id, not the terminal
+        # event's differing value.
         assert job.vendor_session_id == "vend-stream"
         assert job.cost_usd == 0.042
 
@@ -771,7 +775,9 @@ class TestParsers:
             raw["parse"] = {"result": "$.result", "session_id": "$.session_id"}
         return parse_coding_config(raw).adapter
 
-    def test_stream_json_last_result_wins(self):
+    def test_stream_json_result_last_session_first(self):
+        """Result: last non-empty extraction wins. Session id: first
+        match wins (it never changes mid-run)."""
         adapter = self._adapter("stream-json")
         stdout = "\n".join(
             [
@@ -782,7 +788,7 @@ class TestParsers:
         )
         parsed = parse_output(adapter, stdout)
         assert parsed.result == "final"
-        assert parsed.session_id == "late"
+        assert parsed.session_id == "early"
         assert parsed.event_count == 2  # unparseable line skipped
 
     def test_json_document(self):
@@ -897,3 +903,83 @@ class TestParsers:
         parsed = parse_output(adapter, stdout)
         assert parsed.result == "All done."
         assert parsed.session_id == "0199aaaa-bbbb-7ccc-8ddd-eeeeffff0001"
+
+    def test_pi_session_id_survives_later_root_level_ids(self):
+        """First-match session capture: a later event carrying an
+        unrelated root-level "id" (tool-call shaped; plausible in a
+        credentialed run, never observed in the credential-less
+        verification) must not clobber the header UUID."""
+        from muxi.runtime.services.coding.config import resolve_adapter_template
+
+        adapter = resolve_adapter_template("pi", None)
+        header_id = "0199aaaa-bbbb-7ccc-8ddd-eeeeffff0001"
+        stdout = "\n".join(
+            [
+                json.dumps({"type": "session", "version": 3, "id": header_id, "cwd": "/tmp/x"}),
+                json.dumps({"type": "agent_start"}),
+                json.dumps(
+                    {
+                        "type": "tool_execution_start",
+                        "id": "call_9f2a",  # unrelated root-level id
+                        "toolCallId": "call_9f2a",
+                        "toolName": "bash",
+                        "args": {"command": "ls"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "agent_end",
+                        "messages": [
+                            {
+                                "role": "assistant",
+                                "content": [{"type": "text", "text": "done"}],
+                                "stopReason": "stop",
+                            }
+                        ],
+                    }
+                ),
+            ]
+        )
+        parsed = parse_output(adapter, stdout)
+        assert parsed.session_id == header_id
+        assert parsed.result == "done"
+
+    def test_pi_thinking_block_last_falls_back_to_raw_stdout(self):
+        """When the final content block has no text (thinking last), the
+        pi result selector extracts nothing and the documented fallback
+        -- raw stdout as the result -- is what carries the outcome."""
+        from muxi.runtime.services.coding.config import resolve_adapter_template
+
+        adapter = resolve_adapter_template("pi", None)
+        stdout = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "session",
+                        "version": 3,
+                        "id": "0199aaaa-bbbb-7ccc-8ddd-eeeeffff0002",
+                        "cwd": "/tmp/x",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "agent_end",
+                        "messages": [
+                            {
+                                "role": "assistant",
+                                "content": [
+                                    {"type": "text", "text": "partial"},
+                                    {"type": "thinking", "thinking": "trailing thought"},
+                                ],
+                                "stopReason": "stop",
+                            }
+                        ],
+                    }
+                ),
+            ]
+        )
+        parsed = parse_output(adapter, stdout)
+        # No .text on the final block -> selector extracts nothing ->
+        # the raw stdout fallback keeps the run from reporting empty.
+        assert parsed.result == stdout
+        assert parsed.session_id == "0199aaaa-bbbb-7ccc-8ddd-eeeeffff0002"


### PR DESCRIPTION
Phase 2a of the coding-agent delegation PRD (#274 follow-up): the two remaining bundled adapter templates, plus e2e coverage and docs. Escalation flow and artifact capture (Phase 2b) are deliberately NOT in this PR.

## What's verified-real vs docs-only

**opencode — fully verified against the real, authenticated binary (opencode 1.14.46, real runs):**
- `opencode run [message..]` positional prompt; `--format json` emits JSONL events (`step_start`, `tool_use`, `step_finish`, `text`) → `output: stream-json`
- Every event carries a top-level `sessionID` → `parse.session_id: "$.sessionID"`; text events carry the complete part text → `parse.result: "$.part.text"` (last-wins = final assistant message; validated against captured real output in a unit test)
- `--session <id>` is resume-ONLY: a fresh id fails with "Session not found" (exit 1), so the template uses the captured-id path (PRD `[verify]` resolved)
- `--model provider/model` opaque passthrough; `--dir` (the tool's cwd flag) on the forbidden list

**pi — flags verified against a real local install (pi 0.73.1 via npm, credential-less); successful-run event schema docs-only:**
- `pi --print --mode json [messages..]` headless JSONL; the session header event `{"type":"session","version":3,"id":"<uuid>",...}` is REAL output (emitted even on a keyless run) → `parse.session_id: "$.id"` is verified
- `--session <path|id>` is resume-ONLY (fresh id → "No session found matching", exit 1, verified); id lookup falls back to a global cross-project search (source-verified), so resume from a fresh delegation dir works
- ⚠️ `parse.result: "$.messages[-1].content[-1].text"` derives from that version's bundled `docs/json.md` (`agent_end` event) — no provider credentials were available for a real successful run, so it is marked with a `# [verify]` comment in the template

**Mechanism fix (unit-pinned):** delegation subprocesses now get `PWD` rewritten to the delegation directory. opencode resolves its working directory from `$PWD` rather than the real cwd (verified empirically: with cwd=A and PWD=B it writes to B), and the inherited runtime value made it operate on the wrong tree.

## E2E coverage

| Test | Tool | Kind | Notes |
|---|---|---|---|
| 24A7 opencode ad-hoc | real `opencode run` | real | + asserts tool-assigned session id captured (resumable) |
| 24A8 opencode new-project | real | real | git init + commit in delegation dir |
| 24A9 opencode existing-project | real | real | hermetic local bare `file://` remote, branch pushed |
| 24A10 pi | fixture CLI | fixture | fixture emits the REAL pi 0.73.1 shapes; exercises the bundled template's selectors + captured-session continuation (`--session <captured id>` round-trip) end to end |

All four pass locally; 24A1 (claude ad-hoc) re-run after the PWD change as a regression check — passes.

## Gates

- `tests/unit/` full suite: 3518 passed, 10 skipped (one order-dependent flake in `test_atomic_yaml_rename` on the first run, unrelated to this change; passes in isolation and on full-suite rerun)
- `e2e run_random_tests.py 5`: 5/5 (4_mcp, 7_orchestration ×2, 17_multiple_identities, 21_skills)
- `scripts/validate_events.py`: 1424/1424 (100%)
- black / isort / ruff: clean
- CHANGELOG.md: entry appended under [unreleased]

🤖 Generated with [Claude Code](https://claude.com/claude-code)