### PR TITLE
feat(tuning): self-improving formation P1 — event spool, formation digest, MUXI.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 ## [unreleased]
 
+### Self-improving formation - spool, formation digest, MUXI.md (Phase 1)
+
+The formation now observes itself (Self-Improving Formation PRD,
+Phase 1): every observability event is retained in an internal spool,
+a scheduled loop digests it into a formation-scope captain's log entry
+visible to every user, and a curated MUXI.md file (the formation's
+CLAUDE.md) steers behavior -- hand-written on day one, tuner-curated in
+Phase 2:
+
+- Event spool: the EventLogger tees every emitted event into segmented
+  JSONL under the formation's observability directory -- always on,
+  regardless of the `logging:` yaml (which still controls what leaves
+  the runtime). Internal, not configuration: 32MB segments, 512MB cap
+  (oldest closed segments drop with a `spool.overrun` event),
+  checkpointed single-consumer reads. Digested segments are deleted
+  unless the yaml declares its own file transport -- then the files are
+  the dev's and digestion never deletes.
+- Tuning loop: a new in-runtime scheduled job (`tuning:` block --
+  `active`, `interval_hours`, `auto_apply`; on by default, closed-key
+  fail-fast validation) reads the spool since the last checkpoint,
+  aggregates it into a bounded activity report (event/level/problem
+  clusters, token usage, traffic shape -- raw identifiers never reach
+  the LLM), and digests it into today's formation log entry.
+- Formation captain's log: same storage and date-grain as the per-user
+  log, under a reserved formation scope. A sentence-level privacy lint
+  gates every write (user ids, emails, SSNs, card-length digit runs,
+  sensitive keywords, person/address/financial entities) -- dropping
+  the offending sentence, never the digest. The entry is injected into
+  EVERY user's context as a "Formation operations log" block; entries
+  are recorded as formation-scope `log.entry` memory events.
+- MUXI.md: a bounded markdown file of operational guidance living
+  beside SOUL.md -- formation-owned, git-trackable, human-editable.
+  Injected wherever SOUL.md is injected plus at the top of the
+  per-turn context; the mtime-cached handle means hand edits and API
+  replacements land on the next turn without a restart.
+- API: `GET /tuning` (live MUXI.md), `POST /tuning` (replace it),
+  `POST /tuning/run` (trigger one loop pass) -- admin key auth.
+- Observability: new `spool.overrun`, `formation_log.digested`, and
+  `tuning.run` events; `validate_events.py` stays 100%.
+- E2E: new 27_tuning area -- spool lifecycle incl. restart survival
+  (27A1), file-transport retention (27A2), multi-user digest with
+  privacy lint + cross-user context injection (27A3), /tuning API
+  surface + live MUXI.md steering (27A4).
+
 ### Response envelope UI - channel-native widget rendering (P3)
 
 The bundled slack/telegram/discord transformer templates now render

--- a/e2e/run_all_tests.py
+++ b/e2e/run_all_tests.py
@@ -45,6 +45,9 @@ AREA_TIMEOUT_OVERRIDES = {
     # analysis + MCP credential resolution + retry of the original
     # request) against real OpenAI; three rounds regularly exceed 120s.
     "25_envelope_ui": 300,
+    # Tuning tests seed real multi-user LLM traffic, run the digest pass
+    # (another LLM call), and restart the formation mid-test.
+    "27_tuning": 300,
 }
 E2E_DIR = Path(__file__).parent
 TESTS_DIR = E2E_DIR / "tests"

