### PR TITLE
feat(tuning): self-improving formation P2 — tuner step, pending flow, /learnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 ## [unreleased]
 
+### Self-improving formation - tuner step, pending flow, /learnings (Phase 2)
+
+The tuning loop now closes the observe-learn-steer cycle (Self-Improving
+Formation PRD, Phase 2): each pass distills the activity report into
+concrete learnings, curates MUXI.md, tracks every learning as an
+experiment with a watch window, and reports to the formation owner:
+
+- Tuner step: after the digest, the same pass asks the LLM to detect
+  patterns (cost hotspots, misrouted request classes, flaky tools) and
+  produce a revised MUXI.md plus structured learnings and prose
+  recommendations. Tuner-written content passes a line-level privacy
+  lint (markdown survives), the bounded-file contract is enforced on
+  the tuner's own writes, and deployment-shaped ideas (yaml edits, plan
+  upgrades) are never written to MUXI.md -- they ship as
+  recommendations for a human. The activity report now names failing
+  tools explicitly so learnings stay specific.
+- Experiments: learnings live in a sidecar store
+  (`observability/tuner/experiments.json`) with content-hash dedup
+  across their whole lifecycle -- pending, active, retired, dismissed.
+  Applying a learning opens a watch window (default 7 days) frozen at
+  the proposal-time baseline; when the watched metric has not improved
+  by 10% at window close, the learning is retired and never
+  re-proposed. Dismissals are equally terminal.
+- Pending flow: with `tuning.auto_apply: false` the tuner writes
+  PENDING-MUXI.md beside the live file and nothing changes until a
+  human acts -- `/learnings` (show/pending/apply/dismiss builtin,
+  mutating verbs refused in multi-user mode), the admin API
+  (`GET`/`PATCH`/`DELETE /tuning/pending`), or the morning report's
+  buttons.
+- Morning report: each pass with anything to say notifies the owner
+  through the formation's proactive channels -- applied or suggested
+  revision, new learnings, retirements, recommendations. Under manual
+  mode the report carries an apply/dismiss options widget rendered
+  natively on channels (P3 machinery); the button press resolves
+  session-independently.
+- NotificationRouter: `notify()` gains an optional `ui=` widget
+  pass-through into channel rendering and webhook payloads.
+- Spool fix: segment numbering now survives a delete-all commit
+  (checkpoint participates in the sequence scan), so post-digest events
+  can never land in an already-checkpointed name and vanish.
+- Observability: new `tuning.applied`, `tuning.suggested`,
+  `tuning.retired`, `tuning.dismissed` events plus pending-surface API
+  events; `validate_events.py` stays 100%.
+- E2E: 27A5 (auto-apply steering + deterministic watch-window
+  retirement), 27A6 (pending flow through /learnings and the admin
+  API, terminal dismissals), 27A7 (morning report delivery + widget
+  round-trip from an unrelated session).
+
 ### Self-improving formation - spool, formation digest, MUXI.md (Phase 1)
 
 The formation now observes itself (Self-Improving Formation PRD,

--- a/e2e/tests/27_tuning/test_27a5_tuner_auto_apply.py
+++ b/e2e/tests/27_tuning/test_27a5_tuner_auto_apply.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Test 27A5: tuner auto-apply (Self-Improving Formation, Phase 2 step 2).
+
+A planted flaky-tool pattern in the spool -> one tuning pass (real LLM)
+distills learnings and applies a MUXI.md revision directly (auto_apply
+default) -> the revision is provably injected into the next turn's
+context -> a planted expired experiment whose watched metric did not
+move is deterministically retired on a later pass.
+"""
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from tuning_common import (
+    build_formation,
+    chat,
+    experiments_path_for,
+    load_formation,
+    plant_tool_failures,
+    run_tuning_pass,
+    spool_dir_for,
+    teardown,
+    unique_formation_id,
+    wait_for_segments,
+)
+
+USER = "tuner-e2e-user"
+
+
+async def main():
+    print("MUXI Runtime - Test 27A5: tuner auto-apply + watch-window retirement")
+    print("=" * 60)
+
+    formation = None
+    formation_id = unique_formation_id("autoapply")
+    tmp = Path(tempfile.mkdtemp(prefix="muxi-tuning-27a5-"))
+    transcript = []
+    try:
+        formation_dir = build_formation(tmp, formation_id)
+        formation, overlord = await load_formation(formation_dir)
+        print(f"Formation loaded: {formation_id}")
+
+        # 1. Real traffic plus the planted flaky-tool pattern.
+        task = "What is 3 + 4? Digits only."
+        reply = await chat(overlord, task, USER, "tuner-session")
+        transcript.append((task, reply))
+        print(f"User: {task}\nSystem: {reply}")
+        plant_tool_failures(count=30, tool="acme-crm")
+        wait_for_segments(spool_dir_for(formation_id))
+
+        # 2. One pass: digest + tune. auto_apply is the default, so the
+        #    revision lands in the live MUXI.md.
+        result = await run_tuning_pass(overlord)
+        print(f"Tuning pass: {result}")
+        assert result["spool_committed"] is True
+        assert result["muxi_md_applied"] is True, f"the tuner did not apply a revision: {result}"
+        muxi_md = overlord.muxi_md.read()
+        assert muxi_md, "MUXI.md is empty after an applied revision"
+        print(f"Applied MUXI.md:\n{muxi_md}")
+
+        # 3. Learnings recorded as active experiments with open windows,
+        #    and the planted flaky tool surfaced in the distillation
+        #    (in the applied guidance or in a recorded learning).
+        experiments = json.loads(experiments_path_for(formation_id).read_text())["experiments"]
+        active = [record for record in experiments if record["status"] == "active"]
+        assert active, f"no active experiment was recorded: {experiments}"
+        print(f"Recorded {len(active)} active learning(s):")
+        for record in active:
+            print(f"  - {record['learning']} (metric: {record['metric_key']})")
+        distilled = (
+            muxi_md.lower()
+            + " ".join(
+                (record.get("learning") or "") + (record.get("evidence") or "") for record in active
+            ).lower()
+        )
+        assert "acme-crm" in distilled or "acme" in distilled, (
+            "the planted flaky-tool pattern did not surface in the applied "
+            f"guidance or recorded learnings: {muxi_md!r} / {active}"
+        )
+        assert any(
+            record["metric_key"] == "problem:mcp.tool.failed" for record in active
+        ), f"no learning watches the planted failure metric: {active}"
+
+        # 4. The applied guidance is injected into the very next turn's
+        #    context (agent-bound bundle seam; no restart).
+        bundle = await overlord.chat_orchestrator._build_clean_chat_context(
+            current_user_message="Anything to know?",
+            user_id=USER,
+            session_id="tuner-session",
+        )
+        assert muxi_md in bundle["user_profile_text"], (
+            "the applied MUXI.md revision was not injected into the next " "turn's context"
+        )
+        print("Applied revision present in the next turn's context bundle")
+
+        # 5. Watch-window retirement is deterministic: plant an expired
+        #    experiment whose baseline is near zero, keep the failures
+        #    flowing, and the next pass retires it (the rate can never
+        #    improve on a near-zero baseline while failures persist).
+        path = experiments_path_for(formation_id)
+        payload = json.loads(path.read_text())
+        payload["experiments"].append(
+            {
+                "content_hash": "planted-hash-for-retirement",
+                "status": "active",
+                "learning": "Planted learning that changed nothing.",
+                "evidence": "planted",
+                "metric_key": "problem:mcp.tool.failed",
+                "baseline": 0.0001,
+                "watch": {"opened_at": time.time() - 8 * 24 * 3600, "window_hours": 168},
+                "created_at": time.time(),
+                "updated_at": time.time(),
+            }
+        )
+        path.write_text(json.dumps(payload))
+        plant_tool_failures(count=30, tool="acme-crm")  # rate stays 1.0 -- no movement
+        result = await run_tuning_pass(overlord)
+        print(f"Retirement pass: {result}")
+        assert result["learnings_retired"] >= 1, f"no learning was retired: {result}"
+
+        experiments = json.loads(path.read_text())["experiments"]
+        planted = next(
+            record
+            for record in experiments
+            if record["content_hash"] == "planted-hash-for-retirement"
+        )
+        assert planted["status"] == "retired", f"planted learning was not retired: {planted}"
+        assert planted["outcome"]["moved"] is False
+        print("Planted no-movement learning retired on the later pass")
+
+        print("\n" + "=" * 40)
+        print("\n### Test Result:")
+        print("  SUCCESS: tuner auto-apply works end-to-end")
+        print("  - a planted flaky-tool pattern was distilled into MUXI.md (auto_apply)")
+        print("  - learnings were recorded as active experiments with open windows")
+        print("  - the applied revision steers the very next turn's context")
+        print("  - a no-movement learning was deterministically retired on a later run")
+        print("\n" + "=" * 40)
+        print("\n### Chat transcript:")
+        for task, reply in transcript:
+            print(f"\nUser: {task}")
+            print(f"System: {reply}")
+
+        print("\nTest 27A5 PASSED")
+        return True
+
+    except Exception as e:
+        print(f"\nTest failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+    finally:
+        if formation is not None:
+            await teardown(formation, formation_id)
+        import shutil
+
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0 if success else 1)

--- a/e2e/tests/27_tuning/test_27a6_pending_flow.py
+++ b/e2e/tests/27_tuning/test_27a6_pending_flow.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Test 27A6: pending flow (auto_apply: false) + /learnings + pending API.
+
+Under manual mode the tuner writes PENDING-MUXI.md and never touches the
+live file. The suggestion is reviewed and accepted through the built-in
+/learnings command (chat path), a later suggestion is dismissed through
+DELETE /tuning/pending (admin API), and the dismissal is remembered: the
+dismissed experiments stay terminal across subsequent passes.
+"""
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import httpx
+from tuning_common import (
+    ADMIN_KEY,
+    build_formation,
+    chat,
+    experiments_path_for,
+    load_formation,
+    plant_tool_failures,
+    run_tuning_pass,
+    spool_dir_for,
+    teardown,
+    unique_formation_id,
+    wait_for_segments,
+)
+
+PORT = 8273
+BASE_URL = f"http://127.0.0.1:{PORT}/v1"
+HEADERS = {"X-Muxi-Admin-Key": ADMIN_KEY, "Content-Type": "application/json"}
+
+HAND_WRITTEN = "# Operational learnings\n\n- Keep replies terse.\n"
+USER = "pending-flow-user"
+
+
+async def main():
+    print("MUXI Runtime - Test 27A6: pending flow + /learnings + pending API")
+    print("=" * 60)
+
+    formation = None
+    formation_id = unique_formation_id("pending")
+    tmp = Path(tempfile.mkdtemp(prefix="muxi-tuning-27a6-"))
+    transcript = []
+    try:
+        formation_dir = build_formation(
+            tmp,
+            formation_id,
+            server_port=PORT,
+            muxi_md=HAND_WRITTEN,
+            manual_tuning=True,
+            commands=True,
+        )
+        formation, overlord = await load_formation(formation_dir)
+        await formation.start_server(block=False)
+        await asyncio.sleep(2)
+        print(f"Formation loaded with server: {formation_id}")
+
+        # 1. Traffic + planted pattern -> one pass writes PENDING-MUXI.md
+        #    and leaves the live file alone.
+        task = "What is 5 + 5? Digits only."
+        reply = await chat(overlord, task, USER, "pending-session")
+        transcript.append((task, reply))
+        print(f"User: {task}\nSystem: {reply}")
+        plant_tool_failures(count=30, tool="jira")
+        wait_for_segments(spool_dir_for(formation_id))
+
+        result = await run_tuning_pass(overlord)
+        print(f"Tuning pass: {result}")
+        assert result["muxi_md_suggested"] is True, f"no suggestion was written: {result}"
+        assert result["muxi_md_applied"] is False
+        assert overlord.muxi_md.read() == HAND_WRITTEN.strip(), "live MUXI.md was touched"
+        suggestion = overlord.muxi_md.read_pending()
+        assert suggestion, "PENDING-MUXI.md is missing"
+        assert (formation_dir / "PENDING-MUXI.md").is_file()
+        print(f"Suggested revision:\n{suggestion}")
+
+        # 2. GET /tuning/pending serves the suggestion.
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.get(f"{BASE_URL}/tuning/pending", headers=HEADERS)
+            assert response.status_code == 200, response.text
+            assert response.json()["data"]["content"] == suggestion
+            print("GET /tuning/pending serves the suggestion")
+
+        # 3. Review and accept through the chat path: /learnings.
+        for command, needles in (
+            ("/learnings", ("Keep replies terse.", "/learnings pending")),
+            ("/learnings pending", (suggestion.splitlines()[0],)),
+        ):
+            reply = (
+                await overlord.chat(
+                    message=command,
+                    user_id=USER,
+                    session_id="pending-session",
+                    use_async=False,
+                    stream=False,
+                )
+            ).content
+            transcript.append((command, reply))
+            print(f"User: {command}\nSystem: {reply[:160]}")
+            for needle in needles:
+                assert needle in reply, f"{command} reply missing {needle!r}: {reply!r}"
+
+        reply = (
+            await overlord.chat(
+                message="/learnings apply",
+                user_id=USER,
+                session_id="pending-session",
+                use_async=False,
+                stream=False,
+            )
+        ).content
+        transcript.append(("/learnings apply", reply))
+        print(f"User: /learnings apply\nSystem: {reply}")
+        assert "Applied" in reply, f"apply did not confirm: {reply!r}"
+        assert overlord.muxi_md.read() == suggestion, "pending was not promoted to live"
+        assert overlord.muxi_md.read_pending() is None
+
+        experiments = json.loads(experiments_path_for(formation_id).read_text())["experiments"]
+        assert any(record["status"] == "active" for record in experiments), experiments
+        print("/learnings apply promoted the suggestion; learnings are under observation")
+
+        # 4. A later suggestion is dismissed through the admin API, and
+        #    the dismissal is terminal.
+        plant_tool_failures(count=30, tool="confluence")
+        result = await run_tuning_pass(overlord)
+        print(f"Second pass: {result}")
+        if not result["muxi_md_suggested"]:
+            # The tuner may legitimately decide the live file already covers
+            # it; force a reviewable suggestion through the file contract.
+            overlord.muxi_md.write_pending(overlord.muxi_md.read() + "\n- Placeholder suggestion.")
+        assert overlord.muxi_md.read_pending() is not None
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.delete(f"{BASE_URL}/tuning/pending", headers=HEADERS)
+            assert response.status_code == 200, response.text
+            print("DELETE /tuning/pending dismissed the suggestion")
+
+            # Dismissing again is a clean 404: nothing is pending.
+            response = await client.delete(f"{BASE_URL}/tuning/pending", headers=HEADERS)
+            assert response.status_code == 404, response.text
+
+        assert overlord.muxi_md.read_pending() is None
+        experiments = json.loads(experiments_path_for(formation_id).read_text())["experiments"]
+        dismissed_hashes = {
+            record["content_hash"] for record in experiments if record["status"] == "dismissed"
+        }
+        assert not any(
+            record["status"] == "pending" for record in experiments
+        ), f"pending records survived the dismissal: {experiments}"
+
+        # 5. Dismissals survive later passes: the same hashes never leave
+        #    the terminal state.
+        plant_tool_failures(count=10, tool="confluence")
+        await run_tuning_pass(overlord)
+        experiments = json.loads(experiments_path_for(formation_id).read_text())["experiments"]
+        for record in experiments:
+            if record["content_hash"] in dismissed_hashes:
+                assert record["status"] == "dismissed", f"dismissal was resurrected: {record}"
+        print("Dismissed learnings stayed terminal across a later pass")
+
+        print("\n" + "=" * 40)
+        print("\n### Test Result:")
+        print("  SUCCESS: the pending flow works end-to-end")
+        print("  - auto_apply: false wrote PENDING-MUXI.md and left the live file alone")
+        print("  - GET /tuning/pending served the suggestion")
+        print("  - /learnings showed, previewed, and applied the suggestion")
+        print("  - DELETE /tuning/pending dismissed a later suggestion (404 when re-dismissed)")
+        print("  - dismissed learnings stayed terminal across a later pass")
+        print("\n" + "=" * 40)
+        print("\n### Chat transcript:")
+        for task, reply in transcript:
+            print(f"\nUser: {task}")
+            print(f"System: {reply}")
+
+        print("\nTest 27A6 PASSED")
+        return True
+
+    except Exception as e:
+        print(f"\nTest failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+    finally:
+        if formation is not None:
+            await teardown(formation, formation_id)
+        import shutil
+
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0 if success else 1)

--- a/e2e/tests/27_tuning/test_27a7_morning_report.py
+++ b/e2e/tests/27_tuning/test_27a7_morning_report.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+Test 27A7: morning report delivery + apply/dismiss widget round-trip.
+
+A tuning pass under auto_apply: false delivers its report to the
+formation's declared channel (local sink standing in for the channel
+bridge) with the apply/dismiss options widget rendered as native
+buttons -- and a button press (the channel's ui_response path) applies
+the pending suggestion without any session correlation.
+"""
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+from aiohttp import web
+from tuning_common import (
+    build_formation,
+    chat,
+    load_formation,
+    plant_tool_failures,
+    run_tuning_pass,
+    spool_dir_for,
+    teardown,
+    unique_formation_id,
+    wait_for_segments,
+)
+
+HAND_WRITTEN = "# Operational learnings\n\n- Keep replies terse.\n"
+USER = "morning-report-user"
+
+
+class Sink:
+    """Local aiohttp server standing in for the channel bridge."""
+
+    def __init__(self):
+        self.requests = []
+        self.runner = None
+        self.port = None
+
+    async def _handle(self, request):
+        self.requests.append(await request.json())
+        return web.Response(status=200)
+
+    async def start(self):
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", self._handle)
+        self.runner = web.AppRunner(app)
+        await self.runner.setup()
+        site = web.TCPSite(self.runner, "127.0.0.1", 0)
+        await site.start()
+        self.port = site._server.sockets[0].getsockname()[1]
+        return self
+
+    async def stop(self):
+        if self.runner:
+            await self.runner.cleanup()
+
+
+async def main():
+    print("MUXI Runtime - Test 27A7: morning report + widget round-trip")
+    print("=" * 60)
+
+    formation = None
+    sink = None
+    formation_id = unique_formation_id("report")
+    tmp = Path(tempfile.mkdtemp(prefix="muxi-tuning-27a7-"))
+    transcript = []
+    try:
+        sink = await Sink().start()
+        formation_dir = build_formation(
+            tmp,
+            formation_id,
+            muxi_md=HAND_WRITTEN,
+            manual_tuning=True,
+            proactive_url=f"http://127.0.0.1:{sink.port}/report",
+        )
+        formation, overlord = await load_formation(formation_dir)
+        print(f"Formation loaded: {formation_id} (sink on port {sink.port})")
+
+        # 1. Traffic + planted pattern -> pass suggests and reports.
+        task = "What is 6 + 1? Digits only."
+        reply = await chat(overlord, task, USER, "report-session")
+        transcript.append((task, reply))
+        print(f"User: {task}\nSystem: {reply}")
+        plant_tool_failures(count=30, tool="jira")
+        wait_for_segments(spool_dir_for(formation_id))
+
+        result = await run_tuning_pass(overlord)
+        print(f"Tuning pass: {result}")
+        assert result["muxi_md_suggested"] is True, f"no suggestion was written: {result}"
+        assert result["report_delivered"] is True, f"the report was not delivered: {result}"
+        suggestion = overlord.muxi_md.read_pending()
+        assert suggestion, "PENDING-MUXI.md is missing"
+
+        # 2. The report landed on the declared channel with the widget
+        #    rendered as native buttons (P3 template machinery).
+        assert sink.requests, "the channel sink received nothing"
+        payload = sink.requests[-1]
+        print(f"Channel payload:\n{json.dumps(payload, indent=2)[:800]}")
+        assert "Tuning report" in payload["text"]
+        assert "PENDING-MUXI.md" in payload["text"]
+        assert "/learnings apply" in payload["text"], "text fallback instructions are missing"
+        buttons = payload["reply_markup"]["inline_keyboard"]
+        callbacks = [button["callback_data"] for row in buttons for button in row]
+        labels = [button["text"] for row in buttons for button in row]
+        assert labels == ["Apply", "Dismiss"], f"unexpected buttons: {labels}"
+        widget_id = callbacks[0].split("#")[0]
+        assert callbacks == [f"{widget_id}#0", f"{widget_id}#1"]
+        print(f"Report delivered with apply/dismiss buttons (widget {widget_id})")
+
+        # 3. A button press rides the ui_response path: the channel posts
+        #    the callback data, the runtime decodes it to {id, index},
+        #    and the tuning intercept applies the suggestion -- on a
+        #    session that never saw the report.
+        response = await overlord.chat(
+            message="[button press]",
+            user_id=USER,
+            session_id="a-completely-different-session",
+            use_async=False,
+            stream=False,
+            ui_response={"id": widget_id, "index": 0},
+        )
+        transcript.append((f"[button press {callbacks[0]}]", response.content))
+        print(f"Button press reply: {response.content}")
+        assert "Applied" in response.content, f"the press did not apply: {response.content!r}"
+        assert overlord.muxi_md.read() == suggestion, "pending was not promoted to live"
+        assert overlord.muxi_md.read_pending() is None
+
+        # 4. A stale press after resolution falls through to normal chat
+        #    (the widget is gone; the message stands alone).
+        response = await overlord.chat(
+            message="What is 2 + 2? Digits only.",
+            user_id=USER,
+            session_id="report-session",
+            use_async=False,
+            stream=False,
+            ui_response={"id": widget_id, "index": 0},
+        )
+        transcript.append(("stale press + question", response.content))
+        print(f"Stale press reply: {response.content}")
+        assert "4" in response.content, f"stale press broke the normal turn: {response.content!r}"
+
+        print("\n" + "=" * 40)
+        print("\n### Test Result:")
+        print("  SUCCESS: the morning report works end-to-end")
+        print("  - the tuning pass delivered its report to the declared channel")
+        print("  - the apply/dismiss widget rendered as native channel buttons")
+        print("  - a button press applied the suggestion from an unrelated session")
+        print("  - a stale press fell through to a normal chat turn")
+        print("\n" + "=" * 40)
+        print("\n### Chat transcript:")
+        for task, reply in transcript:
+            print(f"\nUser: {task}")
+            print(f"System: {reply}")
+
+        print("\nTest 27A7 PASSED")
+        return True
+
+    except Exception as e:
+        print(f"\nTest failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+    finally:
+        if formation is not None:
+            await teardown(formation, formation_id)
+        if sink is not None:
+            await sink.stop()
+        import shutil
+
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0 if success else 1)

--- a/e2e/tests/27_tuning/tuning_common.py
+++ b/e2e/tests/27_tuning/tuning_common.py
@@ -1,5 +1,5 @@
 """
-Shared helpers for the 27_tuning e2e area (Self-Improving Formation, Phase 1).
+Shared helpers for the 27_tuning e2e area (Self-Improving Formation).
 
 Every test generates its formation at runtime into a temp directory (the
 watch-area standalone pattern) with a UNIQUE formation id: the event
@@ -67,6 +67,33 @@ logging:
     enabled: false
 """
 
+MANUAL_TUNING_BLOCK = """
+tuning:
+  auto_apply: false
+"""
+
+COMMANDS_BLOCK = """
+commands:
+  enabled: true
+"""
+
+PROACTIVE_BLOCK = """
+proactive:
+  channels:
+    report-chan:
+      transformer: report-t
+  default_channel: report-chan
+"""
+
+REPORT_TRANSFORMER = """\
+name: report-t
+endpoint:
+  url: {url}
+body:
+  text: "${{{{ response.content }}}}"
+  reply_markup: "${{{{ ui.telegram.reply_markup }}}}"
+"""
+
 SERVER_BLOCK = """
 server:
   enabled: true
@@ -96,6 +123,9 @@ def build_formation(
     file_logging: bool = False,
     server_port: Optional[int] = None,
     muxi_md: Optional[str] = None,
+    manual_tuning: bool = False,
+    commands: bool = False,
+    proactive_url: Optional[str] = None,
 ) -> Path:
     """Generate a tuning e2e formation under ``base_dir`` and return its path."""
     formation_dir = base_dir / "formation"
@@ -106,6 +136,17 @@ def build_formation(
         content += FILE_LOGGING_BLOCK.format(destination=str(base_dir / "system.jsonl"))
     if server_port is not None:
         content += SERVER_BLOCK.format(port=server_port, admin_key=ADMIN_KEY, client_key=CLIENT_KEY)
+    if manual_tuning:
+        content += MANUAL_TUNING_BLOCK
+    if commands:
+        content += COMMANDS_BLOCK
+    if proactive_url is not None:
+        content += PROACTIVE_BLOCK
+        transformers_dir = formation_dir / "transformers"
+        transformers_dir.mkdir()
+        (transformers_dir / "report-t.yaml").write_text(
+            REPORT_TRANSFORMER.format(url=proactive_url)
+        )
     (formation_dir / "formation.yaml").write_text(content)
     if muxi_md is not None:
         (formation_dir / "MUXI.md").write_text(muxi_md)
@@ -166,6 +207,48 @@ async def run_tuning_pass(overlord) -> dict:
         overlord.tuning_service is not None
     ), "tuning service was not initialized (it is on by default)"
     return await overlord.tuning_service.run_once(digest_model(overlord), trigger="manual")
+
+
+def experiments_path_for(formation_id: str) -> Path:
+    """Where the tuner's experiment memories live for this formation id."""
+    return Path.home() / ".muxi" / formation_id / "observability" / "tuner" / "experiments.json"
+
+
+def plant_tool_failures(count: int = 30, tool: str = "jira") -> None:
+    """Write a planted flaky-tool pattern straight into the event spool.
+
+    The PRD's tuner fixture: a tool failing 14:00-16:00. The spool is an
+    internal JSONL buffer, so the fixture writes the same shape the
+    logger tee produces.
+    """
+    import json as json_module
+
+    from muxi.runtime.services.observability.spool import get_event_spool
+
+    base_ts = 1783864800000  # 14:00 UTC
+    # Distinct descriptions: the report keeps a few deduplicated samples
+    # per cluster, so variety keeps the tool name salient in all of them.
+    problems = [
+        f"{tool} MCP request timed out after 30s",
+        f"{tool} MCP returned 429 (rate limited)",
+        f"{tool} MCP connection reset by peer",
+    ]
+    events = []
+    for index in range(count):
+        events.append(
+            json_module.dumps(
+                {
+                    "event": "mcp.tool.failed",
+                    "level": "warning",
+                    "timestamp": base_ts + index * 240_000,  # spread across 2h
+                    "data": {
+                        "description": problems[index % len(problems)],
+                        "tool": tool,
+                    },
+                }
+            )
+        )
+    get_event_spool().write_lines(events)
 
 
 async def teardown(formation, formation_id: Optional[str] = None) -> None:

--- a/src/muxi/runtime/datatypes/api.py
+++ b/src/muxi/runtime/datatypes/api.py
@@ -40,6 +40,9 @@ class APIEventType(str, Enum):
     TUNING_RETRIEVED = "tuning.retrieved"
     TUNING_UPDATED = "tuning.updated"
     TUNING_RUN_COMPLETED = "tuning.run.completed"
+    TUNING_PENDING_RETRIEVED = "tuning.pending.retrieved"
+    TUNING_PENDING_APPLIED = "tuning.pending.applied"
+    TUNING_PENDING_DISMISSED = "tuning.pending.dismissed"
 
     MEMORY_CREATED = "memory.created"
     MEMORY_RETRIEVED = "memory.retrieved"

--- a/src/muxi/runtime/datatypes/observability.py
+++ b/src/muxi/runtime/datatypes/observability.py
@@ -581,6 +581,18 @@ class SystemEvents(Enum):
     TUNING_RUN = "tuning.run"
     # When one tuning loop pass completes (scheduled or manual trigger)
 
+    TUNING_APPLIED = "tuning.applied"
+    # When a MUXI.md revision goes live (auto_apply or pending accepted)
+
+    TUNING_SUGGESTED = "tuning.suggested"
+    # When the tuner writes a PENDING-MUXI.md suggestion for review
+
+    TUNING_RETIRED = "tuning.retired"
+    # When a learning's watched metric did not move within its window
+
+    TUNING_DISMISSED = "tuning.dismissed"
+    # When a pending suggestion is dismissed (hashes are never re-proposed)
+
     # ===================================================================
     # NETWORK/COMMUNICATION INFRASTRUCTURE
     # ===================================================================

--- a/src/muxi/runtime/formation/builtin_commands.py
+++ b/src/muxi/runtime/formation/builtin_commands.py
@@ -751,6 +751,77 @@ async def _cmd_reset(ctx: BuiltinCommandContext) -> str:
 
 
 # ===================================================================
+# /learnings (Self-Improving Formation: MUXI.md suggestion flow)
+# ===================================================================
+
+_LEARNINGS_USAGE = "Usage: /learnings [pending | apply | dismiss]"
+
+
+async def _cmd_learnings(ctx: BuiltinCommandContext) -> str:
+    muxi_md = getattr(ctx.overlord, "muxi_md", None)
+    if muxi_md is None:
+        return "Learnings are not available: this formation has no MUXI.md surface."
+
+    tokens = ctx.args.split()
+    action = tokens[0].lower() if tokens else "show"
+    if action not in ("show", "pending", "apply", "dismiss"):
+        return _LEARNINGS_USAGE
+
+    if action == "show":
+        content = muxi_md.read()
+        lines = []
+        if content:
+            lines.append("Live MUXI.md:")
+            lines.append("")
+            lines.append(content)
+        else:
+            lines.append("No MUXI.md exists yet -- the formation has no recorded learnings.")
+        if muxi_md.read_pending() is not None:
+            lines.append("")
+            lines.append(
+                "A suggested revision awaits review: /learnings pending to see it, "
+                "/learnings apply to accept, /learnings dismiss to discard."
+            )
+        return "\n".join(lines)
+
+    if action == "pending":
+        pending = muxi_md.read_pending()
+        if pending is None:
+            return "There is no pending MUXI.md suggestion."
+        return (
+            "Suggested MUXI.md revision (diff against the live file):\n\n"
+            f"{pending}\n\n"
+            "/learnings apply to accept, /learnings dismiss to discard."
+        )
+
+    # Mutating verbs. In multi-user mode any chat user could otherwise
+    # steer every user's context; the admin API is the gated surface.
+    if getattr(ctx.overlord, "is_multi_user", False):
+        return (
+            "This formation runs in multi-user mode; applying or dismissing "
+            "suggestions is an operator action (use the admin /tuning API)."
+        )
+    tuning_service = getattr(ctx.overlord, "tuning_service", None)
+    if tuning_service is None:
+        return "Learnings management is not available: tuning is not active."
+
+    try:
+        if action == "apply":
+            result = tuning_service.apply_pending()
+            return (
+                "Applied the suggested MUXI.md revision "
+                f"({result['learnings_activated']} learning(s) now under observation)."
+            )
+        result = tuning_service.dismiss_pending()
+        return (
+            "Dismissed the suggested MUXI.md revision "
+            f"({result['learnings_dismissed']} learning(s) will not be re-proposed)."
+        )
+    except (ValueError, OSError) as e:
+        return f"Could not {action} the suggestion: {e}"
+
+
+# ===================================================================
 # /setup (deterministic multi-step flow)
 # ===================================================================
 
@@ -1055,5 +1126,13 @@ register_builtin(
         description="Clear this session's conversation history",
         usage="/reset",
         handler=_cmd_reset,
+    )
+)
+register_builtin(
+    BuiltinCommand(
+        name="learnings",
+        description="View and manage the formation's learned guidance (MUXI.md)",
+        usage="/learnings [pending|apply|dismiss]",
+        handler=_cmd_learnings,
     )
 )

