### PR TITLE
feat(channels): envelope ui P3 — native widget rendering in channel templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 ## [unreleased]
 
+### Response envelope UI - channel-native widget rendering (P3)
+
+The bundled slack/telegram/discord transformer templates now render
+envelope UI widgets natively (Response Envelope UI PRD, P3 -- owner
+ruling 2026-07-11), and channel button presses round-trip into the
+existing deterministic `ui_response` pinning. The text body always
+ships; widgets are strictly additive to the channel message:
+
+- Template namespace: transformer substitution gains `response.ui`
+  (raw widget array) and channel-native renderings under `ui.*`
+  (`ui.telegram.reply_markup`, `ui.slack.blocks`,
+  `ui.discord.components`). Every entry is None without widgets, so
+  the existing None-dropping dict rendering keeps text-only deliveries
+  byte-identical (pinned by tests). Formations with their own
+  templates see zero change.
+- Bundled templates updated in place (not forked): telegram renders
+  `options` as an inline keyboard and `action_link` as url buttons;
+  slack renders Block Kit (a section carrying the full text -- Slack
+  shows blocks INSTEAD of top-level text -- plus actions buttons);
+  discord renders component action rows (5x5 clamp). Email stays text.
+- Button callback encoding: `<widget_id>#<option_index>` -- index, not
+  value, so the string always fits Telegram's 64-byte callback_data
+  limit; the index resolves against the pending clarification's
+  offered options (no server-side widget state, runtime stays
+  stateless).
+- Inbound: trigger `parse:` specs accept a `ui_response:` path
+  (Telegram `$.callback_query.data`, Slack `$.actions[0].value`,
+  Discord `$.data.custom_id`); the decoded `{id, index}` hint rides
+  the chat re-entry and hits the existing pinning, emitting
+  `ui.response.received` as before. Foreign callback payloads decode
+  to None -- the message stands alone.
+- E2E: telegram inline-keyboard delivery + simulated callback_query
+  pinning round trip (25A6); slack Block Kit variant + text-only
+  template zero-change pin (25A7).
+
 ### Remote async tools - `watch_job` for MCP job-id + poll services
 
 MCP-reachable work that outlives a turn (image/video generation, long

--- a/e2e/tests/25_envelope_ui/formations/formation-envelope-channels/agents/example_agent.yaml
+++ b/e2e/tests/25_envelope_ui/formations/formation-envelope-channels/agents/example_agent.yaml
@@ -1,0 +1,16 @@
+schema: "1.0.0"
+id: "example_agent"
+name: "Example Agent"
+description: "AI assistant used to exercise the response envelope UI affordances"
+
+system_message: |
+  You are an AI assistant with access to MCP (Model Context Protocol) tools.
+  Use the available GitHub tools when the user asks about repositories.
+  Be concise and direct.
+
+role: "general"
+specialties:
+  - "mcp"
+  - "github"
+
+mcp_enabled: true

--- a/e2e/tests/25_envelope_ui/formations/formation-envelope-channels/formation.yaml
+++ b/e2e/tests/25_envelope_ui/formations/formation-envelope-channels/formation.yaml
@@ -1,0 +1,60 @@
+schema: "1.0.0"
+id: "envelope-channels-test"
+description: "Formation for testing channel-native widget rendering (Response Envelope UI, P3)"
+
+llm:
+  api_keys:
+    openai: "${{ secrets.OPENAI_API_KEY }}"
+  models:
+    - text: "openai/gpt-4o-mini"
+    - embedding: "openai/text-embedding-3-small"
+
+runtime:
+  built_in_mcps: false
+  mcp_server_startup_timeout: 30
+
+agents:
+  - example_agent
+
+overlord:
+  workflow:
+    auto_decomposition: false
+
+# Dynamic mode allows multi-account clarification (the enumerable
+# interpretations that produce an options widget)
+user_credentials:
+  mode: "dynamic"
+
+mcp:
+  servers:
+    - github-mcp
+  max_tool_calls: 10
+  max_tool_iterations: 5
+
+memory:
+  working:
+    max_memory_mb: 1
+    fifo_interval_min: 5
+    vector_dimension: 1536
+    mode: "local"
+
+  buffer:
+    size: 50
+    multiplier: 10
+    vector_search: false
+
+  persistent:
+    connection_string: "${{ secrets.POSTGRES_URI }}"
+    embedding_model: "openai/text-embedding-3-small"
+
+server:
+  enabled: true
+  port: 18253
+  api_keys:
+    admin_key: envelope-admin-key
+    client_key: envelope-client-key
+
+logging:
+  system:
+    level: "error"
+    destination: "stdout"

--- a/e2e/tests/25_envelope_ui/formations/formation-envelope-channels/mcp/github.yaml
+++ b/e2e/tests/25_envelope_ui/formations/formation-envelope-channels/mcp/github.yaml
@@ -1,0 +1,17 @@
+# HTTP-based MCP server configuration schema
+schema: "1.0.0"                    # Schema version (Semantic Versioning)
+id: "github-mcp"                    # Unique server name/id (required)
+description: "Github MCP"  # Human-readable description
+type: "http"                       # Server type: http (required)
+
+# Connection details
+endpoint: "https://api.githubcopilot.com/mcp/"  # Server endpoint URL (required)
+# transport_type will be auto-detected with credentials
+timeout_seconds: 30                # Request timeout (overrides default)
+retry_attempts: 3                  # Number of retry attempts (overrides default)
+
+# Authentication (optional)
+auth:
+  type: "bearer"
+  token: "${{ user.credentials.github }}"
+  accept_inline: true  # Allow inline credential collection in dynamic mode

--- a/e2e/tests/25_envelope_ui/formations/formation-envelope-channels/secrets.enc
+++ b/e2e/tests/25_envelope_ui/formations/formation-envelope-channels/secrets.enc
@@ -1,0 +1,1 @@
+../../../../assets/secrets.enc

--- a/e2e/tests/25_envelope_ui/formations/formation-envelope-channels/transformers/plain.yaml
+++ b/e2e/tests/25_envelope_ui/formations/formation-envelope-channels/transformers/plain.yaml
@@ -1,0 +1,8 @@
+# Formation-local text-only template (no widget placeholders): pins the
+# zero-change guarantee for formations that never opted into widgets.
+name: plain
+headers:
+  Content-Type: application/json
+body:
+  room: "${{ context.room }}"
+  reply: "${{ response.content }}"

--- a/e2e/tests/25_envelope_ui/formations/formation-envelope-channels/triggers/plain.md
+++ b/e2e/tests/25_envelope_ui/formations/formation-envelope-channels/triggers/plain.md
@@ -1,0 +1,14 @@
+---
+# Text-only formation-local transformer: the zero-change pin. A
+# ui-bearing response delivered through this template must produce a
+# payload with exactly the template's keys -- widgets never leak into
+# templates that do not reference them.
+transformer: plain
+webhook: http://127.0.0.1:18254/plain-bridge
+parse:
+  message: $.payload.text
+  user_id: $.payload.sender
+  context:
+    room: $.payload.room
+---
+${{ data.payload.text }}

--- a/e2e/tests/25_envelope_ui/formations/formation-envelope-channels/triggers/slack.md
+++ b/e2e/tests/25_envelope_ui/formations/formation-envelope-channels/triggers/slack.md
@@ -1,0 +1,14 @@
+---
+# Inbound Slack message events; the bundled slack transformer formats
+# the outbound reply as a chat.postMessage-style payload delivered to
+# the test's local bridge sink.
+transformer: slack
+webhook: http://127.0.0.1:18254/slack-bridge
+parse:
+  message: $.event.text
+  user_id: $.event.user
+  context:
+    channel: $.event.channel
+    thread_ts: $.event.thread_ts
+---
+${{ data.event.text }}

--- a/e2e/tests/25_envelope_ui/formations/formation-envelope-channels/triggers/telegram-callback.md
+++ b/e2e/tests/25_envelope_ui/formations/formation-envelope-channels/triggers/telegram-callback.md
@@ -1,0 +1,13 @@
+---
+# Inbound Telegram callback_query updates (inline keyboard button
+# presses). parse.ui_response decodes the button's callback data into
+# the {id, index} reply hint that pins the selection deterministically.
+transformer: telegram
+webhook: http://127.0.0.1:18254/telegram-bridge
+parse:
+  user_id: $.callback_query.from.id
+  ui_response: $.callback_query.data
+  context:
+    chat_id: $.callback_query.message.chat.id
+---
+The user pressed an inline keyboard button (callback: ${{ data.callback_query.data }}).

--- a/e2e/tests/25_envelope_ui/formations/formation-envelope-channels/triggers/telegram.md
+++ b/e2e/tests/25_envelope_ui/formations/formation-envelope-channels/triggers/telegram.md
@@ -1,0 +1,13 @@
+---
+# Inbound Telegram message updates (bridge forwards Bot API webhooks).
+# The bundled telegram transformer formats the outbound reply; the
+# webhook URL is the test's local bridge sink.
+transformer: telegram
+webhook: http://127.0.0.1:18254/telegram-bridge
+parse:
+  message: $.message.text
+  user_id: $.message.from.id
+  context:
+    chat_id: $.message.chat.id
+---
+${{ data.message.text }}

--- a/e2e/tests/25_envelope_ui/test_25a6_telegram_widget_roundtrip.py
+++ b/e2e/tests/25_envelope_ui/test_25a6_telegram_widget_roundtrip.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""
+Test 25A6: Response Envelope UI - Telegram widget rendering + callback round trip (P3)
+
+Verifies the two P3 mechanisms for Telegram end to end:
+
+1. Outbound: a trigger response carrying an `options` widget, delivered
+   through the bundled telegram transformer, renders a native
+   inline_keyboard (labels + `<widget_id>#<index>` callback data) while
+   the complete text body still ships (widgets are additive).
+2. Inbound: a simulated callback_query POSTed to the callback trigger
+   route is decoded by `parse.ui_response` into the {id, index} reply
+   hint, rides the chat re-entry, and pins the selection
+   deterministically (the message text alone could never resolve it).
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import httpx
+from aiohttp import web
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from muxi.runtime.formation import Formation  # noqa: E402
+
+SINK_PORT = 18254
+SERVER_PORT = 18253
+BASE_URL = f"http://127.0.0.1:{SERVER_PORT}/v1"
+HEADERS = {"X-Muxi-Client-Key": "envelope-client-key", "X-Muxi-User-Id": "telegram-bridge"}
+
+TELEGRAM_USER = "777001"  # str(message.from.id) after parse coercion
+TELEGRAM_CHAT = 424242
+SESSION_ID = "sess-25a6-telegram"
+
+
+class SinkServer:
+    """Local HTTP sink standing in for the developer's Telegram bridge."""
+
+    def __init__(self):
+        self.requests = []
+        self.runner = None
+
+    async def _handle(self, request: web.Request) -> web.Response:
+        self.requests.append({"path": request.path, "json": await request.json()})
+        return web.json_response({"ok": True})
+
+    async def start(self):
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", self._handle)
+        self.runner = web.AppRunner(app)
+        await self.runner.setup()
+        site = web.TCPSite(self.runner, "127.0.0.1", SINK_PORT)
+        await site.start()
+
+    async def stop(self):
+        if self.runner:
+            await self.runner.cleanup()
+
+    def bridge_requests(self):
+        return [r for r in self.requests if r["path"] == "/telegram-bridge"]
+
+
+async def wait_for(predicate, timeout=90):
+    for _ in range(timeout):
+        if predicate():
+            return True
+        await asyncio.sleep(1)
+    return predicate()
+
+
+async def clear_github_credentials(formation, user_id: str) -> None:
+    """Idempotency across runs: remove previously seeded credentials via SQL."""
+    from sqlalchemy import text
+
+    async with formation._db_manager.get_async_session() as session:
+        await session.execute(
+            text(
+                "DELETE FROM credentials WHERE service = 'github' AND user_id IN "
+                "(SELECT user_id FROM user_identifiers WHERE identifier = :uid)"
+            ),
+            {"uid": user_id},
+        )
+        await session.commit()
+
+
+async def seed_two_accounts(formation, overlord, user_id: str) -> None:
+    """Seed exactly two named GitHub credentials so the choice is enumerable."""
+    await clear_github_credentials(formation, user_id)
+    for name, token in (("acme-prod", f"fake-prod-{user_id}"), ("acme-dev", f"fake-dev-{user_id}")):
+        await overlord.credential_resolver.store_credential(
+            user_id=user_id,
+            service="github",
+            credentials={"token": token},
+            credential_name=name,
+        )
+    overlord.credential_resolver._cache.clear()
+
+
+def cached_github_credential(user_id: str):
+    """Return the MCP-cached credential auth for the user (set on selection)."""
+    from muxi.runtime.services.mcp.service import MCPService
+
+    mcp_svc = MCPService.get_instance()
+    if not mcp_svc:
+        return None
+    for server_id, per_user in (mcp_svc.user_credentials or {}).items():
+        if "github" in server_id.lower() and user_id in per_user:
+            return per_user[user_id]
+    return None
+
+
+async def main() -> int:
+    print("MUXI Runtime - Test 25A6: Telegram widget rendering + callback round trip")
+    print("=" * 70)
+
+    formation_path = Path(__file__).parent / "formations" / "formation-envelope-channels"
+    sink = SinkServer()
+    formation = Formation()
+
+    try:
+        await sink.start()
+        print(f"Bridge sink listening on 127.0.0.1:{SINK_PORT}")
+
+        await formation.load(str(formation_path))
+        await formation.start_server(block=False)
+        await asyncio.sleep(2)
+        overlord = formation._overlord
+
+        await seed_two_accounts(formation, overlord, TELEGRAM_USER)
+        print(f"Seeded two GitHub accounts for user {TELEGRAM_USER}")
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            # ---------------------------------------------------------------
+            # [1] Outbound: options widget -> native inline keyboard
+            # ---------------------------------------------------------------
+            print("\n[1] POST /triggers/telegram (account-ambiguous question)...")
+            response = await client.post(
+                f"{BASE_URL}/triggers/telegram",
+                headers=HEADERS,
+                json={
+                    "data": {
+                        "message": {
+                            "text": "List my GitHub repositories",
+                            "from": {"id": int(TELEGRAM_USER)},
+                            "chat": {"id": TELEGRAM_CHAT},
+                        }
+                    },
+                    "session_id": SESSION_ID,
+                    "use_async": True,
+                },
+            )
+            assert response.status_code == 200, f"Trigger failed: {response.text[:300]}"
+
+            print("    Waiting for the clarification delivery to the bridge sink...")
+            assert await wait_for(
+                lambda: sink.bridge_requests()
+            ), f"No delivery; sink saw: {[r['path'] for r in sink.requests]}"
+            payload = sink.bridge_requests()[0]["json"]
+            print(f"    Telegram payload: {str(payload)[:400]}")
+
+            # Text always ships and is self-sufficient (lists both accounts)
+            text_body = payload.get("text", "")
+            assert text_body, f"Text body missing: {payload}"
+            assert "acme-prod" in text_body and "acme-dev" in text_body, (
+                "Text fallback must list the choices in prose; got: " + text_body[:300]
+            )
+            assert str(payload.get("chat_id")) == str(TELEGRAM_CHAT), payload
+
+            # Widgets are additive: native inline keyboard alongside the text
+            markup = payload.get("reply_markup")
+            assert markup and markup.get(
+                "inline_keyboard"
+            ), f"Expected inline_keyboard, got: {payload}"
+            buttons = [b for row in markup["inline_keyboard"] for b in row]
+            labels = [b.get("text", "") for b in buttons]
+            assert any("prod" in label for label in labels), f"Options missing: {labels}"
+            assert any("dev" in label for label in labels), f"Options missing: {labels}"
+            for button in buttons:
+                data = button.get("callback_data", "")
+                assert data.startswith("ui_") and "#" in data, f"Bad callback data: {button}"
+                assert len(data.encode("utf-8")) <= 64, f"callback_data over 64 bytes: {data}"
+            print(f"    Inline keyboard rendered: {labels}")
+
+            # ---------------------------------------------------------------
+            # [2] Inbound: callback_query -> deterministic pinning
+            # ---------------------------------------------------------------
+            dev_button = next(b for b in buttons if "dev" in b.get("text", ""))
+            print(f"\n[2] POST /triggers/telegram-callback (pressing {dev_button['text']!r})...")
+            response = await client.post(
+                f"{BASE_URL}/triggers/telegram-callback",
+                headers=HEADERS,
+                json={
+                    "data": {
+                        "callback_query": {
+                            "from": {"id": int(TELEGRAM_USER)},
+                            "data": dev_button["callback_data"],
+                            "message": {"chat": {"id": TELEGRAM_CHAT}},
+                        }
+                    },
+                    "session_id": SESSION_ID,
+                    "use_async": True,
+                },
+            )
+            assert response.status_code == 200, f"Callback trigger failed: {response.text[:300]}"
+
+            print("    Waiting for the post-pin reply delivery...")
+            assert await wait_for(
+                lambda: len(sink.bridge_requests()) >= 2
+            ), "No reply delivery after the button press"
+
+            cached = cached_github_credential(TELEGRAM_USER)
+            assert cached is not None, "Expected the pinned credential to be cached for the user"
+            import json as json_lib
+
+            cached_str = json_lib.dumps(cached)
+            assert (
+                f"fake-dev-{TELEGRAM_USER}" in cached_str
+            ), f"Expected acme-dev pinned deterministically, cached={cached_str[:200]}"
+            print("    Button press pinned 'acme-dev' deterministically (credential cached)")
+
+        print("\n" + "=" * 70)
+        print("SUCCESS: inline keyboard rendered additively and the callback_query")
+        print("         round-tripped into deterministic ui_response pinning")
+        return 0
+
+    finally:
+        try:
+            formation.stop()
+        except Exception:
+            pass
+        try:
+            await sink.stop()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    exit_code = asyncio.run(main())
+    os._exit(exit_code)

--- a/e2e/tests/25_envelope_ui/test_25a7_slack_widgets_and_text_only_pin.py
+++ b/e2e/tests/25_envelope_ui/test_25a7_slack_widgets_and_text_only_pin.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+Test 25A7: Response Envelope UI - Slack Block Kit rendering + text-only zero-change pin (P3)
+
+Verifies the remaining P3 channel guarantees:
+
+1. Slack variant: a ui-bearing response delivered through the bundled
+   slack transformer renders Block Kit blocks -- a section carrying the
+   complete text (Slack renders blocks INSTEAD of top-level text) plus
+   an actions block of buttons -- while the top-level `text` fallback
+   still ships.
+2. Zero-change pin: the same ui-bearing response delivered through a
+   plain text-only formation-local template produces a payload with
+   exactly the template's keys -- widgets never leak into templates
+   that do not reference them.
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import httpx
+from aiohttp import web
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from muxi.runtime.formation import Formation  # noqa: E402
+
+SINK_PORT = 18254
+SERVER_PORT = 18253
+BASE_URL = f"http://127.0.0.1:{SERVER_PORT}/v1"
+HEADERS = {"X-Muxi-Client-Key": "envelope-client-key", "X-Muxi-User-Id": "slack-bridge"}
+
+SLACK_USER = "u25a7"  # parse coerces and the runtime lowercases user ids
+PLAIN_USER = "plain-user-25a7"
+
+
+class SinkServer:
+    """Local HTTP sink standing in for the developer's channel bridges."""
+
+    def __init__(self):
+        self.requests = []
+        self.runner = None
+
+    async def _handle(self, request: web.Request) -> web.Response:
+        self.requests.append({"path": request.path, "json": await request.json()})
+        return web.json_response({"ok": True})
+
+    async def start(self):
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", self._handle)
+        self.runner = web.AppRunner(app)
+        await self.runner.setup()
+        site = web.TCPSite(self.runner, "127.0.0.1", SINK_PORT)
+        await site.start()
+
+    async def stop(self):
+        if self.runner:
+            await self.runner.cleanup()
+
+    def requests_for(self, path):
+        return [r for r in self.requests if r["path"] == path]
+
+
+async def wait_for(predicate, timeout=90):
+    for _ in range(timeout):
+        if predicate():
+            return True
+        await asyncio.sleep(1)
+    return predicate()
+
+
+async def clear_github_credentials(formation, user_id: str) -> None:
+    """Idempotency across runs: remove previously seeded credentials via SQL."""
+    from sqlalchemy import text
+
+    async with formation._db_manager.get_async_session() as session:
+        await session.execute(
+            text(
+                "DELETE FROM credentials WHERE service = 'github' AND user_id IN "
+                "(SELECT user_id FROM user_identifiers WHERE identifier = :uid)"
+            ),
+            {"uid": user_id},
+        )
+        await session.commit()
+
+
+async def seed_two_accounts(formation, overlord, user_id: str) -> None:
+    """Seed exactly two named GitHub credentials so the choice is enumerable."""
+    await clear_github_credentials(formation, user_id)
+    for name, token in (("acme-prod", f"fake-prod-{user_id}"), ("acme-dev", f"fake-dev-{user_id}")):
+        await overlord.credential_resolver.store_credential(
+            user_id=user_id,
+            service="github",
+            credentials={"token": token},
+            credential_name=name,
+        )
+    overlord.credential_resolver._cache.clear()
+
+
+async def main() -> int:
+    print("MUXI Runtime - Test 25A7: Slack Block Kit rendering + text-only zero-change pin")
+    print("=" * 70)
+
+    formation_path = Path(__file__).parent / "formations" / "formation-envelope-channels"
+    sink = SinkServer()
+    formation = Formation()
+
+    try:
+        await sink.start()
+        print(f"Bridge sink listening on 127.0.0.1:{SINK_PORT}")
+
+        await formation.load(str(formation_path))
+        await formation.start_server(block=False)
+        await asyncio.sleep(2)
+        overlord = formation._overlord
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            # ---------------------------------------------------------------
+            # [1] Slack variant: options widget -> Block Kit blocks
+            # ---------------------------------------------------------------
+            await seed_two_accounts(formation, overlord, SLACK_USER)
+            print("\n[1] POST /triggers/slack (account-ambiguous question)...")
+            response = await client.post(
+                f"{BASE_URL}/triggers/slack",
+                headers=HEADERS,
+                json={
+                    "data": {
+                        "event": {
+                            "text": "List my GitHub repositories",
+                            "user": SLACK_USER,
+                            "channel": "C25A7",
+                        }
+                    },
+                    "session_id": "sess-25a7-slack",
+                    "use_async": True,
+                },
+            )
+            assert response.status_code == 200, f"Trigger failed: {response.text[:300]}"
+
+            print("    Waiting for the clarification delivery to the bridge sink...")
+            assert await wait_for(
+                lambda: sink.requests_for("/slack-bridge")
+            ), f"No delivery; sink saw: {[r['path'] for r in sink.requests]}"
+            payload = sink.requests_for("/slack-bridge")[0]["json"]
+            print(f"    Slack payload: {str(payload)[:400]}")
+
+            # Top-level text fallback stays (Slack notification fallback)
+            text_body = payload.get("text", "")
+            assert text_body, f"Text body missing: {payload}"
+            assert "acme-prod" in text_body and "acme-dev" in text_body, (
+                "Text fallback must list the choices in prose; got: " + text_body[:300]
+            )
+            assert payload.get("channel") == "C25A7", payload
+            assert set(payload.keys()) <= {
+                "channel",
+                "thread_ts",
+                "text",
+                "blocks",
+            }, f"Unexpected keys in Slack payload: {sorted(payload)}"
+
+            # Blocks: section carrying the text, then the buttons
+            blocks = payload.get("blocks")
+            assert blocks, f"Expected Block Kit blocks, got: {payload}"
+            assert blocks[0]["type"] == "section", blocks[0]
+            assert blocks[0]["text"]["text"] == text_body, (
+                "The section block must carry the complete text (Slack renders "
+                "blocks INSTEAD of top-level text)"
+            )
+            actions = next(b for b in blocks[1:] if b["type"] == "actions")
+            labels = [e["text"]["text"] for e in actions["elements"]]
+            assert any("prod" in label for label in labels), f"Options missing: {labels}"
+            assert any("dev" in label for label in labels), f"Options missing: {labels}"
+            for element in actions["elements"]:
+                value = element.get("value", "")
+                assert value.startswith("ui_") and "#" in value, f"Bad button value: {element}"
+            print(f"    Block Kit buttons rendered: {labels}")
+
+            # ---------------------------------------------------------------
+            # [2] Zero-change pin: text-only template + ui-bearing response
+            # ---------------------------------------------------------------
+            await seed_two_accounts(formation, overlord, PLAIN_USER)
+            print("\n[2] POST /triggers/plain (same ambiguity, text-only template)...")
+            response = await client.post(
+                f"{BASE_URL}/triggers/plain",
+                headers=HEADERS,
+                json={
+                    "data": {
+                        "payload": {
+                            "text": "List my GitHub repositories",
+                            "sender": PLAIN_USER,
+                            "room": "room-25a7",
+                        }
+                    },
+                    "session_id": "sess-25a7-plain",
+                    "use_async": True,
+                },
+            )
+            assert response.status_code == 200, f"Trigger failed: {response.text[:300]}"
+
+            print("    Waiting for the text-only delivery...")
+            assert await wait_for(
+                lambda: sink.requests_for("/plain-bridge")
+            ), f"No delivery; sink saw: {[r['path'] for r in sink.requests]}"
+            plain_payload = sink.requests_for("/plain-bridge")[0]["json"]
+            print(f"    Plain payload: {str(plain_payload)[:400]}")
+
+            # Exactly the template's keys: the ui-bearing response changed
+            # NOTHING about a template that references no widgets.
+            assert set(plain_payload.keys()) == {
+                "room",
+                "reply",
+            }, f"Widgets leaked into a text-only template: {sorted(plain_payload)}"
+            assert plain_payload["room"] == "room-25a7", plain_payload
+            reply = plain_payload["reply"]
+            assert "acme-prod" in reply and "acme-dev" in reply, (
+                "Text-only delivery must still carry the complete prose fallback: " + reply[:300]
+            )
+            print("    Text-only payload shape unchanged (no widget keys)")
+
+        print("\n" + "=" * 70)
+        print("SUCCESS: Slack blocks rendered additively with the text intact and")
+        print("         the text-only template delivery stayed widget-free")
+        return 0
+
+    finally:
+        try:
+            formation.stop()
+        except Exception:
+            pass
+        try:
+            await sink.stop()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    exit_code = asyncio.run(main())
+    os._exit(exit_code)

--- a/src/muxi/runtime/datatypes/ui.py
+++ b/src/muxi/runtime/datatypes/ui.py
@@ -54,11 +54,13 @@ UI_OPTIONS_MAX_ITEMS = 25
 # ``<widget_id>#<option_index>`` — index, not value, so the string is
 # fixed-small and always fits Telegram's 64-byte callback_data limit
 # (widget ids are ``ui_`` + 21-char nanoid = 24 bytes; the index adds
-# at most 3 more). The index resolves back to the option value against
-# the conversation's pending-clarification record (the same state
-# ``resolve_ui_response`` already consults), keeping the runtime
-# stateless: no server-side widget store, ever.
-_UI_CALLBACK_PATTERN = re.compile(r"^(ui_[0-9A-Za-z_]+)#(\d{1,3})$")
+# at most 2 more — options are capped at ``UI_OPTIONS_MAX_ITEMS`` (25),
+# so 0-99 is ample and anything longer is not ours). The index resolves
+# back to the option value against the conversation's
+# pending-clarification record (the same state ``resolve_ui_response``
+# already consults), keeping the runtime stateless: no server-side
+# widget store, ever.
+_UI_CALLBACK_PATTERN = re.compile(r"^(ui_[0-9A-Za-z_]+)#(\d{1,2})$")
 
 
 def encode_ui_callback(widget_id: str, option_index: int) -> str:

--- a/src/muxi/runtime/datatypes/ui.py
+++ b/src/muxi/runtime/datatypes/ui.py
@@ -18,6 +18,7 @@ Size discipline: widgets are clamped per-widget and per-envelope
 bloat every response.
 """
 
+import re
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
@@ -41,6 +42,45 @@ UI_ENVELOPE_MAX_BYTES = 16384
 
 # Maximum number of options in a single options widget.
 UI_OPTIONS_MAX_ITEMS = 25
+
+# ===================================================================
+# CHANNEL CALLBACK ENCODING (Response Envelope UI PRD, P3)
+# ===================================================================
+#
+# When a channel template renders an options widget as native buttons
+# (Telegram inline keyboard, Slack Block Kit, Discord components), each
+# button carries an opaque callback string that must round-trip the
+# widget id back through the channel's trigger route. The encoding is
+# ``<widget_id>#<option_index>`` — index, not value, so the string is
+# fixed-small and always fits Telegram's 64-byte callback_data limit
+# (widget ids are ``ui_`` + 21-char nanoid = 24 bytes; the index adds
+# at most 3 more). The index resolves back to the option value against
+# the conversation's pending-clarification record (the same state
+# ``resolve_ui_response`` already consults), keeping the runtime
+# stateless: no server-side widget store, ever.
+_UI_CALLBACK_PATTERN = re.compile(r"^(ui_[0-9A-Za-z_]+)#(\d{1,3})$")
+
+
+def encode_ui_callback(widget_id: str, option_index: int) -> str:
+    """Encode a widget option as channel button callback data."""
+    return f"{widget_id}#{option_index}"
+
+
+def decode_ui_callback(data: Any) -> Optional[Dict[str, Any]]:
+    """
+    Decode channel button callback data into a ``ui_response`` hint.
+
+    Returns ``{"id": <widget_id>, "index": <option_index>}`` when the
+    string matches the encoding, or None for anything else (channels
+    routinely deliver callback payloads MUXI did not produce — those
+    are not hints and must not become ones).
+    """
+    if not isinstance(data, str):
+        return None
+    match = _UI_CALLBACK_PATTERN.match(data)
+    if not match:
+        return None
+    return {"id": match.group(1), "index": int(match.group(2))}
 
 
 class UIProvenance(Enum):
@@ -182,12 +222,23 @@ def resolve_ui_response(
     and the message stands alone). The runtime stays stateless: the id
     resolves against conversation state that already exists, never a
     server-side widget store.
+
+    Hints from channel button presses carry ``index`` instead of
+    ``value`` (the ``decode_ui_callback`` shape): the index resolves
+    against ``option_values`` — the same order the widget offered and
+    the channel template rendered — and then follows the identical
+    value-membership check.
     """
     if not ui_response or not widget_id or not option_values:
         return None
     if ui_response.get("id") != widget_id:
         return None
     value = ui_response.get("value")
+    if value is None:
+        index = ui_response.get("index")
+        if isinstance(index, int) and not isinstance(index, bool):
+            if 0 <= index < len(option_values):
+                value = option_values[index]
     if value in option_values:
         return value
     return None

--- a/src/muxi/runtime/datatypes/ui.py
+++ b/src/muxi/runtime/datatypes/ui.py
@@ -91,6 +91,8 @@ def decode_ui_callback(data: Any) -> Optional[Dict[str, Any]]:
     if not match:
         return None
     return {"id": match.group(1), "index": int(match.group(2))}
+
+
 # Maximum serialized size of a single mcp_resource widget (bytes). UI
 # resources are whole HTML documents, so the standard per-widget cap
 # would drop nearly all of them; 64KB covers a self-contained MCP App

--- a/src/muxi/runtime/formation/background/builtin/transformers/discord.yaml
+++ b/src/muxi/runtime/formation/background/builtin/transformers/discord.yaml
@@ -8,11 +8,24 @@
 # Discord renders markdown natively, so content passes through unchanged,
 # capped at Discord's 2000-character message limit.
 #
+# Envelope UI widgets (Response Envelope UI, P3): when the response
+# carries a `ui` array, `components` renders it as native message
+# components (`options` -> action rows of buttons whose custom_id
+# carries the reply callback, `action_link` -> link buttons). Without
+# widgets the placeholder resolves to None and the key is dropped, so
+# text-only deliveries stay byte-identical. The content always ships;
+# buttons are additive. Note: plain Discord webhooks cannot send
+# components -- the bridge must post via a bot/application endpoint to
+# surface them. Button presses arrive back as component interactions
+# -- point a trigger's `parse.ui_response` at `$.data.custom_id` to
+# complete the round trip.
+#
 # Shadow this template by placing transformers/discord.yaml in the formation.
 name: discord
 headers:
   Content-Type: application/json
 body:
   content: "${{ response.content }}"
+  components: "${{ ui.discord.components }}"
 content_transform:
   max_length: 2000

--- a/src/muxi/runtime/formation/background/builtin/transformers/slack.yaml
+++ b/src/muxi/runtime/formation/background/builtin/transformers/slack.yaml
@@ -10,6 +10,19 @@
 #   context.thread_ts  optional thread timestamp (dropped from the payload
 #                      when absent, so top-level messages stay top-level)
 #
+# Envelope UI widgets (Response Envelope UI, P3): when the response
+# carries a `ui` array, `blocks` renders it as Block Kit -- a section
+# block carrying the response text (Slack renders blocks INSTEAD of
+# top-level `text` when present, so the text must ride inside them)
+# followed by actions blocks (`options` -> buttons whose action_id and
+# value carry the reply callback, `action_link` -> url buttons). The
+# top-level `text` stays regardless (Slack's notification fallback).
+# Without widgets the placeholder resolves to None and the key is
+# dropped, so text-only deliveries stay byte-identical. Button presses
+# arrive back as block_actions interaction payloads -- point a
+# trigger's `parse.ui_response` at `$.actions[0].value` to complete
+# the round trip.
+#
 # Shadow this template by placing transformers/slack.yaml in the formation.
 name: slack
 headers:
@@ -18,3 +31,4 @@ body:
   channel: "${{ context.channel }}"
   thread_ts: "${{ context.thread_ts }}"
   text: "${{ response.content }}"
+  blocks: "${{ ui.slack.blocks }}"

--- a/src/muxi/runtime/formation/background/builtin/transformers/telegram.yaml
+++ b/src/muxi/runtime/formation/background/builtin/transformers/telegram.yaml
@@ -11,6 +11,15 @@
 # Markdown is stripped (Telegram's default parse mode renders plain text)
 # and messages are capped at Telegram's 4096-character limit.
 #
+# Envelope UI widgets (Response Envelope UI, P3): when the response
+# carries a `ui` array, `reply_markup` renders it as a native inline
+# keyboard (`options` -> callback buttons, `action_link` -> url
+# buttons). Without widgets the placeholder resolves to None and the
+# key is dropped, so text-only deliveries stay byte-identical. The
+# text always ships; buttons are additive. Button presses arrive back
+# as callback_query updates -- point a trigger's `parse.ui_response`
+# at `$.callback_query.data` to complete the round trip.
+#
 # Shadow this template by placing transformers/telegram.yaml in the formation.
 name: telegram
 headers:
@@ -18,6 +27,7 @@ headers:
 body:
   chat_id: "${{ context.chat_id }}"
   text: "${{ response.content }}"
+  reply_markup: "${{ ui.telegram.reply_markup }}"
 content_transform:
   format: text
   max_length: 4096

--- a/src/muxi/runtime/formation/background/transformers.py
+++ b/src/muxi/runtime/formation/background/transformers.py
@@ -92,6 +92,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 import yaml
 
+from ...datatypes.ui import decode_ui_callback, encode_ui_callback
 from ...services import observability
 
 # Trigger/transformer names: same charset as trigger name validation in the
@@ -323,8 +324,6 @@ def extract_parse_values(parse_spec: Optional[Dict[str, Any]], data: Any) -> Dic
 
     ui_response = None
     if parse_spec.get("ui_response"):
-        from ...datatypes.ui import decode_ui_callback
-
         ui_response = decode_ui_callback(extract_path(data, parse_spec["ui_response"]))
 
     return {
@@ -850,8 +849,6 @@ _SLACK_SECTION_TEXT_MAX = 3000
 
 def _ui_option_buttons(widget: Dict[str, Any]) -> List[Tuple[str, str]]:
     """Yield (label, callback_data) pairs for an options widget."""
-    from ...datatypes.ui import encode_ui_callback
-
     widget_id = widget.get("id") or ""
     buttons = []
     for index, option in enumerate(widget.get("options") or []):

--- a/src/muxi/runtime/formation/background/transformers.py
+++ b/src/muxi/runtime/formation/background/transformers.py
@@ -50,8 +50,34 @@ reference a bundled name are completely unaffected.
 Template values use the runtime-wide ``${{ ... }}`` syntax (the same syntax
 used by trigger templates and formation secrets interpolation). Available
 variables: ``response.content``, ``response.files``, ``response.metadata.*``,
-``request.message``, ``request.user_id``, ``request.files``, ``context.*``,
-``secrets.*``, ``agent.name``, and ``timestamp``.
+``response.ui``, ``request.message``, ``request.user_id``, ``request.files``,
+``context.*``, ``secrets.*``, ``agent.name``, ``timestamp``, and the
+channel-native widget renderings under ``ui.*`` (below).
+
+Envelope UI widgets (Response Envelope UI PRD, P3): when the response
+carries a ``ui`` array, the template namespace additionally exposes
+
+    response.ui                   the raw widget array (None when absent)
+    ui.telegram.reply_markup      Telegram inline_keyboard markup
+    ui.slack.blocks               Slack Block Kit blocks (text + buttons)
+    ui.discord.components         Discord message components
+
+Every ``ui.*`` entry is None when the response carries no widgets, and
+dict entries rendering to None are dropped (the ``thread_ts`` idiom), so
+a template line like ``reply_markup: "${{ ui.telegram.reply_markup }}"``
+is strictly additive: without widgets the delivered payload stays
+byte-identical to a template without the line. The text body always
+ships regardless — widgets augment the channel message, never replace
+it (the envelope's text-fallback duty).
+
+A channel button press re-enters through the channel's trigger route
+like any other platform payload: the trigger's ``parse:`` spec may
+declare ``ui_response: <path>`` pointing at the button's callback data
+(Telegram ``$.callback_query.data``, Slack ``$.actions[0].value``,
+Discord ``$.data.custom_id``). The extracted string is decoded from the
+``<widget_id>#<option_index>`` encoding (see ``datatypes.ui``) into the
+``{id, index}`` hint that rides the chat re-entry and hits the existing
+deterministic ``ui_response`` pinning.
 
 Triggers without frontmatter are completely unaffected: parsing returns the
 content unchanged and no transformer machinery is invoked.
@@ -90,7 +116,7 @@ _ALLOWED_FRONTMATTER_KEYS = {"name", "type", "webhook", "transformer", "parse", 
 # only, no URLs). Formation-local transformers/<name>.yaml shadows a bundled
 # template of the same name.
 BUILTIN_TRANSFORMERS_DIR = Path(__file__).parent / "builtin" / "transformers"
-_ALLOWED_PARSE_KEYS = {"message", "user_id", "context", "files"}
+_ALLOWED_PARSE_KEYS = {"message", "user_id", "context", "files", "ui_response"}
 
 
 # ---------------------------------------------------------------------------
@@ -190,7 +216,7 @@ def _validate_parse_spec(parse_spec: Any) -> None:
             f"unknown 'parse' key(s): {sorted(unknown)}. "
             f"Allowed keys: {sorted(_ALLOWED_PARSE_KEYS)}"
         )
-    for key in ("message", "user_id", "files"):
+    for key in ("message", "user_id", "files", "ui_response"):
         value = parse_spec.get(key)
         if value is not None and not isinstance(value, str):
             raise ValueError(f"'parse.{key}' must be a path string (e.g. '$.event.text')")
@@ -251,15 +277,27 @@ def extract_parse_values(parse_spec: Optional[Dict[str, Any]], data: Any) -> Dic
     """
     Extract request values from trigger data per the frontmatter ``parse:`` spec.
 
+    ``ui_response`` extracts the channel button callback string (e.g.
+    Telegram's ``$.callback_query.data``) and decodes the
+    ``<widget_id>#<option_index>`` encoding into a ``{id, index}``
+    reply hint. Callback payloads MUXI did not produce decode to None
+    — the message stands alone, exactly like an absent hint.
+
     Args:
         parse_spec: The (already validated) parse section, or None
         data: The raw trigger request data
 
     Returns:
-        Dict with keys: message, user_id, files, context
+        Dict with keys: message, user_id, files, context, ui_response
     """
     if not parse_spec:
-        return {"message": None, "user_id": None, "files": None, "context": {}}
+        return {
+            "message": None,
+            "user_id": None,
+            "files": None,
+            "context": {},
+            "ui_response": None,
+        }
 
     _validate_parse_spec(parse_spec)
 
@@ -283,7 +321,19 @@ def extract_parse_values(parse_spec: Optional[Dict[str, Any]], data: Any) -> Dic
     if parse_spec.get("files"):
         files = extract_path(data, parse_spec["files"])
 
-    return {"message": message, "user_id": user_id, "files": files, "context": context}
+    ui_response = None
+    if parse_spec.get("ui_response"):
+        from ...datatypes.ui import decode_ui_callback
+
+        ui_response = decode_ui_callback(extract_path(data, parse_spec["ui_response"]))
+
+    return {
+        "message": message,
+        "user_id": user_id,
+        "files": files,
+        "context": context,
+        "ui_response": ui_response,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -758,11 +808,191 @@ def extract_response_files(response: Any) -> List[Dict[str, Any]]:
     return []
 
 
+def extract_response_ui(response: Any) -> List[Dict[str, Any]]:
+    """
+    Extract envelope UI widgets from an agent response, when present.
+
+    Supports response dicts (a ``ui`` key) and objects exposing a ``ui``
+    attribute (MuxiResponse). Returns an empty list otherwise — the
+    common case, and the one that keeps every existing delivery
+    byte-identical.
+    """
+    if isinstance(response, dict):
+        widgets = response.get("ui")
+    else:
+        widgets = getattr(response, "ui", None)
+    if isinstance(widgets, list):
+        return [w for w in widgets if isinstance(w, dict)]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Channel-native widget rendering (Response Envelope UI PRD, P3)
+# ---------------------------------------------------------------------------
+#
+# The template substitution engine has no loops, so an options widget
+# cannot be unrolled into buttons by the template itself. These helpers
+# pre-compute the channel-native structures once per delivery; templates
+# opt in with a single whole-string placeholder (native dict/list
+# substitution) that resolves to None — and is therefore dropped from
+# the payload — when the response carries no widgets. The runtime still
+# renders nothing: these are payload shapes for the platform APIs the
+# bundled templates already speak, delivered through the developer's
+# bridge exactly like the text-only payloads before them.
+
+# Discord allows at most 5 action rows of 5 buttons each.
+_DISCORD_MAX_ROWS = 5
+_DISCORD_ROW_SIZE = 5
+
+# Slack Block Kit section text is capped at 3000 characters.
+_SLACK_SECTION_TEXT_MAX = 3000
+
+
+def _ui_option_buttons(widget: Dict[str, Any]) -> List[Tuple[str, str]]:
+    """Yield (label, callback_data) pairs for an options widget."""
+    from ...datatypes.ui import encode_ui_callback
+
+    widget_id = widget.get("id") or ""
+    buttons = []
+    for index, option in enumerate(widget.get("options") or []):
+        if not isinstance(option, dict):
+            continue
+        label = str(option.get("label") or option.get("value") or "")
+        if not label:
+            continue
+        buttons.append((label, encode_ui_callback(widget_id, index)))
+    return buttons
+
+
+def _ui_telegram_reply_markup(widgets: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Render widgets as a Telegram ``InlineKeyboardMarkup`` object."""
+    rows: List[List[Dict[str, Any]]] = []
+    for widget in widgets:
+        if widget.get("type") == "options":
+            for label, callback_data in _ui_option_buttons(widget):
+                rows.append([{"text": label, "callback_data": callback_data}])
+        elif widget.get("type") == "action_link":
+            label = str(widget.get("label") or widget.get("url") or "")
+            url = widget.get("url")
+            if label and url:
+                rows.append([{"text": label, "url": url}])
+    if not rows:
+        return None
+    return {"inline_keyboard": rows}
+
+
+def _ui_slack_blocks(widgets: List[Dict[str, Any]], text: str) -> Optional[List[Dict[str, Any]]]:
+    """
+    Render widgets as Slack Block Kit blocks.
+
+    The first block is a section carrying the response text: when
+    ``blocks`` is present Slack renders blocks INSTEAD of the top-level
+    ``text`` (which becomes notification fallback), so the text must
+    ride inside the blocks to keep the text-fallback duty intact.
+    """
+    button_blocks: List[Dict[str, Any]] = []
+    for widget in widgets:
+        if widget.get("type") == "options":
+            elements = [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": label},
+                    "action_id": callback_data,
+                    "value": callback_data,
+                }
+                for label, callback_data in _ui_option_buttons(widget)
+            ]
+            if elements:
+                button_blocks.append(
+                    {
+                        "type": "actions",
+                        "block_id": widget.get("id") or "",
+                        "elements": elements,
+                    }
+                )
+        elif widget.get("type") == "action_link":
+            label = str(widget.get("label") or widget.get("url") or "")
+            url = widget.get("url")
+            if label and url:
+                button_blocks.append(
+                    {
+                        "type": "actions",
+                        "block_id": widget.get("id") or "",
+                        "elements": [
+                            {
+                                "type": "button",
+                                "text": {"type": "plain_text", "text": label},
+                                "action_id": widget.get("id") or "",
+                                "url": url,
+                            }
+                        ],
+                    }
+                )
+    if not button_blocks:
+        return None
+    section_text = (
+        text
+        if len(text) <= _SLACK_SECTION_TEXT_MAX
+        else (text[: _SLACK_SECTION_TEXT_MAX - 3] + "...")
+    )
+    return [
+        {"type": "section", "text": {"type": "mrkdwn", "text": section_text}},
+        *button_blocks,
+    ]
+
+
+def _ui_discord_components(widgets: List[Dict[str, Any]]) -> Optional[List[Dict[str, Any]]]:
+    """
+    Render widgets as Discord message components (action rows of
+    buttons, chunked 5 per row, at most 5 rows — overflow buttons are
+    dropped; the text fallback always carries every choice in prose).
+    """
+    buttons: List[Dict[str, Any]] = []
+    for widget in widgets:
+        if widget.get("type") == "options":
+            for label, callback_data in _ui_option_buttons(widget):
+                # type 2 = button, style 2 = secondary
+                buttons.append({"type": 2, "style": 2, "label": label, "custom_id": callback_data})
+        elif widget.get("type") == "action_link":
+            label = str(widget.get("label") or widget.get("url") or "")
+            url = widget.get("url")
+            if label and url:
+                # style 5 = link button (url, no custom_id)
+                buttons.append({"type": 2, "style": 5, "label": label, "url": url})
+    if not buttons:
+        return None
+    buttons = buttons[: _DISCORD_MAX_ROWS * _DISCORD_ROW_SIZE]
+    rows = [
+        # type 1 = action row
+        {"type": 1, "components": buttons[i : i + _DISCORD_ROW_SIZE]}
+        for i in range(0, len(buttons), _DISCORD_ROW_SIZE)
+    ]
+    return rows
+
+
+def build_ui_variables(
+    response_ui: Optional[List[Dict[str, Any]]], response_content: str
+) -> Dict[str, Any]:
+    """
+    Build the ``ui.*`` template namespace: channel-native renderings of
+    the response envelope's widget array. Every entry is None when the
+    response carries no widgets so templating drops the keys and
+    text-only deliveries stay byte-identical.
+    """
+    widgets = [w for w in (response_ui or []) if isinstance(w, dict)]
+    return {
+        "telegram": {"reply_markup": _ui_telegram_reply_markup(widgets)},
+        "slack": {"blocks": _ui_slack_blocks(widgets, response_content)},
+        "discord": {"components": _ui_discord_components(widgets)},
+    }
+
+
 def build_transformer_variables(
     *,
     response_content: str,
     response_files: Optional[List[Dict[str, Any]]] = None,
     response_metadata: Optional[Dict[str, Any]] = None,
+    response_ui: Optional[List[Dict[str, Any]]] = None,
     request_message: Optional[str] = None,
     request_user_id: Optional[str] = None,
     request_files: Optional[Any] = None,
@@ -770,12 +1000,19 @@ def build_transformer_variables(
     agent_name: Optional[str] = None,
     secrets: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
-    """Assemble the template variable namespace for transformer rendering."""
+    """Assemble the template variable namespace for transformer rendering.
+
+    ``response.ui`` is None (not ``[]``) when the response carries no
+    widgets so a template referencing it stays additive: the key drops
+    out of dict bodies instead of shipping an empty array on every
+    text-only delivery.
+    """
     return {
         "response": {
             "content": response_content,
             "files": response_files or [],
             "metadata": response_metadata or {},
+            "ui": response_ui or None,
         },
         "request": {
             "message": request_message,
@@ -785,6 +1022,7 @@ def build_transformer_variables(
         "context": context or {},
         "agent": {"name": agent_name},
         "secrets": secrets or {},
+        "ui": build_ui_variables(response_ui, response_content),
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
@@ -833,6 +1071,7 @@ async def deliver_via_transformer(
         variables = build_transformer_variables(
             response_content=content,
             response_files=extract_response_files(response),
+            response_ui=extract_response_ui(response),
             response_metadata=response_metadata,
             request_message=request_message,
             request_user_id=request_user_id,

--- a/src/muxi/runtime/formation/server/routes/client/triggers.py
+++ b/src/muxi/runtime/formation/server/routes/client/triggers.py
@@ -403,6 +403,13 @@ async def execute_trigger(
     # memory; the header user remains the authenticated principal for GBAC.
     chat_user_id = parsed_request.get("user_id") or user_id
 
+    # Channel button press -> ui_response reply hint (Response Envelope UI,
+    # P3): when the parse spec extracts button callback data, the decoded
+    # {id, index} hint rides the chat re-entry and hits the existing
+    # deterministic pinning. None for ordinary messages and for callback
+    # payloads MUXI did not produce (the message stands alone).
+    ui_response: Optional[Dict[str, Any]] = parsed_request.get("ui_response")
+
     # Render template with provided data
     try:
         rendered_message = render_trigger_template(template, trigger_request.data)
@@ -503,6 +510,7 @@ async def execute_trigger(
                         source_context=parsed_request.get("context"),
                         route_class="trigger",
                         middleware_applied=True,
+                        ui_response=ui_response,
                     )
                 elif webhook_override is not None:
                     # Webhook routing: force async so the standard MUXI
@@ -520,6 +528,7 @@ async def execute_trigger(
                         source_context=parsed_request.get("context"),
                         route_class="trigger",
                         middleware_applied=True,
+                        ui_response=ui_response,
                     )
                 else:
                     # Default routing: unchanged trigger behavior
@@ -536,6 +545,7 @@ async def execute_trigger(
                         source_context=parsed_request.get("context"),
                         route_class="trigger",
                         middleware_applied=True,
+                        ui_response=ui_response,
                     )
 
                 observability.observe(
@@ -601,6 +611,7 @@ async def execute_trigger(
                 source_context=parsed_request.get("context"),
                 route_class="trigger",
                 middleware_applied=True,
+                ui_response=ui_response,
             )
 
             # Extract content from response (handles async generators, MuxiResponse, strings, etc.)

--- a/tests/unit/test_trigger_transformers.py
+++ b/tests/unit/test_trigger_transformers.py
@@ -12,17 +12,24 @@ from urllib.parse import parse_qs
 import pytest
 from aiohttp import web
 
+from muxi.runtime.datatypes.ui import (
+    UIProvenance,
+    build_action_link_widget,
+    build_options_widget,
+)
 from muxi.runtime.formation.background.transformers import (
     BUILTIN_TRANSFORMERS_DIR,
     ContentTransform,
     TransformerConfig,
     apply_content_transform,
     build_transformer_variables,
+    build_ui_variables,
     collect_secret_names,
     deliver_via_transformer,
     extract_parse_values,
     extract_path,
     extract_response_files,
+    extract_response_ui,
     load_transformer,
     parse_trigger_frontmatter,
     render_template_string,
@@ -158,7 +165,13 @@ class TestExtractPath:
 class TestExtractParseValues:
     def test_no_spec_returns_empty_defaults(self):
         result = extract_parse_values(None, {"anything": 1})
-        assert result == {"message": None, "user_id": None, "files": None, "context": {}}
+        assert result == {
+            "message": None,
+            "user_id": None,
+            "files": None,
+            "context": {},
+            "ui_response": None,
+        }
 
     def test_full_extraction(self):
         spec = {
@@ -171,6 +184,33 @@ class TestExtractParseValues:
         assert result["message"] == "hello"
         assert result["user_id"] == "42"  # coerced to string
         assert result["context"] == {"channel": "C1", "thread_ts": None}
+        assert result["ui_response"] is None
+
+    def test_ui_response_callback_decoded(self):
+        # A Telegram-style callback_query carrying MUXI button callback
+        # data decodes into the {id, index} reply hint.
+        spec = {"user_id": "$.callback_query.from.id", "ui_response": "$.callback_query.data"}
+        data = {"callback_query": {"from": {"id": 7}, "data": "ui_abc123#1"}}
+        result = extract_parse_values(spec, data)
+        assert result["ui_response"] == {"id": "ui_abc123", "index": 1}
+        assert result["user_id"] == "7"
+
+    def test_ui_response_foreign_callback_is_none(self):
+        # Callback payloads MUXI did not produce must not become hints.
+        spec = {"ui_response": "$.callback_query.data"}
+        data = {"callback_query": {"data": "some-other-bots-callback"}}
+        assert extract_parse_values(spec, data)["ui_response"] is None
+
+    def test_ui_response_missing_path_is_none(self):
+        spec = {"message": "$.message.text", "ui_response": "$.callback_query.data"}
+        data = {"message": {"text": "an ordinary message"}}
+        result = extract_parse_values(spec, data)
+        assert result["ui_response"] is None
+        assert result["message"] == "an ordinary message"
+
+    def test_ui_response_must_be_path_string(self):
+        with pytest.raises(ValueError, match="parse.ui_response"):
+            extract_parse_values({"ui_response": {"id": "$.x"}}, {})
 
 
 # ---------------------------------------------------------------------------
@@ -557,6 +597,193 @@ class TestExtractResponseFiles:
 
     def test_plain_string_has_no_files(self):
         assert extract_response_files("just text") == []
+
+
+# ---------------------------------------------------------------------------
+# Channel-native widget rendering (Response Envelope UI, P3)
+# ---------------------------------------------------------------------------
+
+
+def _options_widget():
+    return build_options_widget(
+        prompt="Which account?",
+        options=[{"value": "acme-prod", "label": "Prod"}, {"value": "acme-dev", "label": "Dev"}],
+    )
+
+
+def _link_widget():
+    return build_action_link_widget(
+        label="Connect GitHub",
+        url="https://auth.acme.com/connect/github",
+        source=UIProvenance.FORMATION_CONFIG,
+    )
+
+
+class TestExtractResponseUI:
+    def test_object_with_ui_attribute(self):
+        class Response:
+            ui = [{"type": "options", "id": "ui_x"}]
+
+        assert extract_response_ui(Response()) == [{"type": "options", "id": "ui_x"}]
+
+    def test_dict_with_ui_key(self):
+        assert extract_response_ui({"ui": [{"type": "options"}]}) == [{"type": "options"}]
+
+    def test_no_ui_is_empty(self):
+        assert extract_response_ui({"response": []}) == []
+        assert extract_response_ui("just text") == []
+        assert extract_response_ui(None) == []
+
+    def test_non_dict_entries_dropped(self):
+        assert extract_response_ui({"ui": ["junk", None, {"type": "options"}]}) == [
+            {"type": "options"}
+        ]
+
+
+class TestBuildUIVariables:
+    def test_no_widgets_yields_all_none(self):
+        # The zero-change discipline: every channel entry is None so
+        # templating drops the keys from dict bodies.
+        variables = build_ui_variables(None, "text")
+        assert variables["telegram"]["reply_markup"] is None
+        assert variables["slack"]["blocks"] is None
+        assert variables["discord"]["components"] is None
+        assert build_ui_variables([], "text") == variables
+
+    def test_telegram_inline_keyboard(self):
+        widget = _options_widget()
+        link = _link_widget()
+        markup = build_ui_variables([widget, link], "text")["telegram"]["reply_markup"]
+        assert markup == {
+            "inline_keyboard": [
+                [{"text": "Prod", "callback_data": f"{widget['id']}#0"}],
+                [{"text": "Dev", "callback_data": f"{widget['id']}#1"}],
+                [{"text": "Connect GitHub", "url": "https://auth.acme.com/connect/github"}],
+            ]
+        }
+
+    def test_telegram_callback_data_within_limit(self):
+        widget = build_options_widget(
+            prompt="?", options=[{"value": "v" * 300, "label": "L" * 300}] * 3
+        )
+        markup = build_ui_variables([widget], "text")["telegram"]["reply_markup"]
+        for row in markup["inline_keyboard"]:
+            for button in row:
+                if "callback_data" in button:
+                    assert len(button["callback_data"].encode("utf-8")) <= 64
+
+    def test_slack_blocks_carry_text_and_buttons(self):
+        widget = _options_widget()
+        blocks = build_ui_variables([widget], "The text fallback")["slack"]["blocks"]
+        # Section first: Slack renders blocks INSTEAD of top-level text,
+        # so the text-fallback duty requires the text inside the blocks.
+        assert blocks[0] == {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": "The text fallback"},
+        }
+        actions = blocks[1]
+        assert actions["type"] == "actions"
+        assert actions["block_id"] == widget["id"]
+        assert [e["text"]["text"] for e in actions["elements"]] == ["Prod", "Dev"]
+        assert [e["value"] for e in actions["elements"]] == [
+            f"{widget['id']}#0",
+            f"{widget['id']}#1",
+        ]
+
+    def test_slack_action_link_is_url_button(self):
+        link = _link_widget()
+        blocks = build_ui_variables([link], "text")["slack"]["blocks"]
+        button = blocks[1]["elements"][0]
+        assert button["url"] == "https://auth.acme.com/connect/github"
+        assert "value" not in button  # nothing to reply with; the link IS the action
+
+    def test_slack_section_text_clamped(self):
+        blocks = build_ui_variables([_options_widget()], "x" * 4000)["slack"]["blocks"]
+        assert len(blocks[0]["text"]["text"]) <= 3000
+
+    def test_discord_components_rows_of_five(self):
+        widget = build_options_widget(
+            prompt="?", options=[{"value": f"v{i}", "label": f"L{i}"} for i in range(7)]
+        )
+        components = build_ui_variables([widget], "text")["discord"]["components"]
+        assert [len(row["components"]) for row in components] == [5, 2]
+        first = components[0]["components"][0]
+        assert first == {"type": 2, "style": 2, "label": "L0", "custom_id": f"{widget['id']}#0"}
+
+    def test_discord_row_cap_drops_overflow(self):
+        # Two full options widgets exceed Discord's 5-row limit; overflow
+        # buttons are dropped (the text fallback carries every choice).
+        widgets = [
+            build_options_widget(prompt="?", options=[{"value": f"w{n}o{i}"} for i in range(20)])
+            for n in range(2)
+        ]
+        components = build_ui_variables(widgets, "text")["discord"]["components"]
+        assert len(components) == 5
+        assert sum(len(row["components"]) for row in components) == 25
+
+    def test_discord_action_link_is_link_button(self):
+        link = _link_widget()
+        components = build_ui_variables([link], "text")["discord"]["components"]
+        button = components[0]["components"][0]
+        assert button["style"] == 5
+        assert button["url"] == "https://auth.acme.com/connect/github"
+        assert "custom_id" not in button
+
+    def test_unknown_widget_types_skipped(self):
+        variables = build_ui_variables([{"type": "hologram", "id": "ui_x"}], "text")
+        assert variables["telegram"]["reply_markup"] is None
+        assert variables["slack"]["blocks"] is None
+        assert variables["discord"]["components"] is None
+
+
+class TestBundledTemplateWidgetRendering:
+    """The updated bundled templates: widgets additive, text-only unchanged."""
+
+    def _render_bundled_body(self, tmp_path, name, response_ui, content="Pick one"):
+        config = load_transformer(tmp_path, name)
+        variables = build_transformer_variables(
+            response_content=content,
+            response_ui=response_ui,
+            context={"chat_id": "42", "channel": "C1", "thread_ts": None},
+        )
+        return render_template_value(config.body, variables)
+
+    def test_telegram_text_only_body_unchanged(self, tmp_path):
+        # The zero-change pin: without widgets the rendered payload is
+        # key-for-key what the pre-P3 template produced.
+        body = self._render_bundled_body(tmp_path, "telegram", response_ui=None)
+        assert body == {"chat_id": "42", "text": "Pick one"}
+
+    def test_telegram_widgets_render_inline_keyboard(self, tmp_path):
+        widget = _options_widget()
+        body = self._render_bundled_body(tmp_path, "telegram", response_ui=[widget])
+        assert body["text"] == "Pick one"  # text always ships
+        labels = [b["text"] for row in body["reply_markup"]["inline_keyboard"] for b in row]
+        assert labels == ["Prod", "Dev"]
+
+    def test_slack_text_only_body_unchanged(self, tmp_path):
+        body = self._render_bundled_body(tmp_path, "slack", response_ui=[])
+        assert body == {"channel": "C1", "text": "Pick one"}
+
+    def test_slack_widgets_render_blocks(self, tmp_path):
+        body = self._render_bundled_body(tmp_path, "slack", response_ui=[_options_widget()])
+        assert body["text"] == "Pick one"  # notification fallback stays
+        assert body["blocks"][0]["text"]["text"] == "Pick one"
+        assert body["blocks"][1]["type"] == "actions"
+
+    def test_discord_text_only_body_unchanged(self, tmp_path):
+        body = self._render_bundled_body(tmp_path, "discord", response_ui=None)
+        assert body == {"content": "Pick one"}
+
+    def test_discord_widgets_render_components(self, tmp_path):
+        body = self._render_bundled_body(tmp_path, "discord", response_ui=[_link_widget()])
+        assert body["content"] == "Pick one"
+        assert body["components"][0]["components"][0]["style"] == 5
+
+    def test_email_template_has_no_widget_placeholders(self, tmp_path):
+        # Email stays text (explicit P3 ruling).
+        config = load_transformer(tmp_path, "email")
+        assert "ui." not in str(config.body)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_ui_envelope.py
+++ b/tests/unit/test_ui_envelope.py
@@ -207,8 +207,22 @@ class TestUICallbackEncoding:
 
     def test_foreign_callback_data_decodes_to_none(self):
         # Channels routinely deliver callback payloads MUXI did not
-        # produce; those must not become reply hints.
-        for data in ("approve", "ui_abc", "ui_abc#x", "not-ui#1", "", None, 7, {"id": "x"}):
+        # produce; those must not become reply hints. Indexes beyond two
+        # digits are also not ours: options are capped at 25, so a
+        # three-digit index (e.g. ui_abc#999) must not decode at all
+        # rather than decode and silently resolve to None downstream.
+        for data in (
+            "approve",
+            "ui_abc",
+            "ui_abc#x",
+            "not-ui#1",
+            "ui_abc#999",
+            "ui_abc#100",
+            "",
+            None,
+            7,
+            {"id": "x"},
+        ):
             assert decode_ui_callback(data) is None
 
     def test_decoded_hint_pins_through_resolve(self):

--- a/tests/unit/test_ui_envelope.py
+++ b/tests/unit/test_ui_envelope.py
@@ -25,6 +25,8 @@ from muxi.runtime.datatypes.ui import (
     build_action_link_widget,
     build_options_widget,
     clamp_ui,
+    decode_ui_callback,
+    encode_ui_callback,
     resolve_ui_response,
 )
 from muxi.runtime.formation.server.responses import create_success_response
@@ -161,6 +163,59 @@ class TestUIResponseResolution:
     def test_no_pending_widget_ignored(self):
         assert resolve_ui_response({"id": "ui_abc", "value": "a"}, None, None) is None
         assert resolve_ui_response(None, "ui_abc", ["a"]) is None
+
+    def test_index_hint_resolves_to_offered_value(self):
+        # Channel button presses carry {id, index} (decode_ui_callback
+        # shape); the index resolves against the offered options in order.
+        assert (
+            resolve_ui_response({"id": "ui_abc", "index": 1}, "ui_abc", ["acme-prod", "acme-dev"])
+            == "acme-dev"
+        )
+
+    def test_index_out_of_range_ignored(self):
+        assert resolve_ui_response({"id": "ui_abc", "index": 5}, "ui_abc", ["a", "b"]) is None
+        assert resolve_ui_response({"id": "ui_abc", "index": -1}, "ui_abc", ["a", "b"]) is None
+
+    def test_index_must_be_int(self):
+        assert resolve_ui_response({"id": "ui_abc", "index": "1"}, "ui_abc", ["a", "b"]) is None
+        assert resolve_ui_response({"id": "ui_abc", "index": True}, "ui_abc", ["a", "b"]) is None
+
+    def test_explicit_value_wins_over_index(self):
+        assert (
+            resolve_ui_response({"id": "ui_abc", "value": "a", "index": 1}, "ui_abc", ["a", "b"])
+            == "a"
+        )
+
+
+class TestUICallbackEncoding:
+    """Channel button callback round-trip (Response Envelope UI, P3)."""
+
+    def test_encode_decode_round_trip(self):
+        widget = build_options_widget(prompt="?", options=[{"value": "a"}, {"value": "b"}])
+        encoded = encode_ui_callback(widget["id"], 1)
+        assert decode_ui_callback(encoded) == {"id": widget["id"], "index": 1}
+
+    def test_encoding_fits_telegram_callback_data_limit(self):
+        # Telegram callback_data is capped at 64 bytes; widget ids are
+        # fixed-length so index encoding always fits, regardless of how
+        # long the option values are.
+        widget = build_options_widget(
+            prompt="?", options=[{"value": "x" * 500, "label": "y" * 500}]
+        )
+        encoded = encode_ui_callback(widget["id"], 24)
+        assert len(encoded.encode("utf-8")) <= 64
+
+    def test_foreign_callback_data_decodes_to_none(self):
+        # Channels routinely deliver callback payloads MUXI did not
+        # produce; those must not become reply hints.
+        for data in ("approve", "ui_abc", "ui_abc#x", "not-ui#1", "", None, 7, {"id": "x"}):
+            assert decode_ui_callback(data) is None
+
+    def test_decoded_hint_pins_through_resolve(self):
+        widget = build_options_widget(prompt="?", options=[{"value": "a"}, {"value": "b"}])
+        option_values = [o["value"] for o in widget["options"]]
+        hint = decode_ui_callback(encode_ui_callback(widget["id"], 0))
+        assert resolve_ui_response(hint, widget["id"], option_values) == "a"
 
 
 class TestEnvelopeAdditivity:


### PR DESCRIPTION
## Summary

Response Envelope UI **P3** (owner ruling 2026-07-11): the bundled slack/telegram/discord transformer templates now render envelope UI widgets natively, and channel button presses round-trip back into the existing deterministic `ui_response` pinning. Rides on P1 (#277) and the proactiveness Phase 2 transformer machinery (#243/#228).

The runtime still renders nothing itself: these are payload shapes for the platform APIs the bundled templates already speak, delivered through the developer's bridge exactly like the text-only payloads before them. The text body ALWAYS ships — widgets are additive to the channel message, never a replacement.

## Outbound: template seam + updated bundled templates

The `${{ ... }}` substitution engine has no loops, so an options widget cannot be unrolled into buttons by a template. Instead the transformer variable namespace gains pre-computed channel-native structures (computed once per delivery in `transformers.py`):

| Variable | Renders |
|---|---|
| `response.ui` | raw widget array (None when absent) |
| `ui.telegram.reply_markup` | `InlineKeyboardMarkup` — `options` → callback buttons (one per row), `action_link` → url buttons |
| `ui.slack.blocks` | Block Kit — a section carrying the **full text** (Slack renders blocks INSTEAD of top-level `text`, which becomes notification fallback) + actions blocks of buttons |
| `ui.discord.components` | component action rows, 5 buttons x 5 rows clamp; `action_link` → style-5 link buttons |

Every entry is **None when the response carries no widgets**, so the existing None-dropping dict rendering keeps text-only deliveries **byte-identical** (pinned by unit tests key-for-key against the pre-P3 payloads, and by e2e).

**Update vs fork: updated in place.** Because the placeholder line drops out of the payload entirely without widgets, the updated templates are behaviorally identical to the old ones for every existing formation — a `-widgets` fork would have added a second name with zero divergence to justify it. Formation-local templates still shadow bundled ones (unchanged rule), so anyone wanting the old file verbatim copies it into `transformers/`. Email stays text (explicitly untouched).

## Callback-data encoding

`<widget_id>#<option_index>` (e.g. `ui_Xrdj_An2uLFTfF7ipb_kJ#1`), defined next to the widget builders in `datatypes/ui.py`:

- **Index, not value**: widget ids are fixed-length (`ui_` + 21-char nanoid = 24 bytes), so the encoding is always ≤ ~28 bytes and fits Telegram's 64-byte `callback_data` limit no matter how long option values are (no truncation/drop logic needed).
- Statelessness preserved: the index resolves against the pending clarification's offered option values — the same conversation state `resolve_ui_response` already consults, in the same order the widget offered and the template rendered. No server-side widget store.
- `#` cannot appear in a nanoid, so decoding is unambiguous; foreign callback strings (payloads MUXI did not produce) decode to None and never become hints.

The same encoding rides Slack button `action_id`/`value` and Discord `custom_id`.

## Inbound: button press → ui_response

Trigger `parse:` specs accept a new `ui_response:` path key pointing at the channel's callback field (`$.callback_query.data` / `$.actions[0].value` / `$.data.custom_id`). The extracted string is decoded into a `{id, index}` hint that the trigger route now threads into `overlord.chat(ui_response=...)` — hitting the P1 pinning unchanged (`resolve_ui_response` gained index resolution; explicit `value` still wins). `ui.response.received` (matched=true/false) is emitted by the existing choke point; no new events.

A callback update is just another platform payload on the channel's trigger route — the fixture shows the idiom: a `telegram-callback.md` trigger with `parse.ui_response: $.callback_query.data`.

## Test evidence

- **Unit**: 3745 passed, 18 skipped (full suite). New coverage: encode/decode round trip + 64-byte guarantee, index resolution (bounds, bool-guard, value-wins), per-channel rendering shapes, Discord 5x5 clamp, unknown-widget-type skip, bundled-template render pins (text-only body key-identical / widgets additive), parse-spec `ui_response` decode + validation.
- **E2E** (standalone scripts, SUCCESS + exit 0):
  - `25A6`: telegram trigger with account-ambiguous question → sink receives `inline_keyboard` with both account labels AND the complete prose text; simulated `callback_query` POST → `ui.response.received` matched=true, credential pinned deterministically (in-process MCP cache assertion, 25A1 idiom).
  - `25A7`: slack variant (Block Kit section carries the full text + actions buttons, top-level text intact, key-set pinned) + the zero-change pin (ui-bearing response through a text-only formation-local template → payload has exactly the template's keys).
- **Existing e2e re-run**: 23A5 (channel template composition) PASS, 25A5 (channel delivery, P1 no-ui pin) PASS, 25A1 (options + reply path) PASS.
- **random-5**: 5/5 PASS (21_skills, 23_proactive, 3_multimodal, 7_orchestration, 8_clarification).
- **validate_events.py**: 1437/1437 (100%).
- black / isort / ruff clean on all touched files (the two ruff I001/F401 hits in `tests/unit/test_mcp_default_parameters.py` pre-exist on develop, untouched).

## Not in this PR

- `mcp_resource` passthrough (sibling P2 PR, in parallel — CHANGELOG entry appended keep-both style)
- CLI/SDK rendering, docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)