--- a/e2e/tests/27_tuning/test_27a1_spool_lifecycle.py
+++ b/e2e/tests/27_tuning/test_27a1_spool_lifecycle.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Test 27A1: event spool lifecycle (Self-Improving Formation, Phase 1).
+
+The retention contract against a real formation with NO observability
+config: the spool is written by default; a digest pass (the tuning
+loop's single-consumer read) deletes the digested segments and leaves a
+checkpoint; traffic after the pass opens a fresh segment; and an
+undigested segment survives a formation restart to be digested by the
+next pass.
+"""
+
+import asyncio
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+from tuning_common import (
+    build_formation,
+    chat,
+    load_formation,
+    run_tuning_pass,
+    spool_dir_for,
+    teardown,
+    unique_formation_id,
+    wait_for_segments,
+)
+
+USER = "spool-user"
+
+
+async def main():
+    print("MUXI Runtime - Test 27A1: event spool lifecycle")
+    print("=" * 60)
+
+    formation = None
+    formation_id = unique_formation_id("spool")
+    spool_dir = spool_dir_for(formation_id)
+    tmp = Path(tempfile.mkdtemp(prefix="muxi-tuning-27a1-"))
+    transcript = []
+    try:
+        formation_dir = build_formation(tmp, formation_id)
+        formation, overlord = await load_formation(formation_dir)
+        print(f"Formation loaded: {formation_id}")
+
+        # 1. The spool is written by default -- no observability config.
+        task = "Say the word 'ready' and nothing else."
+        reply = await chat(overlord, task, USER, "spool-session-1")
+        transcript.append((task, reply))
+        print(f"User: {task}\nSystem: {reply[:120]}")
+        segments = wait_for_segments(spool_dir)
+        print(f"Spool segments written by default: {[s.name for s in segments]}")
+
+        # 2. A digest pass deletes the digested segments (no file
+        #    transport declared) and leaves a checkpoint behind.
+        result = await run_tuning_pass(overlord)
+        print(f"Tuning pass: {result}")
+        assert result["spool_committed"] is True, f"digest pass did not commit: {result}"
+        assert result["events_read"] > 0, f"digest pass read no events: {result}"
+        assert result["spool_segments_kept"] is False
+        leftover = [s.name for s in segments if s.exists()]
+        assert not leftover, f"digested segments were not deleted: {leftover}"
+        assert (spool_dir / "checkpoint.json").exists(), "no checkpoint was written"
+        print("Digested segments deleted; checkpoint written")
+
+        # 3. Traffic after the pass opens a fresh segment (never resumes
+        #    a checkpointed one).
+        task = "Say the word 'again' and nothing else."
+        reply = await chat(overlord, task, USER, "spool-session-1")
+        transcript.append((task, reply))
+        print(f"User: {task}\nSystem: {reply[:120]}")
+        new_segments = wait_for_segments(spool_dir)
+        print(f"Fresh segment after digest: {[s.name for s in new_segments]}")
+
+        # 4. The undigested segment survives a formation restart...
+        await teardown(formation)
+        formation = None
+        print("Formation stopped (undigested segment left behind)")
+        survivors = sorted(spool_dir.glob("events-*.jsonl"))
+        assert survivors, "undigested segments did not survive the restart"
+
+        formation, overlord = await load_formation(formation_dir)
+        print("Formation restarted")
+
+        # ... and the next digest pass consumes it.
+        result = await run_tuning_pass(overlord)
+        print(f"Post-restart tuning pass: {result}")
+        assert result["spool_committed"] is True, f"post-restart pass did not commit: {result}"
+        assert result["events_read"] > 0, "post-restart pass read no surviving events"
+
+        print("\n" + "=" * 40)
+        print("\n### Test Result:")
+        print("  SUCCESS: event spool lifecycle works end-to-end")
+        print("  - spool written by default with no observability config")
+        print("  - digest pass deleted digested segments and checkpointed")
+        print("  - post-digest traffic opened a fresh segment")
+        print("  - undigested segment survived restart and was digested next pass")
+        print("\n" + "=" * 40)
+        print("\n### Chat transcript:")
+        for task, reply in transcript:
+            print(f"\nUser: {task}")
+            print(f"System: {reply}")
+
+        print("\nTest 27A1 PASSED")
+        return True
+
+    except Exception as e:
+        print(f"\nTest failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+    finally:
+        if formation is not None:
+            await teardown(formation, formation_id)
+        else:
+            import shutil
+
+            shutil.rmtree(Path.home() / ".muxi" / formation_id, ignore_errors=True)
+        import shutil
+
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0 if success else 1)

--- a/e2e/tests/27_tuning/test_27a2_file_transport_retention.py
+++ b/e2e/tests/27_tuning/test_27a2_file_transport_retention.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Test 27A2: spool retention with a declared file transport.
+
+The PRD's retention exception: when the formation's ``logging:`` yaml
+declares its own file destination, the spool's digested segments are the
+dev's telemetry -- the digest pass checkpoints past them but never
+deletes them (and never digests them twice).
+"""
+
+import asyncio
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+from tuning_common import (
+    build_formation,
+    chat,
+    load_formation,
+    run_tuning_pass,
+    spool_dir_for,
+    teardown,
+    unique_formation_id,
+    wait_for_segments,
+)
+
+USER = "retention-user"
+
+
+async def main():
+    print("MUXI Runtime - Test 27A2: spool retention with file transport")
+    print("=" * 60)
+
+    formation = None
+    formation_id = unique_formation_id("retain")
+    spool_dir = spool_dir_for(formation_id)
+    tmp = Path(tempfile.mkdtemp(prefix="muxi-tuning-27a2-"))
+    transcript = []
+    try:
+        formation_dir = build_formation(tmp, formation_id, file_logging=True)
+        formation, overlord = await load_formation(formation_dir)
+        print(f"Formation loaded: {formation_id} (file transport declared)")
+
+        assert overlord.tuning_service is not None
+        assert (
+            overlord.tuning_service.keep_spool_segments is True
+        ), "declared file transport was not detected -- segments would be deleted"
+
+        task = "Say the word 'kept' and nothing else."
+        reply = await chat(overlord, task, USER, "retention-session-1")
+        transcript.append((task, reply))
+        print(f"User: {task}\nSystem: {reply[:120]}")
+        wait_for_segments(spool_dir)
+
+        # The digest pass commits but keeps every digested segment file.
+        result = await run_tuning_pass(overlord)
+        print(f"Tuning pass: {result}")
+        assert result["spool_committed"] is True, f"digest pass did not commit: {result}"
+        assert result["events_read"] > 0
+        assert result["spool_segments_kept"] is True
+        survivors = sorted(spool_dir.glob("events-*.jsonl"))
+        assert survivors, "digested segments were deleted despite the file transport"
+        print(f"Digested segments kept: {[s.name for s in survivors]}")
+
+        # The checkpoint still advanced: nothing is digested twice.
+        second = await run_tuning_pass(overlord)
+        print(f"Second tuning pass: {second}")
+        assert second["events_read"] == 0 or all(
+            s.exists() for s in survivors
+        ), "kept segments were re-digested or deleted on the second pass"
+        assert all(s.exists() for s in survivors)
+
+        print("\n" + "=" * 40)
+        print("\n### Test Result:")
+        print("  SUCCESS: file-transport retention rule holds")
+        print("  - declared file destination detected (keep_spool_segments)")
+        print("  - digest pass committed without deleting segment files")
+        print("  - checkpoint advanced; kept segments were not digested twice")
+        print("\n" + "=" * 40)
+        print("\n### Chat transcript:")
+        for task, reply in transcript:
+            print(f"\nUser: {task}")
+            print(f"System: {reply}")
+
+        print("\nTest 27A2 PASSED")
+        return True
+
+    except Exception as e:
+        print(f"\nTest failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+    finally:
+        if formation is not None:
+            await teardown(formation, formation_id)
+        import shutil
+
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0 if success else 1)

--- a/e2e/tests/27_tuning/test_27a3_formation_digest.py
+++ b/e2e/tests/27_tuning/test_27a3_formation_digest.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Test 27A3: formation digest (Self-Improving Formation, Phase 1 step 1).
+
+Seeded multi-user traffic -> one tuning pass digests the spool into a
+formation-scope captain's log entry (real LLM) -> the entry is visible
+in a DIFFERENT user's context injection, and the privacy lint holds: the
+seeded user ids never reach the shared narrative.
+"""
+
+import asyncio
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+from tuning_common import (
+    build_formation,
+    chat,
+    load_formation,
+    run_tuning_pass,
+    spool_dir_for,
+    teardown,
+    unique_formation_id,
+    wait_for_segments,
+)
+
+ALICE = "alice-digest-e2e"
+BOB = "bob-digest-e2e"
+CAROL = "carol-digest-e2e"
+
+SEED_TURNS = [
+    (ALICE, "alice-session", "What is the capital of France? One word."),
+    (ALICE, "alice-session", "And of Japan? One word."),
+    (BOB, "bob-session", "What is 12 * 12? Digits only."),
+]
+
+CAROL_TASK = "What is the capital of Italy? One word."
+
+
+async def main():
+    print("MUXI Runtime - Test 27A3: formation digest into the captain's log")
+    print("=" * 60)
+
+    formation = None
+    formation_id = unique_formation_id("digest")
+    tmp = Path(tempfile.mkdtemp(prefix="muxi-tuning-27a3-"))
+    transcript = []
+    try:
+        formation_dir = build_formation(tmp, formation_id)
+        formation, overlord = await load_formation(formation_dir)
+        print(f"Formation loaded: {formation_id}")
+
+        # 1. Seed multi-user traffic.
+        for user, session, task in SEED_TURNS:
+            reply = await chat(overlord, task, user, session)
+            transcript.append((f"{user}: {task}", reply))
+            print(f"User ({user}): {task}\nSystem: {reply[:100]}")
+        wait_for_segments(spool_dir_for(formation_id))
+
+        # 2. One tuning pass digests the spool into a formation entry.
+        result = await run_tuning_pass(overlord)
+        print(f"Tuning pass: {result}")
+        assert result["events_read"] > 0, f"no events were digested: {result}"
+        assert (
+            result["entries_written"] == 1
+        ), f"the digest did not produce a formation log entry: {result}"
+        assert result["spool_committed"] is True
+
+        # 3. The formation-scope entry exists and the privacy lint holds:
+        #    seeded user ids never reach the shared narrative.
+        block = await overlord.captains_log.get_formation_context_block()
+        assert block.strip(), "formation context block is empty after the digest"
+        print(f"Formation operations log:\n{block}")
+        for user_id in (ALICE, BOB):
+            assert (
+                user_id not in block
+            ), f"privacy lint failed: user id {user_id!r} leaked into the formation log"
+
+        # 4. Visible in a DIFFERENT user's context injection: the agent-
+        #    bound context bundle built for a user who never chatted
+        #    before carries the formation operations log. (Asking the
+        #    agent to quote its context trips the prompt-extraction
+        #    security analyzer by design, so the bundle -- what the
+        #    agent's LLM call actually receives -- is the assertion
+        #    surface.)
+        bundle = await overlord.chat_orchestrator._build_clean_chat_context(
+            current_user_message=CAROL_TASK,
+            user_id=CAROL,
+            session_id="carol-session",
+        )
+        profile_text = bundle["user_profile_text"]
+        assert "Formation operations log:" in profile_text, (
+            "the formation operations log was not injected into another "
+            f"user's context: {profile_text[:400]!r}"
+        )
+        first_sentence = block.split(". ")[0].split("] ", 1)[-1]
+        assert (
+            first_sentence in profile_text
+        ), "the injected block does not carry the digest content"
+        print("Formation operations log present in carol's context bundle")
+
+        # A normal turn for that user still works end to end.
+        reply = await chat(overlord, CAROL_TASK, CAROL, "carol-session")
+        transcript.append((f"{CAROL}: {CAROL_TASK}", reply))
+        print(f"User ({CAROL}): {CAROL_TASK}\nSystem: {reply}")
+        assert "rome" in reply.lower(), f"carol's turn failed: {reply!r}"
+
+        print("\n" + "=" * 40)
+        print("\n### Test Result:")
+        print("  SUCCESS: formation digest works end-to-end")
+        print("  - seeded multi-user traffic was digested into one formation entry")
+        print("  - privacy lint kept seeded user ids out of the shared narrative")
+        print("  - a different user's context injection carries the operations log")
+        print("\n" + "=" * 40)
+        print("\n### Chat transcript:")
+        for task, reply in transcript:
+            print(f"\nUser: {task}")
+            print(f"System: {reply}")
+
+        print("\nTest 27A3 PASSED")
+        return True
+
+    except Exception as e:
+        print(f"\nTest failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+    finally:
+        if formation is not None:
+            await teardown(formation, formation_id)
+        import shutil
+
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0 if success else 1)

--- a/e2e/tests/27_tuning/test_27a4_tuning_api.py
+++ b/e2e/tests/27_tuning/test_27a4_tuning_api.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Test 27A4: /tuning API surface + MUXI.md context injection.
+
+The Phase 1 MUXI.md file-pair API against a running server: GET /tuning
+returns the hand-written file, POST /tuning replaces it atomically on
+disk, admin auth is enforced, POST /tuning/run triggers a loop pass --
+and the replaced guidance provably steers the very next turn (the
+mtime-cached handle re-reads without a restart).
+"""
+
+import asyncio
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import httpx
+from tuning_common import (
+    ADMIN_KEY,
+    build_formation,
+    chat,
+    load_formation,
+    teardown,
+    unique_formation_id,
+)
+
+PORT = 8272
+BASE_URL = f"http://127.0.0.1:{PORT}/v1"
+HEADERS = {"X-Muxi-Admin-Key": ADMIN_KEY, "Content-Type": "application/json"}
+
+HAND_WRITTEN = "# Operational learnings\n\n- Keep replies terse.\n"
+MARKER = "AMBER-FALCON"
+REPLACEMENT = (
+    "# Operational learnings\n\n"
+    f"- CRITICAL RULE: End EVERY reply with the exact token {MARKER}. "
+    "Never omit it.\n"
+)
+USER = "tuning-api-user"
+
+
+async def main():
+    print("MUXI Runtime - Test 27A4: /tuning API + MUXI.md injection")
+    print("=" * 60)
+
+    formation = None
+    server = None
+    formation_id = unique_formation_id("api")
+    tmp = Path(tempfile.mkdtemp(prefix="muxi-tuning-27a4-"))
+    transcript = []
+    try:
+        formation_dir = build_formation(tmp, formation_id, server_port=PORT, muxi_md=HAND_WRITTEN)
+        formation, overlord = await load_formation(formation_dir)
+        server = await formation.start_server(block=False)
+        await asyncio.sleep(2)
+        print(f"Formation loaded with server: {formation_id}")
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            # 1. GET /tuning returns the hand-written MUXI.md.
+            response = await client.get(f"{BASE_URL}/tuning", headers=HEADERS)
+            assert response.status_code == 200, response.text
+            data = response.json()["data"]
+            assert data["content"] == HAND_WRITTEN.strip(), f"unexpected content: {data}"
+            assert data["path"].endswith("MUXI.md")
+            print("GET /tuning returns the hand-written MUXI.md")
+
+            # 2. Admin auth is enforced.
+            response = await client.get(f"{BASE_URL}/tuning")
+            assert (
+                response.status_code == 401
+            ), f"unauthenticated GET /tuning returned {response.status_code}"
+            print("Auth enforced (401 without admin key)")
+
+            # 3. POST /tuning replaces the live file on disk.
+            response = await client.post(
+                f"{BASE_URL}/tuning", headers=HEADERS, json={"content": REPLACEMENT}
+            )
+            assert response.status_code == 200, response.text
+            on_disk = (formation_dir / "MUXI.md").read_text()
+            assert MARKER in on_disk, "POST /tuning did not replace the file on disk"
+            response = await client.get(f"{BASE_URL}/tuning", headers=HEADERS)
+            assert MARKER in response.json()["data"]["content"]
+            print("POST /tuning replaced the live file (GET reflects it)")
+
+            # 4. POST /tuning/run triggers one loop pass.
+            response = await client.post(f"{BASE_URL}/tuning/run", headers=HEADERS)
+            assert response.status_code == 200, response.text
+            run = response.json()["data"]
+            assert run["spool_committed"] is True, f"manual pass did not commit: {run}"
+            print(f"POST /tuning/run pass: {run}")
+
+        # 5. The replaced guidance steers the very next turn -- no restart.
+        task = "What is 2 + 2? Answer with the number."
+        reply = await chat(overlord, task, USER, "tuning-api-session")
+        transcript.append((task, reply))
+        print(f"User: {task}\nSystem: {reply}")
+        assert (
+            MARKER in reply
+        ), f"MUXI.md guidance was not injected into the turn (no {MARKER!r} in reply)"
+
+        print("\n" + "=" * 40)
+        print("\n### Test Result:")
+        print("  SUCCESS: /tuning API + MUXI.md injection work end-to-end")
+        print("  - GET /tuning served the hand-written file (admin auth enforced)")
+        print("  - POST /tuning atomically replaced the live file")
+        print("  - POST /tuning/run triggered a committed loop pass")
+        print("  - the replaced guidance steered the next turn without a restart")
+        print("\n" + "=" * 40)
+        print("\n### Chat transcript:")
+        for task, reply in transcript:
+            print(f"\nUser: {task}")
+            print(f"System: {reply}")
+
+        print("\nTest 27A4 PASSED")
+        return True
+
+    except Exception as e:
+        print(f"\nTest failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+    finally:
+        if server is not None:
+            try:
+                await server.stop()
+            except Exception:
+                pass
+        if formation is not None:
+            await teardown(formation, formation_id)
+        import shutil
+
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0 if success else 1)

--- a/e2e/tests/27_tuning/test_27a4_tuning_api.py
+++ b/e2e/tests/27_tuning/test_27a4_tuning_api.py
@@ -82,14 +82,26 @@ async def main():
             assert MARKER in response.json()["data"]["content"]
             print("POST /tuning replaced the live file (GET reflects it)")
 
-            # 4. POST /tuning/run triggers one loop pass.
+            # 4. The bounded-file contract is enforced at the write surface.
+            response = await client.post(
+                f"{BASE_URL}/tuning", headers=HEADERS, json={"content": "x" * 40_000}
+            )
+            assert (
+                response.status_code == 413
+            ), f"oversized MUXI.md was accepted: {response.status_code}"
+            assert (
+                MARKER in (formation_dir / "MUXI.md").read_text()
+            ), "oversized POST must not touch the live file"
+            print("Oversized POST /tuning rejected (413), live file untouched")
+
+            # 5. POST /tuning/run triggers one loop pass.
             response = await client.post(f"{BASE_URL}/tuning/run", headers=HEADERS)
             assert response.status_code == 200, response.text
             run = response.json()["data"]
             assert run["spool_committed"] is True, f"manual pass did not commit: {run}"
             print(f"POST /tuning/run pass: {run}")
 
-        # 5. The replaced guidance steers the very next turn -- no restart.
+        # 6. The replaced guidance steers the very next turn -- no restart.
         task = "What is 2 + 2? Answer with the number."
         reply = await chat(overlord, task, USER, "tuning-api-session")
         transcript.append((task, reply))
@@ -103,6 +115,7 @@ async def main():
         print("  SUCCESS: /tuning API + MUXI.md injection work end-to-end")
         print("  - GET /tuning served the hand-written file (admin auth enforced)")
         print("  - POST /tuning atomically replaced the live file")
+        print("  - oversized content rejected at the 32KB bound (413)")
         print("  - POST /tuning/run triggered a committed loop pass")
         print("  - the replaced guidance steered the next turn without a restart")
         print("\n" + "=" * 40)

--- a/e2e/tests/27_tuning/tuning_common.py
+++ b/e2e/tests/27_tuning/tuning_common.py
@@ -1,0 +1,178 @@
+"""
+Shared helpers for the 27_tuning e2e area (Self-Improving Formation, Phase 1).
+
+Every test generates its formation at runtime into a temp directory (the
+watch-area standalone pattern) with a UNIQUE formation id: the event
+spool lives under ~/.muxi/{formation_id}/observability/spool, so a fresh
+id per test run is the isolation mechanism. Helpers cover the spool
+directory surface, digest triggering through the overlord's tuning
+service, and seeded multi-user traffic.
+
+NOTE: the filename deliberately matches the runners' skip patterns
+("common.py") so it is never collected as a test.
+"""
+
+import asyncio
+import os
+import shutil
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from muxi.runtime.formation import Formation  # noqa: E402
+
+AREA_DIR = Path(__file__).parent
+ASSETS_DIR = AREA_DIR.parent.parent / "assets"
+
+FORMATION_TEMPLATE = """\
+schema: "1.0.0"
+id: {formation_id}
+description: E2E formation for the self-improvement tuning loop
+
+llm:
+  api_keys:
+    openai: "${{{{ secrets.OPENAI_API_KEY }}}}"
+  models:
+    - text: "openai/gpt-4o-mini"
+
+runtime:
+  built_in_mcps: false
+
+agents:
+  - id: assistant
+    name: Assistant
+    description: Concise assistant for tuning-loop testing
+    system_message: |
+      You are a helpful assistant. Keep every response under 30 words.
+    default: true
+
+overlord:
+  workflow:
+    auto_decomposition: false
+  response:
+    streaming: false
+    widgets: false
+"""
+
+FILE_LOGGING_BLOCK = """
+logging:
+  system:
+    level: "error"
+    destination: "{destination}"
+  conversation:
+    enabled: false
+"""
+
+SERVER_BLOCK = """
+server:
+  enabled: true
+  port: {port}
+  api_keys:
+    admin_key: {admin_key}
+    client_key: {client_key}
+"""
+
+ADMIN_KEY = "tuning-admin-key-27"
+CLIENT_KEY = "tuning-client-key-27"
+
+
+def unique_formation_id(tag: str) -> str:
+    return f"tuning-e2e-{tag}-{uuid.uuid4().hex[:8]}"
+
+
+def spool_dir_for(formation_id: str) -> Path:
+    """Where the always-on spool writes for this formation id."""
+    return Path.home() / ".muxi" / formation_id / "observability" / "spool"
+
+
+def build_formation(
+    base_dir: Path,
+    formation_id: str,
+    *,
+    file_logging: bool = False,
+    server_port: Optional[int] = None,
+    muxi_md: Optional[str] = None,
+) -> Path:
+    """Generate a tuning e2e formation under ``base_dir`` and return its path."""
+    formation_dir = base_dir / "formation"
+    formation_dir.mkdir(parents=True)
+
+    content = FORMATION_TEMPLATE.format(formation_id=formation_id)
+    if file_logging:
+        content += FILE_LOGGING_BLOCK.format(destination=str(base_dir / "system.jsonl"))
+    if server_port is not None:
+        content += SERVER_BLOCK.format(port=server_port, admin_key=ADMIN_KEY, client_key=CLIENT_KEY)
+    (formation_dir / "formation.yaml").write_text(content)
+    if muxi_md is not None:
+        (formation_dir / "MUXI.md").write_text(muxi_md)
+
+    # Shared e2e secrets: BOTH the blob and its key must resolve, or the
+    # SecretsManager mints a fresh key that cannot decrypt the blob.
+    os.symlink(ASSETS_DIR / "secrets.enc", formation_dir / "secrets.enc")
+    os.symlink(ASSETS_DIR / ".key", formation_dir / ".key")
+
+    return formation_dir
+
+
+async def load_formation(formation_dir: Path):
+    """Load a generated formation and start its overlord."""
+    formation = Formation()
+    await formation.load(str(formation_dir))
+    overlord = await formation.start_overlord()
+    return formation, overlord
+
+
+def content_of(response) -> str:
+    content = getattr(response, "content", None)
+    return content if isinstance(content, str) else str(response)
+
+
+async def chat(overlord, message: str, user: str, session: str) -> str:
+    response = await overlord.chat(
+        message=message,
+        user_id=user,
+        session_id=session,
+        use_async=False,
+        stream=False,
+    )
+    return content_of(response)
+
+
+def wait_for_segments(spool_dir: Path, timeout: float = 20) -> list:
+    """Poll until at least one spool segment file exists."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        segments = sorted(spool_dir.glob("events-*.jsonl"))
+        if segments:
+            return segments
+        time.sleep(0.5)
+    raise AssertionError(f"no spool segments appeared under {spool_dir} within {timeout}s")
+
+
+def digest_model(overlord):
+    """The model the scheduled loop would use for the digest step."""
+    model = getattr(overlord, "extraction_model", None) or getattr(overlord, "default_model", None)
+    assert model is not None, "overlord has no text model for the digest step"
+    return model
+
+
+async def run_tuning_pass(overlord) -> dict:
+    """Trigger one tuning loop pass (the POST /tuning/run path)."""
+    assert (
+        overlord.tuning_service is not None
+    ), "tuning service was not initialized (it is on by default)"
+    return await overlord.tuning_service.run_once(digest_model(overlord), trigger="manual")
+
+
+async def teardown(formation, formation_id: Optional[str] = None) -> None:
+    try:
+        await formation.stop_overlord()
+    except Exception:
+        pass
+    await asyncio.sleep(1)
+    if formation_id:
+        shutil.rmtree(Path.home() / ".muxi" / formation_id, ignore_errors=True)

--- a/src/muxi/runtime/datatypes/api.py
+++ b/src/muxi/runtime/datatypes/api.py
@@ -37,6 +37,10 @@ class APIEventType(str, Enum):
     SECRET_LIST = "secret.list"
     SECRET_RELOADED = "secret.reloaded"
 
+    TUNING_RETRIEVED = "tuning.retrieved"
+    TUNING_UPDATED = "tuning.updated"
+    TUNING_RUN_COMPLETED = "tuning.run.completed"
+
     MEMORY_CREATED = "memory.created"
     MEMORY_RETRIEVED = "memory.retrieved"
     MEMORY_DELETED = "memory.deleted"
@@ -204,6 +208,8 @@ class APIObjectType(str, Enum):
     # Configuration objects
     OVERLORD_CONFIG = "overlord_config"
     SOUL = "soul"
+    TUNING = "tuning"
+    TUNING_RUN = "tuning_run"
     MCP_DEFAULTS = "mcp_defaults"
     MCP_SERVER = "mcp_server"
     MCP_SERVER_LIST = "mcp_server_list"

--- a/src/muxi/runtime/datatypes/observability.py
+++ b/src/muxi/runtime/datatypes/observability.py
@@ -570,6 +570,18 @@ class SystemEvents(Enum):
     # When cron expression timezone is converted
 
     # ===================================================================
+    # SELF-IMPROVEMENT (EVENT SPOOL + TUNING LOOP)
+    # ===================================================================
+    SPOOL_OVERRUN = "spool.overrun"
+    # When the event spool exceeds its internal cap and drops oldest segments
+
+    FORMATION_LOG_DIGESTED = "formation_log.digested"
+    # When the tuning loop digests the spool into the formation captain's log
+
+    TUNING_RUN = "tuning.run"
+    # When one tuning loop pass completes (scheduled or manual trigger)
+
+    # ===================================================================
     # NETWORK/COMMUNICATION INFRASTRUCTURE
     # ===================================================================
     # REMOVED: NETWORK_INTERFACE_INITIALIZED - too granular, not used

--- a/src/muxi/runtime/formation/config/validation.py
+++ b/src/muxi/runtime/formation/config/validation.py
@@ -400,6 +400,10 @@ class FormationValidator:
         if "coding" in config:
             self._validate_coding_config(config["coding"])
 
+        # Validate self-improvement configuration
+        if "tuning" in config:
+            self._validate_tuning_config(config["tuning"])
+
         # Validate LLM configuration
         if "llm" in config:
             self._validate_llm_config(config["llm"])
@@ -3757,6 +3761,22 @@ class FormationValidator:
             parse_coding_config(coding_config, resolve_client=False)
         except CodingConfigError as e:
             self.result.add_error(f"Invalid coding configuration: {e}")
+
+    def _validate_tuning_config(self, tuning_config: Any) -> None:
+        """Validate the top-level ``tuning`` block (self-improvement).
+
+        Reuses the service-level parser so the validator and the runtime
+        can never disagree: closed key set (active, interval_hours,
+        auto_apply), fail-fast types, booleans rejected where numbers are
+        expected. An absent block is valid (defaults on) and never
+        reaches this method.
+        """
+        from ...services.tuning import TuningConfigError, parse_tuning_config
+
+        try:
+            parse_tuning_config(tuning_config)
+        except TuningConfigError as e:
+            self.result.add_error(f"Invalid tuning configuration: {e}")
 
     def _validate_server_config(self, server_config: Dict[str, Any]) -> None:
         """Validate server configuration."""

--- a/src/muxi/runtime/formation/formation.py
+++ b/src/muxi/runtime/formation/formation.py
@@ -234,6 +234,11 @@ class Formation:
         self._watch_config = None
         self._watch_prepared = False
 
+        # Self-improvement (populated by _setup_tuning from the top-level
+        # tuning: block; defaults ON when the block is absent, so this is
+        # never None after _prepare_services)
+        self._tuning_config = None
+
     def set_secrets_manager(self, secrets_manager: SecretsManager) -> None:
         """
         Inject a pre-configured SecretsManager instance.
@@ -1118,6 +1123,10 @@ class Formation:
         # of the adapter, binary, workdirs, groups, and the secrets rule)
         self._setup_coding()
 
+        # Self-improvement (top-level tuning: block; defaults ON when the
+        # block is absent -- every formation self-improves out of the box)
+        self._setup_tuning()
+
         # Prepare and validate service configurations
         self._setup_llm_config()
         self._setup_memory_config()
@@ -1260,6 +1269,7 @@ class Formation:
                 "document_processing_config": self._document_processing_config,
                 "coding_config": self._coding_config,
                 "watch_config": self._watch_config,
+                "tuning_config": self._tuning_config,
                 "scheduler_config": self._scheduler_config,
                 "runtime_config": self._runtime_config,
                 "agents_config": self._agents_config,
@@ -1787,6 +1797,35 @@ class Formation:
 
         self._coding_config = coding_config
         self._coding_prepared = True
+
+    def _setup_tuning(self) -> None:
+        """
+        Parse + fail-fast validate the top-level ``tuning:`` block.
+
+        The entire Self-Improving Formation AFS surface. An absent block
+        means the defaults (active, 24h interval, auto_apply) -- every
+        formation self-improves out of the box; ``tuning: {active: false}``
+        is the off switch. Closed key set: any structural problem is a
+        formation-load error, never a tuning-time surprise.
+        """
+        from ..services.tuning import TuningConfigError, parse_tuning_config
+
+        try:
+            self._tuning_config = parse_tuning_config((self.config or {}).get("tuning"))
+        except TuningConfigError as e:
+            raise ConfigurationValidationError(
+                [f"Invalid tuning configuration: {e}"],
+                {
+                    "suggestion": (
+                        "The tuning block supports exactly three keys: "
+                        "'active' (boolean), 'interval_hours' (positive "
+                        "number), and 'auto_apply' (boolean)"
+                    ),
+                    "example": {
+                        "tuning": {"active": True, "interval_hours": 24, "auto_apply": True}
+                    },
+                },
+            ) from e
 
     def _setup_llm_config(self) -> None:
         """Setup and validate LLM configuration."""

--- a/src/muxi/runtime/formation/overlord/chat_orchestrator.py
+++ b/src/muxi/runtime/formation/overlord/chat_orchestrator.py
@@ -1754,6 +1754,19 @@ class ChatOrchestrator:
                     pass
             return ""
 
+        async def _fetch_formation_log_context() -> str:
+            # Formation captain's log injection (Self-Improving Formation):
+            # the formation-scope operational narrative is visible to every
+            # user -- entries are privacy-linted at write time. Failure-safe
+            # by contract (returns "" on any error or when empty).
+            captains_log = getattr(self.overlord, "captains_log", None)
+            if captains_log:
+                try:
+                    return await captains_log.get_formation_context_block()
+                except Exception:
+                    pass
+            return ""
+
         async def _fetch_memory_index() -> str:
             # Knowledge index injection (Memory Revamp Phase 4): the
             # navigable catalog of what exists in memory, injected at the
@@ -1774,6 +1787,7 @@ class ChatOrchestrator:
             buffer_turns,
             graph_context,
             captains_log_context,
+            formation_log_context,
             memory_index_block,
         ) = await asyncio.gather(
             _fetch_user_synopsis(),
@@ -1781,6 +1795,7 @@ class ChatOrchestrator:
             _fetch_buffer_role_turns(),
             _fetch_graph_context(),
             _fetch_captains_log_context(),
+            _fetch_formation_log_context(),
             _fetch_memory_index(),
         )
 