--- a/src/muxi/runtime/formation/builtin_commands.py
+++ b/src/muxi/runtime/formation/builtin_commands.py
@@ -789,7 +789,7 @@ async def _cmd_learnings(ctx: BuiltinCommandContext) -> str:
         if pending is None:
             return "There is no pending MUXI.md suggestion."
         return (
-            "Suggested MUXI.md revision (diff against the live file):\n\n"
+            "Suggested MUXI.md revision (full replacement for the live file):\n\n"
             f"{pending}\n\n"
             "/learnings apply to accept, /learnings dismiss to discard."
         )

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -6784,6 +6784,15 @@ Agent response: {raw_response}"""
             model_override = model_override or command_result.model
             bypass_workflow_approval = bypass_workflow_approval or command_result.bypass_approval
 
+        # Tuning morning-report widget (Self-Improving Formation): a button
+        # press on the report's apply/dismiss widget resolves against the
+        # tuning service's registered widget id -- session-independent,
+        # since the report is formation-global. Anything else falls
+        # through to the normal per-session ui_response resolution.
+        tuning_result = self._process_tuning_ui_response(ui_response)
+        if tuning_result is not None:
+            return tuning_result
+
         # Get webhook URL from formation config if not provided per-request
         if webhook_url is None:
             webhook_url = self.formation_config.get("async", {}).get("webhook_url")
@@ -7591,6 +7600,62 @@ Agent response: {raw_response}"""
             hint=entry.get("hint"),
             source=UIProvenance.FORMATION_CONFIG,
         )
