### PR TITLE
feat(api): envelope ui P2 — mcp_resource passthrough widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## [unreleased]
 
+### Response envelope UI - `mcp_resource` passthrough widget (P2)
+
+The third envelope widget type lands: when an external MCP server's
+tool result carries an embedded MCP Apps UI resource (a `ui://`-scheme
+embedded resource block), MUXI relays it verbatim to the client as an
+`mcp_resource` widget -- gateway, not app: no rendering, no
+interpretation, no execution (Response Envelope UI PRD, P2):
+
+- Widget shape: `{type: "mcp_resource", id, resource (the ui:// URI),
+  mime_type?, data (embedded content, verbatim), encoding?
+  ("base64" for blob resources; omitted for text), server, tool}`.
+  Provenance is structural and on the widget itself: the producing
+  server + tool are mandatory builder arguments.
+- Detection (honest v1): embedded-resource content blocks
+  (`type: "resource"`) whose URI uses the `ui://` scheme, text or
+  blob contents. `resource_link` blocks are not relayed (no data;
+  MUXI does not proxy `ui://` fetches).
+- Untrusted-content posture: the resource is external data. It is
+  carried outside the LLM-bound result dict, kept out of the flattened
+  tool text, and stripped from tool messages -- the widget extractor is
+  its only consumer; the server's accompanying text blocks remain the
+  model-facing summary. Text keeps the fallback duty: the response is
+  complete without the widget.
+- Size clamps: own budgets (64KB/widget, 128KB/envelope for
+  mcp_resource) so whole UI documents fit without touching the P1
+  budgets for standard widgets; oversized resources are dropped whole,
+  never truncated.
+- Works on both agent execution paths (tool-chain and planning);
+  `ui.emitted` observability reused with the new type value.
+
 ### Remote async tools - `watch_job` for MCP job-id + poll services
 
 MCP-reachable work that outlives a turn (image/video generation, long

--- a/e2e/tests/25_envelope_ui/fixture_ui_server.py
+++ b/e2e/tests/25_envelope_ui/fixture_ui_server.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""One-file stdio MCP server returning an MCP Apps UI resource.
+
+The fixture for the mcp_resource passthrough tests (Response Envelope
+UI, P2): ``show_dashboard`` returns a text summary block for the model
+PLUS an embedded resource whose URI uses the ``ui://`` scheme — the MCP
+Apps convention for UI resources. The runtime must relay the resource
+verbatim to the client as an ``mcp_resource`` widget and keep its
+content out of the LLM-visible text.
+
+Flags:
+    --resource-bytes N    pad the UI resource to at least N bytes
+                          (default 0 = the plain document; used by the
+                          oversized-clamp test)
+
+Only the Python standard library is used. The stdio framing is
+newline-delimited JSON-RPC 2.0, per the MCP specification (the same
+skeleton as the 26_watch fixture).
+"""
+
+import argparse
+import json
+import sys
+
+DASHBOARD_URI = "ui://dashboard/sales.html"
+DASHBOARD_MIME = "text/html"
+DASHBOARD_HTML = (
+    "<!doctype html><html><body><h1>Sales Dashboard</h1>"
+    "<p>Revenue up 5% this quarter.</p>"
+    "<div id='chart'>FIXTURE-CHART-7f3a</div></body></html>"
+)
+SUMMARY_TEXT = (
+    "Dashboard summary: revenue is up 5% this quarter; " "3 of 4 regions are above target."
+)
+
+TOOLS = [
+    {
+        "name": "show_dashboard",
+        "description": (
+            "Show the sales dashboard. Returns a text summary of the "
+            "current sales figures (and an interactive view for capable "
+            "clients)."
+        ),
+        "inputSchema": {"type": "object", "properties": {}},
+    }
+]
+
+
+def dashboard_html(resource_bytes):
+    """The fixture document, padded to at least ``resource_bytes``."""
+    html = DASHBOARD_HTML
+    if resource_bytes > len(html):
+        html += "<!--" + "x" * (resource_bytes - len(html)) + "-->"
+    return html
+
+
+def handle(request, resource_bytes):
+    method = request.get("method")
+    if method == "initialize":
+        params = request.get("params") or {}
+        return {
+            "protocolVersion": params.get("protocolVersion", "2025-06-18"),
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "fixture-ui-server", "version": "1.0.0"},
+        }
+    if method == "ping":
+        return {}
+    if method == "tools/list":
+        return {"tools": TOOLS}
+    if method == "tools/call":
+        params = request.get("params") or {}
+        if params.get("name") != "show_dashboard":
+            raise ValueError(f"unknown tool: {params.get('name')!r}")
+        return {
+            "content": [
+                {"type": "text", "text": SUMMARY_TEXT},
+                {
+                    "type": "resource",
+                    "resource": {
+                        "uri": DASHBOARD_URI,
+                        "mimeType": DASHBOARD_MIME,
+                        "text": dashboard_html(resource_bytes),
+                    },
+                },
+            ],
+            "isError": False,
+        }
+    raise ValueError(f"unsupported method: {method!r}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--resource-bytes", type=int, default=0)
+    args = parser.parse_args()
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except ValueError:
+            continue
+        request_id = request.get("id")
+        if request_id is None:
+            continue  # notification (e.g. notifications/initialized)
+        response = {"jsonrpc": "2.0", "id": request_id}
+        try:
+            response["result"] = handle(request, args.resource_bytes)
+        except Exception as e:  # malformed request -> JSON-RPC error
+            response["error"] = {"code": -32601, "message": str(e)}
+        sys.stdout.write(json.dumps(response) + "\n")
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/tests/25_envelope_ui/mcp_resource_common.py
+++ b/e2e/tests/25_envelope_ui/mcp_resource_common.py
@@ -1,0 +1,135 @@
+"""
+Shared helpers for the mcp_resource passthrough e2e tests (Response
+Envelope UI, P2).
+
+The fixture MCP server needs absolute paths (python interpreter +
+script + flags), so the formation is generated at runtime into a temp
+directory — the same standalone pattern as the 26_watch area. The
+generator writes formation.yaml plus mcp/dashboard-server.yaml and
+symlinks the shared e2e secrets.
+
+NOTE: the filename deliberately matches the runners' skip patterns
+("common.py") so it is never collected as a test.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from muxi.runtime.formation import Formation  # noqa: E402
+
+AREA_DIR = Path(__file__).parent
+ASSETS_DIR = AREA_DIR.parent.parent / "assets"
+FIXTURE_SERVER = AREA_DIR / "fixture_ui_server.py"
+
+TEST_USER = "envelope-ui-user"
+
+AGENT_SYSTEM_MESSAGE = """\
+You are a sales assistant. When the user asks about the sales dashboard
+or sales figures, call the show_dashboard tool exactly once, then answer
+using the summary it returns. Keep every response under 40 words.
+"""
+
+FORMATION_TEMPLATE = """\
+schema: "1.0.0"
+id: formation-envelope-mcp-resource
+description: E2E formation for the mcp_resource passthrough widget
+
+llm:
+  api_keys:
+    openai: "${{{{ secrets.OPENAI_API_KEY }}}}"
+  models:
+    - text: "openai/gpt-4o-mini"
+
+runtime:
+  built_in_mcps: false
+
+mcp:
+  servers:
+    - dashboard-server
+  max_tool_calls: 5
+  max_tool_iterations: 3
+
+agents:
+  - id: assistant
+    name: Assistant
+    description: Sales assistant for mcp_resource testing
+    system_message: |
+{system_message}
+    default: true
+
+overlord:
+  workflow:
+    auto_decomposition: false
+
+logging:
+  system:
+    level: "error"
+    destination: "stdout"
+  conversation:
+    enabled: false
+"""
+
+MCP_SERVER_TEMPLATE = """\
+schema: "1.0.0"
+id: "dashboard-server"
+description: "Fixture MCP Apps server (show_dashboard returns a ui:// resource)"
+
+type: "command"
+command: "{python}"
+args: {args}
+timeout_seconds: 30
+"""
+
+
+def build_formation(base_dir: Path, *, resource_bytes: int = 0) -> Path:
+    """Generate the e2e formation under ``base_dir`` and return its path."""
+    formation_dir = base_dir / "formation"
+    (formation_dir / "mcp").mkdir(parents=True)
+
+    system_message = "".join(
+        f"      {line}\n" for line in AGENT_SYSTEM_MESSAGE.strip().splitlines()
+    )
+    (formation_dir / "formation.yaml").write_text(
+        FORMATION_TEMPLATE.format(system_message=system_message.rstrip("\n"))
+    )
+
+    args = [str(FIXTURE_SERVER), "--resource-bytes", str(resource_bytes)]
+    (formation_dir / "mcp" / "dashboard-server.yaml").write_text(
+        MCP_SERVER_TEMPLATE.format(python=sys.executable, args=json.dumps(args))
+    )
+
+    # Shared e2e secrets: BOTH the blob and its key must resolve, or the
+    # SecretsManager mints a fresh key that cannot decrypt the blob.
+    os.symlink(ASSETS_DIR / "secrets.enc", formation_dir / "secrets.enc")
+    os.symlink(ASSETS_DIR / ".key", formation_dir / ".key")
+
+    return formation_dir
+
+
+async def load_formation(formation_dir: Path):
+    """Load a generated formation and start its overlord."""
+    formation = Formation()
+    await formation.load(str(formation_dir))
+    overlord = await formation.start_overlord()
+    return formation, overlord
+
+
+def content_of(response) -> str:
+    content = getattr(response, "content", None)
+    return content if isinstance(content, str) else str(response)
+
+
+def mcp_resource_widgets(response):
+    return [w for w in (getattr(response, "ui", None) or []) if w.get("type") == "mcp_resource"]
+
+
+async def teardown(formation) -> None:
+    try:
+        await formation.stop_overlord()
+        formation.stop()
+    except Exception:
+        pass

--- a/e2e/tests/25_envelope_ui/test_25b1_mcp_resource_passthrough.py
+++ b/e2e/tests/25_envelope_ui/test_25b1_mcp_resource_passthrough.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Test 25B1: Response Envelope UI - mcp_resource passthrough (P2)
+
+A fixture stdio MCP server returns an embedded ui:// resource in its
+tool result (the MCP Apps convention). Verifies the gateway contract:
+1. The envelope carries an mcp_resource widget with the resource URI,
+   mime type, and data relayed VERBATIM (no rendering, no rewriting)
+2. Provenance is recorded on the widget (producing server + tool)
+3. The text fallback stays complete on its own AND the untrusted UI
+   resource content never passes through the LLM
+"""
+
+import asyncio
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from fixture_ui_server import (  # noqa: E402
+    DASHBOARD_HTML,
+    DASHBOARD_MIME,
+    DASHBOARD_URI,
+)
+from mcp_resource_common import (  # noqa: E402
+    TEST_USER,
+    build_formation,
+    content_of,
+    load_formation,
+    mcp_resource_widgets,
+    teardown,
+)
+
+
+async def main() -> int:
+    print("MUXI Runtime - Test 25B1: mcp_resource passthrough")
+    print("=" * 70)
+
+    with tempfile.TemporaryDirectory(prefix="muxi-e2e-25b1-") as tmp:
+        formation_dir = build_formation(Path(tmp))
+        formation, overlord = await load_formation(formation_dir)
+        await asyncio.sleep(2)  # Give the MCP server time to initialize
+
+        try:
+            print("\n[1] Asking for the sales dashboard...")
+            response = await overlord.chat(
+                message="Show me the sales dashboard",
+                user_id=TEST_USER,
+                session_id="sess-25b1",
+                stream=False,
+            )
+            content = content_of(response)
+            print(f"    Response: {content[:200]}")
+
+            # ---------------------------------------------------------
+            # Verbatim passthrough
+            # ---------------------------------------------------------
+            widgets = mcp_resource_widgets(response)
+            assert (
+                widgets
+            ), f"Expected an mcp_resource widget, got ui={getattr(response, 'ui', None)}"
+            widget = widgets[0]
+            assert widget["resource"] == DASHBOARD_URI, widget
+            assert widget["mime_type"] == DASHBOARD_MIME, widget
+            assert widget["data"] == DASHBOARD_HTML, (
+                "UI resource data was not relayed verbatim "
+                f"(len={len(widget['data'])} vs {len(DASHBOARD_HTML)})"
+            )
+            assert "encoding" not in widget, widget  # text resource: default encoding
+            assert widget["id"].startswith("ui_"), widget
+            print(
+                f"    Widget relayed verbatim: {widget['resource']} "
+                f"({len(widget['data'])} bytes)"
+            )
+
+            # ---------------------------------------------------------
+            # Provenance: producing server + tool on the widget
+            # ---------------------------------------------------------
+            assert widget["server"] == "dashboard-server", widget
+            assert widget["tool"] == "show_dashboard", widget
+            print(f"    Provenance recorded: {widget['server']}.{widget['tool']}")
+
+            # ---------------------------------------------------------
+            # Text fallback duty + untrusted-content posture
+            # ---------------------------------------------------------
+            assert content and len(content.strip()) > 0, "text fallback must be complete alone"
+            assert (
+                "FIXTURE-CHART-7f3a" not in content
+            ), "UI resource content leaked into the LLM-generated text"
+            assert "ui://" not in content, "resource URI leaked into the text"
+            print("    Text complete on its own; resource content stayed out of the LLM")
+
+            print("\n" + "=" * 70)
+            print("SUCCESS: ui:// resource relayed verbatim as an mcp_resource")
+            print("         widget with server+tool provenance; text intact")
+            return 0
+
+        finally:
+            await teardown(formation)
+
+
+if __name__ == "__main__":
+    exit_code = asyncio.run(main())
+    os._exit(exit_code)

--- a/e2e/tests/25_envelope_ui/test_25b2_mcp_resource_oversized.py
+++ b/e2e/tests/25_envelope_ui/test_25b2_mcp_resource_oversized.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+Test 25B2: Response Envelope UI - oversized mcp_resource clamped away
+
+The fixture server pads its ui:// resource beyond the per-widget cap
+(UI_MCP_RESOURCE_MAX_BYTES). Verifies the clamp discipline:
+1. No mcp_resource widget ships (dropped whole, never truncated)
+2. No error surfaces — the turn completes normally
+3. The text fallback stays complete on its own
+"""
+
+import asyncio
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from mcp_resource_common import (  # noqa: E402
+    TEST_USER,
+    build_formation,
+    content_of,
+    load_formation,
+    mcp_resource_widgets,
+    teardown,
+)
+
+from muxi.runtime.datatypes.ui import UI_MCP_RESOURCE_MAX_BYTES  # noqa: E402
+
+
+async def main() -> int:
+    print("MUXI Runtime - Test 25B2: oversized mcp_resource clamped")
+    print("=" * 70)
+
+    with tempfile.TemporaryDirectory(prefix="muxi-e2e-25b2-") as tmp:
+        # Pad well past the per-widget cap so the serialized widget
+        # (data + envelope fields) is unambiguously oversized.
+        formation_dir = build_formation(Path(tmp), resource_bytes=UI_MCP_RESOURCE_MAX_BYTES + 4096)
+        formation, overlord = await load_formation(formation_dir)
+        await asyncio.sleep(2)  # Give the MCP server time to initialize
+
+        try:
+            print("\n[1] Asking for the dashboard (fixture returns an oversized resource)...")
+            response = await overlord.chat(
+                message="Show me the sales dashboard",
+                user_id=TEST_USER,
+                session_id="sess-25b2",
+                stream=False,
+            )
+            content = content_of(response)
+            print(f"    Response: {content[:200]}")
+
+            widgets = mcp_resource_widgets(response)
+            assert (
+                widgets == []
+            ), f"Oversized resource must be clamped away, got {len(widgets)} widget(s)"
+            print("    No mcp_resource widget shipped (clamped whole, not truncated)")
+
+            assert content and len(content.strip()) > 0, "text fallback must be complete alone"
+            lowered = content.lower()
+            assert (
+                "error" not in lowered or "no error" in lowered
+            ), f"clamping must be silent, but the response reads as an error: {content[:300]}"
+            print("    Turn completed cleanly; text intact")
+
+            print("\n" + "=" * 70)
+            print("SUCCESS: oversized ui:// resource dropped cleanly (no widget,")
+            print("         no error) and the text fallback stayed complete")
+            return 0
+
+        finally:
+            await teardown(formation)
+
+
+if __name__ == "__main__":
+    exit_code = asyncio.run(main())
+    os._exit(exit_code)

--- a/src/muxi/runtime/datatypes/ui.py
+++ b/src/muxi/runtime/datatypes/ui.py
@@ -1,5 +1,5 @@
 """
-Response envelope UI affordances (Response Envelope UI PRD, P1).
+Response envelope UI affordances (Response Envelope UI PRD, P1+P2).
 
 The response envelope gains an optional, typed ``ui`` array of
 *affordances*. The runtime never renders anything: clients that
@@ -13,9 +13,17 @@ what makes the ``action_link`` provenance rule structural: a URL can
 only enter a widget through a producer that names its source
 (formation config, tool result, or trigger payload).
 
+``mcp_resource`` (P2) is the gateway passthrough of an MCP App / UI
+resource returned by an external MCP server: MUXI relays the embedded
+``ui://`` resource verbatim — no rendering, no interpretation, no
+execution. It is untrusted external content; the producing server and
+tool are recorded on the widget itself as provenance.
+
 Size discipline: widgets are clamped per-widget and per-envelope
 (defaults validated by unit tests) so a misbehaving producer cannot
-bloat every response.
+bloat every response. ``mcp_resource`` widgets carry whole UI documents
+and get their own, larger budgets; the P1 budgets for standard widgets
+are unchanged.
 """
 
 from enum import Enum
@@ -41,6 +49,18 @@ UI_ENVELOPE_MAX_BYTES = 16384
 
 # Maximum number of options in a single options widget.
 UI_OPTIONS_MAX_ITEMS = 25
+
+# Maximum serialized size of a single mcp_resource widget (bytes). UI
+# resources are whole HTML documents, so the standard per-widget cap
+# would drop nearly all of them; 64KB covers a self-contained MCP App
+# page while still bounding a misbehaving server. Oversized resources
+# are dropped whole (never truncated) — the text fallback stands alone.
+UI_MCP_RESOURCE_MAX_BYTES = 65536
+
+# Maximum combined serialized size of all mcp_resource widgets in one
+# envelope (bytes). A separate budget from UI_ENVELOPE_MAX_BYTES so a
+# fat UI resource can never starve the standard widgets, and vice versa.
+UI_ENVELOPE_MAX_MCP_RESOURCE_BYTES = 131072
 
 
 class UIProvenance(Enum):
@@ -137,16 +157,80 @@ def build_action_link_widget(
     return widget
 
 
+def build_mcp_resource_widget(
+    uri: str,
+    data: str,
+    server: str,
+    tool: str,
+    mime_type: Optional[str] = None,
+    encoding: str = "text",
+) -> Optional[Dict[str, Any]]:
+    """
+    Build an ``mcp_resource`` widget (gateway passthrough of an MCP App /
+    UI resource returned by an external MCP server).
+
+    MUXI relays ``{resource, data}`` VERBATIM — no rendering, no
+    interpretation, no execution. The content is untrusted external
+    data; it is never fed through the LLM. Provenance is structural and
+    recorded on the widget itself: ``server`` and ``tool`` name the
+    producing MCP server and tool, and both are mandatory — a widget
+    cannot exist without them.
+
+    Args:
+        uri: The resource URI. Only the ``ui://`` scheme (the MCP Apps
+            convention for UI resources) is accepted.
+        data: The embedded resource content, verbatim — the ``text`` of
+            a text resource or the base64 ``blob`` of a binary one.
+        server: MCP server id that returned the resource (provenance).
+        tool: Tool name whose result carried the resource (provenance).
+        mime_type: The resource's declared mimeType, when present.
+        encoding: ``"text"`` (default, omitted on the wire) or
+            ``"base64"`` for blob resources.
+
+    Returns:
+        Widget dict, or None when any structural requirement fails
+        (non-``ui://`` URI, empty data, missing provenance).
+    """
+    if not uri or not isinstance(uri, str) or not uri.startswith("ui://"):
+        return None
+    if not data or not isinstance(data, str):
+        return None
+    if not server or not isinstance(server, str) or not tool or not isinstance(tool, str):
+        return None
+    if encoding not in ("text", "base64"):
+        return None
+
+    widget: Dict[str, Any] = {
+        "type": "mcp_resource",
+        "id": f"ui_{generate_nanoid()}",
+        "resource": uri,
+        "data": data,
+        "server": server,
+        "tool": tool,
+    }
+    if mime_type:
+        widget["mime_type"] = str(mime_type)
+    if encoding == "base64":
+        widget["encoding"] = "base64"
+    return widget
+
+
 def clamp_ui(widgets: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Enforce per-widget and per-envelope size caps.
 
     Oversized widgets are dropped (the text fallback is always complete
     on its own); the envelope keeps at most ``UI_ENVELOPE_MAX_WIDGETS``
-    widgets and ``UI_ENVELOPE_MAX_BYTES`` combined serialized bytes.
+    widgets. Standard widgets share the P1 byte budgets
+    (``UI_WIDGET_MAX_BYTES`` per widget, ``UI_ENVELOPE_MAX_BYTES``
+    combined); ``mcp_resource`` widgets carry whole UI documents and
+    have their own (``UI_MCP_RESOURCE_MAX_BYTES`` per widget,
+    ``UI_ENVELOPE_MAX_MCP_RESOURCE_BYTES`` combined) so neither family
+    can starve the other.
     """
     clamped: List[Dict[str, Any]] = []
     total_bytes = 0
+    resource_bytes = 0
 
     for widget in widgets:
         if not widget:
@@ -157,12 +241,19 @@ def clamp_ui(widgets: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             widget_bytes = len(json.dumps(widget).encode("utf-8"))
         except (TypeError, ValueError):
             continue
-        if widget_bytes > UI_WIDGET_MAX_BYTES:
-            continue
-        if total_bytes + widget_bytes > UI_ENVELOPE_MAX_BYTES:
-            break
+        if widget.get("type") == "mcp_resource":
+            if widget_bytes > UI_MCP_RESOURCE_MAX_BYTES:
+                continue
+            if resource_bytes + widget_bytes > UI_ENVELOPE_MAX_MCP_RESOURCE_BYTES:
+                continue
+            resource_bytes += widget_bytes
+        else:
+            if widget_bytes > UI_WIDGET_MAX_BYTES:
+                continue
+            if total_bytes + widget_bytes > UI_ENVELOPE_MAX_BYTES:
+                break
+            total_bytes += widget_bytes
         clamped.append(widget)
-        total_bytes += widget_bytes
 
     return clamped
 

--- a/src/muxi/runtime/datatypes/ui.py
+++ b/src/muxi/runtime/datatypes/ui.py
@@ -250,8 +250,12 @@ def clamp_ui(widgets: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         else:
             if widget_bytes > UI_WIDGET_MAX_BYTES:
                 continue
+            # Skip over (never terminate) on budget exhaustion — same
+            # as the mcp_resource branch above: each family's budget
+            # running out must not drop later widgets from the OTHER
+            # family, whose ledger may still have headroom.
             if total_bytes + widget_bytes > UI_ENVELOPE_MAX_BYTES:
-                break
+                continue
             total_bytes += widget_bytes
         clamped.append(widget)
 

--- a/src/muxi/runtime/formation/agents/agent.py
+++ b/src/muxi/runtime/formation/agents/agent.py
@@ -1142,7 +1142,10 @@ class Agent:
                         rendered_keys = [
                             f"{k}: {v}"
                             for k, v in result.items()
-                            if k != "_artifact" and v is not None and v != ""
+                            # _ui_resources is untrusted external content
+                            # (mcp_resource passthrough) — never rendered
+                            # into LLM-bound text.
+                            if k not in ("_artifact", "_ui_resources") and v is not None and v != ""
                         ]
                         if rendered_keys:
                             section_lines.extend(rendered_keys)
@@ -2789,6 +2792,46 @@ class Agent:
                                     description=f"Failed to extract artifacts in planning: {e}",
                                 )
 
+                        # Extract UI affordances (action_link,
+                        # mcp_resource) from the planned tool results
+                        # (Response Envelope UI): same producers and
+                        # clamp-then-emit discipline as the tool-chain
+                        # path — the gateway contract must not depend on
+                        # which execution path ran the tool.
+                        try:
+                            placeholder_tools = {
+                                step.get(
+                                    "output_placeholder",
+                                    f"{{{step.get('tool_name', 'TOOL').upper()}_OUTPUT}}",
+                                ): (step.get("tool_name") or "").split("__")[-1]
+                                for step in execution_plan.get("my_steps", [])
+                            }
+                            widget_results = [
+                                ToolExecutionResult(
+                                    tool_name=placeholder_tools.get(placeholder) or "unknown",
+                                    parameters={},
+                                    result=result,
+                                    execution_time=0.0,
+                                    success=True,
+                                )
+                                for placeholder, result in my_results.items()
+                                if isinstance(result, dict)
+                            ]
+                            tool_widgets = self._extract_tool_widgets(widget_results)
+                            if tool_widgets:
+                                response.ui = tool_widgets
+                        except Exception as e:
+                            observability.observe(
+                                event_type=observability.ConversationEvents.AGENT_RESPONSE_GENERATED,
+                                level=observability.EventLevel.WARNING,
+                                data={
+                                    "agent_id": self.agent_id,
+                                    "error": str(e),
+                                    "phase": "planning_execution",
+                                },
+                                description=f"Failed to extract tool-result widgets: {e}",
+                            )
+
                     # Add response to conversation context
                     self._messages.append(
                         {
@@ -3287,6 +3330,11 @@ class Agent:
                     serializable_result = result.copy() if isinstance(result, dict) else result
                     if isinstance(serializable_result, dict) and "_artifact" in serializable_result:
                         serializable_result.pop("_artifact")
+                    # UI resources (mcp_resource passthrough) are
+                    # untrusted external content relayed verbatim to the
+                    # client — never fed through the LLM.
+                    if isinstance(serializable_result, dict):
+                        serializable_result.pop("_ui_resources", None)
 
                     tool_results.append(
                         {
@@ -3515,22 +3563,22 @@ class Agent:
         # Clean the content to remove sandbox references and download links
         response.content = self._clean_response_content(content)
 
-        # Extract action_link affordances from tool results (Response
-        # Envelope UI). Same posture as artifact extraction below: only
-        # structured data a tool actually returned can become a widget
-        # (tool-result provenance) — the LLM's text can never fabricate
-        # one into the envelope.
+        # Extract UI affordances (action_link, mcp_resource) from tool
+        # results (Response Envelope UI). Same posture as artifact
+        # extraction below: only structured data a tool actually
+        # returned can become a widget (tool-result provenance) — the
+        # LLM's text can never fabricate one into the envelope.
         if total_tool_calls > 0 and all_tool_execution_results:
             try:
-                link_widgets = self._extract_link_widgets(all_tool_execution_results)
-                if link_widgets:
-                    response.ui = link_widgets
+                tool_widgets = self._extract_tool_widgets(all_tool_execution_results)
+                if tool_widgets:
+                    response.ui = tool_widgets
             except Exception as e:
                 observability.observe(
                     event_type=observability.ConversationEvents.AGENT_RESPONSE_GENERATED,
                     level=observability.EventLevel.WARNING,
                     data={"agent_id": self.agent_id, "error": str(e)},
-                    description=f"Failed to extract action_link widgets: {e}",
+                    description=f"Failed to extract tool-result widgets: {e}",
                 )
 
         # Extract artifacts from tool results if any tools were executed
@@ -3585,26 +3633,38 @@ class Agent:
 
         return response
 
-    def _extract_link_widgets(
+    def _extract_tool_widgets(
         self, tool_execution_results: List[Any]
     ) -> Optional[List[Dict[str, Any]]]:
         """
-        Extract ``action_link`` widgets from tool results (Response
-        Envelope UI, tool-result provenance).
+        Extract UI widgets from tool results (Response Envelope UI,
+        tool-result provenance): ``action_link`` (P1) and
+        ``mcp_resource`` (P2).
 
-        A tool opts in by returning a ``_link`` object — mirroring the
-        ``_artifact`` convention — either at the top level of its result
-        or nested under ``result``:
+        A tool opts in to ``action_link`` by returning a ``_link``
+        object — mirroring the ``_artifact`` convention — either at the
+        top level of its result or nested under ``result``:
 
             {"_link": {"url": "https://...", "label": "...", "hint": "..."}}
 
-        Only URLs a tool actually returned can become widgets; the
-        LLM's text output is never scanned. Clamps FIRST, then emits
-        ``ui.emitted`` only for widgets that survive the clamp — same
-        order as ``Overlord._attach_ui``, so emitted counts match what
-        actually ships on the envelope.
+        ``mcp_resource`` widgets come from ``_ui_resources`` entries the
+        MCP service attached at the top level of its payload when the
+        raw tool result carried embedded ``ui://`` resources (MCP
+        Apps). Each entry already names its provenance (server + tool)
+        and is relayed verbatim.
+
+        Only structured data a tool actually returned can become a
+        widget; the LLM's text output is never scanned. All candidates
+        share one clamp pass (clamp FIRST, then emit ``ui.emitted``
+        only for survivors — same order as ``Overlord._attach_ui``, so
+        emitted counts match what actually ships on the envelope).
         """
-        from ...datatypes.ui import UIProvenance, build_action_link_widget, clamp_ui
+        from ...datatypes.ui import (
+            UIProvenance,
+            build_action_link_widget,
+            build_mcp_resource_widget,
+            clamp_ui,
+        )
 
         widgets: List[Dict[str, Any]] = []
         producer_by_widget_id: Dict[str, str] = {}
@@ -3612,23 +3672,47 @@ class Agent:
             raw = getattr(tool_result, "result", None)
             if not isinstance(raw, dict):
                 continue
-            link = raw.get("_link")
-            if link is None and isinstance(raw.get("result"), dict):
-                link = raw["result"].get("_link")
-            if not isinstance(link, dict):
-                continue
-
+            nested = raw.get("result") if isinstance(raw.get("result"), dict) else None
             tool_name = getattr(tool_result, "tool_name", None)
-            widget = build_action_link_widget(
-                label=link.get("label") or link.get("url"),
-                url=link.get("url"),
-                hint=link.get("hint"),
-                source=UIProvenance.TOOL_RESULT,
-                source_ref=tool_name,
-            )
-            if widget:
-                widgets.append(widget)
-                producer_by_widget_id[widget["id"]] = f"tool_result:{tool_name or 'unknown'}"
+
+            # action_link: the _link opt-in convention (P1)
+            link = raw.get("_link")
+            if link is None and nested is not None:
+                link = nested.get("_link")
+            if isinstance(link, dict):
+                widget = build_action_link_widget(
+                    label=link.get("label") or link.get("url"),
+                    url=link.get("url"),
+                    hint=link.get("hint"),
+                    source=UIProvenance.TOOL_RESULT,
+                    source_ref=tool_name,
+                )
+                if widget:
+                    widgets.append(widget)
+                    producer_by_widget_id[widget["id"]] = f"tool_result:{tool_name or 'unknown'}"
+
+            # mcp_resource: ui:// embedded resources the MCP service
+            # extracted from the raw tool result (P2). Top-level only —
+            # that is where the service puts them, deliberately outside
+            # the ``result`` dict the text paths render.
+            ui_resources = raw.get("_ui_resources")
+            if isinstance(ui_resources, list):
+                for entry in ui_resources:
+                    if not isinstance(entry, dict):
+                        continue
+                    widget = build_mcp_resource_widget(
+                        uri=entry.get("uri"),
+                        data=entry.get("data"),
+                        server=entry.get("server"),
+                        tool=entry.get("tool"),
+                        mime_type=entry.get("mime_type"),
+                        encoding=entry.get("encoding") or "text",
+                    )
+                    if widget:
+                        widgets.append(widget)
+                        producer_by_widget_id[widget["id"]] = (
+                            f"tool_result:{widget['server']}.{widget['tool']}"
+                        )
 
         clamped = clamp_ui(widgets)
         for widget in clamped:
@@ -3637,11 +3721,11 @@ class Agent:
                 event_type=observability.ConversationEvents.UI_EMITTED,
                 level=observability.EventLevel.INFO,
                 data={
-                    "type": "action_link",
+                    "type": widget["type"],
                     "producer": producer,
                     "widget_id": widget["id"],
                 },
-                description=f"UI widget 'action_link' emitted from tool result ({producer})",
+                description=(f"UI widget '{widget['type']}' emitted from tool result ({producer})"),
             )
 
         return clamped or None

--- a/src/muxi/runtime/services/mcp/service.py
+++ b/src/muxi/runtime/services/mcp/service.py
@@ -980,10 +980,29 @@ class MCPService:
                     ),
                 )
 
-                return {
+                response_payload: Dict[str, Any] = {
                     "result": processed_result,
                     "status": "success" if not processed_result["isError"] else "error",
                 }
+
+                # Gateway passthrough of MCP Apps UI resources (Response
+                # Envelope UI PRD, P2): embedded ui:// resources in the
+                # tool result are relayed verbatim to the client as
+                # mcp_resource widgets. They are untrusted external
+                # content, carried at the TOP level of the payload —
+                # deliberately outside ``result`` so the text-rendering
+                # paths (tool messages, planning summaries, raw response
+                # sections) never see them; the widget extractor is
+                # their only consumer. Each entry is tagged with its
+                # provenance (this server + tool).
+                if not processed_result["isError"]:
+                    ui_resources = ModernProtocolFeatures.extract_ui_resources(result)
+                    if ui_resources:
+                        response_payload["_ui_resources"] = [
+                            dict(entry, server=server_id, tool=tool_name) for entry in ui_resources
+                        ]
+
+                return response_payload
 
         except Exception as e:
             # Emit MCP tool invocation failed event

--- a/src/muxi/runtime/services/mcp/transports/protocol_features.py
+++ b/src/muxi/runtime/services/mcp/transports/protocol_features.py
@@ -28,13 +28,101 @@
 # Streamable HTTP implementation plan Phase 2.3.
 # =============================================================================
 
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 
 class ModernProtocolFeatures:
     """
     Support for MCP 2025-06-18 protocol enhancements.
     """
+
+    @staticmethod
+    def _ui_resource_entry(item: Any) -> Optional[Dict[str, Any]]:
+        """
+        Recognize an MCP Apps UI resource inside a tool-result content
+        block (Response Envelope UI PRD, P2 — the gateway passthrough).
+
+        v1 detection is deliberately narrow and honest: an *embedded
+        resource* block (``type: "resource"``, the SDK's
+        ``EmbeddedResource``) whose resource URI uses the ``ui://``
+        scheme — the MCP Apps convention for UI resources. Both text
+        (``TextResourceContents``) and binary (``BlobResourceContents``,
+        base64) contents are relayed. ``resource_link`` blocks are NOT
+        relayed: they carry no data, and MUXI does not proxy ``ui://``
+        resource fetches.
+
+        Handles both dict-shaped blocks (``model_dump()`` output from
+        the transports) and attribute-shaped SDK objects.
+
+        Returns:
+            ``{"uri", "data", "encoding", "mime_type"?}`` with the
+            content relayed verbatim, or None when the block is not a
+            UI resource.
+        """
+        if isinstance(item, dict):
+            block_type = item.get("type")
+            resource = item.get("resource")
+        else:
+            block_type = getattr(item, "type", None)
+            resource = getattr(item, "resource", None)
+        if block_type != "resource" or resource is None:
+            return None
+
+        if isinstance(resource, dict):
+            uri = resource.get("uri")
+            mime_type = resource.get("mimeType")
+            text = resource.get("text")
+            blob = resource.get("blob")
+        else:
+            uri = getattr(resource, "uri", None)
+            mime_type = getattr(resource, "mimeType", None)
+            text = getattr(resource, "text", None)
+            blob = getattr(resource, "blob", None)
+
+        # Transports hand us model_dump() output where uri is a
+        # pydantic AnyUrl — normalize to the plain string.
+        uri = str(uri) if uri is not None else ""
+        if not uri.startswith("ui://"):
+            return None
+
+        if isinstance(text, str) and text:
+            entry: Dict[str, Any] = {"uri": uri, "data": text, "encoding": "text"}
+        elif isinstance(blob, str) and blob:
+            entry = {"uri": uri, "data": blob, "encoding": "base64"}
+        else:
+            return None
+        if mime_type:
+            entry["mime_type"] = str(mime_type)
+        return entry
+
+    @staticmethod
+    def extract_ui_resources(result: Any) -> List[Dict[str, Any]]:
+        """
+        Extract MCP Apps UI resources (``ui://`` embedded resources)
+        from a raw tool result, before content flattening loses the
+        block structure.
+
+        Args:
+            result: Raw tool result (dict from ``model_dump()`` or a
+                CallToolResult-shaped object).
+
+        Returns:
+            List of relay entries (see ``_ui_resource_entry``), empty
+            when the result carries none.
+        """
+        if isinstance(result, dict):
+            content = result.get("content")
+        else:
+            content = getattr(result, "content", None)
+        if not isinstance(content, list):
+            return []
+
+        entries = []
+        for item in content:
+            entry = ModernProtocolFeatures._ui_resource_entry(item)
+            if entry is not None:
+                entries.append(entry)
+        return entries
 
     @staticmethod
     def extract_display_name(tool_info: Dict[str, Any]) -> str:
@@ -82,6 +170,14 @@ class ModernProtocolFeatures:
             if isinstance(content, list):
                 content_parts = []
                 for item in content:
+                    # UI resources (ui:// embedded resources) are
+                    # untrusted external content relayed verbatim to the
+                    # client as mcp_resource widgets — they are never
+                    # flattened into the LLM-visible text. The server's
+                    # accompanying text blocks carry the model-facing
+                    # summary.
+                    if ModernProtocolFeatures._ui_resource_entry(item) is not None:
+                        continue
                     if isinstance(item, dict):
                         text_value = item.get("text")
                         content_parts.append(

--- a/tests/unit/test_ui_envelope.py
+++ b/tests/unit/test_ui_envelope.py
@@ -257,6 +257,39 @@ class TestSizeClamps:
         ]
         assert len(clamp_ui(widgets)) == UI_ENVELOPE_MAX_WIDGETS
 
+    def test_standard_budget_exhaustion_does_not_drop_later_resource(self):
+        # Budget exhaustion in one family skips over, never terminates:
+        # enough near-cap standard widgets to blow the standard byte
+        # budget, THEN an in-budget mcp_resource — the resource's own
+        # ledger has headroom, so it must survive.
+        links = [
+            build_action_link_widget(
+                label="x" * (UI_WIDGET_MAX_BYTES - 200),
+                url=f"https://portal.acme.com/{i}",
+                source=UIProvenance.TOOL_RESULT,
+            )
+            for i in range(6)  # ~6 x ~3.9KB > 16KB standard budget
+        ]
+        resource = self._resource_widget(1024)
+        clamped = clamp_ui(links + [resource])
+        assert resource in clamped, "resource dropped by the OTHER family's budget exhaustion"
+        standard_total = sum(
+            len(json.dumps(w).encode("utf-8")) for w in clamped if w["type"] != "mcp_resource"
+        )
+        assert standard_total <= UI_ENVELOPE_MAX_BYTES
+        assert 0 < len(clamped) - 1 < len(links)  # some links clamped, not all
+
+    def test_resource_budget_exhaustion_does_not_drop_later_standard(self):
+        # The mirror case: resources blow the mcp_resource budget, then
+        # an in-budget standard widget follows — it must survive.
+        resources = [self._resource_widget(UI_MCP_RESOURCE_MAX_BYTES - 200) for _ in range(3)]
+        link = build_action_link_widget(
+            label="ok", url="https://portal.acme.com", source=UIProvenance.TOOL_RESULT
+        )
+        clamped = clamp_ui(resources + [link])
+        assert link in clamped, "standard widget dropped by the resource budget exhaustion"
+        assert sum(1 for w in clamped if w["type"] == "mcp_resource") == 2
+
 
 class TestUIResponseResolution:
     def test_matching_hint_pins_value(self):

--- a/tests/unit/test_ui_envelope.py
+++ b/tests/unit/test_ui_envelope.py
@@ -1,13 +1,17 @@
 """
-Unit tests for the Response Envelope UI affordances (P1).
+Unit tests for the Response Envelope UI affordances (P1 + P2).
 
 Covers:
-- Widget builders (options, action_link) and the structural provenance rule
-- Size clamps (per-widget and per-envelope, load-validated defaults)
+- Widget builders (options, action_link, mcp_resource) and the
+  structural provenance rules
+- Size clamps (per-widget and per-envelope, load-validated defaults;
+  separate budgets for mcp_resource widgets)
 - ui_response hint resolution (deterministic pinning vs ignored hints)
 - Envelope additivity: responses without widgets serialize byte-identically
   to the pre-feature envelope, both directly and nested inside the API
   response (the critical zero-behavior-change pin)
+- MCP Apps ui:// resource detection on the raw tool-result path
+  (extraction + keeping untrusted content out of the LLM-visible text)
 - links: formation config section validation
 """
 
@@ -19,15 +23,19 @@ from muxi.runtime.datatypes.api import APIEventType, APIObjectType
 from muxi.runtime.datatypes.response import MuxiResponse
 from muxi.runtime.datatypes.ui import (
     UI_ENVELOPE_MAX_BYTES,
+    UI_ENVELOPE_MAX_MCP_RESOURCE_BYTES,
     UI_ENVELOPE_MAX_WIDGETS,
+    UI_MCP_RESOURCE_MAX_BYTES,
     UI_WIDGET_MAX_BYTES,
     UIProvenance,
     build_action_link_widget,
+    build_mcp_resource_widget,
     build_options_widget,
     clamp_ui,
     resolve_ui_response,
 )
 from muxi.runtime.formation.server.responses import create_success_response
+from muxi.runtime.services.mcp.transports.protocol_features import ModernProtocolFeatures
 
 
 class TestOptionsWidget:
@@ -98,6 +106,67 @@ class TestActionLinkWidget:
         assert "hint" not in widget
 
 
+class TestMcpResourceWidget:
+    def test_builds_text_resource_widget(self):
+        widget = build_mcp_resource_widget(
+            uri="ui://dashboard/sales.html",
+            data="<h1>Sales</h1>",
+            server="dashboard-server",
+            tool="show_dashboard",
+            mime_type="text/html",
+        )
+        assert widget["type"] == "mcp_resource"
+        assert widget["id"].startswith("ui_")
+        assert widget["resource"] == "ui://dashboard/sales.html"
+        assert widget["data"] == "<h1>Sales</h1>"  # verbatim
+        assert widget["mime_type"] == "text/html"
+        assert widget["server"] == "dashboard-server"
+        assert widget["tool"] == "show_dashboard"
+        assert "encoding" not in widget  # text is the default
+
+    def test_builds_blob_resource_widget(self):
+        widget = build_mcp_resource_widget(
+            uri="ui://viewer/model.glb",
+            data="aGVsbG8=",
+            server="viewer-server",
+            tool="show_model",
+            encoding="base64",
+        )
+        assert widget["data"] == "aGVsbG8="
+        assert widget["encoding"] == "base64"
+        assert "mime_type" not in widget
+
+    def test_rejects_non_ui_schemes(self):
+        for bad_uri in ("https://evil.example.com/app.html", "file:///etc/passwd", "", None):
+            assert (
+                build_mcp_resource_widget(uri=bad_uri, data="<h1>x</h1>", server="srv", tool="tool")
+                is None
+            )
+
+    def test_provenance_is_structural(self):
+        # No server/tool, no widget — provenance is recorded on the
+        # widget itself and cannot be omitted.
+        for server, tool in ((None, "tool"), ("srv", None), ("", "tool"), ("srv", "")):
+            assert (
+                build_mcp_resource_widget(
+                    uri="ui://x/y.html", data="<p>x</p>", server=server, tool=tool
+                )
+                is None
+            )
+
+    def test_rejects_empty_data_and_bad_encoding(self):
+        assert build_mcp_resource_widget(uri="ui://x/y.html", data="", server="s", tool="t") is None
+        assert (
+            build_mcp_resource_widget(uri="ui://x/y.html", data=None, server="s", tool="t") is None
+        )
+        assert (
+            build_mcp_resource_widget(
+                uri="ui://x/y.html", data="x", server="s", tool="t", encoding="hex"
+            )
+            is None
+        )
+
+
 class TestSizeClamps:
     def test_oversized_widget_dropped(self):
         big = build_options_widget(
@@ -132,6 +201,61 @@ class TestSizeClamps:
 
     def test_none_entries_skipped(self):
         assert clamp_ui([None, None]) == []
+
+    def _resource_widget(self, data_bytes: int):
+        return build_mcp_resource_widget(
+            uri="ui://fixture/page.html",
+            data="x" * data_bytes,
+            server="srv",
+            tool="tool",
+            mime_type="text/html",
+        )
+
+    def test_mcp_resource_survives_beyond_standard_cap(self):
+        # A UI resource bigger than the standard per-widget cap but
+        # under its own cap must survive — the whole point of the
+        # separate budget.
+        widget = self._resource_widget(UI_WIDGET_MAX_BYTES * 4)
+        assert clamp_ui([widget]) == [widget]
+
+    def test_oversized_mcp_resource_dropped(self):
+        widget = self._resource_widget(UI_MCP_RESOURCE_MAX_BYTES + 1)
+        assert clamp_ui([widget]) == []
+
+    def test_mcp_resource_envelope_budget(self):
+        # Widgets individually under the per-resource cap but
+        # collectively over the resource envelope budget: survivors
+        # stay within budget, later smaller widgets are not blocked.
+        resources = [self._resource_widget(UI_MCP_RESOURCE_MAX_BYTES - 200) for _ in range(3)]
+        small_link = build_action_link_widget(
+            label="ok", url="https://portal.acme.com", source=UIProvenance.TOOL_RESULT
+        )
+        clamped = clamp_ui(resources + [small_link])
+        resource_total = sum(
+            len(json.dumps(w).encode("utf-8")) for w in clamped if w["type"] == "mcp_resource"
+        )
+        assert resource_total <= UI_ENVELOPE_MAX_MCP_RESOURCE_BYTES
+        assert sum(1 for w in clamped if w["type"] == "mcp_resource") == 2
+        # The standard widget rides its own budget, untouched by the
+        # fat resources before it.
+        assert small_link in clamped
+
+    def test_budgets_are_independent(self):
+        # A max-size resource must not consume the standard widgets'
+        # byte budget and vice versa.
+        resource = self._resource_widget(UI_MCP_RESOURCE_MAX_BYTES - 200)
+        options = [
+            build_options_widget(prompt=f"q{i}", options=[{"value": "a", "label": "a"}])
+            for i in range(3)
+        ]
+        clamped = clamp_ui([resource] + options)
+        assert len(clamped) == 4
+
+    def test_count_cap_shared_across_types(self):
+        widgets = [self._resource_widget(64) for _ in range(UI_ENVELOPE_MAX_WIDGETS)] + [
+            build_options_widget(prompt="?", options=[{"value": "a", "label": "a"}])
+        ]
+        assert len(clamp_ui(widgets)) == UI_ENVELOPE_MAX_WIDGETS
 
 
 class TestUIResponseResolution:
@@ -211,8 +335,8 @@ class _StubToolResult:
         self.tool_name = tool_name
 
 
-class TestToolResultLinkExtraction:
-    """Agent._extract_link_widgets: the tool-result action_link producer."""
+class _WidgetExtractionMixin:
+    """Shared harness for Agent._extract_tool_widgets tests."""
 
     def _extract(self, monkeypatch, tool_results):
         """Run extraction with ui.emitted events captured."""
@@ -232,8 +356,12 @@ class TestToolResultLinkExtraction:
         monkeypatch.setattr(agent_module.observability, "observe", capture)
 
         stub = object.__new__(Agent)  # method uses no instance state
-        widgets = Agent._extract_link_widgets(stub, tool_results)
+        widgets = Agent._extract_tool_widgets(stub, tool_results)
         return widgets, emitted
+
+
+class TestToolResultLinkExtraction(_WidgetExtractionMixin):
+    """Agent._extract_tool_widgets: the tool-result action_link producer (P1)."""
 
     def test_link_extracted_and_emitted(self, monkeypatch):
         widgets, emitted = self._extract(
@@ -297,6 +425,209 @@ class TestToolResultLinkExtraction:
         assert len(widgets) == 1
         assert widgets[0]["url"] == "https://nested.acme.com"
         assert len(emitted) == 1
+
+
+class TestToolResultMcpResourceExtraction(_WidgetExtractionMixin):
+    """Agent._extract_tool_widgets: the mcp_resource passthrough producer (P2)."""
+
+    ENTRY = {
+        "uri": "ui://dashboard/sales.html",
+        "data": "<h1>Sales</h1>",
+        "encoding": "text",
+        "mime_type": "text/html",
+        "server": "dashboard-server",
+        "tool": "show_dashboard",
+    }
+
+    def test_resource_extracted_verbatim_and_emitted(self, monkeypatch):
+        # The MCP service attaches _ui_resources at the TOP level of
+        # its payload, next to (not inside) the result dict the text
+        # paths render: {"result": {...}, "status": ..., "_ui_resources": [...]}
+        widgets, emitted = self._extract(
+            monkeypatch,
+            [
+                _StubToolResult(
+                    {
+                        "result": {"content": "summary"},
+                        "status": "success",
+                        "_ui_resources": [dict(self.ENTRY)],
+                    },
+                    tool_name="show_dashboard",
+                )
+            ],
+        )
+        assert len(widgets) == 1
+        widget = widgets[0]
+        assert widget["type"] == "mcp_resource"
+        assert widget["resource"] == "ui://dashboard/sales.html"
+        assert widget["data"] == "<h1>Sales</h1>"  # verbatim passthrough
+        assert widget["mime_type"] == "text/html"
+        assert widget["server"] == "dashboard-server"
+        assert widget["tool"] == "show_dashboard"
+        assert len(emitted) == 1
+        assert emitted[0]["type"] == "mcp_resource"
+        assert emitted[0]["producer"] == "tool_result:dashboard-server.show_dashboard"
+        assert emitted[0]["widget_id"] == widget["id"]
+
+    def test_oversized_resource_clamped_not_emitted(self, monkeypatch):
+        oversized = dict(self.ENTRY, data="x" * (UI_MCP_RESOURCE_MAX_BYTES + 1))
+        widgets, emitted = self._extract(
+            monkeypatch,
+            [_StubToolResult({"result": {}, "_ui_resources": [oversized]})],
+        )
+        assert widgets is None
+        assert emitted == []
+
+    def test_mixed_link_and_resource_share_one_clamp_pass(self, monkeypatch):
+        widgets, emitted = self._extract(
+            monkeypatch,
+            [
+                _StubToolResult(
+                    {"_link": {"url": "https://portal.acme.com", "label": "Portal"}},
+                    tool_name="portal_tool",
+                ),
+                _StubToolResult(
+                    {"result": {}, "_ui_resources": [dict(self.ENTRY)]},
+                    tool_name="show_dashboard",
+                ),
+            ],
+        )
+        assert [w["type"] for w in widgets] == ["action_link", "mcp_resource"]
+        assert {e["type"] for e in emitted} == {"action_link", "mcp_resource"}
+
+    def test_malformed_entries_ignored(self, monkeypatch):
+        widgets, emitted = self._extract(
+            monkeypatch,
+            [
+                _StubToolResult({"result": {}, "_ui_resources": "not-a-list"}),
+                _StubToolResult({"result": {}, "_ui_resources": ["not-a-dict"]}),
+                # Missing provenance: the builder refuses it
+                _StubToolResult(
+                    {"result": {}, "_ui_resources": [{"uri": "ui://x/y.html", "data": "<p>x</p>"}]}
+                ),
+            ],
+        )
+        assert widgets is None
+        assert emitted == []
+
+
+class TestMcpUiResourceDetection:
+    """ModernProtocolFeatures: ui:// detection on the raw tool-result path."""
+
+    UI_BLOCK = {
+        "type": "resource",
+        "resource": {
+            "uri": "ui://dashboard/sales.html",
+            "mimeType": "text/html",
+            "text": "<h1>Sales</h1>",
+        },
+    }
+
+    def test_extracts_text_ui_resource(self):
+        result = {"content": [{"type": "text", "text": "summary"}, self.UI_BLOCK]}
+        entries = ModernProtocolFeatures.extract_ui_resources(result)
+        assert entries == [
+            {
+                "uri": "ui://dashboard/sales.html",
+                "data": "<h1>Sales</h1>",
+                "encoding": "text",
+                "mime_type": "text/html",
+            }
+        ]
+
+    def test_extracts_blob_ui_resource(self):
+        result = {
+            "content": [
+                {
+                    "type": "resource",
+                    "resource": {"uri": "ui://viewer/model.glb", "blob": "aGVsbG8="},
+                }
+            ]
+        }
+        entries = ModernProtocolFeatures.extract_ui_resources(result)
+        assert entries == [
+            {"uri": "ui://viewer/model.glb", "data": "aGVsbG8=", "encoding": "base64"}
+        ]
+
+    def test_ignores_non_ui_blocks(self):
+        result = {
+            "content": [
+                {"type": "text", "text": "hello"},
+                # Embedded resource with a non-ui scheme: NOT relayed
+                {
+                    "type": "resource",
+                    "resource": {"uri": "file:///tmp/report.txt", "text": "data"},
+                },
+                # resource_link: carries no data, NOT relayed in v1
+                {"type": "resource_link", "uri": "ui://dashboard/sales.html", "name": "d"},
+            ]
+        }
+        assert ModernProtocolFeatures.extract_ui_resources(result) == []
+
+    def test_handles_sdk_objects(self):
+        # The command transport hands over model_dump() output where
+        # uri is a pydantic AnyUrl; the SDK objects themselves must
+        # also be handled (attribute-shaped blocks).
+        mcp_types = pytest.importorskip("mcp.types")
+        embedded = mcp_types.EmbeddedResource(
+            type="resource",
+            resource=mcp_types.TextResourceContents(
+                uri="ui://dashboard/sales.html", mimeType="text/html", text="<h1>S</h1>"
+            ),
+        )
+        result = mcp_types.CallToolResult(content=[embedded])
+        # model_dump path (dict blocks, AnyUrl uri)
+        dumped = ModernProtocolFeatures.extract_ui_resources(result.model_dump())
+        # object path
+        direct = ModernProtocolFeatures.extract_ui_resources(result)
+        for entries in (dumped, direct):
+            assert len(entries) == 1
+            assert entries[0]["uri"] == "ui://dashboard/sales.html"
+            assert entries[0]["data"] == "<h1>S</h1>"
+
+    def test_ui_resource_kept_out_of_llm_text(self):
+        # Untrusted-content posture: the flattened text the LLM sees
+        # must not contain the UI resource content; ordinary blocks
+        # keep flowing.
+        result = {
+            "content": [{"type": "text", "text": "summary for the model"}, self.UI_BLOCK],
+            "isError": False,
+        }
+        processed = ModernProtocolFeatures.process_structured_output(result)
+        assert "summary for the model" in processed["content"]
+        assert "<h1>Sales</h1>" not in processed["content"]
+        assert "ui://dashboard" not in processed["content"]
+
+
+class TestEnvelopeSerializationWithMcpResource:
+    """Runtime-side pin: mcp_resource + options serialize correctly and
+    the no-widget path stays byte-identical (unknown-type ignorability
+    is a client guarantee; this is its runtime counterpart)."""
+
+    def test_mixed_widget_envelope_serializes(self):
+        options = build_options_widget(prompt="?", options=[{"value": "a", "label": "a"}])
+        resource = build_mcp_resource_widget(
+            uri="ui://dashboard/sales.html",
+            data="<h1>Sales</h1>",
+            server="dashboard-server",
+            tool="show_dashboard",
+            mime_type="text/html",
+        )
+        response = MuxiResponse(role="assistant", content="text", ui=[options, resource])
+        dumped = response.model_dump()
+        assert dumped["ui"] == [options, resource]
+        # The wire form is plain JSON (no enums, no pydantic types)
+        roundtripped = json.loads(json.dumps(dumped["ui"]))
+        assert roundtripped == [options, resource]
+
+    def test_no_widget_path_byte_identical(self):
+        # An empty ui list must serialize byte-identically to a
+        # response that never had the field — the zero-behavior-change
+        # discipline, re-pinned with the P2 type in the registry.
+        base = MuxiResponse(role="assistant", content="hello")
+        with_empty_ui = MuxiResponse(role="assistant", content="hello", ui=[])
+        assert json.dumps(base.model_dump()) == json.dumps(with_empty_ui.model_dump())
+        assert "ui" not in base.model_dump()
 
 
 class TestLinksConfigValidation:


### PR DESCRIPTION
## Summary

Response Envelope UI **P2**: the third widget type, `mcp_resource` — the gateway passthrough of an MCP App / UI resource returned by an external MCP server. When a tool result carries an embedded `ui://` resource (the MCP Apps convention), MUXI relays `{resource, data}` **verbatim** to the client on the envelope's `ui` array. Gateway, not app: no rendering, no interpretation, no execution.

Scope per owner ruling (2026-07-11): runtime passthrough only — published SDK type packages are deferred (landing with the CLI); P3 channel rendering is a sibling PR.

PRD: `engineering/prds/response-envelope-ui.md` (P2 section). This is the surviving half of `postponed/mcp-apps-support.md`.

## Widget shape

```jsonc
{
  "type": "mcp_resource",
  "id": "ui_x1y2",                         // runtime-assigned
  "resource": "ui://dashboard/sales.html", // the ui:// URI, verbatim
  "mime_type": "text/html",                // when the server declared one
  "data": "<!doctype html>...",            // embedded content, verbatim
  "encoding": "base64",                    // only for blob resources; omitted for text
  "server": "dashboard-server",            // provenance: producing MCP server
  "tool": "show_dashboard"                 // provenance: producing tool
}
```

Provenance is structural: `server` and `tool` are mandatory builder arguments (`build_mcp_resource_widget` returns None without them) — same posture as `action_link`'s provenance rule.

## Detection (honest v1)

Verified against the installed `mcp` package (**1.27.2**):

- **Recognized:** embedded-resource content blocks (`type: "resource"`, the SDK's `EmbeddedResource`) whose resource URI uses the `ui://` scheme. Both `TextResourceContents` (`text`) and `BlobResourceContents` (`blob`, relayed as base64 with `"encoding": "base64"`) are relayed. Handles both `model_dump()` dicts (what all three transports return; `uri` arrives as pydantic `AnyUrl` and is normalized to a plain string) and attribute-shaped SDK objects.
- **Not relayed:** `resource_link` blocks (they carry no data, and MUXI does not proxy `ui://` resource fetches), non-`ui://` embedded resources, error results (`isError: true`).

## Untrusted-content posture

The resource is external data and never passes through the LLM:

- The MCP service attaches extracted entries as `_ui_resources` at the **top level** of its payload — deliberately outside the `result` dict that every text-rendering path (tool messages, planning raw-response sections, planning summaries) reads.
- The content flattener (`process_structured_output`) now skips `ui://` embedded blocks, so the resource no longer leaks into the LLM-visible tool text (previously an embedded resource's whole dict repr was flattened in via `str(item)`).
- The agent strips `_ui_resources` from LLM-bound tool messages (same idiom as `_artifact`).
- The widget extractor is the only consumer. The server's accompanying text blocks remain the model-facing summary, and `text` keeps the fallback duty — the widget is additive; nothing about the text path changes.

## Size clamps

`mcp_resource` carries whole UI documents, so it gets its own load-validated budgets instead of inheriting the P1 caps (which would drop nearly every resource):

- `UI_MCP_RESOURCE_MAX_BYTES = 65536` (64KB per widget; dropped whole, never truncated)
- `UI_ENVELOPE_MAX_MCP_RESOURCE_BYTES = 131072` (128KB per envelope, separate ledger)

P1 budgets (`4096`/widget, `16384`/envelope) and semantics for standard widgets are **unchanged**; the count cap (8) is shared. Separate ledgers mean a fat resource can never starve an `options`/`action_link` widget and vice versa.

## Extraction path

- `Agent._extract_link_widgets` generalized to `Agent._extract_tool_widgets`: action_link + mcp_resource candidates share **one** clamp pass, then `ui.emitted` fires only for survivors (the #277 clamp-then-emit fix, now across both types).
- Wired on **both** agent execution paths — the iterative tool-chain loop (P1's site) and the planning-execution path, which previously produced no tool-result widgets at all (found because the e2e request routed through it).
- Observability: `ui.emitted` reused with `type: "mcp_resource"`, producer `tool_result:<server>.<tool>`. `validate_events.py`: **100%** (1437/1437).

## Test evidence

- **Unit** (`tests/unit/test_ui_envelope.py`, 49 pass): builder validation (scheme, provenance, encoding), independent clamp budgets, extraction + emit accounting, ui:// detection on dict and SDK-object shapes, flattener exclusion, and the runtime-side pin: an envelope carrying `mcp_resource` + `options` serializes to plain JSON while the no-widget path stays byte-identical.
- **E2E** (`e2e/tests/25_envelope_ui/`, extends the P1 area; standalone scripts, SUCCESS + exit 0): fixture stdio MCP Apps server (`fixture_ui_server.py`) + runtime-generated formation (26_watch pattern).
  - `25B1` passthrough: widget with byte-exact uri/mime/data + server/tool provenance; text complete alone; resource content and `ui://` URI absent from the LLM-generated text. PASS.
  - `25B2` oversized: fixture pads past the cap → no widget, no error, text intact. PASS.
- **Existing e2e re-run**: 25A1–25A5 all PASS.
- **Full unit suite**: 3707 passed, 10 skipped.
- **random-5**: 5/5 PASS (3_multimodal x3, 4_mcp, 5_artifacts).
- black / isort / ruff clean (the flake8 E203/F402 hits in agent.py/service.py pre-exist on develop, untouched lines).

## Flagged for owner review

- The 64KB/128KB clamp defaults are a judgment call (a self-contained MCP App page fits; a misbehaving server stays bounded). Both constants are load-validated in unit tests and easy to tune.
- Blob resources carry `"encoding": "base64"`; text resources omit the field (text is the default). The deferred SDK types should mirror this.

## Not in this PR

- SDK typed packages (deferred, landing with the CLI)
- P3 channel-native rendering (sibling PR, in parallel — CHANGELOG entry appended keep-both style)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