@@ -1805,6 +1820,12 @@ class ChatOrchestrator:
                 f"{user_profile_text}\n\n{log_block}" if user_profile_text else log_block
             )
 
+        if formation_log_context:
+            ops_block = f"Formation operations log:\n{formation_log_context}"
+            user_profile_text = (
+                f"{user_profile_text}\n\n{ops_block}" if user_profile_text else ops_block
+            )
+
         # The knowledge index leads the memory addendum (PRD retrieval
         # flow: "1. Read memory index <- orient: what exists?").
         if memory_index_block:
@@ -1813,6 +1834,24 @@ class ChatOrchestrator:
                 if user_profile_text
                 else memory_index_block
             )
+
+        # MUXI.md leads everything (Self-Improving Formation): prose
+        # operational guidance steering per-turn decisions -- routing,
+        # tool selection, clarification posture. Bounded file, no
+        # retrieval machinery; the mtime-cached read is effectively free.
+        muxi_md = getattr(self.overlord, "muxi_md", None)
+        if muxi_md is not None:
+            try:
+                muxi_guidance = muxi_md.read()
+            except Exception:
+                muxi_guidance = None
+            if muxi_guidance:
+                guidance_block = f"Formation operational guidance (MUXI.md):\n{muxi_guidance}"
+                user_profile_text = (
+                    f"{guidance_block}\n\n{user_profile_text}"
+                    if user_profile_text
+                    else guidance_block
+                )
 
         # Apply the scheduled-execution marker only at the agent's
         # view of the current message. ``buffer_turns`` is left

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -479,6 +479,13 @@ class Overlord:
         # None means no watch_job tool is registered).
         self.watch_service = None
 
+        # Tuning service (self-improving formation; created in
+        # _async_startup unless tuning.active is false). The MUXI.md file
+        # handle is created unconditionally in the constructor: a
+        # hand-written MUXI.md is injected even when the tuner is off.
+        self.tuning_service = None
+        self.muxi_md = None
+
         # Initialize credential resolver if database is configured
         self.credential_resolver = None
         if configured_services:
@@ -943,6 +950,16 @@ class Overlord:
 
         # Load overlord soul (intelligence concerns)
         self._load_soul()
+
+        # MUXI.md -- the formation's CLAUDE.md, sibling of SOUL.md
+        # (Self-Improving Formation PRD). The handle re-reads on mtime
+        # change, so hand edits and POST /tuning replacements take effect
+        # on the next turn without a restart.
+        from ...services.tuning import MuxiMdFile
+
+        self.muxi_md = MuxiMdFile(
+            self._configured_services.get("formation_path") if self._configured_services else None
+        )
 
         # ===================================================================
         # POST-INITIALIZATION SETUP
@@ -1603,6 +1620,10 @@ class Overlord:
         # without declared MCP servers (or 'mcp: { watch: false }').
         await self._initialize_watch_service()
 
+        # Start the tuning loop (self-improving formation). On by default;
+        # no-op only when 'tuning: {active: false}'.
+        self._initialize_tuning_service()
+
         # Register periodic re-sync of remote knowledge sources (Phase 3)
         # after the scheduler for the same reason. No-op for formations
         # without url-based knowledge sources.
@@ -1772,6 +1793,50 @@ class Overlord:
                 f"interval {int(watch_config.interval_seconds)}s, "
                 f"timeout {int(watch_config.timeout_seconds)}s, "
                 f"max {watch_config.max_concurrent} watch(es)/user",
+            )
+        )
+
+    def _initialize_tuning_service(self) -> None:
+        """
+        Create + start the TuningService (self-improving formation).
+
+        On by default: an absent 'tuning:' block means the loop runs with
+        defaults; 'tuning: {active: false}' means no service (the event
+        spool stays within its cap and is otherwise inert). Digested spool
+        segments are deleted unless the formation's yaml declares its own
+        file transport -- then the files are the dev's and their rotation
+        config governs.
+        """
+        tuning_config = (
+            self._configured_services.get("tuning_config") if self._configured_services else None
+        )
+        if tuning_config is None:
+            from ...services.tuning import TuningConfig
+
+            tuning_config = TuningConfig()
+        if not tuning_config.active:
+            return
+
+        from ...datatypes.observability import InitEventFormatter
+        from ...services.tuning import TuningService, yaml_declares_file_transport
+
+        logging_config = (
+            self._configured_services.get("logging_config") if self._configured_services else None
+        ) or {}
+        self.tuning_service = TuningService(
+            config=tuning_config,
+            overlord=self,
+            keep_spool_segments=yaml_declares_file_transport(logging_config),
+        )
+        self.tuning_service.start(
+            lambda: getattr(self, "extraction_model", None) or getattr(self, "default_model", None)
+        )
+
+        print(
+            InitEventFormatter.format_ok(
+                "Tuning loop initialized",
+                f"every {tuning_config.interval_hours:g}h, "
+                f"auto_apply {str(tuning_config.auto_apply).lower()}",
             )
         )
 
@@ -2837,6 +2902,23 @@ class Overlord:
                 description="Failed to load soul, using fallback",
             )
 
+    def _persona_with_guidance(self) -> str:
+        """The soul persona plus MUXI.md operational learnings.
+
+        MUXI.md is injected wherever SOUL.md is injected (Self-Improving
+        Formation PRD): the handle is mtime-cached, so hand edits, tuner
+        curation, and POST /tuning replacements all land on the next turn.
+        Returns the bare persona when the file is absent or empty.
+        """
+        persona = self._default_persona
+        try:
+            guidance = self.muxi_md.read() if self.muxi_md else None
+        except Exception:
+            guidance = None
+        if guidance:
+            persona = f"{persona}\n\n=== FORMATION OPERATIONAL GUIDANCE (MUXI.md) ===\n{guidance}"
+        return persona
+
     async def _get_local_classifier(self) -> LocalClassifier:
         """Return the lazily-initialized prototype-similarity classifier
         used by the binary pre-planning gates.
@@ -3292,7 +3374,7 @@ class Overlord:
 
                 system_prompt = PromptLoader.get(
                     "overlord_greeting_response.md",
-                    default_persona=self._default_persona,
+                    default_persona=self._persona_with_guidance(),
                     user_message=actual_user_message,
                 )
 
@@ -3392,7 +3474,7 @@ class Overlord:
                         "'Hey there', 'Hi', 'Hello', etc. Get straight to the answer."
                     )
 
-                system_prompt = f"""{self._default_persona}
+                system_prompt = f"""{self._persona_with_guidance()}
 
 Reformat the agent's response to match your persona while preserving all technical details and information.
 Make it conversational and friendly while keeping accuracy.
@@ -4847,6 +4929,18 @@ Agent response: {raw_response}"""
                     level=observability.EventLevel.WARNING,
                     data={"error": str(e), "service": "knowledge_graph"},
                     description=f"Error stopping knowledge graph service: {e}",
+                )
+
+        # Stop the tuning loop if running
+        if getattr(self, "tuning_service", None):
+            try:
+                await self.tuning_service.stop()
+            except Exception as e:
+                observability.observe(
+                    event_type=observability.ErrorEvents.INTERNAL_ERROR,
+                    level=observability.EventLevel.WARNING,
+                    data={"error": str(e), "service": "tuning"},
+                    description=f"Error stopping tuning service: {e}",
                 )
 
         # Stop the captain's log summarization loop if running

--- a/src/muxi/runtime/formation/server/routes/admin/__init__.py
+++ b/src/muxi/runtime/formation/server/routes/admin/__init__.py
@@ -15,6 +15,7 @@ from . import (
     overlord,
     scheduler,
     secrets,
+    tuning,
 )
 
 __all__ = [
@@ -32,4 +33,5 @@ __all__ = [
     "overlord",
     "scheduler",
     "secrets",
+    "tuning",
 ]

--- a/src/muxi/runtime/formation/server/routes/admin/tuning.py
+++ b/src/muxi/runtime/formation/server/routes/admin/tuning.py
@@ -1,0 +1,110 @@
+"""
+Self-improvement (tuning) endpoints.
+
+The MUXI.md file-pair API surface (Self-Improving Formation PRD, Phase 1
+slice) plus the manual loop trigger, requiring admin API key auth:
+
+- ``GET /tuning`` -- the live MUXI.md (the formation's CLAUDE.md).
+- ``POST /tuning`` -- replace the live file (human upload; hand-editing
+  the file on disk is equally legitimate -- the mtime-cached handle
+  re-reads either way).
+- ``POST /tuning/run`` -- trigger one tuning loop pass (admin/testing).
+
+The pending-file endpoints (``/tuning/pending``) arrive with Phase 2's
+tuner step.
+"""
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from .....datatypes.api import APIEventType, APIObjectType
+from ...responses import APIResponse, create_error_response, create_success_response
+
+router = APIRouter(tags=["Tuning"])
+
+
+class TuningUpdate(BaseModel):
+    """Replacement content for the live MUXI.md."""
+
+    content: str
+
+
+def _muxi_md(request: Request):
+    """The overlord's MUXI.md handle, or None before overlord start."""
+    formation = request.app.state.formation
+    overlord = getattr(formation, "_overlord", None)
+    return getattr(overlord, "muxi_md", None) if overlord else None
+
+
+@router.get("/tuning", response_model=APIResponse)
+async def get_tuning(request: Request) -> JSONResponse:
+    """Get the live MUXI.md content (null when the file does not exist)."""
+    request_id = getattr(request.state, "request_id", None)
+    muxi_md = _muxi_md(request)
+    if muxi_md is None:
+        response = create_error_response(
+            "SERVICE_UNAVAILABLE", "Overlord not started", None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=503)
+
+    response = create_success_response(
+        APIObjectType.TUNING,
+        APIEventType.TUNING_RETRIEVED,
+        {"content": muxi_md.read(), "path": muxi_md.resolve_path()},
+        request_id,
+    )
+    return JSONResponse(content=response.model_dump(), status_code=200)
+
+
+@router.post("/tuning", response_model=APIResponse)
+async def replace_tuning(request: Request, update: TuningUpdate) -> JSONResponse:
+    """Replace the live MUXI.md with the posted content."""
+    request_id = getattr(request.state, "request_id", None)
+    muxi_md = _muxi_md(request)
+    if muxi_md is None:
+        response = create_error_response(
+            "SERVICE_UNAVAILABLE", "Overlord not started", None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=503)
+
+    try:
+        path = muxi_md.write(update.content)
+    except (ValueError, OSError) as e:
+        response = create_error_response(
+            "TUNING_WRITE_FAILED", f"Could not write MUXI.md: {e}", None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=500)
+
+    response = create_success_response(
+        APIObjectType.TUNING,
+        APIEventType.TUNING_UPDATED,
+        {"path": path, "bytes": len(update.content.encode("utf-8"))},
+        request_id,
+    )
+    return JSONResponse(content=response.model_dump(), status_code=200)
+
+
+@router.post("/tuning/run", response_model=APIResponse)
+async def run_tuning(request: Request) -> JSONResponse:
+    """Trigger one tuning loop pass now (admin/testing surface)."""
+    request_id = getattr(request.state, "request_id", None)
+    formation = request.app.state.formation
+    overlord = getattr(formation, "_overlord", None)
+    tuning_service = getattr(overlord, "tuning_service", None) if overlord else None
+    if tuning_service is None:
+        response = create_error_response(
+            "SERVICE_UNAVAILABLE",
+            "Tuning is not active for this formation",
+            None,
+            request_id,
+        )
+        return JSONResponse(content=response.model_dump(), status_code=503)
+
+    model = getattr(overlord, "extraction_model", None) or getattr(overlord, "default_model", None)
+    result = await tuning_service.run_once(model, trigger="manual")
+
+    response = create_success_response(
+        APIObjectType.TUNING_RUN, APIEventType.TUNING_RUN_COMPLETED, result, request_id
+    )
+    return JSONResponse(content=response.model_dump(), status_code=200)

--- a/src/muxi/runtime/formation/server/routes/admin/tuning.py
+++ b/src/muxi/runtime/formation/server/routes/admin/tuning.py
@@ -23,6 +23,12 @@ from ...responses import APIResponse, create_error_response, create_success_resp
 
 router = APIRouter(tags=["Tuning"])
 
+# MUXI.md is read on every chat turn and injected into every user's
+# context, so the "bounded file" contract is enforced at the write
+# surface: ~32KB keeps it comparable to a large SOUL.md while bounding
+# per-turn context inflation across all users.
+MUXI_MD_MAX_BYTES = 32_768
+
 
 class TuningUpdate(BaseModel):
     """Replacement content for the live MUXI.md."""
@@ -67,6 +73,17 @@ async def replace_tuning(request: Request, update: TuningUpdate) -> JSONResponse
             "SERVICE_UNAVAILABLE", "Overlord not started", None, request_id
         )
         return JSONResponse(content=response.model_dump(), status_code=503)
+
+    content_bytes = len(update.content.encode("utf-8"))
+    if content_bytes > MUXI_MD_MAX_BYTES:
+        response = create_error_response(
+            "TUNING_CONTENT_TOO_LARGE",
+            f"MUXI.md content is {content_bytes} bytes; the bound is "
+            f"{MUXI_MD_MAX_BYTES} bytes (it is injected into every turn)",
+            None,
+            request_id,
+        )
+        return JSONResponse(content=response.model_dump(), status_code=413)
 
     try:
         path = muxi_md.write(update.content)

--- a/src/muxi/runtime/formation/server/server.py
+++ b/src/muxi/runtime/formation/server/server.py
@@ -635,6 +635,7 @@ class FormationServer:
             memory,
             overlord,
             secrets,
+            tuning,
         )
         from .routes.admin.async_routes import router as async_router
 
@@ -657,6 +658,7 @@ class FormationServer:
             # scheduler.router moved to dual_auth_routers (GET /scheduler/jobs needs both keys)
             a2a.router,
             audit.router,
+            tuning.router,
         ]
 
         for router in admin_routers:

--- a/src/muxi/runtime/services/memory/lint.py
+++ b/src/muxi/runtime/services/memory/lint.py
@@ -279,6 +279,8 @@ class MemoryLintService:
 
     async def _list_user_ids(self) -> Set[str]:
         """Every user with knowledge graph or captain's log rows."""
+        from .log.formation import FORMATION_LOG_USER_ID
+
         users: Set[str] = set()
         async with self.db_manager.get_async_session() as session:
             stmt = select(KGEntity.user_id).filter_by(formation_id=self.formation_id).distinct()
@@ -289,6 +291,10 @@ class MemoryLintService:
                 .distinct()
             )
             users.update(str(row[0]) for row in (await session.execute(stmt)).all())
+        # The formation-scope log sentinel is not a user: its cadence is
+        # the tuning interval, so the per-user log-gap check would flag it
+        # spuriously (and per-user lint passes have nothing to audit).
+        users.discard(FORMATION_LOG_USER_ID)
         return users
 
     async def _unresolved_conflicts(self, user_id: str) -> List[str]:

