### PR TITLE
fix(overlord): repair dead A2A credential-clarification branch

### DIFF
--- a/src/muxi/runtime/formation/agents/agent.py
+++ b/src/muxi/runtime/formation/agents/agent.py
@@ -58,7 +58,7 @@ from ...utils.id_generator import generate_nanoid
 from ...utils.security import sanitize_message_preview
 from ..artifacts.extractor import extract_artifacts_from_tool_results
 from ..background.cancellation import RequestCancelledException
-from ..credentials import MissingCredentialError
+from ..credentials import AmbiguousCredentialError, MissingCredentialError
 
 
 class Agent:
@@ -2429,10 +2429,6 @@ class Agent:
                         except Exception as e:
                             # Re-raise credential errors to trigger clarification flow
                             from ...services.mcp.service import CredentialSelectionNeededError
-                            from ..credentials import (
-                                AmbiguousCredentialError,
-                                MissingCredentialError,
-                            )
 
                             if isinstance(
                                 e,
@@ -2863,7 +2859,6 @@ class Agent:
             except Exception as e:
                 # Re-raise credential errors to trigger clarification flow
                 from ...services.mcp.service import CredentialSelectionNeededError
-                from ..credentials import AmbiguousCredentialError, MissingCredentialError
 
                 if isinstance(
                     e,
@@ -4695,7 +4690,6 @@ class Agent:
         except Exception as e:
             # Check if this is a credential error
             from ...services.mcp.service import CredentialSelectionNeededError
-            from ..credentials import AmbiguousCredentialError
 
             if isinstance(e, CredentialSelectionNeededError):
                 # Convert to AmbiguousCredentialError and raise to overlord

--- a/src/muxi/runtime/formation/overlord/clarification.py
+++ b/src/muxi/runtime/formation/overlord/clarification.py
@@ -63,21 +63,20 @@ def _format_service_name(service: str) -> str:
     )
 
 
+# Known services by the credential field name their APIs expect. Unknown
+# services fall back to suffix matches on the service name (exact/suffix
+# only — plain substring checks misfire on names like "monkey").
+_TOKEN_SERVICES = {"github", "gitlab", "slack", "discord", "bitbucket"}
+_API_KEY_SERVICES = {"openai", "anthropic", "cohere", "pinecone"}
+
+
 def _credential_field_name(service: str) -> str:
     """Pick the credential field name most APIs of this service expect."""
     service_lower = service.lower()
-    if "token" in service_lower or service_lower in {
-        "github",
-        "gitlab",
-        "slack",
-        "discord",
-        "bitbucket",
-    }:
+    if service_lower in _TOKEN_SERVICES or service_lower.endswith("token"):
         return "token"
-    if (
-        "api" in service_lower
-        or "key" in service_lower
-        or service_lower in {"openai", "anthropic", "cohere", "pinecone"}
+    if service_lower in _API_KEY_SERVICES or service_lower.endswith(
+        ("_api", "-api", "_key", "-key")
     ):
         return "api_key"
     return "token"

--- a/src/muxi/runtime/formation/overlord/clarification.py
+++ b/src/muxi/runtime/formation/overlord/clarification.py
@@ -2,8 +2,15 @@ import logging
 import re
 import time
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
+from ...datatypes.clarification import (
+    ClarificationQuestion,
+    ClarificationRequest,
+    ClarificationResponse,
+    QuestionStyle,
+    RequestType,
+)
 from ...services import observability
 from ...utils.fastjson import json
 
@@ -35,6 +42,119 @@ class ClarificationResult:
     # The question text MUST still list the same choices in prose
     # (text carries the fallback duty).
     options: Optional[List[Dict[str, str]]] = None
+
+
+# Display names for services whose brand casing differs from .title()
+_SERVICE_DISPLAY_NAMES = {
+    "github": "GitHub",
+    "gitlab": "GitLab",
+    "openai": "OpenAI",
+    "mongodb": "MongoDB",
+    "postgresql": "PostgreSQL",
+    "mysql": "MySQL",
+    "aws": "AWS",
+    "gcp": "GCP",
+}
+
+
+def _format_service_name(service: str) -> str:
+    return _SERVICE_DISPLAY_NAMES.get(
+        service.lower(), service.replace("_", " ").replace("-", " ").title()
+    )
+
+
+def _credential_field_name(service: str) -> str:
+    """Pick the credential field name most APIs of this service expect."""
+    service_lower = service.lower()
+    if "token" in service_lower or service_lower in {
+        "github",
+        "gitlab",
+        "slack",
+        "discord",
+        "bitbucket",
+    }:
+        return "token"
+    if (
+        "api" in service_lower
+        or "key" in service_lower
+        or service_lower in {"openai", "anthropic", "cohere", "pinecone"}
+    ):
+        return "api_key"
+    return "token"
+
+
+def build_credential_clarification_request(
+    service: str,
+    user_id: str,
+    agent_id: str = "system",
+    context: Optional[Dict[str, Any]] = None,
+) -> ClarificationRequest:
+    """
+    Build a clarification request for a missing credential.
+
+    Replaces the standalone CredentialClarificationHandler that was removed
+    with the unified clarification system; the overlord's
+    handle_missing_credential path uses this to ask the user for a service
+    credential when a tool raises MissingCredentialError.
+    """
+    display_name = _format_service_name(service)
+    tool_name = context.get("tool_name") if context else None
+
+    message_parts = [f"I need your {display_name} credentials to continue."]
+    if tool_name:
+        message_parts.append(f"This is required to use the '{tool_name}' tool.")
+    message_parts.append(
+        f"Please provide your {display_name} credentials "
+        f"(API key, token, or authentication details)."
+    )
+
+    question = ClarificationQuestion(
+        question_id=f"credential_{service}",
+        question_text=" ".join(message_parts),
+        parameter_name="credential",
+        parameter_type="credential",
+        parameter_description=f"{display_name} credential",
+        required=True,
+        validation_rules={"min_length": 8},
+        context_hints=[f"This credential is needed for {display_name} integration"],
+        style=QuestionStyle.CONVERSATIONAL,
+    )
+
+    return ClarificationRequest(
+        user_id=user_id,
+        agent_id=agent_id,
+        request_type=RequestType.TOOL_CALL,
+        tool_name=tool_name,
+        intent=f"Request {service} credentials",
+        missing_info=[f"{service}_credential"],
+        clarification_plan=[question],
+        context={"reason": "missing_credential", "service": service, **(context or {})},
+    )
+
+
+def parse_credential_clarification_response(
+    response: ClarificationResponse, service: str
+) -> Optional[Dict[str, Any]]:
+    """
+    Extract credential data from a user's clarification response.
+
+    Returns a single-field dict (e.g. {"token": ...}) or None if the
+    response carries no usable credential.
+    """
+    field_name = _credential_field_name(service)
+
+    for answer in response.answers or []:
+        if answer.get("id") == f"credential_{service}":
+            value = (answer.get("answer") or "").strip()
+            if value:
+                return {field_name: value}
+
+    # Users often just paste the credential as free text
+    raw = (response.raw_response or "").strip()
+    if raw:
+        return {field_name: raw}
+
+    return None
 
 
 class UnifiedClarificationSystem:

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -217,7 +217,11 @@ from .a2a_coordinator import A2ACoordinator
 from .active_agents_tracker import ActiveAgentsTracker
 from .agent_router import AgentRouter
 from .chat_orchestrator import ChatOrchestrator
-from .clarification import UnifiedClarificationSystem
+from .clarification import (
+    UnifiedClarificationSystem,
+    build_credential_clarification_request,
+    parse_credential_clarification_response,
+)
 from .input_validation import InputLimits, InputValidationError, InputValidator
 from .mcp_coordinator import MCPCoordinator
 
@@ -11998,14 +12002,10 @@ Agent response: {raw_response}"""
                 )
                 return None
 
-            # Import credential handler
-            from ..clarification.credential_handler import CredentialClarificationHandler
-
-            # Create credential clarification handler
-            handler = CredentialClarificationHandler()
-
-            # Generate clarification request
-            clarification_request = handler.generate_credential_request(
+            # Generate clarification request (the standalone credential
+            # clarification handler was folded into overlord/clarification.py
+            # when the unified clarification system landed)
+            clarification_request = build_credential_clarification_request(
                 service=service, user_id=user_id, agent_id="system", context=context
             )
 
@@ -12021,7 +12021,6 @@ Agent response: {raw_response}"""
                     "service": service,
                     "user_id": user_id,
                     "request": clarification_request,
-                    "handler": handler,
                     "timestamp": time.time(),
                 }
 
@@ -12083,77 +12082,74 @@ Agent response: {raw_response}"""
                     clarification_info.get("type") == "credential"
                     and clarification_info.get("service") == service
                 ):
-                    handler = clarification_info.get("handler")
-
                     # Parse the credential from the response
-                    if handler:
-                        credential_data = handler.parse_credential_response(response, service)
+                    credential_data = parse_credential_clarification_response(response, service)
 
-                        if credential_data and self.credential_resolver:
-                            # Validate credential data structure before storing
-                            if self.credential_handler.validate_credential_data(
-                                credential_data, service
-                            ):
-                                # Store the credential
-                                await self.credential_resolver.store_credential(
-                                    user_id=user_id,
-                                    service=service,
-                                    credentials=credential_data,
-                                    mcp_service=self.mcp_service,
-                                )
+                    if credential_data and self.credential_resolver:
+                        # Validate credential data structure before storing
+                        if self.credential_handler.validate_credential_data(
+                            credential_data, service
+                        ):
+                            # Store the credential
+                            await self.credential_resolver.store_credential(
+                                user_id=user_id,
+                                service=service,
+                                credentials=credential_data,
+                                mcp_service=self.mcp_service,
+                            )
 
-                                # Asynchronously update credential name with smart discovery
-                                async def update_name():
-                                    with suppress(Exception):
-                                        # Attempt to update credential name, but don't fail if it doesn't work
-                                        await self.credential_resolver.update_credential_name_with_discovery(
-                                            user_id=user_id,
-                                            service=service,
-                                            mcp_service=self.mcp_service,
-                                        )
+                            # Asynchronously update credential name with smart discovery
+                            async def update_name():
+                                with suppress(Exception):
+                                    # Attempt to update credential name, but don't fail if it doesn't work
+                                    await self.credential_resolver.update_credential_name_with_discovery(
+                                        user_id=user_id,
+                                        service=service,
+                                        mcp_service=self.mcp_service,
+                                    )
 
-                                self._create_tracked_task(
-                                    update_name(), name=f"update_cred_name_{service}_{user_id}"
-                                )
-                            else:
-                                observability.observe(
-                                    event_type=observability.ErrorEvents.VALIDATION_FAILED,
-                                    level=observability.EventLevel.ERROR,
-                                    data={
-                                        "service": service,
-                                        "user_id": user_id,
-                                        "credential_keys": (
-                                            list(credential_data.keys())
-                                            if isinstance(credential_data, dict)
-                                            else "invalid_type"
-                                        ),
-                                        "validation_error": "invalid_credential_structure",
-                                    },
-                                    description=f"Invalid credential data structure for {service}",
-                                )
-                                return False
-
-                            # Clean up pending clarification
-                            self._delete_pending_clarification(session_id)
-
+                            self._create_tracked_task(
+                                update_name(), name=f"update_cred_name_{service}_{user_id}"
+                            )
+                        else:
                             observability.observe(
-                                event_type=observability.ConversationEvents.CREDENTIAL_PROVIDED,
-                                level=observability.EventLevel.INFO,
+                                event_type=observability.ErrorEvents.VALIDATION_FAILED,
+                                level=observability.EventLevel.ERROR,
                                 data={
                                     "service": service,
                                     "user_id": user_id,
-                                    "credential_type": (
-                                        list(credential_data.keys())[0]
-                                        if credential_data
-                                        else "unknown"
+                                    "credential_keys": (
+                                        list(credential_data.keys())
+                                        if isinstance(credential_data, dict)
+                                        else "invalid_type"
                                     ),
-                                    "via_clarification": True,
-                                    "session_id": session_id,
+                                    "validation_error": "invalid_credential_structure",
                                 },
-                                description=f"User provided {service} credentials via clarification",
+                                description=f"Invalid credential data structure for {service}",
                             )
+                            return False
 
-                            return True
+                        # Clean up pending clarification
+                        self._delete_pending_clarification(session_id)
+
+                        observability.observe(
+                            event_type=observability.ConversationEvents.CREDENTIAL_PROVIDED,
+                            level=observability.EventLevel.INFO,
+                            data={
+                                "service": service,
+                                "user_id": user_id,
+                                "credential_type": (
+                                    list(credential_data.keys())[0]
+                                    if credential_data
+                                    else "unknown"
+                                ),
+                                "via_clarification": True,
+                                "session_id": session_id,
+                            },
+                            description=f"User provided {service} credentials via clarification",
+                        )
+
+                        return True
 
             return False
 

--- a/tests/unit/test_a2a_credential_clarification.py
+++ b/tests/unit/test_a2a_credential_clarification.py
@@ -229,3 +229,15 @@ def test_parse_credential_clarification_response_empty_returns_none():
     response = ClarificationResponse(answers=[], raw_response="   ")
 
     assert parse_credential_clarification_response(response, "github") is None
+
+
+def test_parse_credential_field_name_ignores_incidental_substrings():
+    """Only exact service names or explicit suffixes may pick "api_key";
+    incidental substrings ("monkey" contains "key") must not."""
+    monkey = ClarificationResponse(answers=[], raw_response="tok-123456")
+    assert parse_credential_clarification_response(monkey, "monkey") == {"token": "tok-123456"}
+
+    capital = ClarificationResponse(answers=[], raw_response="cap-123456")
+    assert parse_credential_clarification_response(capital, "capital-api") == {
+        "api_key": "cap-123456"
+    }

--- a/tests/unit/test_a2a_credential_clarification.py
+++ b/tests/unit/test_a2a_credential_clarification.py
@@ -1,0 +1,231 @@
+"""
+Regression tests for the A2A delegation credential-clarification path.
+
+Background
+----------
+When a tool invoked by an A2A-delegated agent raises a credential error,
+two long-dead branches used to break the clarification flow (both only
+observable in e2e logs because the direct chat path takes a different
+route):
+
+1. ``Overlord.handle_missing_credential`` imported
+   ``..clarification.credential_handler`` — a module removed when the
+   unified clarification system landed — so every call raised
+   ``ModuleNotFoundError`` ("No module named
+   'muxi.runtime.formation.clarification'"), was swallowed by the broad
+   except, and returned ``None`` instead of a ClarificationRequest.
+
+2. ``Agent.process_message`` referenced ``AmbiguousCredentialError`` in
+   its tool-loop exception handler while other branches of the same
+   function imported the name locally. The local imports made the name
+   function-local everywhere, so the tool-loop branch raised
+   ``UnboundLocalError`` ("cannot access local variable
+   'AmbiguousCredentialError'") whenever it ran before a branch that
+   performed the import — which is exactly what the A2A path does.
+
+These tests pin both fixes.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from muxi.runtime.datatypes.clarification import ClarificationRequest, ClarificationResponse
+from muxi.runtime.formation.agents.agent import Agent
+from muxi.runtime.formation.credentials import AmbiguousCredentialError, MissingCredentialError
+from muxi.runtime.formation.overlord.clarification import (
+    build_credential_clarification_request,
+    parse_credential_clarification_response,
+)
+from muxi.runtime.formation.overlord.overlord import Overlord
+
+
+def _make_overlord_stub() -> Overlord:
+    """Minimally-wired Overlord exposing what handle_missing_credential touches."""
+    overlord = Overlord.__new__(Overlord)
+    overlord.clarification_config = SimpleNamespace(enabled=True)
+    overlord._set_pending_clarification = MagicMock()
+    return overlord
+
+
+def _make_agent_stub(overlord: Overlord) -> Agent:
+    """Minimally-wired Agent exposing what invoke_tool touches on the MCP path."""
+    agent = object.__new__(Agent)
+    agent.agent_id = "a2a-delegate"
+    agent.overlord = overlord
+    agent.request_timeout = None
+    agent._messages = []
+    agent._mcp_service = MagicMock()
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: phantom import in Overlord.handle_missing_credential
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_missing_credential_returns_clarification_request():
+    """Must build a real ClarificationRequest — not swallow a ModuleNotFoundError
+    from the long-removed formation.clarification package and return None."""
+    overlord = _make_overlord_stub()
+
+    request = await overlord.handle_missing_credential(
+        service="github",
+        user_id="user-1",
+        context={"agent_id": "a2a-delegate", "tool_name": "github_create_issue"},
+    )
+
+    assert isinstance(request, ClarificationRequest)
+    assert request.user_id == "user-1"
+    assert request.tool_name == "github_create_issue"
+    assert "github_credential" in request.missing_info
+    assert request.clarification_plan, "expected at least one clarification question"
+    assert "GitHub" in request.clarification_plan[0].question_text
+
+
+@pytest.mark.asyncio
+async def test_handle_missing_credential_stores_pending_for_session():
+    overlord = _make_overlord_stub()
+
+    request = await overlord.handle_missing_credential(
+        service="slack",
+        user_id="user-2",
+        context={"session_id": "sess-42", "request_id": "req-9"},
+    )
+
+    assert isinstance(request, ClarificationRequest)
+    overlord._set_pending_clarification.assert_called_once()
+    session_id, pending = overlord._set_pending_clarification.call_args.args
+    assert session_id == "sess-42"
+    assert pending["type"] == "credential"
+    assert pending["service"] == "slack"
+    assert pending["user_id"] == "user-2"
+    assert pending["request"] is request
+    assert pending["request_id"] == "req-9"
+
+
+@pytest.mark.asyncio
+async def test_handle_missing_credential_returns_none_when_clarification_disabled():
+    overlord = _make_overlord_stub()
+    overlord.clarification_config = SimpleNamespace(enabled=False)
+
+    request = await overlord.handle_missing_credential(service="github", user_id="user-1")
+
+    assert request is None
+    overlord._set_pending_clarification.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_invoke_tool_missing_credential_triggers_overlord_handler_and_reraises():
+    """The A2A seam: a delegated agent's tool raises MissingCredentialError,
+    the agent must run the overlord's (now working) clarification handler and
+    re-raise so the error bubbles up for the clarification flow."""
+    overlord = _make_overlord_stub()
+    agent = _make_agent_stub(overlord)
+    agent._mcp_service.invoke_tool = AsyncMock(
+        side_effect=MissingCredentialError(service="github", user_id="user-1")
+    )
+
+    handler_results = []
+    real_handler = overlord.handle_missing_credential
+
+    async def recording_handler(**kwargs):
+        result = await real_handler(**kwargs)
+        handler_results.append(result)
+        return result
+
+    overlord.handle_missing_credential = recording_handler
+
+    with pytest.raises(MissingCredentialError):
+        await agent.invoke_tool(
+            tool_name="github_create_issue",
+            parameters={"title": "hi"},
+            server_id="github",
+            user_id="user-1",
+        )
+
+    assert len(handler_results) == 1
+    assert isinstance(handler_results[0], ClarificationRequest)
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: AmbiguousCredentialError shadowed into a local in process_message
+# ---------------------------------------------------------------------------
+
+
+def test_credential_error_names_are_not_locals_in_process_message():
+    """Local ``from ..credentials import ...`` statements anywhere inside
+    process_message make the names function-local for the WHOLE function,
+    so branches that run before the import raise UnboundLocalError. The
+    names must resolve at module level instead."""
+    import muxi.runtime.formation.agents.agent as agent_module
+
+    code = Agent.process_message.__code__
+    assert "AmbiguousCredentialError" not in code.co_varnames
+    assert "MissingCredentialError" not in code.co_varnames
+    assert agent_module.AmbiguousCredentialError is AmbiguousCredentialError
+    assert agent_module.MissingCredentialError is MissingCredentialError
+
+
+@pytest.mark.asyncio
+async def test_invoke_tool_reraises_ambiguous_credential_error():
+    """Ambiguous-credential selection must bubble up (it drives the account
+    picker), not degrade into a generic tool failure."""
+    overlord = _make_overlord_stub()
+    agent = _make_agent_stub(overlord)
+    error = AmbiguousCredentialError(
+        service="github",
+        user_id="user-1",
+        available_credentials=["work", "personal"],
+    )
+    agent._mcp_service.invoke_tool = AsyncMock(side_effect=error)
+
+    with pytest.raises(AmbiguousCredentialError):
+        await agent.invoke_tool(
+            tool_name="github_create_issue",
+            parameters={"title": "hi"},
+            server_id="github",
+            user_id="user-1",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helper coverage: build/parse round trip
+# ---------------------------------------------------------------------------
+
+
+def test_build_credential_clarification_request_content():
+    request = build_credential_clarification_request(
+        service="github",
+        user_id="user-1",
+        context={"tool_name": "github_create_issue"},
+    )
+
+    assert request.missing_info == ["github_credential"]
+    question = request.clarification_plan[0]
+    assert question.question_id == "credential_github"
+    assert "github_create_issue" in question.question_text
+    assert request.context["reason"] == "missing_credential"
+    assert request.context["service"] == "github"
+
+
+def test_parse_credential_clarification_response_structured_answer():
+    response = ClarificationResponse(answers=[{"id": "credential_github", "answer": "ghp_abc123"}])
+
+    assert parse_credential_clarification_response(response, "github") == {"token": "ghp_abc123"}
+
+
+def test_parse_credential_clarification_response_raw_text_fallback():
+    response = ClarificationResponse(answers=[], raw_response="sk-openai-key")
+
+    assert parse_credential_clarification_response(response, "openai") == {
+        "api_key": "sk-openai-key"
+    }
+
+
+def test_parse_credential_clarification_response_empty_returns_none():
+    response = ClarificationResponse(answers=[], raw_response="   ")
+
+    assert parse_credential_clarification_response(response, "github") is None


### PR DESCRIPTION
## Summary

Fixes two pre-existing bugs in the A2A delegation path's credential-clarification error handling, discovered via e2e logs during envelope-UI P3 work (#280). Both were only reachable on the A2A branch — the direct chat path routes around them.

### Bug 1: phantom import in `Overlord.handle_missing_credential`
`overlord.py` imported `..clarification.credential_handler.CredentialClarificationHandler`, which resolves to `muxi.runtime.formation.clarification` — a package deleted in ec520f63 when the unified clarification system landed. Every call raised `ModuleNotFoundError` ("No module named 'muxi.runtime.formation.clarification'"), was swallowed by the broad `except`, and returned `None` instead of a `ClarificationRequest`.

**Fix:** the request builder and response parser now live as module functions in `overlord/clarification.py` (`build_credential_clarification_request`, `parse_credential_clarification_response`), preserving the deleted handler's semantics (service display names, credential field-name heuristic, structured-answer + raw-text parsing). `handle_missing_credential` and `process_credential_clarification_response` use them directly; pending clarification data no longer carries a handler object.

### Bug 2: `UnboundLocalError` on `AmbiguousCredentialError` in `Agent.process_message`
The tool-call loop's exception handler referenced `AmbiguousCredentialError`, but other branches of the same (very large) function imported the name locally via `from ..credentials import ...`. Any local binding makes the name function-local for the whole function, so when the tool-loop branch ran before an importing branch — exactly what the A2A path does — it raised `UnboundLocalError` ("cannot access local variable 'AmbiguousCredentialError'"), replacing the credential error that should have driven the account-selection clarification.

**Fix:** hoisted the import to module level (alongside the existing `MissingCredentialError` import) and removed the three shadowing local imports.

### Tests
New `tests/unit/test_a2a_credential_clarification.py` (10 tests) pins both fixes so the branch can't silently rot again:
- `handle_missing_credential` returns a real `ClarificationRequest` (would be `None` with the phantom import) and stores pending state for the session
- the `invoke_tool` → overlord seam runs the handler successfully and re-raises `MissingCredentialError` / `AmbiguousCredentialError`
- a code-object guard asserting the credential error names are never locals of `process_message`
- build/parse helper coverage (structured answer, raw-text fallback, empty response)

## Verification
- `uv run --extra dev python -m pytest tests/unit` — 3752 passed, 10 skipped
- `black --line-length 100` clean, `ruff check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)