+
+    def _process_tuning_ui_response(
+        self, ui_response: Optional[Dict[str, Any]]
+    ) -> Optional["MuxiResponse"]:
+        """
+        Resolve an inbound ``ui_response`` against the tuning morning
+        report's apply/dismiss widget, when one is outstanding.
+
+        Returns a terminal MuxiResponse when the hint matches the
+        registered widget (the pending suggestion is applied or
+        dismissed), or None so the hint falls through to the normal
+        per-session clarification resolution. Never raises: a failed
+        apply becomes a friendly error reply.
+        """
+        if not ui_response:
+            return None
+        tuning_service = getattr(self, "tuning_service", None)
+        pending_widget = getattr(tuning_service, "pending_widget", None)
+        if not pending_widget:
+            return None
+
+        from ...datatypes.ui import resolve_ui_response
+
+        pinned_value = resolve_ui_response(
+            ui_response, pending_widget.get("ui_id"), pending_widget.get("ui_options")
+        )
+        if pinned_value not in ("apply", "dismiss"):
+            return None
+
+        observability.observe(
+            event_type=observability.ConversationEvents.UI_RESPONSE_RECEIVED,
+            level=observability.EventLevel.INFO,
+            data={
+                "type": "options",
+                "matched": True,
+                "widget_id": ui_response.get("id"),
+                "producer": "tuning",
+            },
+            description="ui_response hint matched the tuning report widget",
+        )
+        try:
+            if pinned_value == "apply":
+                result = tuning_service.apply_pending()
+                content = (
+                    "Applied the suggested MUXI.md revision "
+                    f"({result['learnings_activated']} learning(s) now under observation)."
+                )
+            else:
+                result = tuning_service.dismiss_pending()
+                content = (
+                    "Dismissed the suggested MUXI.md revision "
+                    f"({result['learnings_dismissed']} learning(s) will not be re-proposed)."
+                )
+        except (ValueError, OSError) as e:
+            content = f"Could not {pinned_value} the suggestion: {e}"
+        return MuxiResponse(role="assistant", content=content, metadata={"producer": "tuning"})
 
     async def _resolve_ui_response_hint(
         self, ui_response: Optional[Dict[str, Any]], session_id: Optional[str]

--- a/src/muxi/runtime/formation/proactive/router.py
+++ b/src/muxi/runtime/formation/proactive/router.py
@@ -20,7 +20,9 @@ Reserved routing names:
 - ``preferred``: the user's preferred channel
 - ``webhook``: the formation's async webhook
 
-v1 notifications are text-only; multi-channel arrays are supported.
+Notifications are text-first (the message must stand alone); envelope UI
+widgets may ride along and render natively where the channel template
+supports them. Multi-channel arrays are supported.
 """
 
 from datetime import datetime, timezone
@@ -178,16 +180,21 @@ class NotificationRouter:
         channels: Optional[List[str]] = None,
         request_id: Optional[str] = None,
         source: str = "notification",
+        ui: Optional[List[Dict[str, Any]]] = None,
     ) -> Dict[str, Any]:
         """
         Route and deliver a text notification to a user.
 
         Args:
             user_id: External user id
-            message: Notification text (v1 is text-only)
+            message: Notification text (text-first: the message MUST stand
+                alone without the widgets)
             channels: Optional explicit channel names (overrides preference)
             request_id: Optional correlation id (generated when absent)
             source: What produced the notification (e.g. "heartbeat", "api")
+            ui: Optional envelope UI widgets riding along; channel
+                templates render them natively (P3), the webhook payload
+                carries them under ``ui``
 
         Returns:
             Dict with ``channels`` (resolved), ``delivered``, ``failed``,
@@ -220,7 +227,11 @@ class NotificationRouter:
             try:
                 if channel == WEBHOOK_TARGET:
                     success = await self._deliver_webhook(
-                        user_id=user_id, message=message, request_id=request_id, source=source
+                        user_id=user_id,
+                        message=message,
+                        request_id=request_id,
+                        source=source,
+                        ui=ui,
                     )
                 else:
                     success = await self._deliver_channel(
@@ -229,6 +240,7 @@ class NotificationRouter:
                         user_id=user_id,
                         message=message,
                         request_id=request_id,
+                        ui=ui,
                     )
             except Exception as e:
                 success = False
@@ -271,6 +283,7 @@ class NotificationRouter:
                 request_id=request_id,
                 source=source,
                 failed_channels=failed,
+                ui=ui,
             ):
                 delivered.append(WEBHOOK_TARGET)
 
@@ -289,6 +302,7 @@ class NotificationRouter:
         user_id: str,
         message: str,
         request_id: str,
+        ui: Optional[List[Dict[str, Any]]] = None,
     ) -> bool:
         """Deliver via the channel's transformer (existing delivery stack)."""
         transformer = self._transformers[channel]
@@ -298,6 +312,7 @@ class NotificationRouter:
             transformer=transformer,
             url_override=self.config.channels[channel].url,
             response_content=message,
+            response={"ui": ui} if ui else None,
             request_user_id=user_id,
             context=context,
             agent_name=self.agent_name,
@@ -317,6 +332,7 @@ class NotificationRouter:
         request_id: str,
         source: str,
         failed_channels: Optional[List[str]] = None,
+        ui: Optional[List[Dict[str, Any]]] = None,
     ) -> bool:
         """Deliver the standard notification payload to the async webhook."""
         if not self.async_webhook_url:
@@ -345,6 +361,8 @@ class NotificationRouter:
             "response": [{"type": "text", "text": message}],
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
+        if ui:
+            payload["ui"] = ui
         if failed_channels:
             payload["failed_channels"] = failed_channels
 

--- a/src/muxi/runtime/formation/server/routes/admin/tuning.py
+++ b/src/muxi/runtime/formation/server/routes/admin/tuning.py
@@ -10,8 +10,15 @@ slice) plus the manual loop trigger, requiring admin API key auth:
   re-reads either way).
 - ``POST /tuning/run`` -- trigger one tuning loop pass (admin/testing).
 
-The pending-file endpoints (``/tuning/pending``) arrive with Phase 2's
-tuner step.
+The pending-suggestion surface (auto_apply: false review flow):
+
+- ``GET /tuning/pending`` -- the tuner's suggested next version of the
+  live file (PENDING-MUXI.md), null when none exists.
+- ``PATCH /tuning/pending`` -- accept: promote pending to live.
+- ``DELETE /tuning/pending`` -- dismiss: discard the suggestion; its
+  learnings are content-hashed away and never re-proposed.
+
+Partial acceptance = edit the pending content and POST it as live.
 """
 
 from fastapi import APIRouter, Request
@@ -19,15 +26,10 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from .....datatypes.api import APIEventType, APIObjectType
+from .....services.tuning.muxi_md import MUXI_MD_MAX_BYTES
 from ...responses import APIResponse, create_error_response, create_success_response
 
 router = APIRouter(tags=["Tuning"])
-
-# MUXI.md is read on every chat turn and injected into every user's
-# context, so the "bounded file" contract is enforced at the write
-# surface: ~32KB keeps it comparable to a large SOUL.md while bounding
-# per-turn context inflation across all users.
-MUXI_MD_MAX_BYTES = 32_768
 
 
 class TuningUpdate(BaseModel):
@@ -102,13 +104,91 @@ async def replace_tuning(request: Request, update: TuningUpdate) -> JSONResponse
     return JSONResponse(content=response.model_dump(), status_code=200)
 
 
+def _tuning_service(request: Request):
+    """The overlord's tuning service, or None when tuning is inactive."""
+    formation = request.app.state.formation
+    overlord = getattr(formation, "_overlord", None)
+    return getattr(overlord, "tuning_service", None) if overlord else None
+
+
+@router.get("/tuning/pending", response_model=APIResponse)
+async def get_tuning_pending(request: Request) -> JSONResponse:
+    """Get the pending MUXI.md suggestion (null when none exists)."""
+    request_id = getattr(request.state, "request_id", None)
+    muxi_md = _muxi_md(request)
+    if muxi_md is None:
+        response = create_error_response(
+            "SERVICE_UNAVAILABLE", "Overlord not started", None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=503)
+
+    response = create_success_response(
+        APIObjectType.TUNING,
+        APIEventType.TUNING_PENDING_RETRIEVED,
+        {"content": muxi_md.read_pending(), "path": muxi_md.pending_path()},
+        request_id,
+    )
+    return JSONResponse(content=response.model_dump(), status_code=200)
+
+
+@router.patch("/tuning/pending", response_model=APIResponse)
+async def apply_tuning_pending(request: Request) -> JSONResponse:
+    """Accept the pending suggestion: promote it to the live MUXI.md."""
+    request_id = getattr(request.state, "request_id", None)
+    tuning_service = _tuning_service(request)
+    if tuning_service is None:
+        response = create_error_response(
+            "SERVICE_UNAVAILABLE", "Tuning is not active for this formation", None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=503)
+
+    try:
+        result = tuning_service.apply_pending()
+    except ValueError as e:
+        response = create_error_response("TUNING_NO_PENDING", str(e), None, request_id)
+        return JSONResponse(content=response.model_dump(), status_code=404)
+    except OSError as e:
+        response = create_error_response(
+            "TUNING_WRITE_FAILED", f"Could not apply the suggestion: {e}", None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=500)
+
+    response = create_success_response(
+        APIObjectType.TUNING, APIEventType.TUNING_PENDING_APPLIED, result, request_id
+    )
+    return JSONResponse(content=response.model_dump(), status_code=200)
+
+
+@router.delete("/tuning/pending", response_model=APIResponse)
+async def dismiss_tuning_pending(request: Request) -> JSONResponse:
+    """Dismiss the pending suggestion; its ideas are never re-proposed."""
+    request_id = getattr(request.state, "request_id", None)
+    tuning_service = _tuning_service(request)
+    if tuning_service is None:
+        response = create_error_response(
+            "SERVICE_UNAVAILABLE", "Tuning is not active for this formation", None, request_id
+        )
+        return JSONResponse(content=response.model_dump(), status_code=503)
+
+    try:
+        result = tuning_service.dismiss_pending()
+    except ValueError as e:
+        response = create_error_response("TUNING_NO_PENDING", str(e), None, request_id)
+        return JSONResponse(content=response.model_dump(), status_code=404)
+
+    response = create_success_response(
+        APIObjectType.TUNING, APIEventType.TUNING_PENDING_DISMISSED, result, request_id
+    )
+    return JSONResponse(content=response.model_dump(), status_code=200)
+
+
 @router.post("/tuning/run", response_model=APIResponse)
 async def run_tuning(request: Request) -> JSONResponse:
     """Trigger one tuning loop pass now (admin/testing surface)."""
     request_id = getattr(request.state, "request_id", None)
     formation = request.app.state.formation
     overlord = getattr(formation, "_overlord", None)