--- a/src/muxi/runtime/services/memory/log/formation.py
+++ b/src/muxi/runtime/services/memory/log/formation.py
@@ -1,0 +1,190 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Formation Captain's Log - Digest Prompt and Privacy Lint
+# Description:  Formation-scope narrative digest of the event spool
+# Role:         Prompt builder/parser + sentence-level privacy gate
+# Usage:        Driven by CaptainsLogService.digest_formation (tuning loop)
+# Author:       Muxi Framework Team
+#
+# Self-Improving Formation PRD, part 2 step 1 (Formation Captain's Log).
+# Same storage and date-grain as the per-user log, written under the
+# reserved formation user id. Formation scope is visible to every user,
+# so the privacy rule is hard: no user ids, no prompt content, no
+# user-derived specifics. The privacy lint runs on every write; a
+# rejection drops the offending sentence, never the digest.
+# =============================================================================
+
+import re
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from ....utils.fastjson import json
+from ....utils.redaction import DEFAULT_ENTITY_THRESHOLD, get_entity_detector
+from ....utils.sensitive_terms import SENSITIVE_KEY_TERMS
+
+# Reserved user id scoping formation-wide log entries. Not a real user:
+# "0" is the single-user-mode user, so the sentinel must be distinct and
+# impossible as an external id (external ids are lowercased; this one is
+# also excluded from per-user enumeration paths such as the memory lint).
+FORMATION_LOG_USER_ID = "__formation__"
+
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+_EMAIL_PATTERN = re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b")
+_SSN_PATTERN = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+# Card-length digit runs, tolerant of space/hyphen group separators
+# ("4111111111111111", "4111 1111 1111 1111", "4111-1111-1111-1111").
+_LONG_DIGIT_RUN = re.compile(r"(?:\d[ -]?){14,}\d")
+
+# Entity-detector labels that make a sentence user-derived. ORG and
+# DATE_TIME are deliberately NOT here: tool/vendor names and time windows
+# are the operational content the formation log exists to record
+# ("Jira rate-limits 14:00-16:00" must survive the lint).
+_PRIVATE_ENTITY_LABELS = {"PERSON", "ADDRESS", "FINANCIAL"}
+
+
+class FormationLogSummarizer:
+    """Builds and parses the formation-scope digest LLM call.
+
+    Mirrors CaptainsLogSummarizer's contract: the caller drives the LLM
+    call (build_prompt -> generate_text -> parse_response); every failure
+    parses down to None so the tuning loop is never broken by a digest.
+    """
+
+    def build_prompt(
+        self,
+        activity_report: str,
+        entry_date: str,
+        previous_entry: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Build the formation digest prompt from the aggregated report."""
+        parts: List[str] = [
+            f"You are writing the formation's operations log entry for {entry_date}: a "
+            "concise operational narrative of how this AI formation performed, written "
+            "for the formation itself to learn from.\n",
+            "Capture: traffic shape, tool-failure clusters, routing anomalies, cost "
+            "hotspots, and incidents. Focus on operational patterns, not individual "
+            "conversations.\n",
+            "RULES:\n"
+            "- Base the entry ONLY on the aggregated activity report below. Do not "
+            "invent events.\n"
+            "- HARD PRIVACY RULE: this entry is visible to every user of the "
+            "formation. NEVER include user identifiers, user names, prompt or message "
+            "content, or any user-derived specifics. Generalize: 'a spike of "
+            "FAQ-class requests', never 'user X asked about Y'.\n"
+            "- Write in the past tense. Keep the summary under 120 words.\n"
+            "- Use empty strings for sections with nothing to record.",
+        ]
+
+        if previous_entry is not None:
+            existing = {
+                "summary": previous_entry.get("summary") or "",
+                "context": previous_entry.get("context") or "",
+            }
+            parts.append(
+                "\nAn entry for this date already exists. Merge the new activity into "
+                "it, keeping everything still accurate:\n"
+                f"{json.dumps(existing)}"
+            )
+
+        parts.append(
+            "\nRespond with a JSON object in exactly this structure:\n"
+            "{\n"
+            '  "summary": "...",\n'
+            '  "context": "..."\n'
+            "}\n"
+        )
+        parts.append(f"\nAggregated activity report:\n{activity_report}\n")
+        return "\n".join(parts)
+
+    def parse_response(self, response: str) -> Optional[Dict[str, Optional[str]]]:
+        """Parse the LLM response; None means the caller skips the run."""
+        if not response or not isinstance(response, str):
+            return None
+        clean = response.strip()
+        if clean.startswith("```"):
+            first_newline = clean.find("\n")
+            if first_newline > 0:
+                clean = clean[first_newline + 1 :]
+            if clean.endswith("```"):
+                clean = clean[:-3].strip()
+        try:
+            payload = json.loads(clean)
+        except Exception:
+            return None
+        if not isinstance(payload, dict):
+            return None
+        summary = payload.get("summary")
+        context = payload.get("context")
+        summary = summary.strip() if isinstance(summary, str) and summary.strip() else None
+        context = context.strip() if isinstance(context, str) and context.strip() else None
+        if summary is None:
+            return None
+        return {"summary": summary, "context": context}
+
+
+def lint_formation_digest(
+    text: Optional[str], known_user_ids: Iterable[str]
+) -> Tuple[Optional[str], int]:
+    """Sentence-level privacy gate for formation-scope digest text.
+
+    Drops every sentence that carries a known user id, an email address,
+    an SSN/card-length digit run, a sensitive keyword, or (when the
+    entity detector is enabled) a detected personal entity. Returns the
+    cleaned text and the number of dropped sentences -- never rejects the
+    whole digest.
+    """
+    if not text:
+        return text, 0
+
+    user_id_needles = [
+        user_id.lower()
+        for user_id in known_user_ids
+        # Very short ids ("0" in single-user mode) would match everywhere;
+        # the digest report never carries them verbatim anyway.
+        if isinstance(user_id, str) and len(user_id) >= 3
+    ]
+
+    detector = get_entity_detector()
+    kept: List[str] = []
+    dropped = 0
+    for sentence in _SENTENCE_SPLIT.split(text):
+        if not sentence.strip():
+            continue
+        if _is_private_sentence(sentence, user_id_needles, detector):
+            dropped += 1
+            continue
+        kept.append(sentence.strip())
+
+    cleaned = " ".join(kept)
+    return (cleaned if cleaned else None), dropped
+
+
+def _is_private_sentence(sentence: str, user_id_needles: List[str], detector) -> bool:
+    lowered = sentence.lower()
+    if any(needle in lowered for needle in user_id_needles):
+        return True
+    if _EMAIL_PATTERN.search(sentence) or _SSN_PATTERN.search(sentence):
+        return True
+    if any(term in lowered for term in SENSITIVE_KEY_TERMS):
+        return True
+    if _LONG_DIGIT_RUN.search(sentence):
+        return True
+    if detector is not None:
+        try:
+            if any(
+                span.score >= DEFAULT_ENTITY_THRESHOLD and span.label in _PRIVATE_ENTITY_LABELS
+                for span in detector.detect(sentence)
+            ):
+                return True
+        except Exception:
+            # Fail closed: the formation log is visible to every user,
+            # so an unverifiable sentence is never published.
+            return True
+    return False
+
+
+__all__ = [
+    "FORMATION_LOG_USER_ID",
+    "FormationLogSummarizer",
+    "lint_formation_digest",
+]

--- a/src/muxi/runtime/services/memory/log/service.py
+++ b/src/muxi/runtime/services/memory/log/service.py
@@ -43,6 +43,11 @@ from ..events.models import (
 )
 from ..graph.extractor import KnowledgeGraphExtractor
 from ..graph.service import _schedule_to_seconds
+from .formation import (
+    FORMATION_LOG_USER_ID,
+    FormationLogSummarizer,
+    lint_formation_digest,
+)
 from .models import SOURCE_TYPE_BUFFER_ITEM
 from .storage import CaptainsLogStorage, LessonStorage
 from .summarizer import CaptainsLogSummarizer
@@ -150,6 +155,7 @@ class CaptainsLogService:
         self.storage = CaptainsLogStorage(db_manager, formation_id)
         self.lessons = LessonStorage(db_manager, formation_id)
         self.summarizer = CaptainsLogSummarizer()
+        self.formation_summarizer = FormationLogSummarizer()
         # The digest response's graph fields are validated with the Phase 1
         # extractor's parser at the periodic-pass confidence threshold.
         self.graph_extractor = KnowledgeGraphExtractor(confidence_threshold=DIGEST_GRAPH_CONFIDENCE)
@@ -576,6 +582,99 @@ class CaptainsLogService:
             description=f"Captain's log entry updated for {entry['date']}",
         )
         return {"entries": 1, "sources": source_counts["added"], "lessons": lessons_stored}
+
+    # ------------------------------------------------------------------
+    # Formation-scope digest (Self-Improving Formation, tuning loop step 1)
+    # ------------------------------------------------------------------
+
+    async def digest_formation(
+        self, activity_report: str, model, known_user_ids: Optional[List[str]] = None
+    ) -> Dict[str, int]:
+        """
+        Digest an aggregated spool report into today's formation log entry.
+
+        Same storage and date-grain as the per-user log, written under the
+        reserved formation user id and recorded as a formation-scope
+        ``log.entry`` event. The privacy lint runs on every write: a
+        rejection drops the offending sentence, never the digest. Driven
+        by the tuning loop (never the per-user summarization pass).
+
+        The returned ``consumed`` flag tells the tuning loop whether the
+        report's events reached a terminal outcome (written, linted out,
+        or nothing to record): only then may spool segments be
+        checkpointed away. Transient failures (no model yet, unparseable
+        LLM response) return ``consumed=False`` so the same segments are
+        retried on the next pass.
+        """
+        if not self.enabled or not (activity_report or "").strip():
+            return {"entries": 0, "dropped_sentences": 0, "consumed": True}
+        if model is None:
+            return {"entries": 0, "dropped_sentences": 0, "consumed": False}
+
+        entry_date = utc_now_naive().date()
+        previous_entry = await self.storage.get_entry(FORMATION_LOG_USER_ID, entry_date)
+        raw_response = await model.generate_text(
+            self.formation_summarizer.build_prompt(
+                activity_report,
+                entry_date=entry_date.isoformat(),
+                previous_entry=previous_entry,
+            ),
+            caching=False,
+        )
+        digest = self.formation_summarizer.parse_response(raw_response)
+        if digest is None:
+            return {"entries": 0, "dropped_sentences": 0, "consumed": False}
+
+        known_user_ids = known_user_ids or []
+        summary, dropped_summary = lint_formation_digest(digest["summary"], known_user_ids)
+        context, dropped_context = lint_formation_digest(digest["context"], known_user_ids)
+        dropped = dropped_summary + dropped_context
+        if summary is None:
+            # Every summary sentence failed the lint; there is nothing
+            # publishable this run. The digest itself is never rejected --
+            # the next run writes a clean entry.
+            return {"entries": 0, "dropped_sentences": dropped, "consumed": True}
+
+        entry_payload = {
+            "date": entry_date.isoformat(),
+            "summary": summary,
+            "decisions": [],
+            "projects": [],
+            "context": context,
+            "sources": [],
+        }
+        event = None
+        if self.event_log is not None:
+            event = await self.event_log.record(
+                user_id=FORMATION_LOG_USER_ID,
+                event_type=EVENT_LOG_ENTRY,
+                payload=entry_payload,
+                source=SOURCE_CAPTAINS_LOG,
+                scope_type="formation",
+                scope_id=self.formation_id,
+            )
+        if event is not None and self.event_log.event_first:
+            await self.event_log.apply_event(event)
+        else:
+            await self.apply_log_entry_event(
+                FORMATION_LOG_USER_ID, entry_payload, event_id=event["id"] if event else None
+            )
+
+        observability.observe(
+            event_type=observability.SystemEvents.FORMATION_LOG_DIGESTED,
+            level=observability.EventLevel.INFO,
+            data={
+                "date": entry_payload["date"],
+                "dropped_sentences": dropped,
+                "merged_existing_entry": previous_entry is not None,
+            },
+            description=f"Formation captain's log entry updated for {entry_payload['date']}",
+        )
+        return {"entries": 1, "dropped_sentences": dropped, "consumed": True}
+
+    async def get_formation_context_block(self, limit: Optional[int] = None) -> str:
+        """Render recent formation-scope entries for every user's context."""
+        return await self.get_context_block(FORMATION_LOG_USER_ID, limit=limit)
 
     async def _store_lessons(
         self,

--- a/src/muxi/runtime/services/observability/logger.py
+++ b/src/muxi/runtime/services/observability/logger.py
@@ -45,6 +45,10 @@ class EventLogger:
     # Max events drained per write batch by the background writer
     _WRITER_BATCH_MAX = 100
 
+    # Spool tee backpressure: past this queue depth, spool writes are
+    # dropped rather than growing the writer queue unboundedly
+    _SPOOL_QUEUE_MAX = 10000
+
     def __init__(
         self,
         level: EventLevel = EventLevel.INFO,
@@ -246,6 +250,18 @@ class EventLogger:
             # JSON-L format for easy parsing
             event_line = json.dumps(event, separators=(",", ":"))
 
+            # Tee every emitted event into the internal spool (Self-
+            # Improving Formation PRD): always on, not configuration,
+            # rides the same background writer so the hot path never
+            # touches disk. The spool singleton owns segment state, so
+            # the logger replacement at server-ready loses nothing.
+            # Drop-aware: a stalled writer must never grow the queue
+            # unboundedly for the spool's sake (the digest is best-effort
+            # telemetry; configured outputs keep their existing behavior).
+            write_queue = self._write_queue
+            if write_queue is None or write_queue.qsize() < self._SPOOL_QUEUE_MAX:
+                self._enqueue_write("spool", event_line)
+
             # Route SystemEvents, ServerEvents, APIEvents and ErrorEvents to system_destination
             if isinstance(event_type, (SystemEvents, ErrorEvents, ServerEvents, APIEvents)):
                 self._emit_to_system(event_line)
@@ -339,7 +355,11 @@ class EventLogger:
         """Write one batch of JSON-L lines to a single destination."""
         payload = "\n".join(event_lines) + "\n"
 
-        if kind == "file":
+        if kind == "spool":
+            from .spool import get_event_spool
+
+            get_event_spool().write_lines(event_lines)
+        elif kind == "file":
             file_path = self.output_config.get("path", f"{get_observability_dir()}/muxi.jsonl")
             with open(file_path, "a") as f:
                 f.write(payload)

--- a/src/muxi/runtime/services/observability/spool.py
+++ b/src/muxi/runtime/services/observability/spool.py
@@ -1,0 +1,354 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Event Spool - Internal Observability Retention Buffer
+# Description:  Always-on JSONL segment store feeding the tuning digest loop
+# Role:         Short-lived operational telemetry buffer (self-improvement)
+# Usage:        Written by EventLogger's writer thread; read by TuningService
+# Author:       Muxi Framework Team
+#
+# Self-Improving Formation PRD, part 1 (event spool). The runtime always
+# tees emitted observability events into segment files in the formation's
+# observability directory, regardless of what the ``logging:`` yaml
+# declares. Not configuration, not AFS surface: internal format, bounded
+# by an internal cap, consumed solely by the tuning loop's digest step.
+#
+# Retention contract:
+# - The tuning loop is the single consumer; it checkpoints the last fully
+#   digested segment. ``read_for_digest`` rotates the active segment first
+#   so every segment it returns is closed and fully digestible.
+# - ``commit(delete=True)`` (no file transport declared in the yaml)
+#   deletes digested segments -- steady-state disk is about one interval.
+#   ``commit(delete=False)`` (dev declared a file transport) keeps them.
+# - Total spool size is bounded by SPOOL_MAX_BYTES: oldest closed segments
+#   drop with a ``spool.overrun`` event rather than eating the disk.
+#
+# Threading: writes arrive from EventLogger writer threads (one per logger
+# instance; the logger is replaced at server-ready, so two writer threads
+# can briefly coexist), reads from the tuning loop via asyncio.to_thread.
+# One lock serializes all segment mutation.
+# =============================================================================
+
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+from ...utils.datetime_utils import utc_now_naive
+from ...utils.fastjson import json
+from ...utils.user_dirs import get_observability_dir
+
+# Internal constants -- deliberately not configuration (PRD: the spool has
+# no yaml key; nothing external should parse or tune it).
+SEGMENT_MAX_BYTES = 32 * 1024 * 1024
+SPOOL_MAX_BYTES = 512 * 1024 * 1024
+SEGMENT_PREFIX = "events-"
+SEGMENT_SUFFIX = ".jsonl"
+CHECKPOINT_FILE = "checkpoint.json"
+
+# Rate limit for spool.overrun emission so a sustained overrun does not
+# turn into an event storm (the overrun event itself is spooled).
+OVERRUN_EVENT_MIN_INTERVAL_SECONDS = 60.0
+
+
+class EventSpool:
+    """Segmented JSONL spool with rotation, a size cap, and a checkpoint."""
+
+    def __init__(self, base_dir: str):
+        self.base_dir = Path(base_dir)
+        self._lock = threading.Lock()
+        self._current: Optional[Path] = None
+        self._pending_new_segment = False
+        self._last_overrun_emit = 0.0
+
+    # ------------------------------------------------------------------
+    # Write side (EventLogger writer thread)
+    # ------------------------------------------------------------------
+
+    def write_lines(self, event_lines: List[str]) -> None:
+        """Append JSONL event lines to the active segment.
+
+        Rotates by day and by segment size, then enforces the total cap.
+        Never raises: the spool must never disrupt the writer thread.
+        """
+        if not event_lines:
+            return
+        try:
+            with self._lock:
+                self.base_dir.mkdir(parents=True, exist_ok=True)
+                segment = self._active_segment()
+                payload = "\n".join(event_lines) + "\n"
+                with open(segment, "a", encoding="utf-8") as f:
+                    f.write(payload)
+                self._enforce_cap()
+        except Exception:
+            pass
+
+    def _active_segment(self) -> Path:
+        """Resolve the segment to append to, rotating on day/size change."""
+        today = utc_now_naive().strftime("%Y%m%d")
+        current = self._current
+        if current is None and not self._pending_new_segment:
+            # Restart resume: continue the latest segment ONLY when it has
+            # not been digested yet -- appending to a checkpointed segment
+            # would hide those events from every future read.
+            current = self._latest_segment()
+            checkpoint = self._read_checkpoint()
+            if current is not None and checkpoint is not None and current.name <= checkpoint:
+                current = None
+        if current is not None and current.name.startswith(f"{SEGMENT_PREFIX}{today}-"):
+            try:
+                if current.exists() and current.stat().st_size < SEGMENT_MAX_BYTES:
+                    self._current = current
+                    return current
+            except OSError:
+                pass
+        self._pending_new_segment = False
+        self._current = self._next_segment_path(today)
+        return self._current
+
+    def _latest_segment(self) -> Optional[Path]:
+        segments = self._list_segments()
+        return segments[-1] if segments else None
+
+    def _next_segment_path(self, today: str) -> Path:
+        """Next per-day sequence number; names sort lexicographically."""
+        prefix = f"{SEGMENT_PREFIX}{today}-"
+        max_seq = 0
+        for segment in self._list_segments():
+            if segment.name.startswith(prefix):
+                seq_text = segment.name[len(prefix) : -len(SEGMENT_SUFFIX)]
+                try:
+                    max_seq = max(max_seq, int(seq_text))
+                except ValueError:
+                    continue
+        return self.base_dir / f"{prefix}{max_seq + 1:04d}{SEGMENT_SUFFIX}"
+
+    def _list_segments(self) -> List[Path]:
+        """All segment files, lexicographic order == chronological order."""
+        try:
+            return sorted(
+                p
+                for p in self.base_dir.iterdir()
+                if p.name.startswith(SEGMENT_PREFIX) and p.name.endswith(SEGMENT_SUFFIX)
+            )
+        except OSError:
+            return []
+
+    def _enforce_cap(self) -> None:
+        """Drop oldest closed segments while the spool exceeds the cap."""
+        segments = self._list_segments()
+        sizes = {}
+        for segment in segments:
+            try:
+                sizes[segment] = segment.stat().st_size
+            except OSError:
+                sizes[segment] = 0
+        total = sum(sizes.values())
+        if total <= SPOOL_MAX_BYTES:
+            return
+
+        dropped: List[str] = []
+        dropped_bytes = 0
+        for segment in segments:
+            if total <= SPOOL_MAX_BYTES:
+                break
+            if segment == self._current:
+                break  # never drop the active segment
+            try:
+                segment.unlink()
+            except OSError:
+                continue
+            total -= sizes[segment]
+            dropped_bytes += sizes[segment]
+            dropped.append(segment.name)
+
+        if dropped:
+            self._emit_overrun(dropped, dropped_bytes, total)
+
+    def _emit_overrun(self, dropped: List[str], dropped_bytes: int, total: int) -> None:
+        """Report an overrun, rate-limited to avoid an event storm.
+
+        Two paths: a marker line appended straight into the active
+        segment (unfilterable -- the digest must always learn that
+        retained events were dropped, whatever the ``logging:`` levels
+        say), plus a regular spool.overrun event for external telemetry.
+        """
+        now = time.time()
+        if now - self._last_overrun_emit < OVERRUN_EVENT_MIN_INTERVAL_SECONDS:
+            return
+        self._last_overrun_emit = now
+
+        overrun_data = {
+            "dropped_segments": dropped,
+            "dropped_bytes": dropped_bytes,
+            "spool_bytes": total,
+            "cap_bytes": SPOOL_MAX_BYTES,
+        }
+        description = (
+            f"Event spool exceeded {SPOOL_MAX_BYTES // (1024 * 1024)}MB cap; "
+            f"dropped {len(dropped)} oldest segment(s) before digestion"
+        )
+
+        # Inline marker append (the caller holds self._lock and just
+        # appended to the active segment).
+        if self._current is not None:
+            try:
+                marker = json.dumps(
+                    {
+                        "event": "spool.overrun",
+                        "level": "warning",
+                        "timestamp": int(now * 1000),
+                        "data": {**overrun_data, "description": description},
+                    },
+                    separators=(",", ":"),
+                )
+                with open(self._current, "a", encoding="utf-8") as f:
+                    f.write(marker + "\n")
+            except Exception:
+                pass
+
+        # Local import: spool is imported by the logger module at the
+        # bottom of the observability package's dependency chain.
+        from . import EventLevel, SystemEvents, observe
+
+        observe(
+            event_type=SystemEvents.SPOOL_OVERRUN,
+            level=EventLevel.WARNING,
+            data=overrun_data,
+            description=description,
+        )
+
+    # ------------------------------------------------------------------
+    # Read side (tuning loop, single consumer)
+    # ------------------------------------------------------------------
+
+    def read_for_digest(self) -> Tuple[List[Path], "SpoolCheckpointToken"]:
+        """Rotate the active segment and return the undigested segments.
+
+        Everything returned is a closed segment strictly after the current
+        checkpoint. Call ``commit`` with the returned token once digested.
+        """
+        with self._lock:
+            # Force rotation so the active segment becomes digestible: the
+            # next write MUST open a fresh segment, never resume one that
+            # is about to be checkpointed (or deleted) behind it.
+            self._current = None
+            self._pending_new_segment = True
+            checkpoint = self._read_checkpoint()
+            segments = [
+                segment
+                for segment in self._list_segments()
+                if checkpoint is None or segment.name > checkpoint
+            ]
+            return segments, SpoolCheckpointToken([segment.name for segment in segments])
+
+    def iter_events(self, segments: List[Path]) -> Iterator[Dict[str, Any]]:
+        """Stream parsed events from segment files; skips corrupt lines."""
+        for segment in segments:
+            try:
+                with open(segment, "r", encoding="utf-8") as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            event = json.loads(line)
+                        except Exception:
+                            continue
+                        if isinstance(event, dict):
+                            yield event
+            except OSError:
+                continue
+
+    def commit(self, token: "SpoolCheckpointToken", delete: bool) -> None:
+        """Advance the checkpoint past the digested segments.
+
+        With ``delete=True`` the digested segments are removed (the spool
+        is an internal buffer); with ``delete=False`` they are kept (the
+        yaml declared a file transport, so the files are the dev's).
+        """
+        if not token.segment_names:
+            return
+        with self._lock:
+            self._write_checkpoint(token.segment_names[-1])
+            if delete:
+                for name in token.segment_names:
+                    try:
+                        (self.base_dir / name).unlink()
+                    except OSError:
+                        continue
+
+    def _checkpoint_path(self) -> Path:
+        return self.base_dir / CHECKPOINT_FILE
+
+    def _read_checkpoint(self) -> Optional[str]:
+        try:
+            payload = json.loads(self._checkpoint_path().read_text(encoding="utf-8"))
+        except Exception:
+            return None
+        value = payload.get("digested_through") if isinstance(payload, dict) else None
+        return value if isinstance(value, str) and value else None
+
+    def _write_checkpoint(self, segment_name: str) -> None:
+        try:
+            self.base_dir.mkdir(parents=True, exist_ok=True)
+            tmp_path = self._checkpoint_path().with_suffix(".tmp")
+            tmp_path.write_text(json.dumps({"digested_through": segment_name}), encoding="utf-8")
+            os.replace(tmp_path, self._checkpoint_path())
+        except Exception:
+            pass
+
+    def total_bytes(self) -> int:
+        """Total size of all segments (diagnostics and tests)."""
+        with self._lock:
+            total = 0
+            for segment in self._list_segments():
+                try:
+                    total += segment.stat().st_size
+                except OSError:
+                    continue
+            return total
+
+
+class SpoolCheckpointToken:
+    """Names of the segments one ``read_for_digest`` call returned."""
+
+    def __init__(self, segment_names: List[str]):
+        self.segment_names = segment_names
+
+
+# ---------------------------------------------------------------------------
+# Module singleton: the spool must survive the EventLogger replacement at
+# server-ready (initialization.enable_conversation_logging recreates the
+# logger), so segment/rotation state lives here, keyed by the resolved
+# spool directory (which follows utils.user_dirs.FORMATION_ID).
+# ---------------------------------------------------------------------------
+
+_spool: Optional[EventSpool] = None
+_spool_lock = threading.Lock()
+
+
+def _spool_dir() -> str:
+    return str(Path(get_observability_dir()) / "spool")
+
+
+def get_event_spool() -> EventSpool:
+    """Return the process-wide spool for the current formation."""
+    global _spool
+    base_dir = _spool_dir()
+    spool = _spool
+    if spool is not None and str(spool.base_dir) == base_dir:
+        return spool
+    with _spool_lock:
+        if _spool is None or str(_spool.base_dir) != base_dir:
+            _spool = EventSpool(base_dir)
+        return _spool
+
+
+def reset_event_spool() -> None:
+    """Drop the singleton (tests only)."""
+    global _spool
+    with _spool_lock:
+        _spool = None

--- a/src/muxi/runtime/services/tuning/__init__.py
+++ b/src/muxi/runtime/services/tuning/__init__.py
@@ -1,0 +1,26 @@
+"""
+Self-Improving Formation services (tuning).
+
+Phase 1: the ``tuning:`` config surface, the scheduled digest loop over
+the event spool, and the MUXI.md file contract. Phase 2 adds the tuner
+step (detection, distillation, curation, pending flow, morning report).
+"""
+
+from .config import (
+    DEFAULT_INTERVAL_HOURS,
+    TuningConfig,
+    TuningConfigError,
+    parse_tuning_config,
+)
+from .muxi_md import MuxiMdFile
+from .service import TuningService, yaml_declares_file_transport
+
+__all__ = [
+    "DEFAULT_INTERVAL_HOURS",
+    "MuxiMdFile",
+    "TuningConfig",
+    "TuningConfigError",
+    "TuningService",
+    "parse_tuning_config",
+    "yaml_declares_file_transport",
+]

--- a/src/muxi/runtime/services/tuning/config.py
+++ b/src/muxi/runtime/services/tuning/config.py
@@ -1,0 +1,94 @@
+"""
+Tuning configuration (the top-level ``tuning:`` block).
+
+The entire new AFS surface of the Self-Improving Formation PRD. All
+defaults on: an absent block means the tuner is on with defaults, one
+loop pass a day. ``tuning.active: false`` is the off switch (no digest,
+no tuner; the always-on event spool stays within its cap and is
+otherwise inert). The spool itself has no key -- it is internal runtime
+behavior, not configuration.
+
+Closed key set, fail-fast validation at formation load, booleans
+rejected where numbers are expected.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+_ALLOWED_TUNING_KEYS = {"active", "interval_hours", "auto_apply"}
+
+DEFAULT_INTERVAL_HOURS = 24.0
+
+
+class TuningConfigError(ValueError):
+    """Raised for any invalid ``tuning:`` configuration (fail fast at load)."""
+
+
+@dataclass
+class TuningConfig:
+    """Parsed ``tuning:`` block (or the defaults, when the block is absent)."""
+
+    active: bool = True
+    interval_hours: float = DEFAULT_INTERVAL_HOURS
+    # Phase 1 stores the flag; the tuner step (Phase 2) acts on it.
+    auto_apply: bool = True
+
+
+def _boolean(value: Any, *, key: str) -> bool:
+    if not isinstance(value, bool):
+        raise TuningConfigError(f"tuning.{key} must be a boolean, got: {value!r}")
+    return value
+
+
+def _positive_number(value: Any, *, key: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TuningConfigError(f"tuning.{key} must be a number of hours, got: {value!r}")
+    if value <= 0:
+        raise TuningConfigError(f"tuning.{key} must be positive, got: {value!r}")
+    return float(value)
+
+
+def parse_tuning_config(raw: Any) -> TuningConfig:
+    """
+    Parse the top-level ``tuning:`` block of a formation config.
+
+    Absent block (None) returns the defaults -- every formation
+    self-improves out of the box. ``tuning: false`` is accepted as
+    shorthand for ``tuning: {active: false}``.
+
+    Raises TuningConfigError on any structural problem -- a
+    formation-load error, never a tuning-time surprise.
+    """
+    if raw is None:
+        return TuningConfig()
+    if raw is False:
+        return TuningConfig(active=False)
+    if raw is True:
+        return TuningConfig()
+    if not isinstance(raw, dict):
+        raise TuningConfigError(f"tuning must be a mapping or a boolean, got: {type(raw).__name__}")
+
+    unknown = sorted(set(raw) - _ALLOWED_TUNING_KEYS)
+    if unknown:
+        raise TuningConfigError(
+            f"tuning has unknown key(s) {unknown}; "
+            f"supported keys are {sorted(_ALLOWED_TUNING_KEYS)}"
+        )
+
+    return TuningConfig(
+        active=_boolean(raw["active"], key="active") if "active" in raw else True,
+        interval_hours=(
+            _positive_number(raw["interval_hours"], key="interval_hours")
+            if "interval_hours" in raw
+            else DEFAULT_INTERVAL_HOURS
+        ),
+        auto_apply=(_boolean(raw["auto_apply"], key="auto_apply") if "auto_apply" in raw else True),
+    )
+
+
+__all__ = [
+    "TuningConfig",
+    "TuningConfigError",
+    "parse_tuning_config",
+    "DEFAULT_INTERVAL_HOURS",
+]

--- a/src/muxi/runtime/services/tuning/muxi_md.py
+++ b/src/muxi/runtime/services/tuning/muxi_md.py
@@ -92,7 +92,13 @@ class MuxiMdFile:
                 dir=os.path.dirname(path), prefix=".muxi-md-", suffix=".tmp"
             )
             try:
-                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                try:
+                    f = os.fdopen(fd, "w", encoding="utf-8")
+                except BaseException:
+                    # fdopen never took ownership; close the raw fd.
+                    os.close(fd)
+                    raise
+                with f:
                     f.write(content)
                 os.replace(tmp_path, path)
             except BaseException:

--- a/src/muxi/runtime/services/tuning/muxi_md.py
+++ b/src/muxi/runtime/services/tuning/muxi_md.py
@@ -1,0 +1,110 @@
+"""
+MUXI.md -- the formation's CLAUDE.md.
+
+A bounded, curated markdown file of behavioral learnings living in the
+formation directory, sibling of SOUL.md. Formation-owned, git-trackable,
+human-editable: a dev may write it by hand on day one. Injected into
+overlord context wherever SOUL.md is injected; Phase 2's tuner curates
+it. Reads are mtime-cached so hand edits and API replacements take
+effect on the next turn without a restart.
+"""
+
+import os
+import tempfile
+import threading
+from typing import Optional
+
+# Candidate file names, checked in order (mirrors the SOUL.md loader).
+_CANDIDATES = ("MUXI.md", "muxi.md")
+_CANONICAL = "MUXI.md"
+
+
+class MuxiMdFile:
+    """The live MUXI.md file: mtime-cached reads, atomic replacement."""
+
+    def __init__(self, formation_dir: Optional[str]):
+        self.formation_dir = formation_dir
+        self._lock = threading.Lock()
+        self._cached_content: Optional[str] = None
+        self._cached_mtime: Optional[float] = None
+        self._cached_path: Optional[str] = None
+
+    def resolve_path(self) -> Optional[str]:
+        """The existing MUXI.md path, or None when the file is absent."""
+        if not self.formation_dir:
+            return None
+        for candidate in _CANDIDATES:
+            path = os.path.join(self.formation_dir, candidate)
+            if os.path.isfile(path):
+                return path
+        return None
+
+    def canonical_path(self) -> Optional[str]:
+        """Where a write lands: the existing file, or MUXI.md when absent."""
+        existing = self.resolve_path()
+        if existing:
+            return existing
+        if not self.formation_dir:
+            return None
+        return os.path.join(self.formation_dir, _CANONICAL)
+
+    def read(self) -> Optional[str]:
+        """Current content, or None when absent/unreadable. Never raises."""
+        path = self.resolve_path()
+        if path is None:
+            with self._lock:
+                self._cached_content = None
+                self._cached_mtime = None
+                self._cached_path = None
+            return None
+        try:
+            mtime = os.path.getmtime(path)
+            with self._lock:
+                if (
+                    self._cached_path == path
+                    and self._cached_mtime == mtime
+                    and self._cached_content is not None
+                ):
+                    return self._cached_content
+            with open(path, "r", encoding="utf-8") as f:
+                content = f.read().strip()
+            with self._lock:
+                self._cached_content = content or None
+                self._cached_mtime = mtime
+                self._cached_path = path
+            return content or None
+        except OSError:
+            return None
+
+    def write(self, content: str) -> str:
+        """Replace the live file atomically; returns the written path.
+
+        Raises ValueError when no formation directory exists to hold it.
+        """
+        path = self.canonical_path()
+        if path is None:
+            raise ValueError("Formation has no directory to hold MUXI.md")
+        # The lock covers the whole temp-write/replace/cache sequence so
+        # concurrent replacements cannot interleave, and the temp file is
+        # uniquely named so a crashed writer never corrupts a later one.
+        with self._lock:
+            fd, tmp_path = tempfile.mkstemp(
+                dir=os.path.dirname(path), prefix=".muxi-md-", suffix=".tmp"
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(content)
+                os.replace(tmp_path, path)
+            except BaseException:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
+            self._cached_content = content.strip() or None
+            self._cached_mtime = os.path.getmtime(path)
+            self._cached_path = path
+        return path
+
+
+__all__ = ["MuxiMdFile"]

--- a/src/muxi/runtime/services/tuning/service.py
+++ b/src/muxi/runtime/services/tuning/service.py
@@ -1,0 +1,326 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Tuning Service - The Self-Improvement Loop
+# Description:  Scheduled spool digest into the formation captain's log
+# Role:         Owns the tuning loop (Phase 1: digest step only)
+# Usage:        Created + started by the Overlord when tuning.active
+# Author:       Muxi Framework Team
+#
+# Self-Improving Formation PRD, "The loop". One scheduled in-runtime job
+# (tuning.interval_hours, CaptainsLog lifecycle idiom: started by the
+# Overlord, cancelled on shutdown), Phase 1 scope: read the event spool
+# since the last checkpoint, aggregate it into a compact activity report,
+# digest that into today's formation-scope captain's log entry, then
+# checkpoint (and delete the digested segments unless the formation's
+# yaml declared its own file transport -- then the files are the dev's).
+#
+# Phase 2 adds the tuner step (detection, distillation, MUXI.md curation,
+# pending flow, morning report) behind the same loop.
+# =============================================================================
+
+import asyncio
+import time
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from .. import observability
+from ..observability.spool import get_event_spool
+from .config import TuningConfig
+
+# Bounds keeping the aggregated report LLM-sized regardless of spool size.
+MAX_REPORT_CHARS = 8000
+TOP_EVENT_TYPES = 20
+MAX_SAMPLE_DESCRIPTIONS = 3
+SAMPLE_DESCRIPTION_CHARS = 160
+# Per-request token snapshots tracked during aggregation (last-write-wins
+# per request id; capped so a huge interval cannot balloon memory).
+MAX_TRACKED_REQUESTS = 5000
+
+
+class TuningService:
+    """Owns the tuning loop; Phase 1 runs the digest step only."""
+
+    def __init__(
+        self,
+        config: TuningConfig,
+        overlord,
+        keep_spool_segments: bool = False,
+    ):
+        """
+        Args:
+            config: Parsed ``tuning:`` block (defaults when absent).
+            overlord: The owning Overlord (captains_log + model access).
+            keep_spool_segments: True when the formation's yaml declares a
+                file transport -- digested segments are then kept (their
+                rotation config governs; digestion never deletes).
+        """
+        self.config = config
+        self.overlord = overlord
+        self.keep_spool_segments = keep_spool_segments
+        self.interval_seconds = config.interval_hours * 3600.0
+        self._task: Optional[asyncio.Task] = None
+        self._run_lock = asyncio.Lock()
+        self.last_run: Optional[Dict[str, Any]] = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle (CaptainsLog idiom: overlord starts, shutdown cancels)
+    # ------------------------------------------------------------------
+
+    def start(self, model_getter) -> None:
+        """Start the scheduled loop; first pass one full interval in."""
+        if not self.config.active:
+            return
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(self._loop(model_getter))
+
+    async def stop(self) -> None:
+        """Cancel the loop, if running."""
+        task = self._task
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def _loop(self, model_getter) -> None:
+        while True:
+            await asyncio.sleep(self.interval_seconds)
+            try:
+                await self.run_once(model_getter(), trigger="scheduled")
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                observability.observe(
+                    event_type=observability.ErrorEvents.INTERNAL_ERROR,
+                    level=observability.EventLevel.WARNING,
+                    data={"error": str(e), "error_type": type(e).__name__, "service": "tuning"},
+                    description=f"Tuning loop pass failed: {e}",
+                )
+
+    # ------------------------------------------------------------------
+    # One loop pass (scheduled, or POST /tuning/run)
+    # ------------------------------------------------------------------
+
+    async def run_once(self, model, trigger: str = "manual") -> Dict[str, Any]:
+        """Run one digest pass; safe against overlapping invocations."""
+        async with self._run_lock:
+            started = time.monotonic()
+            spool = get_event_spool()
+            segments, token = spool.read_for_digest()
+
+            report, known_user_ids, event_count = await asyncio.to_thread(
+                _aggregate_segments, spool, segments
+            )
+
+            captains_log = getattr(self.overlord, "captains_log", None)
+            if captains_log is not None:
+                digest = await captains_log.digest_formation(
+                    report, model, known_user_ids=known_user_ids
+                )
+            else:
+                # No narrative layer exists to consume the spool; the
+                # segments still reach their terminal outcome.
+                digest = {"entries": 0, "dropped_sentences": 0, "consumed": True}
+
+            committed = bool(digest.get("consumed"))
+            if committed:
+                spool.commit(token, delete=not self.keep_spool_segments)
+
+            result = {
+                "trigger": trigger,
+                "events_read": event_count,
+                "segments_read": len(token.segment_names),
+                "entries_written": digest.get("entries", 0),
+                "dropped_sentences": digest.get("dropped_sentences", 0),
+                "spool_committed": committed,
+                "spool_segments_kept": self.keep_spool_segments,
+                "duration_ms": round((time.monotonic() - started) * 1000, 1),
+            }
+            self.last_run = result
+            observability.observe(
+                event_type=observability.SystemEvents.TUNING_RUN,
+                level=observability.EventLevel.INFO,
+                data=result,
+                description=(
+                    f"Tuning pass ({trigger}) digested {event_count} event(s) into "
+                    f"{result['entries_written']} formation log entr(y/ies)"
+                ),
+            )
+            return result
+
+
+def yaml_declares_file_transport(logging_config: Optional[Dict[str, Any]]) -> bool:
+    """True when the formation's ``logging:`` yaml declares a file destination.
+
+    The PRD's retention rule: spool segments are an internal buffer and are
+    deleted once digested -- UNLESS the dev declared file logging, in which
+    case segment files are kept (they are the dev's telemetry; digestion
+    never deletes).
+    """
+    if not isinstance(logging_config, dict):
+        return False
+    system_destination = (logging_config.get("system") or {}).get("destination")
+    if isinstance(system_destination, str) and system_destination not in ("", "stdout"):
+        return True
+    conversation = logging_config.get("conversation") or {}
+    for stream in conversation.get("streams") or []:
+        if (
+            isinstance(stream, dict)
+            and stream.get("transport") == "file"
+            and stream.get("destination")
+        ):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Spool aggregation: raw JSONL events -> compact operational report.
+# Runs in a worker thread (segments can be large); the LLM only ever sees
+# the bounded report, never raw events.
+# ---------------------------------------------------------------------------
+
+
+def _aggregate_segments(spool, segments) -> Tuple[str, List[str], int]:
+    """Aggregate spool segments into (report, known_user_ids, event_count)."""
+    stats = _SpoolStats()
+    for event in spool.iter_events(segments):
+        stats.add(event)
+    return stats.render(), sorted(stats.user_ids), stats.total
+
+
+class _SpoolStats:
+    """Streaming accumulator over spool events."""
+
+    def __init__(self):
+        self.total = 0
+        self.first_ts: Optional[int] = None
+        self.last_ts: Optional[int] = None
+        self.event_counts: Dict[str, int] = {}
+        self.level_counts: Dict[str, int] = {}
+        self.problem_counts: Dict[str, int] = {}
+        self.problem_samples: Dict[str, List[str]] = {}
+        self.user_ids: Set[str] = set()
+        self.session_ids: Set[str] = set()
+        self.request_tokens: Dict[str, Dict[str, Any]] = {}
+
+    def add(self, event: Dict[str, Any]) -> None:
+        self.total += 1
+        name = event.get("event")
+        if isinstance(name, str):
+            self.event_counts[name] = self.event_counts.get(name, 0) + 1
+
+        timestamp = event.get("timestamp")
+        if isinstance(timestamp, int):
+            if self.first_ts is None or timestamp < self.first_ts:
+                self.first_ts = timestamp
+            if self.last_ts is None or timestamp > self.last_ts:
+                self.last_ts = timestamp
+
+        level = event.get("level")
+        if isinstance(level, str):
+            self.level_counts[level] = self.level_counts.get(level, 0) + 1
+            if level in ("warning", "error") and isinstance(name, str):
+                self.problem_counts[name] = self.problem_counts.get(name, 0) + 1
+                data = event.get("data")
+                description = data.get("description") if isinstance(data, dict) else None
+                if isinstance(description, str) and description:
+                    samples = self.problem_samples.setdefault(name, [])
+                    if len(samples) < MAX_SAMPLE_DESCRIPTIONS:
+                        snippet = description[:SAMPLE_DESCRIPTION_CHARS]
+                        if snippet not in samples:
+                            samples.append(snippet)
+
+        request = event.get("request")
+        if isinstance(request, dict):
+            user_id = request.get("user_id")
+            if isinstance(user_id, str) and user_id:
+                self.user_ids.add(user_id)
+            request_id = request.get("id")
+            tokens = request.get("tokens")
+            if isinstance(request_id, str) and isinstance(tokens, dict):
+                # Last snapshot per request wins (token counts are running
+                # totals within one request's lifecycle).
+                if request_id in self.request_tokens or (
+                    len(self.request_tokens) < MAX_TRACKED_REQUESTS
+                ):
+                    self.request_tokens[request_id] = tokens
+        session_id = event.get("session_id")
+        if isinstance(session_id, str) and session_id:
+            self.session_ids.add(session_id)
+
+        data = event.get("data")
+        if isinstance(data, dict):
+            data_user = data.get("user_id")
+            if isinstance(data_user, str) and data_user:
+                self.user_ids.add(data_user)
+
+    def render(self) -> str:
+        """Render the bounded plain-text activity report."""
+        if self.total == 0:
+            return ""
+        lines: List[str] = []
+        window = ""
+        if self.first_ts is not None and self.last_ts is not None:
+            window = f" spanning {_format_ts(self.first_ts)} to {_format_ts(self.last_ts)} (UTC)"
+        lines.append(
+            f"Window: {self.total} events{window}; "
+            f"{len(self.user_ids)} distinct user(s), {len(self.session_ids)} session(s), "
+            f"{len(self.request_tokens)} tracked request(s)."
+        )
+
+        levels = ", ".join(f"{level}={count}" for level, count in sorted(self.level_counts.items()))
+        if levels:
+            lines.append(f"Event levels: {levels}.")
+
+        top = sorted(self.event_counts.items(), key=lambda item: -item[1])[:TOP_EVENT_TYPES]
+        if top:
+            lines.append("Top event types:")
+            for name, count in top:
+                lines.append(f"- {name}: {count}")
+
+        if self.problem_counts:
+            lines.append("Warning/error clusters:")
+            for name, count in sorted(self.problem_counts.items(), key=lambda item: -item[1]):
+                lines.append(f"- {name}: {count}")
+                for sample in self.problem_samples.get(name, []):
+                    lines.append(f"  e.g. {sample}")
+
+        token_total, model_totals = self._token_totals()
+        if token_total:
+            lines.append(f"Total tokens across tracked requests: {token_total}.")
+        if model_totals:
+            lines.append("Token usage by model:")
+            for model_name, count in sorted(model_totals.items(), key=lambda item: -item[1]):
+                lines.append(f"- {model_name}: {count}")
+
+        report = "\n".join(lines)
+        return report[:MAX_REPORT_CHARS]
+
+    def _token_totals(self) -> Tuple[int, Dict[str, int]]:
+        total = 0
+        model_totals: Dict[str, int] = {}
+        for tokens in self.request_tokens.values():
+            values = tokens.get("total")
+            if isinstance(values, list) and values and isinstance(values[0], int):
+                total += values[0]
+            breakdown = tokens.get("breakdown")
+            if isinstance(breakdown, dict):
+                for model_name, model_values in breakdown.items():
+                    if (
+                        isinstance(model_values, list)
+                        and model_values
+                        and isinstance(model_values[0], int)
+                    ):
+                        model_totals[model_name] = model_totals.get(model_name, 0) + model_values[0]
+        return total, model_totals
+
+
+def _format_ts(timestamp_ms: int) -> str:
+    from datetime import datetime, timezone
+
+    return datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc).strftime("%Y-%m-%d %H:%M")
+
+
+__all__ = ["TuningService", "yaml_declares_file_transport"]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,20 @@
+"""Unit-suite-wide guards.
+
+Every emitted observability event is teed into the event spool (Self-
+Improving Formation), so any test that logs would otherwise write real
+segment files under ``~/.muxi``. Redirect the spool singleton into the
+test's tmp_path for the whole unit suite.
+"""
+
+import pytest
+
+from muxi.runtime.services.observability import spool as spool_module
+from muxi.runtime.services.observability.spool import reset_event_spool
+
+
+@pytest.fixture(autouse=True)
+def _isolated_event_spool(tmp_path, monkeypatch):
+    monkeypatch.setattr(spool_module, "_spool_dir", lambda: str(tmp_path / "event-spool"))
+    reset_event_spool()
+    yield
+    reset_event_spool()

--- a/tests/unit/test_event_spool.py
+++ b/tests/unit/test_event_spool.py
@@ -1,0 +1,241 @@
+"""Unit tests for the event spool (Self-Improving Formation, part 1).
+
+Pins the retention contract: always-on tee through the EventLogger's
+background writer, day/size segment rotation, checkpointed single-consumer
+reads (read_for_digest rotates first so every returned segment is closed),
+delete-after-digest vs keep-when-file-transport-declared, the internal
+512MB cap dropping oldest closed segments, and checkpoint persistence
+across spool instances (process restarts).
+"""
+
+import pytest
+
+from muxi.runtime.datatypes.observability import ConversationEvents, EventLevel
+from muxi.runtime.services.observability import EventLogger, spool as spool_module
+from muxi.runtime.services.observability.spool import (
+    SEGMENT_MAX_BYTES,
+    EventSpool,
+    get_event_spool,
+    reset_event_spool,
+)
+
+CONV_EVENT = ConversationEvents.MEMORY_WORKING_RETRIEVED
+
+
+@pytest.fixture
+def spool(tmp_path):
+    return EventSpool(str(tmp_path / "spool"))
+
+
+@pytest.fixture
+def isolated_singleton(tmp_path, monkeypatch):
+    """Redirect the module singleton into tmp_path for logger-tee tests."""
+    monkeypatch.setattr(spool_module, "_spool_dir", lambda: str(tmp_path / "spool"))
+    reset_event_spool()
+    yield tmp_path / "spool"
+    reset_event_spool()
+
+
+class TestWriteAndRotation:
+    def test_lines_append_to_one_daily_segment(self, spool):
+        spool.write_lines(['{"event":"a"}', '{"event":"b"}'])
+        spool.write_lines(['{"event":"c"}'])
+        segments = spool._list_segments()
+        assert len(segments) == 1
+        assert segments[0].read_text().strip().splitlines() == [
+            '{"event":"a"}',
+            '{"event":"b"}',
+            '{"event":"c"}',
+        ]
+
+    def test_size_rotation_starts_a_new_segment(self, spool, monkeypatch):
+        monkeypatch.setattr(spool_module, "SEGMENT_MAX_BYTES", 64)
+        # The instance reads the module constant at call time via
+        # _active_segment; patch the comparison by writing past the limit.
+        big_line = '{"event":"x","pad":"' + "p" * 200 + '"}'
+        spool.write_lines([big_line])
+        spool.write_lines([big_line])
+        assert len(spool._list_segments()) == 2
+
+    def test_segment_names_sort_chronologically(self, spool):
+        spool.base_dir.mkdir(parents=True, exist_ok=True)
+        first = spool._next_segment_path("20260712")
+        assert first.name == "events-20260712-0001.jsonl"
+        first.write_text("{}\n")
+        second = spool._next_segment_path("20260712")
+        assert second.name == "events-20260712-0002.jsonl"
+        assert sorted([second.name, first.name]) == [first.name, second.name]
+
+    def test_write_never_raises_on_bad_dir(self, tmp_path):
+        target = tmp_path / "not-a-dir"
+        target.write_text("occupied")
+        broken = EventSpool(str(target))
+        broken.write_lines(['{"event":"a"}'])  # must not raise
+
+
+class TestReadDigestCommit:
+    def test_read_for_digest_rotates_and_returns_closed_segments(self, spool):
+        spool.write_lines(['{"event":"a"}'])
+        segments, token = spool.read_for_digest()
+        assert [segment.name for segment in segments] == token.segment_names
+        assert len(segments) == 1
+        # The next write opens a NEW segment: the returned one is closed.
+        spool.write_lines(['{"event":"b"}'])
+        assert len(spool._list_segments()) == 2
+
+    def test_commit_delete_removes_digested_segments(self, spool):
+        spool.write_lines(['{"event":"a"}'])
+        segments, token = spool.read_for_digest()
+        spool.commit(token, delete=True)
+        assert spool._list_segments() == []
+        # Checkpoint still advances: nothing is re-read.
+        segments, token = spool.read_for_digest()
+        assert segments == []
+
+    def test_commit_keep_preserves_segments_without_rereading(self, spool):
+        spool.write_lines(['{"event":"a"}'])
+        segments, token = spool.read_for_digest()
+        spool.commit(token, delete=False)
+        assert len(spool._list_segments()) == 1
+        again, _ = spool.read_for_digest()
+        assert again == []
+
+    def test_undigested_segments_survive_restart(self, spool):
+        spool.write_lines(['{"event":"a"}'])
+        segments, token = spool.read_for_digest()
+        spool.commit(token, delete=False)
+        spool.write_lines(['{"event":"b"}'])
+
+        reopened = EventSpool(str(spool.base_dir))
+        segments, _ = reopened.read_for_digest()
+        events = list(reopened.iter_events(segments))
+        assert [event["event"] for event in events] == ["b"]
+
+    def test_empty_commit_is_a_noop(self, spool):
+        segments, token = spool.read_for_digest()
+        assert segments == []
+        spool.commit(token, delete=True)
+        assert spool._read_checkpoint() is None
+
+    def test_iter_events_skips_corrupt_lines(self, spool):
+        spool.write_lines(['{"event":"good"}', "not json", '["not a dict"]'])
+        segments, _ = spool.read_for_digest()
+        events = list(spool.iter_events(segments))
+        assert [event["event"] for event in events] == ["good"]
+
+
+class TestCap:
+    def test_cap_drops_oldest_closed_segments(self, spool, monkeypatch):
+        monkeypatch.setattr(spool_module, "SPOOL_MAX_BYTES", 150)
+        emitted = []
+        monkeypatch.setattr(
+            spool, "_emit_overrun", lambda dropped, bytes_, total: emitted.append(dropped)
+        )
+        line = '{"event":"x","pad":"' + "p" * 60 + '"}'
+        spool.write_lines([line])
+        spool.read_for_digest()  # rotate: segment 1 is now closed
+        spool.write_lines([line])
+        spool.read_for_digest()  # rotate: segment 2 closed
+        spool.write_lines([line])
+
+        names = [segment.name for segment in spool._list_segments()]
+        assert len(names) < 3
+        assert emitted, "overrun must be reported"
+
+    def test_active_segment_never_dropped(self, spool, monkeypatch):
+        monkeypatch.setattr(spool_module, "SPOOL_MAX_BYTES", 10)
+        monkeypatch.setattr(spool, "_emit_overrun", lambda *args: None)
+        line = '{"event":"x","pad":"' + "p" * 60 + '"}'
+        spool.write_lines([line])
+        assert len(spool._list_segments()) == 1
+
+    def test_overrun_marker_lands_in_the_spool_itself(self, spool, monkeypatch):
+        # The digest must learn about dropped segments even when the
+        # logging config filters the spool.overrun event away.
+        monkeypatch.setattr(spool_module, "SPOOL_MAX_BYTES", 100)
+        line = '{"event":"x","pad":"' + "p" * 60 + '"}'
+        spool.write_lines([line])
+        spool.read_for_digest()  # close segment 1
+        spool.write_lines([line])  # cap pass drops segment 1
+
+        active = spool._current
+        assert active is not None
+        marker_lines = [
+            event for event in spool.iter_events([active]) if event.get("event") == "spool.overrun"
+        ]
+        assert marker_lines, "no overrun marker was appended to the active segment"
+        dropped = marker_lines[0]["data"]["dropped_segments"]
+        assert dropped and dropped[0].startswith("events-")
+
+
+class TestLoggerTee:
+    def test_stdout_logger_tees_into_spool(self, isolated_singleton, capsys):
+        logger = EventLogger(level=EventLevel.DEBUG, output="stdout")
+        logger.emit_event(CONV_EVENT, level=EventLevel.INFO, data={"seq": 0})
+        logger.flush()
+
+        segments = list(isolated_singleton.glob("events-*.jsonl"))
+        assert len(segments) == 1
+        assert '"seq":0' in segments[0].read_text()
+        assert '"seq":0' in capsys.readouterr().out
+
+    def test_file_logger_tees_to_both_destinations(self, isolated_singleton, tmp_path):
+        log_path = tmp_path / "events.jsonl"
+        logger = EventLogger(
+            level=EventLevel.DEBUG, output="file", output_config={"path": str(log_path)}
+        )
+        logger.emit_event(CONV_EVENT, level=EventLevel.INFO, data={"seq": 1})
+        logger.flush()
+
+        assert '"seq":1' in log_path.read_text()
+        segments = list(isolated_singleton.glob("events-*.jsonl"))
+        assert segments and '"seq":1' in segments[0].read_text()
+
+    def test_deep_writer_queue_sheds_spool_writes(self, isolated_singleton, tmp_path):
+        log_path = tmp_path / "events.jsonl"
+        logger = EventLogger(
+            level=EventLevel.DEBUG, output="file", output_config={"path": str(log_path)}
+        )
+        logger.emit_event(CONV_EVENT, level=EventLevel.INFO, data={"seq": 0})
+        logger.flush()
+        # Simulate a stalled writer: any depth now exceeds the cap.
+        logger._SPOOL_QUEUE_MAX = 0
+        logger.emit_event(CONV_EVENT, level=EventLevel.INFO, data={"seq": 1})
+        logger.flush()
+
+        assert '"seq":1' in log_path.read_text(), "configured output must never shed"
+        segments = list(isolated_singleton.glob("events-*.jsonl"))
+        payload = "".join(segment.read_text() for segment in segments)
+        assert '"seq":0' in payload
+        assert '"seq":1' not in payload, "spool write was not shed at the depth cap"
+
+    def test_spool_survives_logger_replacement(self, isolated_singleton):
+        first = EventLogger(level=EventLevel.DEBUG, output="stdout")
+        first.emit_event(CONV_EVENT, level=EventLevel.INFO, data={"logger": "first"})
+        first.flush()
+        # initialization.enable_conversation_logging recreates the logger
+        # at server-ready; the spool singleton keeps accumulating.
+        second = EventLogger(level=EventLevel.DEBUG, output="stdout")
+        second.emit_event(CONV_EVENT, level=EventLevel.INFO, data={"logger": "second"})
+        second.flush()
+
+        spool = get_event_spool()
+        segments, _ = spool.read_for_digest()
+        payload = "".join(segment.read_text() for segment in segments)
+        assert '"logger":"first"' in payload
+        assert '"logger":"second"' in payload
+
+
+class TestSingleton:
+    def test_singleton_follows_spool_dir(self, isolated_singleton):
+        first = get_event_spool()
+        assert get_event_spool() is first
+
+    def test_reset_drops_instance(self, isolated_singleton):
+        first = get_event_spool()
+        reset_event_spool()
+        assert get_event_spool() is not first
+
+
+def test_segment_max_bytes_is_sane():
+    assert SEGMENT_MAX_BYTES <= spool_module.SPOOL_MAX_BYTES

--- a/tests/unit/test_formation_digest.py
+++ b/tests/unit/test_formation_digest.py
@@ -1,0 +1,284 @@
+"""Unit tests for the formation captain's log digest (Self-Improving Formation).
+
+Covers the FormationLogSummarizer prompt/parse contract, the sentence-level
+privacy lint (drops the offending sentence, never the digest; operational
+content like tool names and time windows survives), the sentinel-scoped
+digest write with its formation-scope memory event, same-date merging, the
+consumed-flag semantics the tuning loop's checkpointing relies on, the
+formation context block read side, and the memory lint's sentinel exclusion.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.events.models import EVENT_LOG_ENTRY
+from muxi.runtime.services.memory.events.service import MemoryEventService
+from muxi.runtime.services.memory.log.formation import (
+    FORMATION_LOG_USER_ID,
+    FormationLogSummarizer,
+    lint_formation_digest,
+)
+from muxi.runtime.services.memory.log.service import CaptainsLogService
+
+FORMATION_ID = "formation-digest-test"
+
+DIGEST_RESPONSE = (
+    "{"
+    '"summary": "Traffic doubled around midday. The jira MCP tool failed repeatedly '
+    'between 14:00 and 16:00 UTC.",'
+    '"context": "Most requests were FAQ-class."'
+    "}"
+)
+
+ACTIVITY_REPORT = (
+    "Window: 120 events spanning 2026-07-12 08:00 to 2026-07-12 18:00 (UTC); "
+    "2 distinct user(s), 5 session(s), 12 tracked request(s).\n"
+    "Warning/error clusters:\n- mcp.tool.failed: 9"
+)
+
+
+class FakeModel:
+    def __init__(self, response=DIGEST_RESPONSE):
+        self.response = response
+        self.calls = 0
+        self.prompts = []
+
+    async def generate_text(self, prompt, caching=True):
+        self.calls += 1
+        self.prompts.append(prompt)
+        if isinstance(self.response, Exception):
+            raise self.response
+        return self.response
+
+
+@pytest.fixture
+def db_manager(tmp_path):
+    manager = DatabaseManager(f"sqlite:///{tmp_path}/log.db")
+    manager.create_tables(Base.metadata)
+    yield manager
+    manager.engine.dispose()
+
+
+@pytest.fixture
+def service(db_manager):
+    return CaptainsLogService(db_manager, FORMATION_ID)
+
+
+class TestSummarizer:
+    def test_prompt_carries_report_and_privacy_rule(self):
+        summarizer = FormationLogSummarizer()
+        prompt = summarizer.build_prompt(ACTIVITY_REPORT, entry_date="2026-07-12")
+        assert ACTIVITY_REPORT in prompt
+        assert "NEVER include user identifiers" in prompt
+        assert "2026-07-12" in prompt
+
+    def test_prompt_merges_previous_entry(self):
+        summarizer = FormationLogSummarizer()
+        prompt = summarizer.build_prompt(
+            ACTIVITY_REPORT,
+            entry_date="2026-07-12",
+            previous_entry={"summary": "Morning was quiet.", "context": ""},
+        )
+        assert "already exists" in prompt
+        assert "Morning was quiet." in prompt
+
+    def test_parse_valid_response(self):
+        digest = FormationLogSummarizer().parse_response(DIGEST_RESPONSE)
+        assert digest["summary"].startswith("Traffic doubled")
+        assert digest["context"] == "Most requests were FAQ-class."
+
+    def test_parse_tolerates_fenced_block(self):
+        fenced = f"```json\n{DIGEST_RESPONSE}\n```"
+        assert FormationLogSummarizer().parse_response(fenced) is not None
+
+    def test_parse_failures_return_none(self):
+        summarizer = FormationLogSummarizer()
+        assert summarizer.parse_response("not json") is None
+        assert summarizer.parse_response("[1, 2]") is None
+        assert summarizer.parse_response('{"context": "no summary"}') is None
+        assert summarizer.parse_response("") is None
+
+
+class TestPrivacyLint:
+    def test_user_id_sentence_dropped(self):
+        text = "Traffic was heavy. User alice-99 hit rate limits. Tools were stable."
+        cleaned, dropped = lint_formation_digest(text, ["alice-99"])
+        assert dropped == 1
+        assert "alice-99" not in cleaned
+        assert "Traffic was heavy." in cleaned
+        assert "Tools were stable." in cleaned
+
+    def test_email_and_ssn_sentences_dropped(self):
+        text = (
+            "Load was normal. Contact bob@example.com asked twice. "
+            "A value 123-45-6789 appeared. All good otherwise."
+        )
+        cleaned, dropped = lint_formation_digest(text, [])
+        assert dropped == 2
+        assert "bob@example.com" not in cleaned
+        assert "123-45-6789" not in cleaned
+        assert "All good otherwise." in cleaned
+
+    def test_sensitive_keyword_sentence_dropped(self):
+        text = "A password was pasted into chat. Routing stayed nominal."
+        cleaned, dropped = lint_formation_digest(text, [])
+        assert dropped == 1
+        assert cleaned == "Routing stayed nominal."
+
+    def test_card_length_digit_run_dropped(self):
+        text = "Someone typed 4111111111111111 in a message. Latency was fine."
+        cleaned, dropped = lint_formation_digest(text, [])
+        assert dropped == 1
+        assert cleaned == "Latency was fine."
+
+    def test_separator_formatted_card_dropped(self):
+        for card in ("4111 1111 1111 1111", "4111-1111-1111-1111"):
+            text = f"A value {card} was pasted. Throughput held steady."
+            cleaned, dropped = lint_formation_digest(text, [])
+            assert dropped == 1, f"missed separator-formatted digits: {card}"
+            assert cleaned == "Throughput held steady."
+
+    def test_detector_failure_fails_closed(self, monkeypatch):
+        from muxi.runtime.services.memory.log import formation as formation_module
+
+        class ExplodingDetector:
+            def detect(self, sentence):
+                raise RuntimeError("model unavailable")
+
+        monkeypatch.setattr(formation_module, "get_entity_detector", lambda: ExplodingDetector())
+        cleaned, dropped = lint_formation_digest("Traffic was heavy today.", [])
+        assert cleaned is None
+        assert dropped == 1
+
+    def test_operational_content_survives(self):
+        text = (
+            "The jira MCP tool rate-limited between 14:00 and 16:00 UTC. "
+            "FAQ-class requests spiked 3x. gpt-4o-mini handled 80% of turns."
+        )
+        cleaned, dropped = lint_formation_digest(text, ["user-abc"])
+        assert dropped == 0
+        assert cleaned == text
+
+    def test_short_user_ids_do_not_wipe_everything(self):
+        # "0" is the single-user-mode id; substring-matching it would drop
+        # every sentence containing a zero.
+        text = "Around 10:00 traffic rose."
+        cleaned, dropped = lint_formation_digest(text, ["0"])
+        assert dropped == 0
+        assert cleaned == text
+
+    def test_empty_and_none_pass_through(self):
+        assert lint_formation_digest(None, []) == (None, 0)
+        assert lint_formation_digest("", []) == ("", 0)
+
+    def test_all_sentences_dropped_returns_none(self):
+        cleaned, dropped = lint_formation_digest("User alice-99 did a thing.", ["alice-99"])
+        assert cleaned is None
+        assert dropped == 1
+
+
+class TestDigestFormation:
+    def test_writes_sentinel_entry(self, service):
+        model = FakeModel()
+        result = asyncio.run(service.digest_formation(ACTIVITY_REPORT, model))
+        assert result == {"entries": 1, "dropped_sentences": 0, "consumed": True}
+        assert model.calls == 1
+        assert ACTIVITY_REPORT in model.prompts[0]
+
+        block = asyncio.run(service.get_formation_context_block())
+        assert "Traffic doubled" in block
+
+    def test_same_date_entry_is_merged_not_duplicated(self, service):
+        model = FakeModel()
+        asyncio.run(service.digest_formation(ACTIVITY_REPORT, model))
+        asyncio.run(service.digest_formation(ACTIVITY_REPORT, model))
+        assert "already exists" in model.prompts[1]
+        entries = asyncio.run(service.storage.list_entries(FORMATION_LOG_USER_ID, limit=10))
+        assert len(entries) == 1
+
+    def test_lint_drops_user_identifying_sentence(self, service):
+        leaky = '{"summary": "Load was fine. User alice-99 spammed the API.", ' '"context": ""}'
+        result = asyncio.run(
+            service.digest_formation(ACTIVITY_REPORT, FakeModel(leaky), known_user_ids=["alice-99"])
+        )
+        assert result["entries"] == 1
+        assert result["dropped_sentences"] == 1
+        block = asyncio.run(service.get_formation_context_block())
+        assert "alice-99" not in block
+        assert "Load was fine." in block
+
+    def test_fully_linted_summary_skips_write_but_consumes(self, service):
+        leaky = '{"summary": "User alice-99 spammed the API.", "context": ""}'
+        result = asyncio.run(
+            service.digest_formation(ACTIVITY_REPORT, FakeModel(leaky), known_user_ids=["alice-99"])
+        )
+        assert result == {"entries": 0, "dropped_sentences": 1, "consumed": True}
+        assert asyncio.run(service.get_formation_context_block()) == ""
+
+    def test_transient_failures_do_not_consume(self, service):
+        no_model = asyncio.run(service.digest_formation(ACTIVITY_REPORT, None))
+        assert no_model["consumed"] is False
+        bad_parse = asyncio.run(service.digest_formation(ACTIVITY_REPORT, FakeModel("not json")))
+        assert bad_parse["consumed"] is False
+
+    def test_empty_report_consumes_without_llm_call(self, service):
+        model = FakeModel()
+        result = asyncio.run(service.digest_formation("", model))
+        assert result == {"entries": 0, "dropped_sentences": 0, "consumed": True}
+        assert model.calls == 0
+
+    def test_disabled_service_consumes_without_writing(self, db_manager):
+        service = CaptainsLogService(db_manager, FORMATION_ID, config={"enabled": False})
+        result = asyncio.run(service.digest_formation(ACTIVITY_REPORT, FakeModel()))
+        assert result == {"entries": 0, "dropped_sentences": 0, "consumed": True}
+
+    def test_records_formation_scope_memory_event(self, db_manager):
+        event_log = MemoryEventService(db_manager, FORMATION_ID, config={"enabled": True})
+        service = CaptainsLogService(db_manager, FORMATION_ID, event_log=event_log)
+        asyncio.run(service.digest_formation(ACTIVITY_REPORT, FakeModel()))
+
+        events = asyncio.run(event_log.storage.list_events(user_id=FORMATION_LOG_USER_ID))
+        assert len(events) == 1
+        assert events[0]["event_type"] == EVENT_LOG_ENTRY
+        assert events[0]["scope_type"] == "formation"
+        assert events[0]["scope_id"] == FORMATION_ID
+
+
+class TestReadSide:
+    def test_formation_block_empty_without_entries(self, service):
+        assert asyncio.run(service.get_formation_context_block()) == ""
+
+    def test_formation_entries_do_not_leak_into_user_block(self, service):
+        asyncio.run(service.digest_formation(ACTIVITY_REPORT, FakeModel()))
+        user_block = asyncio.run(service.get_context_block("real-user"))
+        assert user_block == ""
+
+
+class TestMemoryLintExclusion:
+    def test_sentinel_excluded_from_user_enumeration(self, db_manager):
+        from muxi.runtime.services.memory.lint import MemoryLintService
+
+        service = CaptainsLogService(db_manager, FORMATION_ID)
+        asyncio.run(service.digest_formation(ACTIVITY_REPORT, FakeModel()))
+        asyncio.run(
+            service.apply_log_entry_event(
+                "real-user", {"date": "2026-07-12", "summary": "User day."}
+            )
+        )
+
+        lint = MemoryLintService(
+            db_manager,
+            FORMATION_ID,
+            config={"enabled": True},
+            knowledge_graph=None,
+            captains_log=service,
+            artifact_memory=None,
+            index=None,
+        )
+        users = asyncio.run(lint._list_user_ids())
+        assert FORMATION_LOG_USER_ID not in users
+        assert "real-user" in users

--- a/tests/unit/test_observability_writer.py
+++ b/tests/unit/test_observability_writer.py
@@ -4,21 +4,36 @@ Unit tests for the EventLogger background writer.
 File and network destinations previously did a blocking open/write/flush
 or requests.post per event on the emitting thread. Events are now queued
 to a single writer thread that batches per destination. These tests pin:
-ordering, delivery via flush(), NDJSON batching for stream posts, and
-that stdout-only loggers never spawn the writer.
+ordering, delivery via flush(), and NDJSON batching for stream posts.
+
+Since the event spool (Self-Improving Formation), every emitted event is
+teed to disk through the writer, so even stdout-only loggers spawn it on
+first emit; the tests isolate the spool singleton into tmp_path.
 """
 
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from muxi.runtime.datatypes.observability import (
     ConversationEvents,
     EventLevel,
     SystemEvents,
 )
-from muxi.runtime.services.observability import EventLogger
+from muxi.runtime.services.observability import EventLogger, spool as spool_module
+from muxi.runtime.services.observability.spool import reset_event_spool
 
 CONV_EVENT = ConversationEvents.MEMORY_WORKING_RETRIEVED
 SYS_EVENT = SystemEvents.CONFIG_FORMATION_LOADED
+
+
+@pytest.fixture(autouse=True)
+def isolated_spool(tmp_path, monkeypatch):
+    """Keep the always-on spool tee inside tmp_path for every test here."""
+    monkeypatch.setattr(spool_module, "_spool_dir", lambda: str(tmp_path / "spool"))
+    reset_event_spool()
+    yield
+    reset_event_spool()
 
 
 class TestFileWriter:
@@ -76,12 +91,13 @@ class TestStreamWriter:
 
 
 class TestWriterLifecycle:
-    def test_stdout_output_never_spawns_writer(self, capsys):
+    def test_stdout_output_spawns_writer_for_spool_tee(self, capsys):
         logger = EventLogger(level=EventLevel.DEBUG, output="stdout")
 
         logger.emit_event(CONV_EVENT, level=EventLevel.INFO, data={"seq": 0})
 
-        assert logger._write_queue is None
+        # stdout stays synchronous, but the spool tee rides the writer.
+        assert logger._write_queue is not None
         assert '"seq":0' in capsys.readouterr().out
 
     def test_flush_without_writer_is_noop(self):

--- a/tests/unit/test_tuning_config.py
+++ b/tests/unit/test_tuning_config.py
@@ -1,0 +1,126 @@
+"""Unit tests for the ``tuning:`` config surface (Self-Improving Formation).
+
+Pins the PRD contract: absent block = defaults on (every formation
+self-improves out of the box), ``active: false`` is the off switch,
+closed key set with fail-fast validation, booleans rejected where
+numbers are expected, and the formation validator delegating to the
+service-level parser so the two can never disagree.
+"""
+
+import pytest
+
+from muxi.runtime.services.tuning import (
+    DEFAULT_INTERVAL_HOURS,
+    TuningConfig,
+    TuningConfigError,
+    parse_tuning_config,
+)
+from muxi.runtime.services.tuning.service import yaml_declares_file_transport
+
+
+class TestDefaults:
+    def test_absent_block_means_all_defaults_on(self):
+        config = parse_tuning_config(None)
+        assert config.active is True
+        assert config.interval_hours == DEFAULT_INTERVAL_HOURS == 24.0
+        assert config.auto_apply is True
+
+    def test_empty_mapping_means_defaults(self):
+        assert parse_tuning_config({}) == TuningConfig()
+
+    def test_boolean_shorthand(self):
+        assert parse_tuning_config(False).active is False
+        assert parse_tuning_config(True) == TuningConfig()
+
+
+class TestParsing:
+    def test_full_block(self):
+        config = parse_tuning_config({"active": True, "interval_hours": 6, "auto_apply": False})
+        assert config.active is True
+        assert config.interval_hours == 6.0
+        assert config.auto_apply is False
+
+    def test_fractional_interval(self):
+        assert parse_tuning_config({"interval_hours": 0.5}).interval_hours == 0.5
+
+    def test_active_false_is_the_off_switch(self):
+        assert parse_tuning_config({"active": False}).active is False
+
+
+class TestFailFast:
+    def test_unknown_key_rejected(self):
+        with pytest.raises(TuningConfigError, match="unknown key"):
+            parse_tuning_config({"enabled": True})
+
+    def test_non_mapping_rejected(self):
+        with pytest.raises(TuningConfigError, match="must be a mapping"):
+            parse_tuning_config(["active"])
+
+    def test_boolean_rejected_where_number_expected(self):
+        with pytest.raises(TuningConfigError, match="interval_hours must be a number"):
+            parse_tuning_config({"interval_hours": True})
+
+    def test_string_interval_rejected(self):
+        with pytest.raises(TuningConfigError, match="interval_hours must be a number"):
+            parse_tuning_config({"interval_hours": "24"})
+
+    def test_zero_and_negative_interval_rejected(self):
+        for value in (0, -1):
+            with pytest.raises(TuningConfigError, match="must be positive"):
+                parse_tuning_config({"interval_hours": value})
+
+    def test_non_boolean_active_rejected(self):
+        with pytest.raises(TuningConfigError, match="active must be a boolean"):
+            parse_tuning_config({"active": 1})
+
+    def test_non_boolean_auto_apply_rejected(self):
+        with pytest.raises(TuningConfigError, match="auto_apply must be a boolean"):
+            parse_tuning_config({"auto_apply": "yes"})
+
+
+class TestValidatorDelegation:
+    def test_formation_validator_reports_tuning_errors(self):
+        from muxi.runtime.formation.config.validation import FormationValidator
+
+        validator = FormationValidator()
+        validator._validate_tuning_config({"interval_hours": False})
+        assert any("Invalid tuning configuration" in error for error in validator.result.errors)
+
+    def test_formation_validator_accepts_valid_block(self):
+        from muxi.runtime.formation.config.validation import FormationValidator
+
+        validator = FormationValidator()
+        validator._validate_tuning_config({"active": True, "interval_hours": 12})
+        assert not validator.result.errors
+
+
+class TestFileTransportDetection:
+    def test_no_logging_config(self):
+        assert yaml_declares_file_transport(None) is False
+        assert yaml_declares_file_transport({}) is False
+
+    def test_stdout_system_destination_is_not_a_file(self):
+        assert yaml_declares_file_transport({"system": {"destination": "stdout"}}) is False
+
+    def test_system_file_destination_detected(self):
+        assert (
+            yaml_declares_file_transport({"system": {"destination": "/var/log/muxi.jsonl"}}) is True
+        )
+
+    def test_conversation_file_stream_detected(self):
+        config = {
+            "conversation": {
+                "enabled": True,
+                "streams": [{"transport": "file", "destination": "./events.jsonl"}],
+            }
+        }
+        assert yaml_declares_file_transport(config) is True
+
+    def test_non_file_streams_ignored(self):
+        config = {
+            "conversation": {
+                "enabled": True,
+                "streams": [{"transport": "stdout"}, {"transport": "stream", "url": "http://x"}],
+            }
+        }
+        assert yaml_declares_file_transport(config) is False

--- a/tests/unit/test_tuning_service.py
+++ b/tests/unit/test_tuning_service.py
@@ -1,0 +1,281 @@
+"""Unit tests for the tuning loop (Self-Improving Formation, Phase 1).
+
+Pins one loop pass end-to-end against a real spool and a real
+CaptainsLogService (LLM mocked): spool aggregation into the bounded
+activity report, digest into the formation log, checkpoint semantics
+(delete vs keep, retry on transient failure), lifecycle start/stop, and
+the MuxiMdFile read/write/cache contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.log.service import CaptainsLogService
+from muxi.runtime.services.observability import spool as spool_module
+from muxi.runtime.services.observability.spool import reset_event_spool
+from muxi.runtime.services.tuning import MuxiMdFile, TuningConfig, TuningService
+from muxi.runtime.services.tuning.service import (
+    MAX_REPORT_CHARS,
+    _aggregate_segments,
+    _SpoolStats,
+)
+
+FORMATION_ID = "tuning-test-formation"
+
+DIGEST_RESPONSE = (
+    '{"summary": "The formation handled a small spike; one tool warned twice.", '
+    '"context": "Mostly FAQ traffic."}'
+)
+
+
+class FakeModel:
+    def __init__(self, response=DIGEST_RESPONSE):
+        self.response = response
+        self.calls = 0
+
+    async def generate_text(self, prompt, caching=True):
+        self.calls += 1
+        return self.response
+
+
+class FakeOverlord:
+    def __init__(self, captains_log):
+        self.captains_log = captains_log
+
+
+def spool_event(
+    name="agent.processing",
+    level="info",
+    timestamp=1783862400000,
+    user_id=None,
+    session_id=None,
+    request=None,
+    data=None,
+):
+    event = {"event": name, "level": level, "timestamp": timestamp}
+    if session_id:
+        event["session_id"] = session_id
+    if request:
+        event["request"] = request
+    payload = dict(data or {})
+    if user_id:
+        payload["user_id"] = user_id
+    if payload:
+        event["data"] = payload
+    return event
+
+
+@pytest.fixture
+def isolated_spool(tmp_path, monkeypatch):
+    monkeypatch.setattr(spool_module, "_spool_dir", lambda: str(tmp_path / "spool"))
+    reset_event_spool()
+    yield spool_module.get_event_spool()
+    reset_event_spool()
+
+
+@pytest.fixture
+def captains_log(tmp_path):
+    manager = DatabaseManager(f"sqlite:///{tmp_path}/log.db")
+    manager.create_tables(Base.metadata)
+    yield CaptainsLogService(manager, FORMATION_ID)
+    manager.engine.dispose()
+
+
+@pytest.fixture
+def tuning(captains_log):
+    return TuningService(TuningConfig(), FakeOverlord(captains_log))
+
+
+class TestAggregation:
+    def test_empty_segments_render_empty_report(self, isolated_spool):
+        report, user_ids, count = _aggregate_segments(isolated_spool, [])
+        assert report == ""
+        assert user_ids == []
+        assert count == 0
+
+    def test_report_captures_operational_shape(self, isolated_spool):
+        events = [
+            spool_event(name="request.received", user_id="alice", session_id="s1"),
+            spool_event(
+                name="mcp.tool.failed",
+                level="warning",
+                data={"description": "jira MCP timed out"},
+            ),
+            spool_event(
+                name="request.completed",
+                request={
+                    "id": "req-1",
+                    "user_id": "bob",
+                    "tokens": {
+                        "total": [120, 0.001],
+                        "breakdown": {"openai/gpt-4o-mini": [120, 0.001]},
+                    },
+                },
+            ),
+        ]
+        isolated_spool.write_lines([json.dumps(event) for event in events])
+        segments, _ = isolated_spool.read_for_digest()
+        report, user_ids, count = _aggregate_segments(isolated_spool, segments)
+
+        assert count == 3
+        assert user_ids == ["alice", "bob"]
+        assert "Window: 3 events" in report
+        assert "2 distinct user(s), 1 session(s), 1 tracked request(s)" in report
+        assert "- mcp.tool.failed: 1" in report
+        assert "e.g. jira MCP timed out" in report
+        assert "Total tokens across tracked requests: 120." in report
+        assert "- openai/gpt-4o-mini: 120" in report
+        # Raw identifiers stay out of the LLM-facing report.
+        assert "alice" not in report
+        assert "bob" not in report
+
+    def test_report_is_bounded(self):
+        stats = _SpoolStats()
+        for index in range(500):
+            stats.add(
+                spool_event(
+                    name=f"event.type.{index}",
+                    level="warning",
+                    data={"description": "d" * 200},
+                )
+            )
+        assert len(stats.render()) <= MAX_REPORT_CHARS
+
+    def test_last_token_snapshot_wins_per_request(self):
+        stats = _SpoolStats()
+        for total in (50, 120):
+            stats.add(
+                spool_event(
+                    request={"id": "req-1", "user_id": "u", "tokens": {"total": [total, 0.0]}}
+                )
+            )
+        total, _ = stats._token_totals()
+        assert total == 120
+
+
+class TestRunOnce:
+    def test_digest_pass_writes_entry_and_deletes_segments(
+        self, isolated_spool, captains_log, tuning
+    ):
+        isolated_spool.write_lines([json.dumps(spool_event(user_id="alice"))])
+        result = asyncio.run(tuning.run_once(FakeModel()))
+
+        assert result["events_read"] == 1
+        assert result["segments_read"] == 1
+        assert result["entries_written"] == 1
+        assert result["spool_committed"] is True
+        assert result["spool_segments_kept"] is False
+        assert isolated_spool._list_segments() == []
+        assert "small spike" in asyncio.run(captains_log.get_formation_context_block())
+        assert tuning.last_run == result
+
+    def test_keep_spool_segments_preserves_files(self, isolated_spool, captains_log):
+        tuning = TuningService(TuningConfig(), FakeOverlord(captains_log), keep_spool_segments=True)
+        isolated_spool.write_lines([json.dumps(spool_event())])
+        result = asyncio.run(tuning.run_once(FakeModel()))
+
+        assert result["spool_committed"] is True
+        assert result["spool_segments_kept"] is True
+        assert len(isolated_spool._list_segments()) == 1
+        # But the checkpoint advanced: nothing is digested twice.
+        again = asyncio.run(tuning.run_once(FakeModel()))
+        assert again["events_read"] == 0
+
+    def test_transient_failure_keeps_segments_for_retry(self, isolated_spool, captains_log, tuning):
+        isolated_spool.write_lines([json.dumps(spool_event())])
+        failed = asyncio.run(tuning.run_once(None))  # no model yet
+        assert failed["spool_committed"] is False
+        assert failed["entries_written"] == 0
+        assert len(isolated_spool._list_segments()) == 1
+
+        retried = asyncio.run(tuning.run_once(FakeModel()))
+        assert retried["events_read"] == 1
+        assert retried["spool_committed"] is True
+
+    def test_empty_spool_pass_is_clean(self, isolated_spool, tuning):
+        model = FakeModel()
+        result = asyncio.run(tuning.run_once(model))
+        assert result["events_read"] == 0
+        assert result["entries_written"] == 0
+        assert result["spool_committed"] is True
+        assert model.calls == 0
+
+    def test_missing_captains_log_still_consumes(self, isolated_spool):
+        tuning = TuningService(TuningConfig(), FakeOverlord(captains_log=None))
+        isolated_spool.write_lines([json.dumps(spool_event())])
+        result = asyncio.run(tuning.run_once(FakeModel()))
+        assert result["spool_committed"] is True
+        assert result["entries_written"] == 0
+        assert isolated_spool._list_segments() == []
+
+
+class TestLifecycle:
+    def test_inactive_config_never_starts(self, captains_log):
+        async def scenario():
+            tuning = TuningService(TuningConfig(active=False), FakeOverlord(captains_log))
+            tuning.start(lambda: FakeModel())
+            assert tuning._task is None
+            await tuning.stop()
+
+        asyncio.run(scenario())
+
+    def test_start_and_stop(self, captains_log):
+        async def scenario():
+            tuning = TuningService(TuningConfig(), FakeOverlord(captains_log))
+            tuning.start(lambda: FakeModel())
+            assert tuning._task is not None and not tuning._task.done()
+            await tuning.stop()
+            assert tuning._task is None
+
+        asyncio.run(scenario())
+
+
+class TestMuxiMdFile:
+    def test_absent_file_reads_none(self, tmp_path):
+        assert MuxiMdFile(str(tmp_path)).read() is None
+        assert MuxiMdFile(None).read() is None
+
+    def test_read_write_roundtrip(self, tmp_path):
+        muxi_md = MuxiMdFile(str(tmp_path))
+        path = muxi_md.write("# Learnings\n\n- Prefer reportlab over fpdf.")
+        assert path.endswith("MUXI.md")
+        assert muxi_md.read() == "# Learnings\n\n- Prefer reportlab over fpdf."
+
+    def test_lowercase_variant_resolved_and_reused_on_write(self, tmp_path):
+        (tmp_path / "muxi.md").write_text("hand-written")
+        muxi_md = MuxiMdFile(str(tmp_path))
+        assert muxi_md.read() == "hand-written"
+        muxi_md.write("curated")
+        assert (tmp_path / "muxi.md").read_text() == "curated"
+        # One file either way (case-insensitive filesystems collapse them).
+        assert len(list(tmp_path.iterdir())) == 1
+
+    def test_hand_edit_invalidates_cache(self, tmp_path):
+        import os
+
+        muxi_md = MuxiMdFile(str(tmp_path))
+        muxi_md.write("v1")
+        assert muxi_md.read() == "v1"
+        target = tmp_path / "MUXI.md"
+        target.write_text("v2")
+        os.utime(target, (0, 0))  # force an mtime change either direction
+        assert muxi_md.read() == "v2"
+
+    def test_deleted_file_reads_none_again(self, tmp_path):
+        muxi_md = MuxiMdFile(str(tmp_path))
+        muxi_md.write("v1")
+        (tmp_path / "MUXI.md").unlink()
+        assert muxi_md.read() is None
+
+    def test_write_without_directory_raises(self):
+        with pytest.raises(ValueError, match="no directory"):
+            MuxiMdFile(None).write("content")
+
+    def test_empty_file_reads_none(self, tmp_path):
+        (tmp_path / "MUXI.md").write_text("   \n")
+        assert MuxiMdFile(str(tmp_path)).read() is None


### PR DESCRIPTION
## Summary

Phase 1 of the Self-Improving Formation PRD: the formation observes itself. Every observability event tees into an internal checkpointed spool; a scheduled tuning loop (on by default) aggregates it into a bounded activity report and digests it into a formation-scope captain's log entry visible to every user behind a sentence-level privacy lint; and MUXI.md (the formation's CLAUDE.md, sibling of SOUL.md) steers behavior — hand-written on day one, tuner-curated in Phase 2.

### Event spool (`services/observability/spool.py`)
- Always-on tee from the EventLogger's background writer (hot path never touches disk); segmented JSONL under the formation's observability dir. Internal, not configuration.
- 32MB segments, 512MB cap — oldest closed segments drop with a `spool.overrun` event PLUS an unfilterable marker line in the spool itself, so the digest always learns about dropped telemetry.
- Checkpointed single-consumer reads: `read_for_digest` rotates first so every returned segment is closed; post-digest writes always open a fresh segment (never resume a checkpointed one). Digested segments are deleted UNLESS the yaml declares a file transport — then the files are the dev's.
- Drop-aware writer-queue backpressure: a stalled writer sheds spool writes rather than growing memory; configured outputs keep their behavior.

### Tuning loop (`services/tuning/`)
- `tuning:` block — `active`, `interval_hours`, `auto_apply`; on by default, closed-key fail-fast validation (validator delegates to the service-level parser).
- One pass: read spool since checkpoint → streaming aggregation into a bounded report (event/level/problem clusters with redacted samples, token usage per model, traffic shape — raw identifiers never reach the LLM) → formation digest → checkpoint. Consumed-flag semantics: transient failures leave segments for retry.

### Formation captain's log
- Same storage/date-grain as the per-user log, under a reserved `__formation__` sentinel (excluded from per-user memory-lint enumeration); recorded as formation-scope `log.entry` memory events.
- Sentence-level privacy lint on every write: known user ids, emails, SSNs, card-length digit runs (incl. space/hyphen separators), sensitive keywords, PERSON/ADDRESS/FINANCIAL entities (fail-closed on detector errors). Drops the offending sentence, never the digest; ORG/DATE_TIME survive ("Jira rate-limits 14:00-16:00" is the point).
- Injected into EVERY user's context as a "Formation operations log" block.

### MUXI.md
- Bounded markdown beside SOUL.md — formation-owned, git-trackable, human-editable. Injected wherever SOUL.md is injected plus at the top of per-turn context. mtime-cached handle: hand edits and API replacements land next turn, no restart. Locked, uniquely-named-tempfile atomic writes.

### API
- `GET /tuning` (live MUXI.md), `POST /tuning` (replace), `POST /tuning/run` (manual pass) — admin key auth. New APIEventType/APIObjectType enums.

### Observability
- New validated events: `spool.overrun`, `formation_log.digested`, `tuning.run`; `validate_events.py` stays 100% (1442 events).

## Testing
- **Unit**: 89 new/updated tests (spool rotation/checkpoint/cap/tee, config fail-fast, digest + lint, tuning pass semantics, MuxiMdFile); full suite 3837 passed. Suite-wide conftest guard isolates the spool singleton into tmp_path.
- **E2E**: new `27_tuning` area, all 4 passed live against real OpenAI:
  - 27A1 spool lifecycle — written by default, digested segments delete + checkpoint, fresh segment after digest, undigested segment survives restart
  - 27A2 file-transport retention — digested segments kept, never re-digested
  - 27A3 multi-user digest — 1 formation entry, seeded user ids kept out by the lint, ops log present in a different user's agent-bound context bundle
  - 27A4 /tuning API — GET/POST/auth/run, and a POST-replaced MUXI.md rule provably steered the very next turn ("4 AMBER-FALCON")
- black/isort/ruff/mypy clean; CodeRabbit round: 5 findings fixed, 2 skipped with rationale (bounded one-batch cap overshoot; warning samples are PII-redacted upstream and double-gated by the lint).

Phase 2 (tuner step: detection, distillation, MUXI.md curation, pending flow, morning report) follows in its own PR.
