### PR TITLE
chore(e2e): renumber watch area to 26_watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ response contextually, guided by a bundled SOP fragment:
 - Docs: `contributing/remote-async-tools.md` -- the four long-running
   patterns (slow-sync timeout, watch_job, app-level webhook trigger,
   per-call webhook trigger) with a worked image-generation example.
-- E2E: new `25_watch/` area (fixture stdio MCP job server) -- full
+- E2E: new `26_watch/` area (fixture stdio MCP job server) -- full
   agent loop, timeout path, /jobs cancel mid-watch, GBAC + cross-user
   isolation, and D6 channel-delivery resolution.
 ### Response envelope UI - typed affordances (options, action_link)

--- a/e2e/run_all_tests.py
+++ b/e2e/run_all_tests.py
@@ -40,7 +40,7 @@ AREA_TIMEOUT_OVERRIDES = {
     # Watch tests run real LLM turns (submit -> watch_job recognition,
     # completion re-entry) around fixed-cadence poll loops; the full-loop
     # test alone is ~2 LLM turns + ~6s of polling + channel delivery.
-    "25_watch": 300,
+    "26_watch": 300,
     # Envelope UI tests drive multi-turn clarification flows (LLM
     # analysis + MCP credential resolution + retry of the original
     # request) against real OpenAI; three rounds regularly exceed 120s.

--- a/e2e/tests/26_watch/fixture_job_server.py
+++ b/e2e/tests/26_watch/fixture_job_server.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """One-file stdio MCP server simulating an async job service.
 
-The fixture for the 25_watch e2e area (remote async tools): ``submit``
+The fixture for the 26_watch e2e area (remote async tools): ``submit``
 returns a job handle immediately (``{"job_id": ..., "status":
 "queued"}``) and ``check_status`` flips to ``succeeded`` after N status
 checks. The runtime uses ephemeral connections (a fresh process per

--- a/e2e/tests/26_watch/test_26a1_full_loop.py
+++ b/e2e/tests/26_watch/test_26a1_full_loop.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Test 25A1: watch_job full loop (remote async tools).
+Test 26A1: watch_job full loop (remote async tools).
 
 The complete PRD flow against a real agent and the fixture stdio MCP job
 server: the user asks for a render -> the agent calls submit (an
@@ -62,12 +62,12 @@ class SinkServer:
 
 
 async def main():
-    print("MUXI Runtime - Test 25A1: watch_job full loop")
+    print("MUXI Runtime - Test 26A1: watch_job full loop")
     print("=" * 60)
 
     formation = None
     sink = SinkServer()
-    tmp = Path(tempfile.mkdtemp(prefix="muxi-watch-25a1-"))
+    tmp = Path(tempfile.mkdtemp(prefix="muxi-watch-26a1-"))
     try:
         await sink.start()
         formation_dir = build_formation(
@@ -135,7 +135,7 @@ async def main():
         print(f"System: {reply}")
         print(f"System (notification): {delivered['text']}")
 
-        print("\nTest 25A1 PASSED")
+        print("\nTest 26A1 PASSED")
         return True
 
     except Exception as e:

--- a/e2e/tests/26_watch/test_26a2_timeout.py
+++ b/e2e/tests/26_watch/test_26a2_timeout.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """
-Test 25A2: watch_job timeout path.
+Test 26A2: watch_job timeout path.
 
 The fixture job never reaches a terminal status (--polls-to-done 0), so
 the watch must resolve as timed_out at the formation-configured deadline
 and re-enter the conversation with that status -- nothing silently
 vanishes. Registered through the service surface for deterministic
-timing (the full agent loop is covered by 25A1).
+timing (the full agent loop is covered by 26A1).
 """
 
 import asyncio
@@ -26,11 +26,11 @@ from watch_common import (
 
 
 async def main():
-    print("MUXI Runtime - Test 25A2: watch_job timeout path")
+    print("MUXI Runtime - Test 26A2: watch_job timeout path")
     print("=" * 60)
 
     formation = None
-    tmp = Path(tempfile.mkdtemp(prefix="muxi-watch-25a2-"))
+    tmp = Path(tempfile.mkdtemp(prefix="muxi-watch-26a2-"))
     try:
         formation_dir = build_formation(tmp, interval=1, timeout=5, polls_to_done=0)
         formation, overlord = await load_formation(formation_dir)
@@ -64,7 +64,7 @@ async def main():
         print("\nUser: (service) watch a job that never finishes")
         print(f"System: watch {result['job_id']} resolved as timed_out and re-entered")
 
-        print("\nTest 25A2 PASSED")
+        print("\nTest 26A2 PASSED")
         return True
 
     except Exception as e:

--- a/e2e/tests/26_watch/test_26a3_jobs_cancel.py
+++ b/e2e/tests/26_watch/test_26a3_jobs_cancel.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Test 25A3: /jobs list + cancel mid-watch.
+Test 26A3: /jobs list + cancel mid-watch.
 
 Watches are tracked jobs (PRD D8): the built-in /jobs command lists an
 active watch, cancel stops polling, and a user-initiated cancel produces
@@ -33,11 +33,11 @@ async def run_command(overlord, message: str):
 
 
 async def main():
-    print("MUXI Runtime - Test 25A3: /jobs list + cancel mid-watch")
+    print("MUXI Runtime - Test 26A3: /jobs list + cancel mid-watch")
     print("=" * 60)
 
     formation = None
-    tmp = Path(tempfile.mkdtemp(prefix="muxi-watch-25a3-"))
+    tmp = Path(tempfile.mkdtemp(prefix="muxi-watch-26a3-"))
     try:
         # Long interval: the watch stays active while we exercise /jobs.
         formation_dir = build_formation(
@@ -99,7 +99,7 @@ async def main():
         print(f"\nUser: /jobs cancel {job_id}")
         print(f"System: {cancel_reply}")
 
-        print("\nTest 25A3 PASSED")
+        print("\nTest 26A3 PASSED")
         return True
 
     except Exception as e:

--- a/e2e/tests/26_watch/test_26a4_gbac_isolation.py
+++ b/e2e/tests/26_watch/test_26a4_gbac_isolation.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Test 25A4: cross-user isolation + GBAC context on polls (PRD D5).
+Test 26A4: cross-user isolation + GBAC context on polls (PRD D5).
 
 Against a formation with real group files loaded by the GBAC resolver:
 
@@ -51,11 +51,11 @@ mcp_servers:
 
 
 async def main():
-    print("MUXI Runtime - Test 25A4: cross-user isolation + GBAC on polls")
+    print("MUXI Runtime - Test 26A4: cross-user isolation + GBAC on polls")
     print("=" * 60)
 
     formation = None
-    tmp = Path(tempfile.mkdtemp(prefix="muxi-watch-25a4-"))
+    tmp = Path(tempfile.mkdtemp(prefix="muxi-watch-26a4-"))
     try:
         formation_dir = build_formation(
             tmp,
@@ -145,7 +145,7 @@ async def main():
         print("\nUser (alice/watchers): watch check_status")
         print(f"System: watch {watch_id} completed with {job.result!r}")
 
-        print("\nTest 25A4 PASSED")
+        print("\nTest 26A4 PASSED")
         return True
 
     except Exception as e:

--- a/e2e/tests/26_watch/test_26a5_channel_delivery.py
+++ b/e2e/tests/26_watch/test_26a5_channel_delivery.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Test 25A5: completion delivery resolution (PRD D6).
+Test 26A5: completion delivery resolution (PRD D6).
 
 The channel variant using the existing channel-template fixture
 machinery: the user has a PREFERRED proactiveness channel (chan-b) that
@@ -52,12 +52,12 @@ class SinkServer:
 
 
 async def main():
-    print("MUXI Runtime - Test 25A5: completion delivery resolution (D6)")
+    print("MUXI Runtime - Test 26A5: completion delivery resolution (D6)")
     print("=" * 60)
 
     formation = None
     sink = SinkServer()
-    tmp = Path(tempfile.mkdtemp(prefix="muxi-watch-25a5-"))
+    tmp = Path(tempfile.mkdtemp(prefix="muxi-watch-26a5-"))
     try:
         await sink.start()
         print(f"Sink server listening on 127.0.0.1:{SINK_PORT}")
@@ -108,7 +108,7 @@ async def main():
         print("\nUser: (service) watch a fixture render job")
         print(f"System (chan-b): {delivered['json']['text']}")
 
-        print("\nTest 25A5 PASSED")
+        print("\nTest 26A5 PASSED")
         return True
 
     except Exception as e:

--- a/e2e/tests/26_watch/watch_common.py
+++ b/e2e/tests/26_watch/watch_common.py
@@ -1,5 +1,5 @@
 """
-Shared helpers for the 25_watch e2e area (remote async tools).
+Shared helpers for the 26_watch e2e area (remote async tools).
 
 Every test generates its formation at runtime into a temp directory
 (the scheduler-area standalone pattern): the fixture MCP job server

--- a/mental-model.md
+++ b/mental-model.md
@@ -4189,7 +4189,7 @@ resolver quota; service: always-async, done_when matrix, timeout,
 consecutive failures, cancel, GBAC stored-context restoration,
 re-entry fencing/route_class, /jobs surface; dispatch: SOP shadowing)
 and `TestJobsWatch` in `tests/unit/test_builtin_commands.py`; e2e area
-`e2e/tests/25_watch/` -- five standalone tests over a generated
+`e2e/tests/26_watch/` -- five standalone tests over a generated
 formation + fixture stdio MCP job server (state in a JSON file because
 ephemeral connections spawn a fresh server process per call).
 


### PR DESCRIPTION
The two parallel feature PRs (#277, #278) both claimed e2e area number 25 (`25_envelope_ui`, `25_watch`). Renumber the watch area to `26_watch` — directory, test filenames (`26aN`), internal labels, tempdir prefixes, the runner timeout map, CHANGELOG and mental-model references. Renamed `26a3` smoke-run passed (SUCCESS + exit 0). No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)