-    tuning_service = getattr(overlord, "tuning_service", None) if overlord else None
+    tuning_service = _tuning_service(request)
     if tuning_service is None:
         response = create_error_response(
             "SERVICE_UNAVAILABLE",

--- a/src/muxi/runtime/services/memory/log/formation.py
+++ b/src/muxi/runtime/services/memory/log/formation.py
@@ -104,7 +104,7 @@ class FormationLogSummarizer:
         if clean.startswith("```"):
             first_newline = clean.find("\n")
             if first_newline > 0:
-                clean = clean[first_newline + 1 :]
+                clean = clean[first_newline + 1 :]  # noqa: E203
             if clean.endswith("```"):
                 clean = clean[:-3].strip()
         try:
@@ -159,6 +159,38 @@ def lint_formation_digest(
     return (cleaned if cleaned else None), dropped
 
 
+def lint_formation_lines(
+    text: Optional[str], known_user_ids: Iterable[str]
+) -> Tuple[Optional[str], int]:
+    """Line-level privacy gate for markdown destined for every user.
+
+    Same predicates as :func:`lint_formation_digest` but drops whole
+    lines instead of joining sentences, preserving markdown structure
+    (the tuner's MUXI.md revisions are markdown, not prose). Returns the
+    cleaned text and the number of dropped lines.
+    """
+    if not text:
+        return text, 0
+
+    user_id_needles = [
+        user_id.lower()
+        for user_id in known_user_ids
+        if isinstance(user_id, str) and len(user_id) >= 3
+    ]
+
+    detector = get_entity_detector()
+    kept: List[str] = []
+    dropped = 0
+    for line in text.splitlines():
+        if line.strip() and _is_private_sentence(line, user_id_needles, detector):
+            dropped += 1
+            continue
+        kept.append(line)
+
+    cleaned = "\n".join(kept).strip()
+    return (cleaned if cleaned else None), dropped
+
+
 def _is_private_sentence(sentence: str, user_id_needles: List[str], detector) -> bool:
     lowered = sentence.lower()
     if any(needle in lowered for needle in user_id_needles):
@@ -187,4 +219,5 @@ __all__ = [
     "FORMATION_LOG_USER_ID",
     "FormationLogSummarizer",
     "lint_formation_digest",
+    "lint_formation_lines",
 ]

--- a/src/muxi/runtime/services/observability/spool.py
+++ b/src/muxi/runtime/services/observability/spool.py
@@ -113,12 +113,22 @@ class EventSpool:
         return segments[-1] if segments else None
 
     def _next_segment_path(self, today: str) -> Path:
-        """Next per-day sequence number; names sort lexicographically."""
+        """Next per-day sequence number; names sort lexicographically.
+
+        The checkpoint participates in the numbering: after a digest
+        deletes every segment, a fresh file must still sort AFTER the
+        checkpointed name, or its events would be hidden from every
+        future read.
+        """
         prefix = f"{SEGMENT_PREFIX}{today}-"
         max_seq = 0
-        for segment in self._list_segments():
-            if segment.name.startswith(prefix):
-                seq_text = segment.name[len(prefix) : -len(SEGMENT_SUFFIX)]
+        names = [segment.name for segment in self._list_segments()]
+        checkpoint = self._read_checkpoint()
+        if checkpoint is not None:
+            names.append(checkpoint)
+        for name in names:
+            if name.startswith(prefix) and name.endswith(SEGMENT_SUFFIX):
+                seq_text = name[len(prefix) : -len(SEGMENT_SUFFIX)]  # noqa: E203
                 try:
                     max_seq = max(max_seq, int(seq_text))
                 except ValueError:

--- a/src/muxi/runtime/services/tuning/__init__.py
+++ b/src/muxi/runtime/services/tuning/__init__.py
@@ -1,9 +1,9 @@
 """
 Self-Improving Formation services (tuning).
 
-Phase 1: the ``tuning:`` config surface, the scheduled digest loop over
-the event spool, and the MUXI.md file contract. Phase 2 adds the tuner
-step (detection, distillation, curation, pending flow, morning report).
+The ``tuning:`` config surface, the scheduled loop over the event spool
+(digest step + tune step), the MUXI.md/PENDING-MUXI.md file contract,
+and the tuner's experiment memories.
 """
 
 from .config import (
@@ -12,15 +12,21 @@ from .config import (
     TuningConfigError,
     parse_tuning_config,
 )
-from .muxi_md import MuxiMdFile
+from .experiments import ExperimentStore, learning_hash
+from .muxi_md import MUXI_MD_MAX_BYTES, MuxiMdFile
 from .service import TuningService, yaml_declares_file_transport
+from .tuner import TunerStep
 
 __all__ = [
     "DEFAULT_INTERVAL_HOURS",
+    "ExperimentStore",
+    "MUXI_MD_MAX_BYTES",
     "MuxiMdFile",
+    "TunerStep",
     "TuningConfig",
     "TuningConfigError",
     "TuningService",
+    "learning_hash",
     "parse_tuning_config",
     "yaml_declares_file_transport",
 ]

--- a/src/muxi/runtime/services/tuning/experiments.py
+++ b/src/muxi/runtime/services/tuning/experiments.py
@@ -1,0 +1,230 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Tuner Experiment Memories
+# Description:  Content-hashed learning records with watch-window lifecycle
+# Role:         Sidecar state for the tuning loop's tune step
+# Usage:        Loaded/saved once per tuning pass by the TuningService
+# Author:       Muxi Framework Team
+#
+# Self-Improving Formation PRD, "The loop" step 2: every learning carries
+# its evidence and a watch window; later runs check whether the targeted
+# metric moved and retire learnings that didn't. Retirements and
+# dismissals are recorded here so ideas are never re-proposed.
+#
+# Storage is a sidecar JSON file in the formation's observability
+# directory (sibling of the event spool) written with the same atomic
+# tmp-then-replace idiom: single consumer (the tuning loop, serialized by
+# its run lock), survives restarts, works without persistent memory, and
+# is never in any user-visible retrieval path. Internal format, not
+# configuration, not AFS surface.
+# =============================================================================
+
+import hashlib
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ...utils.user_dirs import get_observability_dir
+
+EXPERIMENTS_FILE = "experiments.json"
+
+# Learning lifecycle. "pending" learnings ride a PENDING-MUXI.md
+# suggestion awaiting human accept; "active" ones are live in MUXI.md
+# under an open watch window; terminal states are never re-proposed.
+STATUS_PENDING = "pending"
+STATUS_ACTIVE = "active"
+STATUS_RETIRED = "retired"
+STATUS_DISMISSED = "dismissed"
+
+# Default observation window before a learning must show metric movement.
+DEFAULT_WATCH_WINDOW_HOURS = 168.0
+
+# A watched metric must improve (drop) by at least this fraction of its
+# baseline within the window, or the learning is retired. Metrics in the
+# snapshot are all "lower is better" rates.
+IMPROVEMENT_FRACTION = 0.1
+
+_WHITESPACE = re.compile(r"\s+")
+
+
+def _default_experiments_dir() -> str:
+    """Where the store lives (follows the formation's observability dir)."""
+    return str(Path(get_observability_dir()) / "tuner")
+
+
+def learning_hash(learning: str) -> str:
+    """Content hash of a learning, tolerant of whitespace/case drift."""
+    normalized = _WHITESPACE.sub(" ", learning.strip().lower())
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+class ExperimentStore:
+    """The tuner's experiment memories: one JSON document, atomic writes."""
+
+    def __init__(self, base_dir: Optional[str] = None):
+        self._base_dir_override = base_dir
+        self.records: List[Dict[str, Any]] = []
+        self.load()
+
+    def _path(self) -> Path:
+        return Path(self._base_dir_override or _default_experiments_dir()) / EXPERIMENTS_FILE
+
+    # ------------------------------------------------------------------
+    # Persistence (spool-checkpoint idiom: tmp write + os.replace)
+    # ------------------------------------------------------------------
+
+    def load(self) -> None:
+        """Read the store from disk; a missing/corrupt file means empty."""
+        try:
+            payload = json.loads(self._path().read_text(encoding="utf-8"))
+        except Exception:
+            self.records = []
+            return
+        experiments = payload.get("experiments") if isinstance(payload, dict) else None
+        self.records = [record for record in experiments or [] if isinstance(record, dict)]
+
+    def save(self) -> None:
+        """Atomically persist the store; failures never break the pass."""
+        path = self._path()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = path.with_suffix(".tmp")
+            tmp_path.write_text(
+                json.dumps({"version": 1, "experiments": self.records}, indent=1),
+                encoding="utf-8",
+            )
+            os.replace(tmp_path, path)
+        except OSError:
+            pass
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def known_hashes(self) -> set:
+        """Hashes in any status -- everything the tuner must not re-propose."""
+        return {record.get("content_hash") for record in self.records}
+
+    def by_status(self, status: str) -> List[Dict[str, Any]]:
+        return [record for record in self.records if record.get("status") == status]
+
+    def propose(
+        self,
+        learning: str,
+        evidence: str,
+        metric_key: Optional[str],
+        baseline: Optional[float],
+        status: str,
+        window_hours: float = DEFAULT_WATCH_WINDOW_HOURS,
+    ) -> Optional[Dict[str, Any]]:
+        """Record a newly distilled learning; None when already known."""
+        content_hash = learning_hash(learning)
+        if content_hash in self.known_hashes():
+            return None
+        now = time.time()
+        record = {
+            "content_hash": content_hash,
+            "status": status,
+            "learning": learning,
+            "evidence": evidence,
+            "metric_key": metric_key,
+            "baseline": baseline,
+            "watch": {
+                "opened_at": now if status == STATUS_ACTIVE else None,
+                "window_hours": window_hours,
+            },
+            "created_at": now,
+            "updated_at": now,
+        }
+        self.records.append(record)
+        return record
+
+    def set_status(self, record: Dict[str, Any], status: str) -> None:
+        record["status"] = status
+        record["updated_at"] = time.time()
+        if status == STATUS_ACTIVE and not (record.get("watch") or {}).get("opened_at"):
+            record.setdefault("watch", {"window_hours": DEFAULT_WATCH_WINDOW_HOURS})
+            record["watch"]["opened_at"] = time.time()
+
+    def activate_pending(self) -> List[Dict[str, Any]]:
+        """Pending suggestion accepted: open every pending watch window."""
+        activated = []
+        for record in self.by_status(STATUS_PENDING):
+            self.set_status(record, STATUS_ACTIVE)
+            activated.append(record)
+        return activated
+
+    def dismiss_pending(self) -> List[Dict[str, Any]]:
+        """Pending suggestion dismissed: hashes stay so ideas never return."""
+        dismissed = []
+        for record in self.by_status(STATUS_PENDING):
+            self.set_status(record, STATUS_DISMISSED)
+            dismissed.append(record)
+        return dismissed
+
+    def evaluate_watch_windows(
+        self, metrics: Dict[str, float], now: Optional[float] = None
+    ) -> List[Dict[str, Any]]:
+        """Retire active learnings whose expired window shows no movement.
+
+        Deterministic: a learning with a watched metric key must show the
+        metric at or below ``baseline * (1 - IMPROVEMENT_FRACTION)`` when
+        its window expires. A metric absent from the current snapshot
+        counts as moved to zero (the problem stopped appearing), which is
+        the movement the learning promised -- the watch simply closes.
+        Learnings without a metric key are observational-only and never
+        auto-retire. A closed watch is final: a learning that proved
+        itself is never re-scored when the metric later regresses.
+        """
+        now = now if now is not None else time.time()
+        retired = []
+        for record in self.by_status(STATUS_ACTIVE):
+            watch = record.get("watch") or {}
+            if watch.get("closed_at"):
+                continue
+            opened_at = watch.get("opened_at")
+            window_hours = watch.get("window_hours") or DEFAULT_WATCH_WINDOW_HOURS
+            if not opened_at or now < opened_at + window_hours * 3600.0:
+                continue
+            metric_key = record.get("metric_key")
+            baseline = record.get("baseline")
+            if not metric_key or not isinstance(baseline, (int, float)) or baseline <= 0:
+                watch["closed_at"] = now
+                continue
+            current = float(metrics.get(metric_key, 0.0))
+            if current <= baseline * (1 - IMPROVEMENT_FRACTION):
+                watch["closed_at"] = now
+                record["outcome"] = {
+                    "metric": metric_key,
+                    "baseline": baseline,
+                    "final": current,
+                    "moved": True,
+                }
+                record["updated_at"] = now
+            else:
+                record["outcome"] = {
+                    "metric": metric_key,
+                    "baseline": baseline,
+                    "final": current,
+                    "moved": False,
+                }
+                self.set_status(record, STATUS_RETIRED)
+                retired.append(record)
+        return retired
+
+
+__all__ = [
+    "DEFAULT_WATCH_WINDOW_HOURS",
+    "EXPERIMENTS_FILE",
+    "ExperimentStore",
+    "IMPROVEMENT_FRACTION",
+    "STATUS_ACTIVE",
+    "STATUS_DISMISSED",
+    "STATUS_PENDING",
+    "STATUS_RETIRED",
+    "learning_hash",
+]

--- a/src/muxi/runtime/services/tuning/muxi_md.py
+++ b/src/muxi/runtime/services/tuning/muxi_md.py
@@ -4,9 +4,13 @@ MUXI.md -- the formation's CLAUDE.md.
 A bounded, curated markdown file of behavioral learnings living in the
 formation directory, sibling of SOUL.md. Formation-owned, git-trackable,
 human-editable: a dev may write it by hand on day one. Injected into
-overlord context wherever SOUL.md is injected; Phase 2's tuner curates
-it. Reads are mtime-cached so hand edits and API replacements take
-effect on the next turn without a restart.
+overlord context wherever SOUL.md is injected; the tuner curates it.
+Reads are mtime-cached so hand edits and API replacements take effect
+on the next turn without a restart.
+
+Under ``auto_apply: false`` the tuner writes PENDING-MUXI.md instead --
+its suggested next version of the live file, regenerated every run.
+Review = diff the two files; accept promotes pending to live.
 """
 
 import os
@@ -17,6 +21,12 @@ from typing import Optional
 # Candidate file names, checked in order (mirrors the SOUL.md loader).
 _CANDIDATES = ("MUXI.md", "muxi.md")
 _CANONICAL = "MUXI.md"
+_PENDING = "PENDING-MUXI.md"
+
+# MUXI.md is injected into every user's turn, so the "bounded file"
+# contract is enforced at every write surface: ~32KB keeps it comparable
+# to a large SOUL.md while bounding per-turn context inflation.
+MUXI_MD_MAX_BYTES = 32_768
 
 
 class MuxiMdFile:
@@ -88,29 +98,88 @@ class MuxiMdFile:
         # concurrent replacements cannot interleave, and the temp file is
         # uniquely named so a crashed writer never corrupts a later one.
         with self._lock:
-            fd, tmp_path = tempfile.mkstemp(
-                dir=os.path.dirname(path), prefix=".muxi-md-", suffix=".tmp"
-            )
-            try:
-                try:
-                    f = os.fdopen(fd, "w", encoding="utf-8")
-                except BaseException:
-                    # fdopen never took ownership; close the raw fd.
-                    os.close(fd)
-                    raise
-                with f:
-                    f.write(content)
-                os.replace(tmp_path, path)
-            except BaseException:
-                try:
-                    os.unlink(tmp_path)
-                except OSError:
-                    pass
-                raise
+            _atomic_write(path, content)
             self._cached_content = content.strip() or None
             self._cached_mtime = os.path.getmtime(path)
             self._cached_path = path
         return path
 
+    # ------------------------------------------------------------------
+    # PENDING-MUXI.md (auto_apply: false suggestion flow)
+    # ------------------------------------------------------------------
 
-__all__ = ["MuxiMdFile"]
+    def pending_path(self) -> Optional[str]:
+        """Where the pending suggestion lives, or None without a dir."""
+        if not self.formation_dir:
+            return None
+        return os.path.join(self.formation_dir, _PENDING)
+
+    def read_pending(self) -> Optional[str]:
+        """Pending suggestion content, or None when absent. Never raises."""
+        path = self.pending_path()
+        if path is None or not os.path.isfile(path):
+            return None
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                content = f.read().strip()
+            return content or None
+        except OSError:
+            return None
+
+    def write_pending(self, content: str) -> str:
+        """Replace the pending suggestion atomically; returns the path."""
+        path = self.pending_path()
+        if path is None:
+            raise ValueError("Formation has no directory to hold PENDING-MUXI.md")
+        with self._lock:
+            _atomic_write(path, content)
+        return path
+
+    def promote_pending(self) -> str:
+        """Accept the suggestion: pending becomes live, pending is removed.
+
+        Raises ValueError when no pending suggestion exists.
+        """
+        content = self.read_pending()
+        if content is None:
+            raise ValueError("No pending MUXI.md suggestion to apply")
+        path = self.write(content)
+        self.discard_pending()
+        return path
+
+    def discard_pending(self) -> bool:
+        """Dismiss the suggestion; True when a pending file was removed."""
+        path = self.pending_path()
+        if path is None:
+            return False
+        try:
+            os.unlink(path)
+            return True
+        except FileNotFoundError:
+            return False
+        except OSError:
+            return False
+
+
+def _atomic_write(path: str, content: str) -> None:
+    """Uniquely-named-tempfile atomic replace (crash never corrupts)."""
+    fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(path), prefix=".muxi-md-", suffix=".tmp")
+    try:
+        try:
+            f = os.fdopen(fd, "w", encoding="utf-8")
+        except BaseException:
+            # fdopen never took ownership; close the raw fd.
+            os.close(fd)
+            raise
+        with f:
+            f.write(content)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+__all__ = ["MUXI_MD_MAX_BYTES", "MuxiMdFile"]

--- a/src/muxi/runtime/services/tuning/service.py
+++ b/src/muxi/runtime/services/tuning/service.py
@@ -9,14 +9,18 @@
 #
 # Self-Improving Formation PRD, "The loop". One scheduled in-runtime job
 # (tuning.interval_hours, CaptainsLog lifecycle idiom: started by the
-# Overlord, cancelled on shutdown), Phase 1 scope: read the event spool
-# since the last checkpoint, aggregate it into a compact activity report,
-# digest that into today's formation-scope captain's log entry, then
-# checkpoint (and delete the digested segments unless the formation's
-# yaml declared its own file transport -- then the files are the dev's).
+# Overlord, cancelled on shutdown), two steps per pass:
 #
-# Phase 2 adds the tuner step (detection, distillation, MUXI.md curation,
-# pending flow, morning report) behind the same loop.
+# 1. Digest: read the event spool since the last checkpoint, aggregate it
+#    into a compact activity report, digest that into today's
+#    formation-scope captain's log entry, then checkpoint (and delete the
+#    digested segments unless the formation's yaml declared its own file
+#    transport -- then the files are the dev's).
+# 2. Tune: read the fresh digest, recent formation-log entries, and the
+#    experiment memories; detect patterns; distill behavioral learnings
+#    into a candidate MUXI.md revision (applied directly or written as
+#    PENDING-MUXI.md per auto_apply); retire learnings whose watched
+#    metric did not move; deliver a morning report.
 # =============================================================================
 
 import asyncio
@@ -24,8 +28,12 @@ import time
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from .. import observability
+from ..memory.log.formation import lint_formation_lines
 from ..observability.spool import get_event_spool
 from .config import TuningConfig
+from .experiments import STATUS_ACTIVE, STATUS_PENDING, ExperimentStore
+from .muxi_md import MUXI_MD_MAX_BYTES
+from .tuner import TunerStep
 
 # Bounds keeping the aggregated report LLM-sized regardless of spool size.
 MAX_REPORT_CHARS = 8000
@@ -38,7 +46,7 @@ MAX_TRACKED_REQUESTS = 5000
 
 
 class TuningService:
-    """Owns the tuning loop; Phase 1 runs the digest step only."""
+    """Owns the tuning loop: digest step + tune step."""
 
     def __init__(
         self,
@@ -61,6 +69,14 @@ class TuningService:
         self._task: Optional[asyncio.Task] = None
         self._run_lock = asyncio.Lock()
         self.last_run: Optional[Dict[str, Any]] = None
+        self.tuner = TunerStep()
+        # Overrides the experiment store location (tests only; None means
+        # the formation's observability directory).
+        self.experiments_dir: Optional[str] = None
+        # The apply/dismiss widget the last morning report carried, so a
+        # channel button press can resolve regardless of which session
+        # the reply arrives on (the report is formation-global).
+        self.pending_widget: Optional[Dict[str, Any]] = None
 
     # ------------------------------------------------------------------
     # Lifecycle (CaptainsLog idiom: overlord starts, shutdown cancels)
@@ -104,13 +120,13 @@ class TuningService:
     # ------------------------------------------------------------------
 
     async def run_once(self, model, trigger: str = "manual") -> Dict[str, Any]:
-        """Run one digest pass; safe against overlapping invocations."""
+        """Run one full pass (digest + tune); safe against overlaps."""
         async with self._run_lock:
             started = time.monotonic()
             spool = get_event_spool()
             segments, token = spool.read_for_digest()
 
-            report, known_user_ids, event_count = await asyncio.to_thread(
+            report, known_user_ids, event_count, metrics = await asyncio.to_thread(
                 _aggregate_segments, spool, segments
             )
 
@@ -128,6 +144,26 @@ class TuningService:
             if committed:
                 spool.commit(token, delete=not self.keep_spool_segments)
 
+            # Step 2: tune. Runs only on a consumed digest with traffic;
+            # a tuner failure never breaks the pass (the digest already
+            # reached its terminal outcome).
+            tune_result: Dict[str, Any] = {}
+            if committed and event_count > 0 and model is not None:
+                try:
+                    tune_result = await self._tune(model, report, metrics, known_user_ids)
+                except Exception as e:
+                    tune_result = {"tuner_error": f"{type(e).__name__}: {e}"}
+                    observability.observe(
+                        event_type=observability.ErrorEvents.INTERNAL_ERROR,
+                        level=observability.EventLevel.WARNING,
+                        data={
+                            "error": str(e),
+                            "error_type": type(e).__name__,
+                            "service": "tuning",
+                        },
+                        description=f"Tune step failed: {e}",
+                    )
+
             result = {
                 "trigger": trigger,
                 "events_read": event_count,
@@ -136,6 +172,7 @@ class TuningService:
                 "dropped_sentences": digest.get("dropped_sentences", 0),
                 "spool_committed": committed,
                 "spool_segments_kept": self.keep_spool_segments,
+                **tune_result,
                 "duration_ms": round((time.monotonic() - started) * 1000, 1),
             }
             self.last_run = result
@@ -149,6 +186,252 @@ class TuningService:
                 ),
             )
             return result
+
+    # ------------------------------------------------------------------
+    # Step 2: tune (detection, distillation, curation, morning report)
+    # ------------------------------------------------------------------
+
+    async def _tune(
+        self,
+        model,
+        activity_report: str,
+        metrics: Dict[str, float],
+        known_user_ids: List[str],
+    ) -> Dict[str, Any]:
+        muxi_md = getattr(self.overlord, "muxi_md", None)
+        if muxi_md is None:
+            return {}
+
+        store = ExperimentStore(self.experiments_dir)
+        retired = store.evaluate_watch_windows(metrics)
+        for record in retired:
+            observability.observe(
+                event_type=observability.SystemEvents.TUNING_RETIRED,
+                level=observability.EventLevel.INFO,
+                data={
+                    "content_hash": record.get("content_hash"),
+                    "metric_key": record.get("metric_key"),
+                    "outcome": record.get("outcome"),
+                },
+                description="Tuning learning retired: watched metric did not move",
+            )
+
+        captains_log = getattr(self.overlord, "captains_log", None)
+        formation_log_block = ""
+        if captains_log is not None:
+            formation_log_block = await captains_log.get_formation_context_block()
+
+        prompt = self.tuner.build_prompt(
+            activity_report=activity_report,
+            current_muxi_md=muxi_md.read(),
+            formation_log_block=formation_log_block,
+            active_learnings=store.by_status(STATUS_ACTIVE),
+            retired_learnings=retired,
+            dismissed_learnings=[
+                record.get("learning", "") for record in store.by_status("dismissed")
+            ],
+            metric_keys=sorted(metrics),
+            max_bytes=MUXI_MD_MAX_BYTES,
+        )
+        # temperature=0: curation should be a deterministic distillation of
+        # the report, not a creative writing pass.
+        parsed = self.tuner.parse_response(
+            await model.generate_text(prompt, temperature=0.0, caching=False)
+        )
+        if parsed is None:
+            store.save()
+            return {"learnings_retired": len(retired), "tuner_skipped": "unparseable_response"}
+
+        # Record the distilled learnings; already-known hashes (dismissed,
+        # retired, still-watched) are silently skipped -- never re-proposed.
+        new_status = STATUS_ACTIVE if self.config.auto_apply else STATUS_PENDING
+        recorded = []
+        for item in parsed["learnings"]:
+            baseline = metrics.get(item["metric_key"]) if item["metric_key"] else None
+            proposal = store.propose(
+                learning=item["learning"],
+                evidence=item["evidence"],
+                metric_key=item["metric_key"],
+                baseline=baseline,
+                status=new_status,
+            )
+            if proposal is not None:
+                recorded.append(proposal)
+
+        # Curate the file. The candidate passes the same privacy gate as
+        # the formation log (line-level so markdown survives), and the
+        # bounded-file contract is enforced on the tuner's own writes.
+        applied = False
+        suggested = False
+        dropped_lines = 0
+        candidate = parsed["muxi_md"]
+        if candidate:
+            candidate, dropped_lines = lint_formation_lines(candidate, known_user_ids)
+        if not candidate and recorded:
+            # The model sometimes records learnings without producing the
+            # revised file; append them so the file never lags the store.
+            current = muxi_md.read() or ""
+            appended = "\n".join(f"- {record['learning']}" for record in recorded)
+            fallback = f"{current}\n\n{appended}" if current else appended
+            candidate, dropped_lines = lint_formation_lines(fallback, known_user_ids)
+        rejected_oversize = False
+        if candidate and len(candidate.encode("utf-8")) > MUXI_MD_MAX_BYTES:
+            candidate = None
+            rejected_oversize = True
+        if candidate and candidate != (muxi_md.read() or ""):
+            if self.config.auto_apply:
+                muxi_md.write(candidate)
+                applied = True
+                observability.observe(
+                    event_type=observability.SystemEvents.TUNING_APPLIED,
+                    level=observability.EventLevel.INFO,
+                    data={
+                        "bytes": len(candidate.encode("utf-8")),
+                        "learnings_recorded": len(recorded),
+                        "dropped_lines": dropped_lines,
+                    },
+                    description="Tuner applied a MUXI.md revision (auto_apply)",
+                )
+            else:
+                muxi_md.write_pending(candidate)
+                suggested = True
+                observability.observe(
+                    event_type=observability.SystemEvents.TUNING_SUGGESTED,
+                    level=observability.EventLevel.INFO,
+                    data={
+                        "bytes": len(candidate.encode("utf-8")),
+                        "learnings_recorded": len(recorded),
+                        "dropped_lines": dropped_lines,
+                    },
+                    description="Tuner wrote a PENDING-MUXI.md suggestion",
+                )
+        store.save()
+
+        report_delivery = await self._deliver_morning_report(
+            applied=applied,
+            suggested=suggested,
+            recorded=recorded,
+            retired=retired,
+            recommendations=parsed["recommendations"],
+        )
+
+        return {
+            "learnings_recorded": len(recorded),
+            "learnings_retired": len(retired),
+            "muxi_md_applied": applied,
+            "muxi_md_suggested": suggested,
+            "muxi_md_rejected_oversize": rejected_oversize,
+            "recommendations": len(parsed["recommendations"]),
+            "report_delivered": report_delivery,
+        }
+
+    async def _deliver_morning_report(
+        self,
+        *,
+        applied: bool,
+        suggested: bool,
+        recorded: List[Dict[str, Any]],
+        retired: List[Dict[str, Any]],
+        recommendations: List[str],
+    ) -> bool:
+        """Deliver the morning report; False when there is nothing/nowhere.
+
+        Recipient resolution follows the notification precedence from
+        user "0" (the single-user identity): preferred channel >
+        formation default_channel > async webhook. Formations without a
+        ``proactive:`` block get no report -- the same state remains
+        visible via /learnings and the /tuning API.
+        """
+        if not (applied or suggested or retired or recommendations):
+            return False
+        router = getattr(self.overlord, "notification_router", None)
+        if router is None:
+            return False
+
+        lines: List[str] = ["Tuning report"]
+        if applied:
+            lines.append(
+                "MUXI.md was updated with this pass's learnings (git history is the undo)."
+            )
+        if suggested:
+            lines.append(
+                "A suggested MUXI.md revision awaits review in PENDING-MUXI.md "
+                "(diff it against the live file)."
+            )
+        if recorded:
+            lines.append("New learnings:")
+            lines.extend(f"- {record.get('learning')}" for record in recorded)
+        if retired:
+            lines.append("Retired (watched metric did not move):")
+            lines.extend(f"- {record.get('learning')}" for record in retired)
+        if recommendations:
+            lines.append("Recommendations requiring a human deployment:")
+            lines.extend(f"- {item}" for item in recommendations)
+
+        widgets = None
+        self.pending_widget = None
+        if suggested:
+            lines.append("Reply '/learnings apply' to accept or '/learnings dismiss' to discard.")
+            from ...datatypes.ui import build_options_widget
+
+            widget = build_options_widget(
+                "Apply the suggested MUXI.md revision?",
+                [
+                    {"value": "apply", "label": "Apply"},
+                    {"value": "dismiss", "label": "Dismiss"},
+                ],
+            )
+            if widget is not None:
+                widgets = [widget]
+                self.pending_widget = {"ui_id": widget["id"], "ui_options": ["apply", "dismiss"]}
+
+        result = await router.notify(
+            user_id="0", message="\n".join(lines), source="tuning", ui=widgets
+        )
+        return bool(result.get("delivered"))
+
+    # ------------------------------------------------------------------
+    # Pending suggestion surface (/learnings, /tuning/pending, widget)
+    # ------------------------------------------------------------------
+
+    def apply_pending(self) -> Dict[str, Any]:
+        """Promote PENDING-MUXI.md to live; opens the watch windows.
+
+        Raises ValueError when no pending suggestion exists.
+        """
+        muxi_md = self.overlord.muxi_md
+        path = muxi_md.promote_pending()
+        store = ExperimentStore(self.experiments_dir)
+        activated = store.activate_pending()
+        store.save()
+        self.pending_widget = None
+        observability.observe(
+            event_type=observability.SystemEvents.TUNING_APPLIED,
+            level=observability.EventLevel.INFO,
+            data={"path": path, "learnings_activated": len(activated)},
+            description="Pending MUXI.md suggestion applied",
+        )
+        return {"path": path, "learnings_activated": len(activated)}
+
+    def dismiss_pending(self) -> Dict[str, Any]:
+        """Discard PENDING-MUXI.md; dismissed hashes are never re-proposed.
+
+        Raises ValueError when no pending suggestion exists.
+        """
+        muxi_md = self.overlord.muxi_md
+        if not muxi_md.discard_pending():
+            raise ValueError("No pending MUXI.md suggestion to dismiss")
+        store = ExperimentStore(self.experiments_dir)
+        dismissed = store.dismiss_pending()
+        store.save()
+        self.pending_widget = None
+        observability.observe(
+            event_type=observability.SystemEvents.TUNING_DISMISSED,
+            level=observability.EventLevel.INFO,
+            data={"learnings_dismissed": len(dismissed)},
+            description="Pending MUXI.md suggestion dismissed",
+        )
+        return {"learnings_dismissed": len(dismissed)}
 
 
 def yaml_declares_file_transport(logging_config: Optional[Dict[str, Any]]) -> bool:
@@ -182,12 +465,12 @@ def yaml_declares_file_transport(logging_config: Optional[Dict[str, Any]]) -> bo
 # ---------------------------------------------------------------------------
 
 
-def _aggregate_segments(spool, segments) -> Tuple[str, List[str], int]:
-    """Aggregate spool segments into (report, known_user_ids, event_count)."""
+def _aggregate_segments(spool, segments) -> Tuple[str, List[str], int, Dict[str, float]]:
+    """Aggregate segments into (report, known_user_ids, count, metrics)."""
     stats = _SpoolStats()
     for event in spool.iter_events(segments):
         stats.add(event)
-    return stats.render(), sorted(stats.user_ids), stats.total
+    return stats.render(), sorted(stats.user_ids), stats.total, stats.metric_snapshot()
 
 
 class _SpoolStats:
@@ -201,6 +484,7 @@ class _SpoolStats:
         self.level_counts: Dict[str, int] = {}
         self.problem_counts: Dict[str, int] = {}
         self.problem_samples: Dict[str, List[str]] = {}
+        self.tool_failures: Dict[str, int] = {}
         self.user_ids: Set[str] = set()
         self.session_ids: Set[str] = set()
         self.request_tokens: Dict[str, Dict[str, Any]] = {}
@@ -231,6 +515,9 @@ class _SpoolStats:
                         snippet = description[:SAMPLE_DESCRIPTION_CHARS]
                         if snippet not in samples:
                             samples.append(snippet)
+                tool = data.get("tool") if isinstance(data, dict) else None
+                if isinstance(tool, str) and tool:
+                    self.tool_failures[tool] = self.tool_failures.get(tool, 0) + 1
 
         request = event.get("request")
         if isinstance(request, dict):
@@ -255,6 +542,23 @@ class _SpoolStats:
             data_user = data.get("user_id")
             if isinstance(data_user, str) and data_user:
                 self.user_ids.add(data_user)
+
+    def metric_snapshot(self) -> Dict[str, float]:
+        """Closed set of lower-is-better rates for watch-window checks.
+
+        Keys: ``error_rate``, ``warning_rate``, and ``problem:<event>``
+        per warning/error event type. Baselines are frozen from this
+        snapshot at proposal time; later snapshots verify movement.
+        """
+        if self.total == 0:
+            return {}
+        metrics: Dict[str, float] = {
+            "error_rate": self.level_counts.get("error", 0) / self.total,
+            "warning_rate": self.level_counts.get("warning", 0) / self.total,
+        }
+        for name, count in self.problem_counts.items():
+            metrics[f"problem:{name}"] = count / self.total
+        return metrics
 
     def render(self) -> str:
         """Render the bounded plain-text activity report."""
@@ -286,6 +590,12 @@ class _SpoolStats:
                 lines.append(f"- {name}: {count}")
                 for sample in self.problem_samples.get(name, []):
                     lines.append(f"  e.g. {sample}")
+
+        if self.tool_failures:
+            lines.append("Failing tools (by name):")
+            ranked = sorted(self.tool_failures.items(), key=lambda item: -item[1])
+            for tool, count in ranked[:TOP_EVENT_TYPES]:
+                lines.append(f"- {tool}: {count} failure(s)")
 
         token_total, model_totals = self._token_totals()
         if token_total:

--- a/src/muxi/runtime/services/tuning/service.py
+++ b/src/muxi/runtime/services/tuning/service.py
@@ -31,7 +31,7 @@ from .. import observability
 from ..memory.log.formation import lint_formation_lines
 from ..observability.spool import get_event_spool
 from .config import TuningConfig
-from .experiments import STATUS_ACTIVE, STATUS_PENDING, ExperimentStore
+from .experiments import STATUS_ACTIVE, STATUS_DISMISSED, STATUS_PENDING, ExperimentStore
 from .muxi_md import MUXI_MD_MAX_BYTES
 from .tuner import TunerStep
 
@@ -215,6 +215,10 @@ class TuningService:
                 },
                 description="Tuning learning retired: watched metric did not move",
             )
+        # Persist the retirements before the pass yields: the pending
+        # surfaces (apply/dismiss) load the store fresh from disk and could
+        # otherwise run against -- or be overwritten by -- stale state.
+        store.save()
 
         captains_log = getattr(self.overlord, "captains_log", None)
         formation_log_block = ""
@@ -228,7 +232,7 @@ class TuningService:
             active_learnings=store.by_status(STATUS_ACTIVE),
             retired_learnings=retired,
             dismissed_learnings=[
-                record.get("learning", "") for record in store.by_status("dismissed")
+                record.get("learning", "") for record in store.by_status(STATUS_DISMISSED)
             ],
             metric_keys=sorted(metrics),
             max_bytes=MUXI_MD_MAX_BYTES,
@@ -239,8 +243,12 @@ class TuningService:
             await model.generate_text(prompt, temperature=0.0, caching=False)
         )
         if parsed is None:
-            store.save()
             return {"learnings_retired": len(retired), "tuner_skipped": "unparseable_response"}
+
+        # Reload: the pending surfaces may have advanced the store (apply,
+        # dismiss) while the pass was awaiting the LLM; recording onto a
+        # fresh copy respects those decisions instead of overwriting them.
+        store = ExperimentStore(self.experiments_dir)
 
         # Record the distilled learnings; already-known hashes (dismissed,
         # retired, still-watched) are silently skipped -- never re-proposed.
@@ -267,12 +275,14 @@ class TuningService:
         candidate = parsed["muxi_md"]
         if candidate:
             candidate, dropped_lines = lint_formation_lines(candidate, known_user_ids)
-        if not candidate and recorded:
-            # The model sometimes records learnings without producing the
-            # revised file; append them so the file never lags the store.
-            current = muxi_md.read() or ""
+        current = muxi_md.read() or ""
+        if recorded and (not candidate or candidate == current):
+            # The model sometimes records learnings without folding them
+            # into a revision (empty or verbatim file); append them so the
+            # file never lags the store.
+            base = candidate or current
             appended = "\n".join(f"- {record['learning']}" for record in recorded)
-            fallback = f"{current}\n\n{appended}" if current else appended
+            fallback = f"{base}\n\n{appended}" if base else appended
             candidate, dropped_lines = lint_formation_lines(fallback, known_user_ids)
         rejected_oversize = False
         if candidate and len(candidate.encode("utf-8")) > MUXI_MD_MAX_BYTES:

--- a/src/muxi/runtime/services/tuning/tuner.py
+++ b/src/muxi/runtime/services/tuning/tuner.py
@@ -1,0 +1,192 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        The Tuner - Detection, Distillation, MUXI.md Curation
+# Description:  Prompt builder/parser for the tuning loop's tune step
+# Role:         Turns the digest pass into MUXI.md revisions + learnings
+# Usage:        Driven by TuningService.run_once after the digest step
+# Author:       Muxi Framework Team
+#
+# Self-Improving Formation PRD, "The loop" step 2. The tuner reads the
+# fresh digest, recent formation-log entries, and its experiment
+# memories; detects patterns worth acting on (cost hotspots, misrouted
+# request classes, flaky tools, model over-provisioning); and distills
+# behavioral learnings into a candidate MUXI.md revision. It never
+# touches formation config -- config changes are human deployments,
+# surfaced only as prose recommendations.
+#
+# Mirrors the FormationLogSummarizer contract: the caller drives the LLM
+# call (build_prompt -> generate_text -> parse_response); every failure
+# parses down to None so the tuning loop is never broken by the tuner.
+# =============================================================================
+
+from typing import Any, Dict, List, Optional
+
+from ...utils.fastjson import json
+
+# Bounds on what one pass may propose; curation is rewriting, not
+# accretion, so a run never needs more than a handful of changes.
+MAX_LEARNINGS_PER_RUN = 5
+MAX_RECOMMENDATIONS_PER_RUN = 5
+MAX_LEARNING_CHARS = 500
+MAX_EVIDENCE_CHARS = 500
+MAX_RECOMMENDATION_CHARS = 500
+
+
+class TunerStep:
+    """Builds and parses the tune-step LLM call."""
+
+    def build_prompt(
+        self,
+        activity_report: str,
+        current_muxi_md: Optional[str],
+        formation_log_block: Optional[str],
+        active_learnings: List[Dict[str, Any]],
+        retired_learnings: List[Dict[str, Any]],
+        dismissed_learnings: List[str],
+        metric_keys: List[str],
+        max_bytes: int,
+    ) -> str:
+        parts: List[str] = [
+            "You are the tuner of an AI formation: you curate MUXI.md, the "
+            "formation's file of behavioral learnings. MUXI.md steers dynamic "
+            "per-turn decisions (routing, model choice within the shipped "
+            "hierarchy, tool selection, clarification thresholds). It is "
+            "injected into every turn's context, so it must stay concise, "
+            "operational, and general.\n",
+            "Detect patterns worth acting on in the activity below: cost "
+            "hotspots, misrouted request classes, flaky tools, model "
+            "over-provisioning. Distill them into learnings and produce a "
+            "revised MUXI.md.\n",
+            "RULES:\n"
+            "- Base every learning ONLY on the activity report and log entries "
+            "below. Do not invent patterns.\n"
+            "- CURATE, never append: rewrite sections, merge overlapping "
+            "guidance, retire stale learnings. The revised file MUST stay "
+            f"under {max_bytes} bytes.\n"
+            "- NEVER suggest configuration or yaml changes inside MUXI.md; "
+            "anything requiring a deployment (yaml edits, plan upgrades, new "
+            "tools) goes into 'recommendations' as prose for a human.\n"
+            "- HARD PRIVACY RULE: MUXI.md is injected into every user's "
+            "context. NEVER include user identifiers, user names, prompt or "
+            "message content, or any user-derived specifics.\n"
+            "- BE SPECIFIC about operations: name the exact tools, models, "
+            "event types, and time windows involved ('the jira MCP', not "
+            "'some tools'). Operational specifics are the point; only "
+            "user-derived specifics are banned.\n"
+            "- Each learning is one imperative sentence of operational "
+            "guidance (e.g. 'Back off the jira MCP during 14:00-16:00 UTC "
+            "rate-limit windows.').\n"
+            "- When a learning targets a measurable problem, set its "
+            "'metric_key' to one of the observed metric keys listed below so "
+            "later runs can verify the metric moved; use null otherwise.\n"
+            "- Propose at most "
+            f"{MAX_LEARNINGS_PER_RUN} learnings; an empty list is a fine "
+            "answer when nothing stands out. Do not re-propose dismissed or "
+            "retired learnings.",
+        ]
+
+        parts.append(f"\nCurrent MUXI.md:\n{current_muxi_md or '(the file does not exist yet)'}")
+
+        if formation_log_block:
+            parts.append(f"\nRecent formation log entries:\n{formation_log_block}")
+
+        if active_learnings:
+            lines = [
+                f"- {record.get('learning')} (watching {record.get('metric_key') or 'nothing'})"
+                for record in active_learnings
+            ]
+            parts.append(
+                "\nLearnings currently under observation (keep them):\n" + "\n".join(lines)
+            )
+
+        if retired_learnings:
+            lines = [f"- {record.get('learning')}" for record in retired_learnings]
+            parts.append(
+                "\nRetired learnings -- their watched metric did not move; the "
+                "revised MUXI.md MUST NOT contain them:\n" + "\n".join(lines)
+            )
+
+        if dismissed_learnings:
+            lines = [f"- {learning}" for learning in dismissed_learnings]
+            parts.append(
+                "\nDismissed learnings -- the operator rejected these; NEVER "
+                "re-propose them:\n" + "\n".join(lines)
+            )
+
+        if metric_keys:
+            parts.append("\nObserved metric keys:\n" + "\n".join(f"- {key}" for key in metric_keys))
+
+        parts.append(
+            "\nRespond with a JSON object in exactly this structure:\n"
+            "{\n"
+            '  "muxi_md": "the full revised MUXI.md content, or an empty string '
+            'when nothing should change",\n'
+            '  "learnings": [{"learning": "...", "evidence": "...", '
+            '"metric_key": "... or null"}],\n'
+            '  "recommendations": ["prose recommendation for a human '
+            'deployment"]\n'
+            "}\n"
+        )
+        parts.append(f"\nAggregated activity report:\n{activity_report}\n")
+        return "\n".join(parts)
+
+    def parse_response(self, response: str) -> Optional[Dict[str, Any]]:
+        """Parse the LLM response; None means the tuner skips this run."""
+        if not response or not isinstance(response, str):
+            return None
+        clean = response.strip()
+        if clean.startswith("```"):
+            first_newline = clean.find("\n")
+            if first_newline > 0:
+                clean = clean[first_newline + 1 :]  # noqa: E203
+            if clean.endswith("```"):
+                clean = clean[:-3].strip()
+        try:
+            payload = json.loads(clean)
+        except Exception:
+            return None
+        if not isinstance(payload, dict):
+            return None
+
+        muxi_md = payload.get("muxi_md")
+        muxi_md = muxi_md.strip() if isinstance(muxi_md, str) and muxi_md.strip() else None
+
+        learnings: List[Dict[str, Optional[str]]] = []
+        for item in payload.get("learnings") or []:
+            if not isinstance(item, dict):
+                continue
+            learning = item.get("learning")
+            if not isinstance(learning, str) or not learning.strip():
+                continue
+            evidence = item.get("evidence")
+            metric_key = item.get("metric_key")
+            learnings.append(
+                {
+                    "learning": learning.strip()[:MAX_LEARNING_CHARS],
+                    "evidence": (
+                        evidence.strip()[:MAX_EVIDENCE_CHARS]
+                        if isinstance(evidence, str) and evidence.strip()
+                        else ""
+                    ),
+                    "metric_key": (
+                        metric_key.strip()
+                        if isinstance(metric_key, str) and metric_key.strip()
+                        else None
+                    ),
+                }
+            )
+            if len(learnings) >= MAX_LEARNINGS_PER_RUN:
+                break
+
+        recommendations: List[str] = []
+        for item in payload.get("recommendations") or []:
+            if isinstance(item, str) and item.strip():
+                recommendations.append(item.strip()[:MAX_RECOMMENDATION_CHARS])
+            if len(recommendations) >= MAX_RECOMMENDATIONS_PER_RUN:
+                break
+
+        return {"muxi_md": muxi_md, "learnings": learnings, "recommendations": recommendations}
+
+
+__all__ = ["MAX_LEARNINGS_PER_RUN", "TunerStep"]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,11 +10,15 @@ import pytest
 
 from muxi.runtime.services.observability import spool as spool_module
 from muxi.runtime.services.observability.spool import reset_event_spool
+from muxi.runtime.services.tuning import experiments as experiments_module
 
 
 @pytest.fixture(autouse=True)
 def _isolated_event_spool(tmp_path, monkeypatch):
     monkeypatch.setattr(spool_module, "_spool_dir", lambda: str(tmp_path / "event-spool"))
+    monkeypatch.setattr(
+        experiments_module, "_default_experiments_dir", lambda: str(tmp_path / "tuner")
+    )
     reset_event_spool()
     yield
     reset_event_spool()

--- a/tests/unit/test_event_spool.py
+++ b/tests/unit/test_event_spool.py
@@ -92,6 +92,20 @@ class TestReadDigestCommit:
         segments, token = spool.read_for_digest()
         assert segments == []
 
+    def test_events_after_delete_commit_stay_visible(self, spool):
+        # After delete=True removes every segment, the numbering must
+        # continue past the checkpoint -- a reset would produce a name
+        # that sorts at/below it, hiding all subsequent events forever.
+        spool.write_lines(['{"event":"a"}'])
+        segments, token = spool.read_for_digest()
+        spool.commit(token, delete=True)
+
+        spool.write_lines(['{"event":"b"}'])
+        segments, token = spool.read_for_digest()
+        events = list(spool.iter_events(segments))
+        assert [event["event"] for event in events] == ["b"]
+        spool.commit(token, delete=True)
+
     def test_commit_keep_preserves_segments_without_rereading(self, spool):
         spool.write_lines(['{"event":"a"}'])
         segments, token = spool.read_for_digest()

--- a/tests/unit/test_notification_router.py
+++ b/tests/unit/test_notification_router.py
@@ -232,6 +232,74 @@ class TestConstruction:
         assert router.config.channels["slack"].transformer == "slack"
 
 
+class TestUiWidgets:
+    async def test_channel_delivery_renders_ui_variables(self, tmp_path):
+        from muxi.runtime.datatypes.ui import build_options_widget
+
+        sink = await Sink().start()
+        try:
+            transformers_dir = tmp_path / "transformers"
+            transformers_dir.mkdir(exist_ok=True)
+            (transformers_dir / "t-ui.yaml").write_text(
+                "name: t-ui\n"
+                "endpoint:\n"
+                f"  url: http://127.0.0.1:{sink.port}/notify\n"
+                "body:\n"
+                '  text: "${{ response.content }}"\n'
+                '  reply_markup: "${{ ui.telegram.reply_markup }}"\n'
+            )
+            router, store = _router(tmp_path, {"channels": {"chan-u": {"transformer": "t-ui"}}})
+            await store.set_preferences("ran", preferred_channel="chan-u")
+
+            widget = build_options_widget(
+                "Apply?", [{"value": "apply", "label": "Apply"}, {"value": "dismiss"}]
+            )
+            result = await router.notify(user_id="ran", message="report", ui=[widget])
+
+            assert result["delivered"] == ["chan-u"]
+            payload = json.loads(sink.requests[0]["body"])
+            assert payload["text"] == "report"
+            buttons = payload["reply_markup"]["inline_keyboard"]
+            callbacks = [button["callback_data"] for row in buttons for button in row]
+            assert callbacks == [f"{widget['id']}#0", f"{widget['id']}#1"]
+        finally:
+            await sink.stop()
+
+    async def test_webhook_payload_carries_ui(self, tmp_path):
+        from muxi.runtime.datatypes.ui import build_options_widget
+
+        sink = await Sink().start()
+        try:
+            router, _ = _router(
+                tmp_path,
+                {"channels": {}},
+                async_webhook_url=f"http://127.0.0.1:{sink.port}/hook",
+            )
+            widget = build_options_widget("Apply?", [{"value": "apply"}])
+            result = await router.notify(user_id="ran", message="report", ui=[widget])
+
+            assert result["delivered"] == ["webhook"]
+            payload = json.loads(sink.requests[0]["body"])
+            assert payload["response"] == [{"type": "text", "text": "report"}]
+            assert payload["ui"][0]["id"] == widget["id"]
+        finally:
+            await sink.stop()
+
+    async def test_text_only_notification_is_unchanged(self, tmp_path):
+        sink = await Sink().start()
+        try:
+            router, _ = _router(
+                tmp_path,
+                {"channels": {}},
+                async_webhook_url=f"http://127.0.0.1:{sink.port}/hook",
+            )
+            await router.notify(user_id="ran", message="plain")
+            payload = json.loads(sink.requests[0]["body"])
+            assert "ui" not in payload
+        finally:
+            await sink.stop()
+
+
 class TestDelivery:
     async def test_delivers_to_channel_with_user_context(self, tmp_path):
         sink = await Sink().start()

--- a/tests/unit/test_tuning_experiments.py
+++ b/tests/unit/test_tuning_experiments.py
@@ -1,0 +1,168 @@
+"""Unit tests for the tuner's experiment memories (Phase 2).
+
+Pins the sidecar store contract: content-hash dedupe across every
+status (dismissed ideas are never re-proposed), the pending -> active ->
+retired lifecycle, deterministic watch-window evaluation, and atomic
+persistence that survives corrupt/missing files.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+from muxi.runtime.services.tuning.experiments import (
+    DEFAULT_WATCH_WINDOW_HOURS,
+    STATUS_ACTIVE,
+    STATUS_DISMISSED,
+    STATUS_PENDING,
+    STATUS_RETIRED,
+    ExperimentStore,
+    learning_hash,
+)
+
+
+def make_store(tmp_path):
+    return ExperimentStore(str(tmp_path / "tuner"))
+
+
+class TestLearningHash:
+    def test_whitespace_and_case_insensitive(self):
+        assert learning_hash("Route FAQ  requests\nto sonnet.") == learning_hash(
+            "route faq requests to sonnet."
+        )
+
+    def test_distinct_content_distinct_hash(self):
+        assert learning_hash("a") != learning_hash("b")
+
+
+class TestPersistence:
+    def test_roundtrip(self, tmp_path):
+        store = make_store(tmp_path)
+        store.propose("Back off jira 14:00-16:00.", "timeouts clustered", None, None, STATUS_ACTIVE)
+        store.save()
+
+        reloaded = make_store(tmp_path)
+        assert len(reloaded.records) == 1
+        assert reloaded.records[0]["learning"] == "Back off jira 14:00-16:00."
+        assert reloaded.records[0]["status"] == STATUS_ACTIVE
+
+    def test_missing_file_means_empty(self, tmp_path):
+        assert make_store(tmp_path).records == []
+
+    def test_corrupt_file_means_empty(self, tmp_path):
+        base = tmp_path / "tuner"
+        base.mkdir()
+        (base / "experiments.json").write_text("{not json")
+        assert make_store(tmp_path).records == []
+
+    def test_non_dict_records_are_dropped(self, tmp_path):
+        base = tmp_path / "tuner"
+        base.mkdir()
+        (base / "experiments.json").write_text(
+            json.dumps({"version": 1, "experiments": ["junk", {"content_hash": "x"}]})
+        )
+        assert make_store(tmp_path).records == [{"content_hash": "x"}]
+
+
+class TestLifecycle:
+    def test_propose_dedupes_across_statuses(self, tmp_path):
+        store = make_store(tmp_path)
+        record = store.propose("Route FAQ to sonnet.", "e", None, None, STATUS_PENDING)
+        assert record is not None
+        store.set_status(record, STATUS_DISMISSED)
+        # A dismissed idea is never re-proposed, even normalized differently.
+        assert store.propose("route faq  to sonnet.", "e2", None, None, STATUS_ACTIVE) is None
+        assert len(store.records) == 1
+
+    def test_active_proposal_opens_watch_window(self, tmp_path):
+        store = make_store(tmp_path)
+        record = store.propose("L", "e", "error_rate", 0.4, STATUS_ACTIVE)
+        assert record["watch"]["opened_at"] is not None
+        assert record["watch"]["window_hours"] == DEFAULT_WATCH_WINDOW_HOURS
+        assert record["baseline"] == 0.4
+
+    def test_pending_proposal_holds_watch_until_activated(self, tmp_path):
+        store = make_store(tmp_path)
+        record = store.propose("L", "e", "error_rate", 0.4, STATUS_PENDING)
+        assert record["watch"]["opened_at"] is None
+
+        activated = store.activate_pending()
+        assert [r["content_hash"] for r in activated] == [record["content_hash"]]
+        assert record["status"] == STATUS_ACTIVE
+        assert record["watch"]["opened_at"] is not None
+
+    def test_dismiss_pending_marks_all_pending(self, tmp_path):
+        store = make_store(tmp_path)
+        store.propose("L1", "e", None, None, STATUS_PENDING)
+        store.propose("L2", "e", None, None, STATUS_PENDING)
+        store.propose("L3", "e", None, None, STATUS_ACTIVE)
+
+        dismissed = store.dismiss_pending()
+        assert len(dismissed) == 2
+        assert len(store.by_status(STATUS_DISMISSED)) == 2
+        assert len(store.by_status(STATUS_ACTIVE)) == 1
+
+
+class TestWatchWindows:
+    def _expired(self, record):
+        record["watch"]["opened_at"] = time.time() - 8 * 24 * 3600  # past the 168h default
+
+    def test_unmoved_metric_retires_the_learning(self, tmp_path):
+        store = make_store(tmp_path)
+        record = store.propose("L", "e", "problem:mcp.tool.failed", 0.4, STATUS_ACTIVE)
+        self._expired(record)
+
+        retired = store.evaluate_watch_windows({"problem:mcp.tool.failed": 0.39})
+        assert retired == [record]
+        assert record["status"] == STATUS_RETIRED
+        assert record["outcome"]["moved"] is False
+
+    def test_moved_metric_keeps_the_learning(self, tmp_path):
+        store = make_store(tmp_path)
+        record = store.propose("L", "e", "problem:mcp.tool.failed", 0.4, STATUS_ACTIVE)
+        self._expired(record)
+
+        retired = store.evaluate_watch_windows({"problem:mcp.tool.failed": 0.1})
+        assert retired == []
+        assert record["status"] == STATUS_ACTIVE
+        assert record["outcome"]["moved"] is True
+        assert record["watch"]["closed_at"] is not None
+
+    def test_absent_metric_counts_as_moved_to_zero(self, tmp_path):
+        store = make_store(tmp_path)
+        record = store.propose("L", "e", "problem:mcp.tool.failed", 0.4, STATUS_ACTIVE)
+        self._expired(record)
+
+        assert store.evaluate_watch_windows({}) == []
+        assert record["status"] == STATUS_ACTIVE
+        assert record["outcome"]["moved"] is True
+
+    def test_open_window_is_left_alone(self, tmp_path):
+        store = make_store(tmp_path)
+        record = store.propose("L", "e", "error_rate", 0.4, STATUS_ACTIVE)
+        assert store.evaluate_watch_windows({"error_rate": 0.4}) == []
+        assert record["status"] == STATUS_ACTIVE
+        assert "outcome" not in record
+
+    def test_closed_watch_is_never_rescored(self, tmp_path):
+        store = make_store(tmp_path)
+        record = store.propose("L", "e", "problem:mcp.tool.failed", 0.4, STATUS_ACTIVE)
+        self._expired(record)
+        store.evaluate_watch_windows({"problem:mcp.tool.failed": 0.1})
+        assert record["outcome"]["moved"] is True
+
+        # The metric regresses after the watch proved the learning.
+        retired = store.evaluate_watch_windows({"problem:mcp.tool.failed": 0.9})
+        assert retired == []
+        assert record["status"] == STATUS_ACTIVE
+        assert record["outcome"]["moved"] is True
+
+    def test_observational_learning_never_auto_retires(self, tmp_path):
+        store = make_store(tmp_path)
+        record = store.propose("L", "e", None, None, STATUS_ACTIVE)
+        self._expired(record)
+
+        assert store.evaluate_watch_windows({"error_rate": 1.0}) == []
+        assert record["status"] == STATUS_ACTIVE
+        assert record["watch"]["closed_at"] is not None

--- a/tests/unit/test_tuning_service.py
+++ b/tests/unit/test_tuning_service.py
@@ -93,10 +93,11 @@ def tuning(captains_log):
 
 class TestAggregation:
     def test_empty_segments_render_empty_report(self, isolated_spool):
-        report, user_ids, count = _aggregate_segments(isolated_spool, [])
+        report, user_ids, count, metrics = _aggregate_segments(isolated_spool, [])
         assert report == ""
         assert user_ids == []
         assert count == 0
+        assert metrics == {}
 
     def test_report_captures_operational_shape(self, isolated_spool):
         events = [
@@ -120,9 +121,12 @@ class TestAggregation:
         ]
         isolated_spool.write_lines([json.dumps(event) for event in events])
         segments, _ = isolated_spool.read_for_digest()
-        report, user_ids, count = _aggregate_segments(isolated_spool, segments)
+        report, user_ids, count, metrics = _aggregate_segments(isolated_spool, segments)
 
         assert count == 3
+        assert metrics["problem:mcp.tool.failed"] == pytest.approx(1 / 3)
+        assert metrics["warning_rate"] == pytest.approx(1 / 3)
+        assert metrics["error_rate"] == 0.0
         assert user_ids == ["alice", "bob"]
         assert "Window: 3 events" in report
         assert "2 distinct user(s), 1 session(s), 1 tracked request(s)" in report

--- a/tests/unit/test_tuning_tuner.py
+++ b/tests/unit/test_tuning_tuner.py
@@ -271,6 +271,33 @@ class TestTuneStep:
         assert pending.startswith("hand-written")
         assert "- Back off the jira MCP during afternoon spikes." in pending
 
+    def test_verbatim_candidate_falls_back_to_appending_learnings(
+        self, tmp_path, isolated_spool, captains_log
+    ):
+        tuning, muxi_md = make_tuning(tmp_path, captains_log, auto_apply=False)
+        muxi_md.write("hand-written")
+        response = json.dumps(
+            {
+                "muxi_md": "hand-written",
+                "learnings": [
+                    {
+                        "learning": "Back off the jira MCP during afternoon spikes.",
+                        "evidence": "clustered failures",
+                        "metric_key": None,
+                    }
+                ],
+                "recommendations": [],
+            }
+        )
+        isolated_spool.write_lines([json.dumps(spool_event())])
+
+        result = asyncio.run(tuning.run_once(SequencedModel([DIGEST_RESPONSE, response])))
+
+        assert result["muxi_md_suggested"] is True
+        pending = muxi_md.read_pending()
+        assert pending.startswith("hand-written")
+        assert "- Back off the jira MCP during afternoon spikes." in pending
+
     def test_oversized_candidate_is_never_written(self, tmp_path, isolated_spool, captains_log):
         tuning, muxi_md = make_tuning(tmp_path, captains_log, auto_apply=True)
         response = json.dumps(
@@ -313,6 +340,32 @@ class TestTuneStep:
         store = ExperimentStore(tuning.experiments_dir)
         assert len(store.records) == 1
         assert store.records[0]["status"] == "dismissed"
+
+    def test_dismissal_during_llm_await_is_not_overwritten(
+        self, tmp_path, isolated_spool, captains_log
+    ):
+        tuning, muxi_md = make_tuning(tmp_path, captains_log, auto_apply=False)
+
+        isolated_spool.write_lines([json.dumps(spool_event())])
+        asyncio.run(tuning.run_once(SequencedModel([DIGEST_RESPONSE, TUNER_RESPONSE])))
+        assert muxi_md.read_pending() is not None
+
+        class DismissingModel(SequencedModel):
+            """Dismisses the pending suggestion while the tuner awaits."""
+
+            async def generate_text(self, prompt, **kwargs):
+                if not self.responses or self.responses[0] != DIGEST_RESPONSE:
+                    tuning.dismiss_pending()
+                return await super().generate_text(prompt, **kwargs)
+
+        isolated_spool.write_lines([json.dumps(spool_event())])
+        result = asyncio.run(tuning.run_once(DismissingModel([DIGEST_RESPONSE, TUNER_RESPONSE])))
+
+        # The store keeps the dismissal: the pass reloads before recording,
+        # so the stale in-memory copy never overwrites the user's decision.
+        assert result["learnings_recorded"] == 0
+        store = ExperimentStore(tuning.experiments_dir)
+        assert [record["status"] for record in store.records] == ["dismissed"]
 
     def test_no_muxi_md_surface_skips_the_tune_step(self, isolated_spool, captains_log):
         overlord = FakeOverlord(captains_log, muxi_md=None)

--- a/tests/unit/test_tuning_tuner.py
+++ b/tests/unit/test_tuning_tuner.py
@@ -1,0 +1,513 @@
+"""Unit tests for the tune step (Self-Improving Formation, Phase 2).
+
+Pins the tuner end-to-end against a real spool, a real CaptainsLogService
+and real files (LLM mocked): distillation into MUXI.md (auto_apply) or
+PENDING-MUXI.md (manual), the privacy gate on tuner-written content, the
+bounded-file contract, experiment recording and dismissal semantics, the
+morning report delivery (widget included), the apply/dismiss surfaces,
+and the /learnings command.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from muxi.runtime.formation.builtin_commands import BuiltinCommandContext, _cmd_learnings
+from muxi.runtime.formation.overlord.overlord import Overlord
+from muxi.runtime.services.db import Base, DatabaseManager
+from muxi.runtime.services.memory.log.service import CaptainsLogService
+from muxi.runtime.services.observability import spool as spool_module
+from muxi.runtime.services.observability.spool import reset_event_spool
+from muxi.runtime.services.tuning import ExperimentStore, MuxiMdFile, TuningConfig, TuningService
+from muxi.runtime.services.tuning.experiments import STATUS_ACTIVE, STATUS_PENDING
+from muxi.runtime.services.tuning.muxi_md import MUXI_MD_MAX_BYTES
+from muxi.runtime.services.tuning.tuner import MAX_LEARNINGS_PER_RUN, TunerStep
+
+FORMATION_ID = "tuner-test-formation"
+
+DIGEST_RESPONSE = '{"summary": "Traffic was steady; one tool flaked.", "context": ""}'
+
+TUNER_RESPONSE = json.dumps(
+    {
+        "muxi_md": "# Learnings\n\n- Back off the jira MCP during afternoon spikes.",
+        "learnings": [
+            {
+                "learning": "Back off the jira MCP during afternoon spikes.",
+                "evidence": "mcp.tool.failed clustered",
+                "metric_key": "problem:mcp.tool.failed",
+            }
+        ],
+        "recommendations": ["Consider a jira plan upgrade."],
+    }
+)
+
+
+class SequencedModel:
+    """generate_text returns queued responses in order (digest, tune)."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.prompts = []
+
+    async def generate_text(self, prompt, **kwargs):
+        self.prompts.append(prompt)
+        return self.responses.pop(0) if self.responses else ""
+
+
+class FakeRouter:
+    def __init__(self):
+        self.calls = []
+
+    async def notify(self, *, user_id, message, channels=None, request_id=None, source, ui=None):
+        self.calls.append({"user_id": user_id, "message": message, "source": source, "ui": ui})
+        return {"request_id": "r", "channels": ["chan"], "delivered": ["chan"], "failed": []}
+
+
+class FakeOverlord:
+    def __init__(self, captains_log, muxi_md, router=None):
+        self.captains_log = captains_log
+        self.muxi_md = muxi_md
+        self.notification_router = router
+
+
+def spool_event(name="agent.processing", level="info", user_id=None, data=None):
+    event = {"event": name, "level": level, "timestamp": 1783862400000}
+    payload = dict(data or {})
+    if user_id:
+        payload["user_id"] = user_id
+    if payload:
+        event["data"] = payload
+    return event
+
+
+@pytest.fixture
+def isolated_spool(tmp_path, monkeypatch):
+    monkeypatch.setattr(spool_module, "_spool_dir", lambda: str(tmp_path / "spool"))
+    reset_event_spool()
+    yield spool_module.get_event_spool()
+    reset_event_spool()
+
+
+@pytest.fixture
+def captains_log(tmp_path):
+    manager = DatabaseManager(f"sqlite:///{tmp_path}/log.db")
+    manager.create_tables(Base.metadata)
+    yield CaptainsLogService(manager, FORMATION_ID)
+    manager.engine.dispose()
+
+
+def make_tuning(tmp_path, captains_log, auto_apply=True, router=None):
+    formation_dir = tmp_path / "formation"
+    formation_dir.mkdir(exist_ok=True)
+    muxi_md = MuxiMdFile(str(formation_dir))
+    overlord = FakeOverlord(captains_log, muxi_md, router)
+    tuning = TuningService(TuningConfig(auto_apply=auto_apply), overlord)
+    tuning.experiments_dir = str(tmp_path / "tuner")
+    return tuning, muxi_md
+
+
+class TestTunerStepParse:
+    def test_valid_response(self):
+        parsed = TunerStep().parse_response(TUNER_RESPONSE)
+        assert parsed["muxi_md"].startswith("# Learnings")
+        assert parsed["learnings"][0]["metric_key"] == "problem:mcp.tool.failed"
+        assert parsed["recommendations"] == ["Consider a jira plan upgrade."]
+
+    def test_fenced_response(self):
+        parsed = TunerStep().parse_response(f"```json\n{TUNER_RESPONSE}\n```")
+        assert parsed is not None
+        assert len(parsed["learnings"]) == 1
+
+    def test_garbage_parses_to_none(self):
+        step = TunerStep()
+        assert step.parse_response("not json") is None
+        assert step.parse_response("") is None
+        assert step.parse_response('["a list"]') is None
+
+    def test_malformed_items_are_dropped_and_capped(self):
+        payload = {
+            "muxi_md": "",
+            "learnings": [{"learning": f"L{i}"} for i in range(10)]
+            + ["junk", {"evidence": "no learning"}],
+            "recommendations": [f"R{i}" for i in range(10)] + [42],
+        }
+        parsed = TunerStep().parse_response(json.dumps(payload))
+        assert parsed["muxi_md"] is None
+        assert len(parsed["learnings"]) == MAX_LEARNINGS_PER_RUN
+        assert all(item["metric_key"] is None for item in parsed["learnings"])
+        assert len(parsed["recommendations"]) == 5
+
+    def test_prompt_carries_every_input(self):
+        prompt = TunerStep().build_prompt(
+            activity_report="THE-REPORT",
+            current_muxi_md="EXISTING-GUIDANCE",
+            formation_log_block="LOG-BLOCK",
+            active_learnings=[{"learning": "KEEP-ME", "metric_key": "error_rate"}],
+            retired_learnings=[{"learning": "RETIRE-ME"}],
+            dismissed_learnings=["NEVER-AGAIN"],
+            metric_keys=["error_rate", "problem:mcp.tool.failed"],
+            max_bytes=MUXI_MD_MAX_BYTES,
+        )
+        for needle in (
+            "THE-REPORT",
+            "EXISTING-GUIDANCE",
+            "LOG-BLOCK",
+            "KEEP-ME",
+            "RETIRE-ME",
+            "NEVER-AGAIN",
+            "problem:mcp.tool.failed",
+            str(MUXI_MD_MAX_BYTES),
+        ):
+            assert needle in prompt
+
+
+class TestTuneStep:
+    def test_auto_apply_writes_live_file_and_records_learnings(
+        self, tmp_path, isolated_spool, captains_log
+    ):
+        router = FakeRouter()
+        tuning, muxi_md = make_tuning(tmp_path, captains_log, auto_apply=True, router=router)
+        isolated_spool.write_lines(
+            [json.dumps(spool_event(name="mcp.tool.failed", level="warning"))]
+        )
+
+        result = asyncio.run(tuning.run_once(SequencedModel([DIGEST_RESPONSE, TUNER_RESPONSE])))
+
+        assert result["muxi_md_applied"] is True
+        assert result["muxi_md_suggested"] is False
+        assert result["learnings_recorded"] == 1
+        assert "jira MCP" in muxi_md.read()
+        assert muxi_md.read_pending() is None
+
+        store = ExperimentStore(tuning.experiments_dir)
+        [record] = store.by_status(STATUS_ACTIVE)
+        assert record["metric_key"] == "problem:mcp.tool.failed"
+        assert record["baseline"] == 1.0  # the only event was the failure
+        assert record["watch"]["opened_at"] is not None
+
+        # Morning report delivered without a widget (nothing to approve).
+        [call] = router.calls
+        assert call["source"] == "tuning"
+        assert call["ui"] is None
+        assert "jira MCP" in call["message"]
+        assert "Consider a jira plan upgrade." in call["message"]
+        assert tuning.pending_widget is None
+
+    def test_manual_mode_writes_pending_with_widget(self, tmp_path, isolated_spool, captains_log):
+        router = FakeRouter()
+        tuning, muxi_md = make_tuning(tmp_path, captains_log, auto_apply=False, router=router)
+        muxi_md.write("hand-written")
+        isolated_spool.write_lines([json.dumps(spool_event())])
+
+        result = asyncio.run(tuning.run_once(SequencedModel([DIGEST_RESPONSE, TUNER_RESPONSE])))
+
+        assert result["muxi_md_suggested"] is True
+        assert result["muxi_md_applied"] is False
+        assert muxi_md.read() == "hand-written"
+        assert "jira MCP" in muxi_md.read_pending()
+
+        store = ExperimentStore(tuning.experiments_dir)
+        [record] = store.by_status(STATUS_PENDING)
+        assert record["watch"]["opened_at"] is None
+
+        [call] = router.calls
+        assert call["ui"] is not None and call["ui"][0]["type"] == "options"
+        assert [o["value"] for o in call["ui"][0]["options"]] == ["apply", "dismiss"]
+        assert "/learnings apply" in call["message"]
+        assert tuning.pending_widget == {
+            "ui_id": call["ui"][0]["id"],
+            "ui_options": ["apply", "dismiss"],
+        }
+
+    def test_privacy_lint_drops_user_lines_from_candidate(
+        self, tmp_path, isolated_spool, captains_log
+    ):
+        tuning, muxi_md = make_tuning(tmp_path, captains_log, auto_apply=True)
+        response = json.dumps(
+            {
+                "muxi_md": "# Learnings\n- alice keeps asking about invoices.\n- Back off jira.",
+                "learnings": [],
+                "recommendations": [],
+            }
+        )
+        isolated_spool.write_lines([json.dumps(spool_event(user_id="alice"))])
+
+        result = asyncio.run(tuning.run_once(SequencedModel([DIGEST_RESPONSE, response])))
+
+        assert result["muxi_md_applied"] is True
+        content = muxi_md.read()
+        assert "alice" not in content
+        assert "Back off jira." in content
+
+    def test_empty_candidate_falls_back_to_appending_learnings(
+        self, tmp_path, isolated_spool, captains_log
+    ):
+        tuning, muxi_md = make_tuning(tmp_path, captains_log, auto_apply=False)
+        muxi_md.write("hand-written")
+        response = json.dumps(
+            {
+                "muxi_md": "",
+                "learnings": [
+                    {
+                        "learning": "Back off the jira MCP during afternoon spikes.",
+                        "evidence": "clustered failures",
+                        "metric_key": None,
+                    }
+                ],
+                "recommendations": [],
+            }
+        )
+        isolated_spool.write_lines([json.dumps(spool_event())])
+
+        result = asyncio.run(tuning.run_once(SequencedModel([DIGEST_RESPONSE, response])))
+
+        assert result["muxi_md_suggested"] is True
+        assert muxi_md.read() == "hand-written"
+        pending = muxi_md.read_pending()
+        assert pending.startswith("hand-written")
+        assert "- Back off the jira MCP during afternoon spikes." in pending
+
+    def test_oversized_candidate_is_never_written(self, tmp_path, isolated_spool, captains_log):
+        tuning, muxi_md = make_tuning(tmp_path, captains_log, auto_apply=True)
+        response = json.dumps(
+            {"muxi_md": "x" * (MUXI_MD_MAX_BYTES + 1), "learnings": [], "recommendations": []}
+        )
+        isolated_spool.write_lines([json.dumps(spool_event())])
+
+        result = asyncio.run(tuning.run_once(SequencedModel([DIGEST_RESPONSE, response])))
+
+        assert result["muxi_md_applied"] is False
+        assert result["muxi_md_rejected_oversize"] is True
+        assert muxi_md.read() is None
+
+    def test_unparseable_tuner_response_skips_but_pass_commits(
+        self, tmp_path, isolated_spool, captains_log
+    ):
+        tuning, muxi_md = make_tuning(tmp_path, captains_log)
+        isolated_spool.write_lines([json.dumps(spool_event())])
+
+        result = asyncio.run(tuning.run_once(SequencedModel([DIGEST_RESPONSE, "garbage"])))
+
+        assert result["spool_committed"] is True
+        assert result["tuner_skipped"] == "unparseable_response"
+        assert muxi_md.read() is None
+
+    def test_dismissed_idea_is_not_re_recorded(self, tmp_path, isolated_spool, captains_log):
+        router = FakeRouter()
+        tuning, muxi_md = make_tuning(tmp_path, captains_log, auto_apply=False, router=router)
+
+        isolated_spool.write_lines([json.dumps(spool_event())])
+        asyncio.run(tuning.run_once(SequencedModel([DIGEST_RESPONSE, TUNER_RESPONSE])))
+        tuning.dismiss_pending()
+        assert muxi_md.read_pending() is None
+
+        # The tuner proposes the same idea again on the next pass.
+        isolated_spool.write_lines([json.dumps(spool_event())])
+        result = asyncio.run(tuning.run_once(SequencedModel([DIGEST_RESPONSE, TUNER_RESPONSE])))
+
+        assert result["learnings_recorded"] == 0
+        store = ExperimentStore(tuning.experiments_dir)
+        assert len(store.records) == 1
+        assert store.records[0]["status"] == "dismissed"
+
+    def test_no_muxi_md_surface_skips_the_tune_step(self, isolated_spool, captains_log):
+        overlord = FakeOverlord(captains_log, muxi_md=None)
+        tuning = TuningService(TuningConfig(), overlord)
+        isolated_spool.write_lines([json.dumps(spool_event())])
+
+        result = asyncio.run(tuning.run_once(SequencedModel([DIGEST_RESPONSE])))
+        assert result["spool_committed"] is True
+        assert "muxi_md_applied" not in result
+
+
+class TestPendingSurfaces:
+    def _suggested(self, tmp_path, captains_log):
+        tuning, muxi_md = make_tuning(tmp_path, captains_log, auto_apply=False)
+        muxi_md.write_pending("# Suggested\n- Learning.")
+        store = ExperimentStore(tuning.experiments_dir)
+        store.propose("Learning.", "e", None, None, STATUS_PENDING)
+        store.save()
+        tuning.pending_widget = {"ui_id": "ui_x", "ui_options": ["apply", "dismiss"]}
+        return tuning, muxi_md
+
+    def test_apply_pending_promotes_and_activates(self, tmp_path, captains_log):
+        tuning, muxi_md = self._suggested(tmp_path, captains_log)
+        result = tuning.apply_pending()
+
+        assert result["learnings_activated"] == 1
+        assert muxi_md.read() == "# Suggested\n- Learning."
+        assert muxi_md.read_pending() is None
+        assert tuning.pending_widget is None
+        store = ExperimentStore(tuning.experiments_dir)
+        assert store.records[0]["status"] == STATUS_ACTIVE
+
+    def test_dismiss_pending_discards_and_remembers(self, tmp_path, captains_log):
+        tuning, muxi_md = self._suggested(tmp_path, captains_log)
+        result = tuning.dismiss_pending()
+
+        assert result["learnings_dismissed"] == 1
+        assert muxi_md.read() is None
+        assert muxi_md.read_pending() is None
+        assert tuning.pending_widget is None
+
+    def test_apply_without_pending_raises(self, tmp_path, captains_log):
+        tuning, _ = make_tuning(tmp_path, captains_log)
+        with pytest.raises(ValueError, match="No pending"):
+            tuning.apply_pending()
+        with pytest.raises(ValueError, match="No pending"):
+            tuning.dismiss_pending()
+
+
+class TestMuxiMdPending:
+    def test_pending_roundtrip_and_promote(self, tmp_path):
+        muxi_md = MuxiMdFile(str(tmp_path))
+        muxi_md.write("live")
+        assert muxi_md.read_pending() is None
+        muxi_md.write_pending("suggested")
+        assert muxi_md.read_pending() == "suggested"
+        assert muxi_md.read() == "live"
+
+        path = muxi_md.promote_pending()
+        assert path.endswith("MUXI.md")
+        assert muxi_md.read() == "suggested"
+        assert muxi_md.read_pending() is None
+
+    def test_discard_pending(self, tmp_path):
+        muxi_md = MuxiMdFile(str(tmp_path))
+        assert muxi_md.discard_pending() is False
+        muxi_md.write_pending("suggested")
+        assert muxi_md.discard_pending() is True
+        assert muxi_md.read_pending() is None
+
+    def test_promote_without_pending_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="No pending"):
+            MuxiMdFile(str(tmp_path)).promote_pending()
+
+    def test_pending_without_directory_raises(self):
+        with pytest.raises(ValueError, match="no directory"):
+            MuxiMdFile(None).write_pending("content")
+
+
+class TestTuningUiIntercept:
+    def _fake_overlord(self, tuning):
+        return SimpleNamespace(tuning_service=tuning)
+
+    def test_apply_button_press(self, tmp_path, captains_log):
+        tuning, muxi_md = make_tuning(tmp_path, captains_log)
+        muxi_md.write_pending("suggested")
+        store = ExperimentStore(tuning.experiments_dir)
+        store.propose("Learning.", "e", None, None, STATUS_PENDING)
+        store.save()
+        tuning.pending_widget = {"ui_id": "ui_abc", "ui_options": ["apply", "dismiss"]}
+
+        response = Overlord._process_tuning_ui_response(
+            self._fake_overlord(tuning), {"id": "ui_abc", "value": "apply"}
+        )
+        assert response is not None
+        assert "Applied" in response.content
+        assert muxi_md.read() == "suggested"
+        assert tuning.pending_widget is None
+
+    def test_dismiss_button_press(self, tmp_path, captains_log):
+        tuning, muxi_md = make_tuning(tmp_path, captains_log)
+        muxi_md.write_pending("suggested")
+        tuning.pending_widget = {"ui_id": "ui_abc", "ui_options": ["apply", "dismiss"]}
+
+        response = Overlord._process_tuning_ui_response(
+            self._fake_overlord(tuning), {"id": "ui_abc", "index": 1}
+        )
+        assert response is not None
+        assert "Dismissed" in response.content
+        assert muxi_md.read_pending() is None
+
+    def test_unknown_widget_falls_through(self, tmp_path, captains_log):
+        tuning, _ = make_tuning(tmp_path, captains_log)
+        tuning.pending_widget = {"ui_id": "ui_abc", "ui_options": ["apply", "dismiss"]}
+        fake = self._fake_overlord(tuning)
+
+        assert (
+            Overlord._process_tuning_ui_response(fake, {"id": "ui_other", "value": "apply"}) is None
+        )
+        assert Overlord._process_tuning_ui_response(fake, None) is None
+        tuning.pending_widget = None
+        assert (
+            Overlord._process_tuning_ui_response(fake, {"id": "ui_abc", "value": "apply"}) is None
+        )
+
+    def test_no_tuning_service_falls_through(self):
+        fake = SimpleNamespace(tuning_service=None)
+        assert (
+            Overlord._process_tuning_ui_response(fake, {"id": "ui_abc", "value": "apply"}) is None
+        )
+
+
+class TestLearningsCommand:
+    def _ctx(self, overlord, args=""):
+        return BuiltinCommandContext(
+            overlord=overlord, user_id="0", session_id="s", args=args, config=None
+        )
+
+    def _overlord(self, tmp_path, captains_log, multi_user=False):
+        tuning, muxi_md = make_tuning(tmp_path, captains_log)
+        overlord = SimpleNamespace(muxi_md=muxi_md, tuning_service=tuning, is_multi_user=multi_user)
+        tuning.overlord = overlord
+        return overlord
+
+    def test_show_without_file(self, tmp_path, captains_log):
+        overlord = self._overlord(tmp_path, captains_log)
+        reply = asyncio.run(_cmd_learnings(self._ctx(overlord)))
+        assert "No MUXI.md exists yet" in reply
+
+    def test_show_with_live_and_pending(self, tmp_path, captains_log):
+        overlord = self._overlord(tmp_path, captains_log)
+        overlord.muxi_md.write("# Learnings\n- Live guidance.")
+        overlord.muxi_md.write_pending("# Suggested")
+        reply = asyncio.run(_cmd_learnings(self._ctx(overlord)))
+        assert "Live guidance." in reply
+        assert "/learnings pending" in reply
+
+    def test_pending_view(self, tmp_path, captains_log):
+        overlord = self._overlord(tmp_path, captains_log)
+        reply = asyncio.run(_cmd_learnings(self._ctx(overlord, "pending")))
+        assert "no pending" in reply.lower()
+        overlord.muxi_md.write_pending("# Suggested")
+        reply = asyncio.run(_cmd_learnings(self._ctx(overlord, "pending")))
+        assert "# Suggested" in reply
+
+    def test_apply_and_dismiss(self, tmp_path, captains_log):
+        overlord = self._overlord(tmp_path, captains_log)
+        overlord.muxi_md.write_pending("# Suggested")
+        reply = asyncio.run(_cmd_learnings(self._ctx(overlord, "apply")))
+        assert "Applied" in reply
+        assert overlord.muxi_md.read() == "# Suggested"
+
+        overlord.muxi_md.write_pending("# Another")
+        reply = asyncio.run(_cmd_learnings(self._ctx(overlord, "dismiss")))
+        assert "Dismissed" in reply
+        assert overlord.muxi_md.read_pending() is None
+
+    def test_apply_without_pending_is_friendly(self, tmp_path, captains_log):
+        overlord = self._overlord(tmp_path, captains_log)
+        reply = asyncio.run(_cmd_learnings(self._ctx(overlord, "apply")))
+        assert "Could not apply" in reply
+
+    def test_mutating_verbs_refused_in_multi_user(self, tmp_path, captains_log):
+        overlord = self._overlord(tmp_path, captains_log, multi_user=True)
+        overlord.muxi_md.write_pending("# Suggested")
+        reply = asyncio.run(_cmd_learnings(self._ctx(overlord, "apply")))
+        assert "multi-user" in reply
+        assert overlord.muxi_md.read_pending() == "# Suggested"
+
+    def test_bad_action_shows_usage(self, tmp_path, captains_log):
+        overlord = self._overlord(tmp_path, captains_log)
+        reply = asyncio.run(_cmd_learnings(self._ctx(overlord, "bogus")))
+        assert reply.startswith("Usage:")
+
+    def test_no_surface(self):
+        overlord = SimpleNamespace(muxi_md=None)
+        reply = asyncio.run(_cmd_learnings(self._ctx(overlord)))
+        assert "not available" in reply


### PR DESCRIPTION
## Summary

Phase 2 of the Self-Improving Formation PRD: the tuning loop now closes the observe-learn-steer cycle. Each pass distills the aggregated activity report into concrete learnings, curates MUXI.md, tracks every learning as an experiment with a watch window, and reports to the formation owner.

### Tuner step
- After the Phase 1 digest, the same pass asks the LLM to detect patterns (cost hotspots, misrouted request classes, flaky tools) and produce a revised MUXI.md plus structured learnings and prose recommendations (`temperature=0`, unparseable responses skip the step, never break the pass).
- Tuner-written content passes a line-level privacy lint (markdown survives), the bounded-file contract (32KB) is enforced on the tuner's own writes, and deployment-shaped ideas (yaml edits, plan upgrades) never reach MUXI.md — they ship as recommendations for a human.
- The activity report now names failing tools explicitly (`Failing tools (by name):`) so learnings stay specific instead of 'some tools flaked'.
- When the model records learnings but returns no revision, the learnings are appended so the file never lags the store.

### Experiments (watch windows)
- Sidecar store at `observability/tuner/experiments.json` with content-hash dedup across the whole lifecycle: pending, active, retired, dismissed.
- Applying a learning opens a watch window (default 7 days) frozen at the proposal-time baseline; if the watched metric hasn't improved 10% at window close, the learning retires and is never re-proposed. A closed (proven) watch is final — later regressions can't retro-retire it. Dismissals are equally terminal.

### Pending flow (`auto_apply: false`)
- The tuner writes PENDING-MUXI.md beside the live file; nothing changes until a human acts through any of three equivalent surfaces:
  - `/learnings` builtin (show / pending / apply / dismiss; mutating verbs refused in multi-user mode)
  - Admin API: `GET`/`PATCH`/`DELETE /tuning/pending`
  - The morning report's apply/dismiss buttons

### Morning report
- Each pass with anything to say notifies the owner over the formation's proactive channels: applied or suggested revision, new learnings, retirements, recommendations.
- Under manual mode the report carries an options widget rendered natively on channels (P3 machinery); the button press resolves session-independently in the overlord before normal clarification pinning, and stale presses fall through to a normal turn.
- `NotificationRouter.notify()` gains an optional `ui=` widget pass-through into channel rendering and webhook payloads.

### Spool fix (Phase 1 bug found by Phase 2 tests)
- `_next_segment_path` now includes the checkpoint name in its sequence scan, so after a delete-all commit a fresh segment can never reuse a name at or below the checkpoint and silently hide every future event. Regression test included.

### Observability
- New `tuning.applied`, `tuning.suggested`, `tuning.retired`, `tuning.dismissed` events plus pending-surface API events; `validate_events.py` at 100%.

## Testing
- Unit: 3889 passed, 10 skipped (new: test_tuning_experiments.py 13, test_tuning_tuner.py 26, spool regression, notification ui widgets)
- E2E (live, gpt-4o-mini):
  - 27A5 auto-apply: planted flaky-tool traffic distilled into MUXI.md naming the tool, revision steers the next turn's context bundle, deterministic watch-window retirement
  - 27A6 pending flow: PENDING-MUXI.md written, live file untouched, /learnings show/pending/apply round-trip, DELETE /tuning/pending + 404 on re-dismiss, dismissals stay terminal across later passes
  - 27A7 morning report: delivered to the declared channel with native apply/dismiss buttons, button press applies from an unrelated session, stale press falls through
- Lint/format/mypy clean; CodeRabbit round: 2 fixed (closed-watch finality, oversize-rejection observability), 1 skipped (thread locks — all MuxiMdFile access rides the single event loop with no awaits inside the sequences)