### PR TITLE
feat(tuning): self-improving formation P3 — meta-agent benchmark observation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## [unreleased]
 
+### Self-improving formation - meta-agent benchmark observation (Phase 3)
+
+The tuning loop gains a second evidence source (Self-Improving
+Formation PRD, Phase 3): the shipped memory benchmarks, run by the
+loop itself against a real formation steered by the live MUXI.md. A
+cold-start formation with zero users gets deterministic evidence on
+day one, and MUXI.md regressions surface against a consistent baseline
+instead of drifting traffic:
+
+- Benchmark observation: each pass may run the fixture-scale suites
+  (LongMemEval sample + structured recall, QA on) as subprocesses of a
+  harness checkout -- opt-in via `MUXI_BENCH_ROOT`, at most one attempt
+  per suite per 24h, bounded by a per-suite timeout. The complete
+  report is the verdict, not the exit code (runners can die in
+  native-library teardown after writing it); partial or
+  errored-question reports are never scored.
+- Metrics: scores invert to the watch windows' lower-is-better
+  contract (`benchmark:<suite>.recall_gap`, `benchmark:<suite>.qa_error`)
+  and persist in a sidecar (`observability/tuner/benchmarks.json`).
+  They carry forward through skipped or failed passes, so a broken
+  harness can never false-validate a learning through metric absence.
+- Tune step: runs on benchmark evidence alone (the cold-start case),
+  sees the scores with previous-run deltas as a prompt block, and is
+  bound by an overfitting guard -- benchmark-derived learnings must
+  generalize, and benchmark answers or dataset specifics never enter
+  MUXI.md. Memory-tuning knobs remain human recommendations.
+- Steering seam: the bench runners accept `--muxi-md`; the file rides
+  the QA answer prompt, the bench equivalent of the runtime injecting
+  it into every turn. The benchmark formation declares `tuning: false`
+  (the measuring stick never tunes itself).
+- Observability: new `tuning.benchmark` event per suite attempt;
+  `tuning.run` carries `benchmark_suites_run`/`benchmark_skipped`; the
+  morning report shows the scores when there is something to say.
+
 ### Self-improving formation - tuner step, pending flow, /learnings (Phase 2)
 
 The tuning loop now closes the observe-learn-steer cycle (Self-Improving

--- a/bench/memory/adapter.py
+++ b/bench/memory/adapter.py
@@ -101,6 +101,7 @@ class MuxiMemoryAdapter:
         secrets_dir: Optional[Path] = None,
         max_embed_chars: int = DEFAULT_MAX_EMBED_CHARS,
         keep_run_dir: bool = False,
+        muxi_md: Optional[Path] = None,
     ):
         if mode not in MODES:
             raise ValueError(f"Unknown mode: {mode} (expected one of {MODES})")
@@ -110,6 +111,8 @@ class MuxiMemoryAdapter:
         self.secrets_dir = Path(secrets_dir or DEFAULT_SECRETS_DIR)
         self.max_embed_chars = max_embed_chars
         self.keep_run_dir = keep_run_dir
+        self.muxi_md = Path(muxi_md) if muxi_md else None
+        self._muxi_md_content: Optional[str] = None
 
         self.formation = None
         self.overlord = None
@@ -170,6 +173,13 @@ class MuxiMemoryAdapter:
         from muxi.runtime.datatypes.observability import RequestContext
         from muxi.runtime.formation import Formation
         from muxi.runtime.services.observability.context import set_request_context
+
+        # An explicitly requested MUXI.md must be readable: silently
+        # scoring a run that ignored its steering file would corrupt the
+        # tuning loop's benchmark evidence. Read fail-fast, before the
+        # formation boots.
+        if self.muxi_md is not None:
+            self._muxi_md_content = self.muxi_md.read_text(encoding="utf-8").strip() or None
 
         rendered = self._prepare_run_dir()
         self.formation = Formation()
@@ -398,10 +408,21 @@ class MuxiMemoryAdapter:
             f"Conversation excerpts (most relevant first):\n{context}\n\n"
             f"Question: {question.question}"
         )
+        # MUXI.md rides the QA system prompt -- the bench equivalent of
+        # the runtime injecting it into every turn's context -- so the
+        # tuning loop's benchmark observation measures the steered
+        # formation, not a bare model.
+        system_prompt = _ANSWER_SYSTEM_PROMPT
+        if self._muxi_md_content:
+            system_prompt = (
+                f"{_ANSWER_SYSTEM_PROMPT}\n\n"
+                "Operational learnings (MUXI.md) steering this formation:\n"
+                f"{self._muxi_md_content}"
+            )
         self.llm_requests += 1
         response = await model.chat(
             messages=[
-                {"role": "system", "content": _ANSWER_SYSTEM_PROMPT},
+                {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_message},
             ],
             temperature=0.0,
@@ -460,6 +481,8 @@ class MuxiMemoryAdapter:
             "formation_yaml": relativize(self.formation_yaml, REPO_ROOT),
             "max_embed_chars": self.max_embed_chars,
         }
+        if self.muxi_md is not None:
+            config["muxi_md"] = str(self.muxi_md)
         if self.overlord is not None and self.overlord.buffer_memory is not None:
             config["working_embedding_model"] = self.overlord.buffer_memory.embedding_model_name
         capability_models = getattr(self.formation, "_capability_models", None) or {}

--- a/bench/memory/formation/formation.yaml
+++ b/bench/memory/formation/formation.yaml
@@ -19,6 +19,10 @@ description: "Formation used by the Tier 1 memory benchmark harness"
 runtime:
   built_in_mcps: false
 
+# A benchmark run must never tune itself: the tuning loop belongs to
+# the formation under measurement, not the measuring stick.
+tuning: false
+
 llm:
   settings:
     temperature: 0.0

--- a/bench/memory/runner.py
+++ b/bench/memory/runner.py
@@ -148,6 +148,14 @@ def build_arg_parser(benchmark: str, default_k: int) -> argparse.ArgumentParser:
         help="Directory holding .key/secrets.enc (default: <repo>/e2e/assets).",
     )
     parser.add_argument(
+        "--muxi-md",
+        default=None,
+        help=(
+            "Path to a live MUXI.md injected into the QA answer prompt "
+            "(the tuning loop's benchmark observation passes the formation's file)."
+        ),
+    )
+    parser.add_argument(
         "--output",
         default=None,
         help=(
@@ -209,6 +217,7 @@ async def run_benchmark(benchmark: str, args: argparse.Namespace) -> int:
         run_dir=Path(args.run_dir) if args.run_dir else None,
         secrets_dir=Path(args.secrets_dir) if args.secrets_dir else None,
         keep_run_dir=args.keep_run_dir,
+        muxi_md=Path(args.muxi_md) if args.muxi_md else None,
     )
 
     print(

--- a/bench/memory/structured_recall_runner.py
+++ b/bench/memory/structured_recall_runner.py
@@ -152,6 +152,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--secrets-dir", default=None)
     parser.add_argument(
+        "--muxi-md",
+        default=None,
+        help=(
+            "Path to a live MUXI.md injected into the QA answer prompt "
+            "(the tuning loop's benchmark observation passes the formation's file)."
+        ),
+    )
+    parser.add_argument(
         "--output",
         default=None,
         help=(
@@ -187,6 +195,7 @@ async def run_benchmark(args: argparse.Namespace) -> int:
         run_dir=Path(args.run_dir) if args.run_dir else None,
         secrets_dir=Path(args.secrets_dir) if args.secrets_dir else None,
         keep_run_dir=args.keep_run_dir,
+        muxi_md=Path(args.muxi_md) if args.muxi_md else None,
     )
 
     print(

--- a/e2e/tests/27_tuning/test_27a8_benchmark_observation.py
+++ b/e2e/tests/27_tuning/test_27a8_benchmark_observation.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Test 27A8: benchmark observation (Self-Improving Formation, Phase 3).
+
+The meta-agent's cold start against the real harness: a formation with
+ZERO traffic (no users, empty spool) runs one tuning pass with
+$MUXI_BENCH_ROOT pointing at this checkout -> both fixture suites run
+as real subprocesses (real formation, real embeddings, real QA + judge)
+with the live MUXI.md riding the QA prompt -> the scores land in the
+tuner sidecar and give the tune step enough evidence to run without a
+single event -> a second pass reuses the fresh scores instead of paying
+for a rerun.
+"""
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+from tuning_common import (
+    REPO_ROOT,
+    build_formation,
+    load_formation,
+    run_tuning_pass,
+    teardown,
+    tuner_dir_for,
+    unique_formation_id,
+)
+
+MUXI_MD = (
+    "# Learnings\n\n"
+    "- Answer strictly from the retrieved conversation excerpts; when they "
+    "lack the answer, say you do not know.\n"
+)
+
+SUITE_NAMES = ("longmemeval", "structured_recall")
+
+
+async def main():
+    print("MUXI Runtime - Test 27A8: benchmark observation (meta-agent cold start)")
+    print("=" * 60)
+
+    formation = None
+    formation_id = unique_formation_id("bench")
+    tmp = Path(tempfile.mkdtemp(prefix="muxi-tuning-27a8-"))
+    try:
+        os.environ["MUXI_BENCH_ROOT"] = str(REPO_ROOT)
+        formation_dir = build_formation(tmp, formation_id, muxi_md=MUXI_MD)
+        formation, overlord = await load_formation(formation_dir)
+        print(f"Formation loaded: {formation_id} (no traffic -- cold start)")
+
+        # 1. One pass on a formation nobody has ever talked to (the
+        #    spool holds only the formation's own startup events): the
+        #    benchmark suites are the evidence that makes tuning possible.
+        print("Running tuning pass with real benchmark suites (takes minutes)...")
+        result = await run_tuning_pass(overlord)
+        print(f"Tuning pass: {result}")
+        assert result["spool_committed"] is True
+        assert sorted(result["benchmark_suites_run"]) == sorted(
+            SUITE_NAMES
+        ), f"both fixture suites should have run: {result}"
+        assert (
+            "learnings_recorded" in result or "tuner_skipped" in result
+        ), f"the tune step did not run: {result}"
+        print("Tuning pass completed with benchmark evidence (no user traffic)")
+
+        # 2. Real scores in the sidecar, from complete (non-partial) runs.
+        sidecar = json.loads((tuner_dir_for(formation_id) / "benchmarks.json").read_text())
+        for name in SUITE_NAMES:
+            record = sidecar["suites"][name]
+            assert record["succeeded"] is True, f"suite {name} failed: {record}"
+            scores = record["scores"]
+            assert 0.0 <= scores["recall_at_k"] <= 1.0, f"bad recall for {name}: {scores}"
+            assert 0.0 <= scores["qa_accuracy"] <= 1.0, f"bad accuracy for {name}: {scores}"
+            print(
+                f"  {name}: recall@{scores['k']:.0f}={scores['recall_at_k']:.3f}, "
+                f"qa_accuracy={scores['qa_accuracy']:.3f}, "
+                f"cost=${scores.get('estimated_usd', 0.0):.4f}, "
+                f"duration={record['duration_seconds']:.0f}s"
+            )
+
+        # 3. The live MUXI.md steered the QA runs: the benchmark reports
+        #    echo the exact file the runner was pointed at.
+        live_path = overlord.muxi_md.resolve_path()
+        assert live_path, "the formation's MUXI.md went missing"
+        for name in SUITE_NAMES:
+            report = json.loads((tuner_dir_for(formation_id) / f"bench-{name}.json").read_text())
+            assert (
+                report["config"]["muxi_md"] == live_path
+            ), f"suite {name} did not receive the live MUXI.md: {report['config']}"
+        print(f"Both suites ran with the live MUXI.md: {live_path}")
+
+        # 4. Fresh scores are reused, not repurchased: a second pass
+        #    skips every suite and the attempt timestamps do not move.
+        attempted = {name: sidecar["suites"][name]["attempted_at"] for name in SUITE_NAMES}
+        again = await run_tuning_pass(overlord)
+        print(f"Second pass: {again}")
+        assert again["benchmark_suites_run"] == [], f"fresh suites were rerun: {again}"
+        assert again["benchmark_skipped"] == "all suites fresh"
+        sidecar = json.loads((tuner_dir_for(formation_id) / "benchmarks.json").read_text())
+        for name in SUITE_NAMES:
+            assert sidecar["suites"][name]["attempted_at"] == attempted[name]
+        print("Second pass reused the fresh scores (no rerun)")
+
+        print("\n" + "=" * 40)
+        print("\n### Test Result:")
+        print("  SUCCESS: the benchmark observation works end-to-end")
+        print("  - a zero-traffic formation ran both fixture suites in one tuning pass")
+        print("  - real recall/QA scores landed in the tuner sidecar")
+        print("  - the live MUXI.md rode every QA prompt")
+        print("  - the tune step ran on benchmark evidence alone (cold start)")
+        print("  - a second pass reused the fresh scores instead of rerunning")
+        print("\n" + "=" * 40)
+        print("\n### Chat transcript:")
+        print("\n(none -- the point of this test is a formation with zero traffic)")
+
+        print("\nTest 27A8 PASSED")
+        return True
+
+    except Exception as e:
+        print(f"\nTest failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+    finally:
+        os.environ.pop("MUXI_BENCH_ROOT", None)
+        if formation is not None:
+            await teardown(formation, formation_id)
+        import shutil
+
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0 if success else 1)

--- a/e2e/tests/27_tuning/test_27a9_benchmark_retirement.py
+++ b/e2e/tests/27_tuning/test_27a9_benchmark_retirement.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Test 27A9: benchmark carry-forward + deterministic retirement (Phase 3).
+
+The regression-guard half of the meta-agent, provable without paying
+for a real benchmark run: a planted sidecar score is carried forward
+into the watch windows even when the harness is broken (a failing fake
+harness records its error and never breaks the pass), and a planted
+expired learning watching a benchmark metric that did not move is
+deterministically retired. Metric absence must NEVER false-validate a
+learning -- that is exactly what carry-forward exists to prevent.
+"""
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from tuning_common import (
+    build_formation,
+    experiments_path_for,
+    load_formation,
+    run_tuning_pass,
+    teardown,
+    tuner_dir_for,
+    unique_formation_id,
+)
+
+FAILING_RUNNER = "import sys\nprint('planted harness failure', file=sys.stderr)\nsys.exit(1)\n"
+
+
+def build_failing_harness(root: Path) -> Path:
+    """A fake bench checkout whose runners always fail (no LLM, no cost)."""
+    memory = root / "bench" / "memory"
+    memory.mkdir(parents=True)
+    (root / "bench" / "__init__.py").write_text("")
+    (memory / "__init__.py").write_text("")
+    (memory / "runner.py").write_text("")  # the discovery marker
+    for module in ("longmemeval_runner.py", "structured_recall_runner.py"):
+        (memory / module).write_text(FAILING_RUNNER)
+    return root
+
+
+def plant_benchmark_scores(formation_id: str) -> None:
+    """A fresh longmemeval score in the sidecar: qa_error = 0.25."""
+    tuner_dir = tuner_dir_for(formation_id)
+    tuner_dir.mkdir(parents=True, exist_ok=True)
+    (tuner_dir / "benchmarks.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "suites": {
+                    "longmemeval": {
+                        "attempted_at": time.time(),  # fresh: never rerun today
+                        "succeeded": True,
+                        "scores": {"k": 5.0, "recall_at_k": 0.8, "qa_accuracy": 0.75},
+                        "previous_scores": None,
+                        "error": None,
+                        "duration_seconds": 60.0,
+                    }
+                },
+            }
+        )
+    )
+
+
+def plant_expired_benchmark_learning(formation_id: str) -> None:
+    """An active learning whose expired window watched a flat benchmark metric."""
+    path = experiments_path_for(formation_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "experiments": [
+                    {
+                        "content_hash": "planted-benchmark-retirement",
+                        "status": "active",
+                        "learning": "Planted learning that never moved the benchmark.",
+                        "evidence": "planted",
+                        "metric_key": "benchmark:longmemeval.qa_error",
+                        "baseline": 0.25,
+                        "watch": {
+                            "opened_at": time.time() - 8 * 24 * 3600,
+                            "window_hours": 168,
+                        },
+                        "created_at": time.time(),
+                        "updated_at": time.time(),
+                    }
+                ],
+            }
+        )
+    )
+
+
+async def main():
+    print("MUXI Runtime - Test 27A9: benchmark carry-forward + retirement")
+    print("=" * 60)
+
+    formation = None
+    formation_id = unique_formation_id("benchretire")
+    tmp = Path(tempfile.mkdtemp(prefix="muxi-tuning-27a9-"))
+    try:
+        # 1. Plant the state BEFORE the pass: a fresh longmemeval score
+        #    (qa_error 0.25), an expired learning watching that exact
+        #    metric, and a harness whose every runner fails.
+        plant_benchmark_scores(formation_id)
+        plant_expired_benchmark_learning(formation_id)
+        os.environ["MUXI_BENCH_ROOT"] = str(build_failing_harness(tmp / "harness"))
+
+        formation_dir = build_formation(tmp, formation_id)
+        formation, formation_overlord = await load_formation(formation_dir)
+        print(f"Formation loaded: {formation_id}")
+
+        # 2. One pass: the stale structured_recall suite is attempted
+        #    against the broken harness (fails, recorded, fail-soft),
+        #    the fresh longmemeval score is reused, and its carried
+        #    metric feeds the watch windows -- retiring the planted
+        #    no-movement learning.
+        result = await run_tuning_pass(formation_overlord)
+        print(f"Tuning pass: {result}")
+        assert result["spool_committed"] is True
+        assert result["benchmark_suites_run"] == [
+            "structured_recall"
+        ], f"only the stale suite should have been attempted: {result}"
+        assert result["learnings_retired"] >= 1, f"no learning was retired: {result}"
+        assert "tuner_error" not in result, f"the pass broke on the benchmark step: {result}"
+
+        # 3. The broken harness was recorded, not fatal -- and the
+        #    planted longmemeval score survived it untouched.
+        sidecar = json.loads((tuner_dir_for(formation_id) / "benchmarks.json").read_text())
+        structured = sidecar["suites"]["structured_recall"]
+        assert structured["succeeded"] is False
+        assert "planted harness failure" in structured["error"], f"error lost: {structured}"
+        assert sidecar["suites"]["longmemeval"]["scores"]["qa_accuracy"] == 0.75
+        print("Broken harness recorded per-suite; planted scores carried forward")
+
+        # 4. The retirement is the carried metric's doing: final == the
+        #    planted 0.25 (had the metric been absent, 0.0 would have
+        #    false-validated the learning as 'moved').
+        experiments = json.loads(experiments_path_for(formation_id).read_text())["experiments"]
+        planted = next(
+            record
+            for record in experiments
+            if record["content_hash"] == "planted-benchmark-retirement"
+        )
+        assert planted["status"] == "retired", f"planted learning was not retired: {planted}"
+        assert planted["outcome"]["moved"] is False
+        assert (
+            planted["outcome"]["final"] == 0.25
+        ), f"the carried benchmark metric did not feed the window: {planted['outcome']}"
+        print("No-movement benchmark learning deterministically retired (final=0.25)")
+
+        # 5. Fail-soft without any harness: unset the root and the next
+        #    pass skips the observation cleanly.
+        os.environ.pop("MUXI_BENCH_ROOT", None)
+        again = await run_tuning_pass(formation_overlord)
+        print(f"Pass without harness: {again}")
+        assert again["spool_committed"] is True
+        assert again["benchmark_suites_run"] == []
+        assert "MUXI_BENCH_ROOT" in (again["benchmark_skipped"] or "")
+        print("Missing harness skips the observation without breaking the pass")
+
+        print("\n" + "=" * 40)
+        print("\n### Test Result:")
+        print("  SUCCESS: benchmark carry-forward and retirement work end-to-end")
+        print("  - a failing harness was recorded per-suite and never broke the pass")
+        print("  - fresh planted scores were reused, not rerun")
+        print("  - the carried metric fed the watch windows (no false validation)")
+        print("  - the planted no-movement learning was deterministically retired")
+        print("  - an unset $MUXI_BENCH_ROOT skips the observation cleanly")
+        print("\n" + "=" * 40)
+        print("\n### Chat transcript:")
+        print("\n(none -- this test drives the tuning loop directly, without traffic)")
+
+        print("\nTest 27A9 PASSED")
+        return True
+
+    except Exception as e:
+        print(f"\nTest failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+    finally:
+        os.environ.pop("MUXI_BENCH_ROOT", None)
+        if formation is not None:
+            await teardown(formation, formation_id)
+        import shutil
+
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0 if success else 1)

--- a/e2e/tests/27_tuning/tuning_common.py
+++ b/e2e/tests/27_tuning/tuning_common.py
@@ -23,10 +23,16 @@ from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
 
+# The benchmark observation is opt-in via $MUXI_BENCH_ROOT; a globally
+# exported value must not make every area-27 pass spend minutes (and
+# tokens) on real benchmark suites. 27A8 sets it back explicitly.
+os.environ.pop("MUXI_BENCH_ROOT", None)
+
 from muxi.runtime.formation import Formation  # noqa: E402
 
 AREA_DIR = Path(__file__).parent
 ASSETS_DIR = AREA_DIR.parent.parent / "assets"
+REPO_ROOT = AREA_DIR.parent.parent.parent
 
 FORMATION_TEMPLATE = """\
 schema: "1.0.0"
@@ -212,6 +218,11 @@ async def run_tuning_pass(overlord) -> dict:
 def experiments_path_for(formation_id: str) -> Path:
     """Where the tuner's experiment memories live for this formation id."""
     return Path.home() / ".muxi" / formation_id / "observability" / "tuner" / "experiments.json"
+
+
+def tuner_dir_for(formation_id: str) -> Path:
+    """The tuner sidecar directory (experiments, benchmark scores/reports)."""
+    return Path.home() / ".muxi" / formation_id / "observability" / "tuner"
 
 
 def plant_tool_failures(count: int = 30, tool: str = "jira") -> None:

--- a/src/muxi/runtime/datatypes/observability.py
+++ b/src/muxi/runtime/datatypes/observability.py
@@ -593,6 +593,9 @@ class SystemEvents(Enum):
     TUNING_DISMISSED = "tuning.dismissed"
     # When a pending suggestion is dismissed (hashes are never re-proposed)
 
+    TUNING_BENCHMARK = "tuning.benchmark"
+    # When a tuning pass attempts one benchmark suite (meta-agent observation)
+
     # ===================================================================
     # NETWORK/COMMUNICATION INFRASTRUCTURE
     # ===================================================================

--- a/src/muxi/runtime/services/tuning/benchmark.py
+++ b/src/muxi/runtime/services/tuning/benchmark.py
@@ -189,9 +189,11 @@ class BenchmarkStep:
                     suite, bench_root, muxi_md_path, previous=record
                 )
                 suites_run.append(suite["name"])
+                # Persist per attempt: a pass cancelled between suites
+                # must not lose (and later re-buy) a completed result.
+                self._save_sidecar(sidecar)
             if not suites_run:
                 skipped = "all suites fresh"
-            self._save_sidecar(sidecar)
 
         return {
             "metrics": self._metrics(sidecar),
@@ -263,7 +265,12 @@ class BenchmarkStep:
                 )
             except asyncio.TimeoutError:
                 process.kill()
-                await process.wait()
+                # Drain the stderr pipe (not just wait()) so the killed
+                # child's transport closes cleanly.
+                try:
+                    await process.communicate()
+                except Exception:
+                    await process.wait()
                 record["error"] = f"timed out after {self.suite_timeout_seconds:.0f}s"
                 return self._finish_attempt(suite, record, started)
 

--- a/src/muxi/runtime/services/tuning/benchmark.py
+++ b/src/muxi/runtime/services/tuning/benchmark.py
@@ -1,0 +1,387 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Benchmark Observation - The Meta-Agent's Measuring Stick
+# Description:  Runs the shipped memory benchmarks as a tuning observation
+# Role:         Deterministic metric source for the tuning loop (Phase 3)
+# Usage:        Driven by TuningService.run_once between digest and tune
+# Author:       Muxi Framework Team
+#
+# Self-Improving Formation PRD, Phase 3 (meta-agent). The same tuning
+# loop, with the shipped benchmark tiers as an additional observation
+# source: fixture-scale suites (LongMemEval sample + structured recall)
+# run with QA against a real formation, steered by the live MUXI.md.
+# Their scores become lower-is-better metrics next to the spool rates,
+# so learnings can watch "benchmark:longmemeval.qa_error" exactly like
+# "error_rate" -- cold-start formations get evidence before their first
+# user, and MUXI.md regressions show up against a consistent baseline.
+#
+# The harness lives in the repo's ``bench/`` tree, not the installed
+# package, and every runner owns its own asyncio loop and OneLLM
+# singleton -- so suites run as subprocesses of a harness checkout,
+# opted in via $MUXI_BENCH_ROOT (benchmark runs cost tokens; nothing
+# should spend them by surprise). Everything here fails soft: no
+# harness, a failed run, or a timeout degrades to the previous scores
+# (carried forward so watch windows keep evaluating) and never breaks
+# the tuning pass.
+# =============================================================================
+
+import asyncio
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ...utils.user_dirs import get_observability_dir
+from .. import observability
+
+BENCHMARKS_FILE = "benchmarks.json"
+
+# Explicit pointer to the directory containing the ``bench`` package
+# (the repo checkout root, or wherever a deployment ships the harness).
+# The observation is opt-in via this variable: auto-discovering a repo
+# checkout would make every dev formation and e2e run silently spend
+# tokens on benchmark subprocesses.
+BENCH_ROOT_ENV = "MUXI_BENCH_ROOT"
+
+# The fixture-scale suites the loop observes: committed samples, QA on,
+# default combined retrieval -- cheap (cents), bounded (minutes), and
+# deterministic in shape.
+SUITES = (
+    {"name": "longmemeval", "module": "bench.memory.longmemeval_runner"},
+    {"name": "structured_recall", "module": "bench.memory.structured_recall_runner"},
+)
+
+# One attempt (successful or not) per suite per interval: a broken
+# environment must not burn minutes on every pass, and scores fresher
+# than a day carry no new signal for a daily loop.
+DEFAULT_MIN_INTERVAL_HOURS = 24.0
+DEFAULT_SUITE_TIMEOUT_SECONDS = 600.0
+
+# Tail of subprocess output kept for diagnostics in the sidecar/event.
+MAX_ERROR_CHARS = 500
+
+
+def _default_base_dir() -> str:
+    """Sidecar home: the tuner directory (sibling of experiments.json)."""
+    return str(Path(get_observability_dir()) / "tuner")
+
+
+def discover_bench_root() -> Optional[Path]:
+    """The directory containing the ``bench`` harness package, or None.
+
+    Resolved from ``$MUXI_BENCH_ROOT`` only -- unset, empty, or a
+    directory without the harness means the observation skips.
+    """
+    env = os.environ.get(BENCH_ROOT_ENV)
+    if not env:
+        return None
+    root = Path(env)
+    return root if root.joinpath("bench", "memory", "runner.py").is_file() else None
+
+
+def parse_report(payload: Any) -> Optional[Dict[str, float]]:
+    """Extract the loop's scores from one benchmark report; None = unusable.
+
+    A partial report is unusable (its rates cover an arbitrary subset of
+    questions), and so is one with errored questions: an environment
+    blip deflating a score must never masquerade as a capability
+    regression.
+    """
+    if not isinstance(payload, dict) or payload.get("partial"):
+        return None
+    k = payload.get("k")
+    metrics = payload.get("metrics")
+    if not isinstance(k, int) or not isinstance(metrics, dict):
+        return None
+    if metrics.get("questions_errored"):
+        return None
+    try:
+        recall = metrics["retrieval"]["session_level"]["overall"][f"recall@{k}"]
+        accuracy = metrics["qa"]["overall"]["accuracy"]
+    except (KeyError, TypeError):
+        return None
+    if not isinstance(recall, (int, float)) or not isinstance(accuracy, (int, float)):
+        return None
+    scores = {"k": float(k), "recall_at_k": float(recall), "qa_accuracy": float(accuracy)}
+    usage = payload.get("usage")
+    if isinstance(usage, dict):
+        cost = (usage.get("cost") or {}).get("estimated_usd")
+        if isinstance(cost, (int, float)):
+            scores["estimated_usd"] = float(cost)
+    return scores
+
+
+class BenchmarkStep:
+    """Runs the shipped benchmark suites and turns scores into metrics."""
+
+    def __init__(self, base_dir: Optional[str] = None):
+        """
+        Args:
+            base_dir: Overrides the sidecar location (tests only; None
+                means the formation's observability tuner directory).
+        """
+        self._base_dir_override = base_dir
+        self.min_interval_hours = DEFAULT_MIN_INTERVAL_HOURS
+        self.suite_timeout_seconds = DEFAULT_SUITE_TIMEOUT_SECONDS
+
+    def _base_dir(self) -> Path:
+        return Path(self._base_dir_override or _default_base_dir())
+
+    def _sidecar_path(self) -> Path:
+        return self._base_dir() / BENCHMARKS_FILE
+
+    # ------------------------------------------------------------------
+    # Sidecar persistence (experiment-store idiom: tmp write + replace)
+    # ------------------------------------------------------------------
+
+    def _load_sidecar(self) -> Dict[str, Any]:
+        try:
+            payload = json.loads(self._sidecar_path().read_text(encoding="utf-8"))
+        except Exception:
+            return {"version": 1, "suites": {}}
+        suites = payload.get("suites") if isinstance(payload, dict) else None
+        return {"version": 1, "suites": suites if isinstance(suites, dict) else {}}
+
+    def _save_sidecar(self, sidecar: Dict[str, Any]) -> None:
+        path = self._sidecar_path()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = path.with_suffix(".tmp")
+            tmp_path.write_text(json.dumps(sidecar, indent=1), encoding="utf-8")
+            os.replace(tmp_path, path)
+        except OSError:
+            pass
+
+    # ------------------------------------------------------------------
+    # The observation: run due suites, carry scores forward, report
+    # ------------------------------------------------------------------
+
+    async def observe(self, muxi_md_path: Optional[str] = None) -> Dict[str, Any]:
+        """Run due suites and return the benchmark observation. Never raises.
+
+        Returns ``{"metrics": {...}, "report_block": str, "suites_run":
+        [...], "skipped": reason-or-None}``. Metrics carry the latest
+        successful scores of every suite (this pass's or an earlier
+        one's), inverted to lower-is-better so watch windows evaluate
+        them like spool rates.
+        """
+        sidecar = self._load_sidecar()
+        bench_root = discover_bench_root()
+        suites_run: List[str] = []
+        skipped: Optional[str] = None
+
+        if bench_root is None:
+            skipped = f"bench harness not configured (${BENCH_ROOT_ENV})"
+        else:
+            now = time.time()
+            for suite in SUITES:
+                record = sidecar["suites"].get(suite["name"]) or {}
+                attempted_at = record.get("attempted_at")
+                if (
+                    isinstance(attempted_at, (int, float))
+                    and now - attempted_at < self.min_interval_hours * 3600.0
+                ):
+                    continue
+                sidecar["suites"][suite["name"]] = await self._run_suite(
+                    suite, bench_root, muxi_md_path, previous=record
+                )
+                suites_run.append(suite["name"])
+            if not suites_run:
+                skipped = "all suites fresh"
+            self._save_sidecar(sidecar)
+
+        return {
+            "metrics": self._metrics(sidecar),
+            "report_block": self._render_block(sidecar),
+            "suites_run": suites_run,
+            "skipped": skipped,
+        }
+
+    async def _run_suite(
+        self,
+        suite: Dict[str, str],
+        bench_root: Path,
+        muxi_md_path: Optional[str],
+        previous: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """One subprocess attempt; the returned record replaces the old one.
+
+        The previous scores are kept on the record (as ``scores`` after a
+        failure, as ``previous_scores`` after a success) so metrics carry
+        forward and the tuner sees deltas.
+        """
+        started = time.monotonic()
+        output_path = self._base_dir() / f"bench-{suite['name']}.json"
+        command = [
+            sys.executable,
+            "-m",
+            suite["module"],
+            "--fixture",
+            "--qa",
+            "--output",
+            str(output_path),
+        ]
+        if muxi_md_path:
+            command.extend(["--muxi-md", muxi_md_path])
+
+        record: Dict[str, Any] = {
+            "attempted_at": time.time(),
+            "succeeded": False,
+            "scores": previous.get("scores"),
+            "previous_scores": previous.get("previous_scores"),
+            "error": None,
+        }
+        # A harness checkout carries the runtime under src/; putting it
+        # first lets the benchmark measure that checkout's code and
+        # keeps the subprocess importable when muxi is not installed
+        # into the interpreter.
+        env = os.environ.copy()
+        src_dir = bench_root / "src"
+        if src_dir.is_dir():
+            existing = env.get("PYTHONPATH", "")
+            env["PYTHONPATH"] = str(src_dir) + (os.pathsep + existing if existing else "")
+
+        process = None
+        try:
+            self._base_dir().mkdir(parents=True, exist_ok=True)
+            # Never trust a stale report: only a file this attempt wrote
+            # may become this attempt's evidence.
+            output_path.unlink(missing_ok=True)
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                cwd=str(bench_root),
+                env=env,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                _, stderr = await asyncio.wait_for(
+                    process.communicate(), timeout=self.suite_timeout_seconds
+                )
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.wait()
+                record["error"] = f"timed out after {self.suite_timeout_seconds:.0f}s"
+                return self._finish_attempt(suite, record, started)
+
+            scores = None
+            try:
+                scores = parse_report(json.loads(output_path.read_text(encoding="utf-8")))
+            except Exception:
+                pass
+            record["exit_code"] = process.returncode
+            # The report is the verdict, not the exit code: runners have
+            # been seen segfaulting in native-library teardown AFTER
+            # writing a complete report, and parse_report already rejects
+            # partial or errored runs.
+            if scores is not None:
+                record["succeeded"] = True
+                record["previous_scores"] = previous.get("scores")
+                record["scores"] = scores
+            else:
+                tail = (stderr or b"").decode("utf-8", errors="replace").strip()
+                record["error"] = (
+                    f"no usable report (exit {process.returncode}"
+                    + (f": {tail[-MAX_ERROR_CHARS:]}" if tail else "")
+                    + ")"
+                )
+        except BaseException as e:
+            # No orphans: a crash here -- or the loop's own cancellation
+            # at shutdown -- must not leave a benchmark subprocess (and
+            # its formation) running.
+            if process is not None and process.returncode is None:
+                process.kill()
+                await process.wait()
+            if not isinstance(e, Exception):
+                raise
+            record["error"] = f"{type(e).__name__}: {e}"
+        return self._finish_attempt(suite, record, started)
+
+    def _finish_attempt(
+        self, suite: Dict[str, str], record: Dict[str, Any], started: float
+    ) -> Dict[str, Any]:
+        record["duration_seconds"] = round(time.monotonic() - started, 1)
+        scores = record.get("scores") if record["succeeded"] else None
+        observability.observe(
+            event_type=observability.SystemEvents.TUNING_BENCHMARK,
+            level=(
+                observability.EventLevel.INFO
+                if record["succeeded"]
+                else observability.EventLevel.WARNING
+            ),
+            data={
+                "suite": suite["name"],
+                "succeeded": record["succeeded"],
+                "duration_seconds": record["duration_seconds"],
+                "scores": scores,
+                "error": record.get("error"),
+            },
+            description=(
+                f"Benchmark suite {suite['name']} "
+                + (
+                    f"scored recall@{scores['k']:.0f}={scores['recall_at_k']:.3f}, "
+                    f"qa_accuracy={scores['qa_accuracy']:.3f}"
+                    if scores
+                    else f"failed: {record.get('error')}"
+                )
+            ),
+        )
+        return record
+
+    # ------------------------------------------------------------------
+    # Scores -> metrics/prose
+    # ------------------------------------------------------------------
+
+    def _metrics(self, sidecar: Dict[str, Any]) -> Dict[str, float]:
+        """Lower-is-better metrics from the latest scores of every suite.
+
+        Inverted (gap/error, not recall/accuracy) to satisfy the watch
+        windows' "improvement is a drop" contract, and always carried
+        forward from the sidecar so a skipped or failed pass never
+        false-validates a learning through metric absence.
+        """
+        metrics: Dict[str, float] = {}
+        for name, record in (sidecar.get("suites") or {}).items():
+            scores = record.get("scores") if isinstance(record, dict) else None
+            if not isinstance(scores, dict):
+                continue
+            recall = scores.get("recall_at_k")
+            accuracy = scores.get("qa_accuracy")
+            if isinstance(recall, (int, float)):
+                metrics[f"benchmark:{name}.recall_gap"] = round(1.0 - float(recall), 6)
+            if isinstance(accuracy, (int, float)):
+                metrics[f"benchmark:{name}.qa_error"] = round(1.0 - float(accuracy), 6)
+        return metrics
+
+    def _render_block(self, sidecar: Dict[str, Any]) -> str:
+        """Prose benchmark results for the tuner prompt ('' = nothing)."""
+        lines: List[str] = []
+        for suite in SUITES:
+            record = sidecar.get("suites", {}).get(suite["name"])
+            if not isinstance(record, dict):
+                continue
+            scores = record.get("scores")
+            if isinstance(scores, dict):
+                line = (
+                    f"- {suite['name']} (fixture, QA): "
+                    f"recall@{scores.get('k', 0):.0f} {scores.get('recall_at_k', 0.0):.1%}, "
+                    f"QA accuracy {scores.get('qa_accuracy', 0.0):.1%}"
+                )
+                previous = record.get("previous_scores")
+                if isinstance(previous, dict):
+                    line += (
+                        f" (previous run: recall {previous.get('recall_at_k', 0.0):.1%}, "
+                        f"QA {previous.get('qa_accuracy', 0.0):.1%})"
+                    )
+                if not record.get("succeeded"):
+                    line += f" [stale: latest attempt failed: {record.get('error')}]"
+                lines.append(line)
+            elif record.get("error"):
+                lines.append(f"- {suite['name']}: no scores yet ({record['error']})")
+        return "\n".join(lines)
+
+
+__all__ = ["BenchmarkStep", "discover_bench_root", "parse_report"]

--- a/src/muxi/runtime/services/tuning/service.py
+++ b/src/muxi/runtime/services/tuning/service.py
@@ -21,6 +21,11 @@
 #    into a candidate MUXI.md revision (applied directly or written as
 #    PENDING-MUXI.md per auto_apply); retire learnings whose watched
 #    metric did not move; deliver a morning report.
+#
+# Between the two, the benchmark observation (Phase 3, meta-agent): the
+# shipped fixture-scale benchmark suites run against a real formation
+# steered by the live MUXI.md, their scores feeding the tune step as
+# additional lower-is-better metrics and prose evidence.
 # =============================================================================
 
 import asyncio
@@ -30,6 +35,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 from .. import observability
 from ..memory.log.formation import lint_formation_lines
 from ..observability.spool import get_event_spool
+from .benchmark import BenchmarkStep
 from .config import TuningConfig
 from .experiments import STATUS_ACTIVE, STATUS_DISMISSED, STATUS_PENDING, ExperimentStore
 from .muxi_md import MUXI_MD_MAX_BYTES
@@ -70,6 +76,9 @@ class TuningService:
         self._run_lock = asyncio.Lock()
         self.last_run: Optional[Dict[str, Any]] = None
         self.tuner = TunerStep()
+        # Phase 3 (meta-agent): the benchmark observation. Tests replace
+        # this with a BenchmarkStep pointed at a scratch directory.
+        self.benchmark = BenchmarkStep()
         # Overrides the experiment store location (tests only; None means
         # the formation's observability directory).
         self.experiments_dir: Optional[str] = None
@@ -144,13 +153,41 @@ class TuningService:
             if committed:
                 spool.commit(token, delete=not self.keep_spool_segments)
 
-            # Step 2: tune. Runs only on a consumed digest with traffic;
-            # a tuner failure never breaks the pass (the digest already
+            # Benchmark observation (Phase 3, meta-agent): the shipped
+            # fixture suites as a second evidence source. Fails soft --
+            # a missing harness or a broken run degrades to the previous
+            # scores and never touches the digest's outcome.
+            bench: Dict[str, Any] = {}
+            try:
+                muxi_md = getattr(self.overlord, "muxi_md", None)
+                bench = await self.benchmark.observe(
+                    muxi_md.resolve_path() if muxi_md is not None else None
+                )
+            except Exception as e:
+                bench = {"skipped": f"{type(e).__name__}: {e}"}
+                observability.observe(
+                    event_type=observability.ErrorEvents.INTERNAL_ERROR,
+                    level=observability.EventLevel.WARNING,
+                    data={"error": str(e), "error_type": type(e).__name__, "service": "tuning"},
+                    description=f"Benchmark observation failed: {e}",
+                )
+            benchmark_metrics: Dict[str, float] = bench.get("metrics") or {}
+
+            # Step 2: tune. Runs on a consumed digest with evidence --
+            # spool traffic or benchmark scores (a cold-start formation
+            # has no users yet, but the benchmarks still measure it); a
+            # tuner failure never breaks the pass (the digest already
             # reached its terminal outcome).
             tune_result: Dict[str, Any] = {}
-            if committed and event_count > 0 and model is not None:
+            if committed and (event_count > 0 or benchmark_metrics) and model is not None:
                 try:
-                    tune_result = await self._tune(model, report, metrics, known_user_ids)
+                    tune_result = await self._tune(
+                        model,
+                        report,
+                        {**metrics, **benchmark_metrics},
+                        known_user_ids,
+                        benchmark_block=bench.get("report_block") or "",
+                    )
                 except Exception as e:
                     tune_result = {"tuner_error": f"{type(e).__name__}: {e}"}
                     observability.observe(
@@ -172,6 +209,8 @@ class TuningService:
                 "dropped_sentences": digest.get("dropped_sentences", 0),
                 "spool_committed": committed,
                 "spool_segments_kept": self.keep_spool_segments,
+                "benchmark_suites_run": bench.get("suites_run") or [],
+                "benchmark_skipped": bench.get("skipped"),
                 **tune_result,
                 "duration_ms": round((time.monotonic() - started) * 1000, 1),
             }
@@ -197,6 +236,7 @@ class TuningService:
         activity_report: str,
         metrics: Dict[str, float],
         known_user_ids: List[str],
+        benchmark_block: str = "",
     ) -> Dict[str, Any]:
         muxi_md = getattr(self.overlord, "muxi_md", None)
         if muxi_md is None:
@@ -229,6 +269,7 @@ class TuningService:
             activity_report=activity_report,
             current_muxi_md=muxi_md.read(),
             formation_log_block=formation_log_block,
+            benchmark_block=benchmark_block,
             active_learnings=store.by_status(STATUS_ACTIVE),
             retired_learnings=retired,
             dismissed_learnings=[
@@ -323,6 +364,7 @@ class TuningService:
             recorded=recorded,
             retired=retired,
             recommendations=parsed["recommendations"],
+            benchmark_block=benchmark_block,
         )
 
         return {
@@ -343,6 +385,7 @@ class TuningService:
         recorded: List[Dict[str, Any]],
         retired: List[Dict[str, Any]],
         recommendations: List[str],
+        benchmark_block: str = "",
     ) -> bool:
         """Deliver the morning report; False when there is nothing/nowhere.
 
@@ -377,6 +420,9 @@ class TuningService:
         if recommendations:
             lines.append("Recommendations requiring a human deployment:")
             lines.extend(f"- {item}" for item in recommendations)
+        if benchmark_block:
+            lines.append("Benchmark scores (fixture suites, live MUXI.md):")
+            lines.append(benchmark_block)
 
         widgets = None
         self.pending_widget = None

--- a/src/muxi/runtime/services/tuning/tuner.py
+++ b/src/muxi/runtime/services/tuning/tuner.py
@@ -8,9 +8,10 @@
 # Author:       Muxi Framework Team
 #
 # Self-Improving Formation PRD, "The loop" step 2. The tuner reads the
-# fresh digest, recent formation-log entries, and its experiment
-# memories; detects patterns worth acting on (cost hotspots, misrouted
-# request classes, flaky tools, model over-provisioning); and distills
+# fresh digest, recent formation-log entries, the latest benchmark
+# scores (Phase 3, meta-agent), and its experiment memories; detects
+# patterns worth acting on (cost hotspots, misrouted request classes,
+# flaky tools, model over-provisioning, capability regressions); and distills
 # behavioral learnings into a candidate MUXI.md revision. It never
 # touches formation config -- config changes are human deployments,
 # surfaced only as prose recommendations.
@@ -46,6 +47,7 @@ class TunerStep:
         dismissed_learnings: List[str],
         metric_keys: List[str],
         max_bytes: int,
+        benchmark_block: str = "",
     ) -> str:
         parts: List[str] = [
             "You are the tuner of an AI formation: you curate MUXI.md, the "
@@ -56,17 +58,23 @@ class TunerStep:
             "operational, and general.\n",
             "Detect patterns worth acting on in the activity below: cost "
             "hotspots, misrouted request classes, flaky tools, model "
-            "over-provisioning. Distill them into learnings and produce a "
-            "revised MUXI.md.\n",
+            "over-provisioning, capability regressions in the benchmark "
+            "results. Distill them into learnings and produce a revised "
+            "MUXI.md.\n",
             "RULES:\n"
-            "- Base every learning ONLY on the activity report and log entries "
-            "below. Do not invent patterns.\n"
+            "- Base every learning ONLY on the activity report, log entries, "
+            "and benchmark results below. Do not invent patterns.\n"
             "- CURATE, never append: rewrite sections, merge overlapping "
             "guidance, retire stale learnings. The revised file MUST stay "
             f"under {max_bytes} bytes.\n"
             "- NEVER suggest configuration or yaml changes inside MUXI.md; "
             "anything requiring a deployment (yaml edits, plan upgrades, new "
-            "tools) goes into 'recommendations' as prose for a human.\n"
+            "tools, memory sizing or retrieval knobs) goes into "
+            "'recommendations' as prose for a human.\n"
+            "- Benchmark-derived learnings must generalize: propose one only "
+            "when it names an operational behavior that would hold beyond the "
+            "benchmark tasks. NEVER encode benchmark answers, question "
+            "keywords, or dataset specifics into MUXI.md.\n"
             "- HARD PRIVACY RULE: MUXI.md is injected into every user's "
             "context. NEVER include user identifiers, user names, prompt or "
             "message content, or any user-derived specifics.\n"
@@ -90,6 +98,12 @@ class TunerStep:
 
         if formation_log_block:
             parts.append(f"\nRecent formation log entries:\n{formation_log_block}")
+
+        if benchmark_block:
+            parts.append(
+                "\nLatest benchmark results (fixture-scale memory/QA suites "
+                "run against this formation with the live MUXI.md):\n" + benchmark_block
+            )
 
         if active_learnings:
             lines = [
@@ -128,7 +142,10 @@ class TunerStep:
             'deployment"]\n'
             "}\n"
         )
-        parts.append(f"\nAggregated activity report:\n{activity_report}\n")
+        parts.append(
+            "\nAggregated activity report:\n"
+            f"{activity_report or '(no traffic in this window)'}\n"
+        )
         return "\n".join(parts)
 
     def parse_response(self, response: str) -> Optional[Dict[str, Any]]:

--- a/tests/unit/test_tuning_benchmark.py
+++ b/tests/unit/test_tuning_benchmark.py
@@ -1,0 +1,269 @@
+"""Unit tests for the benchmark observation (Self-Improving Formation, Phase 3).
+
+Pins the BenchmarkStep contract against a fake harness (a real
+subprocess with the real CLI surface, no LLM): explicit opt-in
+discovery, the once-per-interval run policy, score parsing and
+lower-is-better inversion, carry-forward across failed/skipped passes,
+MUXI.md plumbing, timeout kill, and the report block's delta rendering.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from muxi.runtime.services.tuning.benchmark import (
+    BENCH_ROOT_ENV,
+    SUITES,
+    BenchmarkStep,
+    discover_bench_root,
+    parse_report,
+)
+
+GOOD_REPORT = {
+    "k": 5,
+    "metrics": {
+        "retrieval": {"session_level": {"overall": {"recall@5": 0.8}}},
+        "qa": {"overall": {"accuracy": 0.75}},
+    },
+    "usage": {"cost": {"estimated_usd": 0.003}},
+}
+
+# A fake runner speaking the real CLI surface: writes a canned report
+# to --output (echoing --muxi-md so tests can assert the plumbing).
+FAKE_RUNNER = f"""
+import argparse, json, sys
+parser = argparse.ArgumentParser()
+parser.add_argument("--fixture", action="store_true")
+parser.add_argument("--qa", action="store_true")
+parser.add_argument("--output", required=True)
+parser.add_argument("--muxi-md", default=None)
+args = parser.parse_args()
+report = json.loads({json.dumps(json.dumps(GOOD_REPORT))})
+if args.muxi_md:
+    report["config"] = {{"muxi_md": args.muxi_md}}
+with open(args.output, "w") as handle:
+    json.dump(report, handle)
+"""
+
+FAILING_RUNNER = """
+import sys
+print("embedding model unavailable", file=sys.stderr)
+sys.exit(1)
+"""
+
+# Writes a complete report, then dies -- the native-teardown segfault
+# shape observed on macOS. The report is the verdict, not the exit code.
+CRASH_AFTER_REPORT_RUNNER = FAKE_RUNNER + """
+sys.exit(11)
+"""
+
+SLEEPING_RUNNER = """
+import time
+time.sleep(60)
+"""
+
+
+def build_harness(root: Path, runner_source: str = FAKE_RUNNER) -> Path:
+    """Lay down a fake ``bench`` package satisfying discovery and -m runs."""
+    memory = root / "bench" / "memory"
+    memory.mkdir(parents=True, exist_ok=True)
+    (root / "bench" / "__init__.py").write_text("")
+    (memory / "__init__.py").write_text("")
+    (memory / "runner.py").write_text("")  # the discovery marker
+    for suite in SUITES:
+        module_file = suite["module"].rsplit(".", 1)[-1] + ".py"
+        (memory / module_file).write_text(runner_source)
+    return root
+
+
+@pytest.fixture
+def step(tmp_path):
+    step = BenchmarkStep(base_dir=str(tmp_path / "tuner"))
+    step.suite_timeout_seconds = 30.0
+    return step
+
+
+class TestDiscovery:
+    def test_unset_env_means_no_harness(self, monkeypatch):
+        monkeypatch.delenv(BENCH_ROOT_ENV, raising=False)
+        assert discover_bench_root() is None
+
+    def test_empty_env_means_no_harness(self, monkeypatch):
+        monkeypatch.setenv(BENCH_ROOT_ENV, "")
+        assert discover_bench_root() is None
+
+    def test_root_without_harness_means_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(BENCH_ROOT_ENV, str(tmp_path))
+        assert discover_bench_root() is None
+
+    def test_valid_root_resolves(self, tmp_path, monkeypatch):
+        build_harness(tmp_path)
+        monkeypatch.setenv(BENCH_ROOT_ENV, str(tmp_path))
+        assert discover_bench_root() == tmp_path
+
+
+class TestParseReport:
+    def test_scores_extracted(self):
+        scores = parse_report(GOOD_REPORT)
+        assert scores == {
+            "k": 5.0,
+            "recall_at_k": 0.8,
+            "qa_accuracy": 0.75,
+            "estimated_usd": 0.003,
+        }
+
+    def test_partial_report_is_unusable(self):
+        assert parse_report({**GOOD_REPORT, "partial": True}) is None
+
+    def test_errored_questions_make_the_report_unusable(self):
+        payload = json.loads(json.dumps(GOOD_REPORT))
+        payload["metrics"]["questions_errored"] = 2
+        assert parse_report(payload) is None
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            None,
+            [],
+            {},
+            {"k": 5, "metrics": {}},
+            {"k": 5, "metrics": {"retrieval": {}, "qa": {}}},
+            {"k": "5", "metrics": GOOD_REPORT["metrics"]},
+        ],
+    )
+    def test_malformed_reports_are_unusable(self, payload):
+        assert parse_report(payload) is None
+
+
+class TestObserve:
+    def test_no_harness_skips_with_empty_metrics(self, step, monkeypatch):
+        monkeypatch.delenv(BENCH_ROOT_ENV, raising=False)
+        result = asyncio.run(step.observe())
+        assert BENCH_ROOT_ENV in result["skipped"]
+        assert result["metrics"] == {}
+        assert result["report_block"] == ""
+        assert result["suites_run"] == []
+
+    def test_run_inverts_scores_and_persists(self, step, tmp_path, monkeypatch):
+        build_harness(tmp_path / "harness")
+        monkeypatch.setenv(BENCH_ROOT_ENV, str(tmp_path / "harness"))
+        result = asyncio.run(step.observe())
+
+        assert sorted(result["suites_run"]) == sorted(s["name"] for s in SUITES)
+        assert result["skipped"] is None
+        for suite in SUITES:
+            name = suite["name"]
+            assert result["metrics"][f"benchmark:{name}.recall_gap"] == pytest.approx(0.2)
+            assert result["metrics"][f"benchmark:{name}.qa_error"] == pytest.approx(0.25)
+            assert f"{name} (fixture, QA): recall@5 80.0%, QA accuracy 75.0%" in (
+                result["report_block"]
+            )
+
+        sidecar = json.loads((tmp_path / "tuner" / "benchmarks.json").read_text())
+        for suite in SUITES:
+            record = sidecar["suites"][suite["name"]]
+            assert record["succeeded"] is True
+            assert record["scores"]["recall_at_k"] == 0.8
+            assert record["previous_scores"] is None
+
+    def test_fresh_scores_are_reused_not_rerun(self, step, tmp_path, monkeypatch):
+        build_harness(tmp_path / "harness")
+        monkeypatch.setenv(BENCH_ROOT_ENV, str(tmp_path / "harness"))
+        asyncio.run(step.observe())
+        again = asyncio.run(step.observe())
+
+        assert again["suites_run"] == []
+        assert again["skipped"] == "all suites fresh"
+        # Carried forward: metrics never vanish between runs.
+        for suite in SUITES:
+            assert f"benchmark:{suite['name']}.qa_error" in again["metrics"]
+
+    def test_stale_scores_rerun_and_keep_previous(self, step, tmp_path, monkeypatch):
+        build_harness(tmp_path / "harness")
+        monkeypatch.setenv(BENCH_ROOT_ENV, str(tmp_path / "harness"))
+        step.min_interval_hours = 0.0
+        asyncio.run(step.observe())
+        again = asyncio.run(step.observe())
+
+        assert sorted(again["suites_run"]) == sorted(s["name"] for s in SUITES)
+        assert "previous run: recall 80.0%, QA 75.0%" in again["report_block"]
+        sidecar = json.loads((tmp_path / "tuner" / "benchmarks.json").read_text())
+        for suite in SUITES:
+            assert sidecar["suites"][suite["name"]]["previous_scores"]["qa_accuracy"] == 0.75
+
+    def test_failed_run_carries_scores_forward(self, step, tmp_path, monkeypatch):
+        harness = tmp_path / "harness"
+        build_harness(harness)
+        monkeypatch.setenv(BENCH_ROOT_ENV, str(harness))
+        step.min_interval_hours = 0.0
+        asyncio.run(step.observe())
+
+        build_harness(harness, runner_source=FAILING_RUNNER)
+        result = asyncio.run(step.observe())
+
+        # The attempt failed, but the previous scores still feed the
+        # watch windows -- absence would false-validate learnings.
+        for suite in SUITES:
+            assert result["metrics"][f"benchmark:{suite['name']}.qa_error"] == pytest.approx(0.25)
+        assert "stale: latest attempt failed" in result["report_block"]
+        assert "embedding model unavailable" in result["report_block"]
+        sidecar = json.loads((tmp_path / "tuner" / "benchmarks.json").read_text())
+        for suite in SUITES:
+            record = sidecar["suites"][suite["name"]]
+            assert record["succeeded"] is False
+            assert record["scores"]["qa_accuracy"] == 0.75
+
+    def test_complete_report_beats_a_crashed_exit_code(self, step, tmp_path, monkeypatch):
+        build_harness(tmp_path / "harness", runner_source=CRASH_AFTER_REPORT_RUNNER)
+        monkeypatch.setenv(BENCH_ROOT_ENV, str(tmp_path / "harness"))
+        result = asyncio.run(step.observe())
+
+        for suite in SUITES:
+            assert result["metrics"][f"benchmark:{suite['name']}.qa_error"] == pytest.approx(0.25)
+        sidecar = json.loads((tmp_path / "tuner" / "benchmarks.json").read_text())
+        for suite in SUITES:
+            record = sidecar["suites"][suite["name"]]
+            assert record["succeeded"] is True
+            assert record["exit_code"] == 11
+            assert record["error"] is None
+
+    def test_failure_before_any_success_yields_no_metrics(self, step, tmp_path, monkeypatch):
+        build_harness(tmp_path / "harness", runner_source=FAILING_RUNNER)
+        monkeypatch.setenv(BENCH_ROOT_ENV, str(tmp_path / "harness"))
+        result = asyncio.run(step.observe())
+
+        assert result["metrics"] == {}
+        assert "no scores yet" in result["report_block"]
+
+    def test_muxi_md_path_reaches_the_runner(self, step, tmp_path, monkeypatch):
+        build_harness(tmp_path / "harness")
+        monkeypatch.setenv(BENCH_ROOT_ENV, str(tmp_path / "harness"))
+        muxi_md = tmp_path / "MUXI.md"
+        muxi_md.write_text("- Prefer terse answers.")
+        asyncio.run(step.observe(str(muxi_md)))
+
+        for suite in SUITES:
+            report = json.loads((tmp_path / "tuner" / f"bench-{suite['name']}.json").read_text())
+            assert report["config"]["muxi_md"] == str(muxi_md)
+
+    def test_timeout_kills_the_suite(self, step, tmp_path, monkeypatch):
+        build_harness(tmp_path / "harness", runner_source=SLEEPING_RUNNER)
+        monkeypatch.setenv(BENCH_ROOT_ENV, str(tmp_path / "harness"))
+        step.suite_timeout_seconds = 1.0
+        result = asyncio.run(step.observe())
+
+        assert result["metrics"] == {}
+        sidecar = json.loads((tmp_path / "tuner" / "benchmarks.json").read_text())
+        for suite in SUITES:
+            assert "timed out" in sidecar["suites"][suite["name"]]["error"]
+
+    def test_corrupt_sidecar_starts_fresh(self, step, tmp_path, monkeypatch):
+        monkeypatch.delenv(BENCH_ROOT_ENV, raising=False)
+        (tmp_path / "tuner").mkdir(parents=True)
+        (tmp_path / "tuner" / "benchmarks.json").write_text("{not json")
+        result = asyncio.run(step.observe())
+        assert result["metrics"] == {}

--- a/tests/unit/test_tuning_service.py
+++ b/tests/unit/test_tuning_service.py
@@ -19,6 +19,8 @@ from muxi.runtime.services.memory.log.service import CaptainsLogService
 from muxi.runtime.services.observability import spool as spool_module
 from muxi.runtime.services.observability.spool import reset_event_spool
 from muxi.runtime.services.tuning import MuxiMdFile, TuningConfig, TuningService
+from muxi.runtime.services.tuning.benchmark import BENCH_ROOT_ENV, BenchmarkStep
+from muxi.runtime.services.tuning.experiments import ExperimentStore
 from muxi.runtime.services.tuning.service import (
     MAX_REPORT_CHARS,
     _aggregate_segments,
@@ -70,6 +72,13 @@ def spool_event(
     return event
 
 
+@pytest.fixture(autouse=True)
+def no_bench_harness(tmp_path, monkeypatch):
+    """Keep every pass's benchmark observation inert and hermetic."""
+    monkeypatch.delenv(BENCH_ROOT_ENV, raising=False)
+    yield
+
+
 @pytest.fixture
 def isolated_spool(tmp_path, monkeypatch):
     monkeypatch.setattr(spool_module, "_spool_dir", lambda: str(tmp_path / "spool"))
@@ -87,8 +96,10 @@ def captains_log(tmp_path):
 
 
 @pytest.fixture
-def tuning(captains_log):
-    return TuningService(TuningConfig(), FakeOverlord(captains_log))
+def tuning(captains_log, tmp_path):
+    service = TuningService(TuningConfig(), FakeOverlord(captains_log))
+    service.benchmark = BenchmarkStep(base_dir=str(tmp_path / "tuner"))
+    return service
 
 
 class TestAggregation:
@@ -178,8 +189,9 @@ class TestRunOnce:
         assert "small spike" in asyncio.run(captains_log.get_formation_context_block())
         assert tuning.last_run == result
 
-    def test_keep_spool_segments_preserves_files(self, isolated_spool, captains_log):
+    def test_keep_spool_segments_preserves_files(self, isolated_spool, captains_log, tmp_path):
         tuning = TuningService(TuningConfig(), FakeOverlord(captains_log), keep_spool_segments=True)
+        tuning.benchmark = BenchmarkStep(base_dir=str(tmp_path / "tuner"))
         isolated_spool.write_lines([json.dumps(spool_event())])
         result = asyncio.run(tuning.run_once(FakeModel()))
 
@@ -209,8 +221,9 @@ class TestRunOnce:
         assert result["spool_committed"] is True
         assert model.calls == 0
 
-    def test_missing_captains_log_still_consumes(self, isolated_spool):
+    def test_missing_captains_log_still_consumes(self, isolated_spool, tmp_path):
         tuning = TuningService(TuningConfig(), FakeOverlord(captains_log=None))
+        tuning.benchmark = BenchmarkStep(base_dir=str(tmp_path / "tuner"))
         isolated_spool.write_lines([json.dumps(spool_event())])
         result = asyncio.run(tuning.run_once(FakeModel()))
         assert result["spool_committed"] is True
@@ -283,3 +296,116 @@ class TestMuxiMdFile:
     def test_empty_file_reads_none(self, tmp_path):
         (tmp_path / "MUXI.md").write_text("   \n")
         assert MuxiMdFile(str(tmp_path)).read() is None
+
+
+TUNER_RESPONSE = json.dumps(
+    {
+        "muxi_md": "- Ground every QA answer in the retrieved excerpts.",
+        "learnings": [
+            {
+                "learning": "Ground every QA answer in the retrieved excerpts.",
+                "evidence": "benchmark qa_error at 0.25",
+                "metric_key": "benchmark:longmemeval.qa_error",
+            }
+        ],
+        "recommendations": [],
+    }
+)
+
+
+class TunerModel:
+    """FakeModel variant matching the tune step's generate_text signature."""
+
+    def __init__(self, response=TUNER_RESPONSE):
+        self.response = response
+        self.prompts = []
+
+    async def generate_text(self, prompt, **kwargs):
+        self.prompts.append(prompt)
+        return self.response
+
+
+class StubBenchmark:
+    """Canned benchmark observation (or a raising one)."""
+
+    def __init__(self, metrics=None, block="", error=None):
+        self.metrics = metrics or {}
+        self.block = block
+        self.error = error
+        self.observed_with = "never-called"
+
+    async def observe(self, muxi_md_path=None):
+        self.observed_with = muxi_md_path
+        if self.error is not None:
+            raise self.error
+        return {
+            "metrics": self.metrics,
+            "report_block": self.block,
+            "suites_run": sorted({key.split(":")[1].split(".")[0] for key in self.metrics}),
+            "skipped": None,
+        }
+
+
+class TestBenchmarkWiring:
+    """The meta-agent seam: benchmark scores feeding the tune step."""
+
+    @pytest.fixture
+    def cold_start_tuning(self, captains_log, tmp_path):
+        overlord = FakeOverlord(captains_log)
+        (tmp_path / "formation").mkdir()
+        overlord.muxi_md = MuxiMdFile(str(tmp_path / "formation"))
+        service = TuningService(TuningConfig(), overlord)
+        service.experiments_dir = str(tmp_path / "experiments")
+        return service
+
+    def test_benchmark_evidence_tunes_without_traffic(self, isolated_spool, cold_start_tuning):
+        """Cold start: no users, no events -- benchmarks still drive a tune."""
+        tuning = cold_start_tuning
+        tuning.benchmark = StubBenchmark(
+            metrics={"benchmark:longmemeval.qa_error": 0.25},
+            block="- longmemeval (fixture, QA): recall@5 80.0%, QA accuracy 75.0%",
+        )
+        model = TunerModel()
+        result = asyncio.run(tuning.run_once(model))
+
+        assert result["events_read"] == 0
+        assert result["benchmark_suites_run"] == ["longmemeval"]
+        assert result["learnings_recorded"] == 1
+        assert result["muxi_md_applied"] is True
+        assert "retrieved excerpts" in tuning.overlord.muxi_md.read()
+        assert "Latest benchmark results" in model.prompts[0]
+        assert "QA accuracy 75.0%" in model.prompts[0]
+        assert "benchmark:longmemeval.qa_error" in model.prompts[0]
+        # The watched benchmark metric froze its baseline at proposal time.
+        record = ExperimentStore(tuning.experiments_dir).records[0]
+        assert record["metric_key"] == "benchmark:longmemeval.qa_error"
+        assert record["baseline"] == pytest.approx(0.25)
+
+    def test_live_muxi_md_path_reaches_the_observation(self, isolated_spool, cold_start_tuning):
+        tuning = cold_start_tuning
+        tuning.overlord.muxi_md.write("- Existing learning.")
+        stub = StubBenchmark()
+        tuning.benchmark = stub
+        asyncio.run(tuning.run_once(TunerModel()))
+        assert stub.observed_with == tuning.overlord.muxi_md.resolve_path()
+
+    def test_benchmark_failure_never_breaks_the_pass(self, isolated_spool, cold_start_tuning):
+        tuning = cold_start_tuning
+        tuning.benchmark = StubBenchmark(error=RuntimeError("harness exploded"))
+        isolated_spool.write_lines([json.dumps(spool_event(user_id="alice"))])
+        model = TunerModel(DIGEST_RESPONSE)
+        result = asyncio.run(tuning.run_once(model))
+
+        assert result["spool_committed"] is True
+        assert "harness exploded" in result["benchmark_skipped"]
+        assert result["benchmark_suites_run"] == []
+
+    def test_no_evidence_at_all_skips_the_tuner(self, isolated_spool, cold_start_tuning):
+        tuning = cold_start_tuning
+        tuning.benchmark = StubBenchmark()  # harness skipped, no scores yet
+        model = TunerModel()
+        result = asyncio.run(tuning.run_once(model))
+
+        assert result["events_read"] == 0
+        assert model.prompts == []
+        assert "learnings_recorded" not in result


### PR DESCRIPTION
## Summary

Phase 3 of the Self-Improving Formation PRD (meta-agent): the same tuning loop, with the shipped benchmark tiers as an additional observation source alongside live traffic. Same MUXI.md / experiment-memory surfaces.

- **Benchmark observation** (`services/tuning/benchmark.py`): each pass may run the fixture-scale suites (LongMemEval sample + structured recall, QA on) as subprocesses of a harness checkout — opt-in via `MUXI_BENCH_ROOT`, at most one attempt per suite per 24h, bounded timeout, no orphaned subprocesses (kill on timeout/cancellation). The complete report is the verdict, not the exit code (runners have segfaulted in native-library teardown after writing a healthy report); partial or errored-question reports are never scored.
- **Metrics**: scores invert to the watch windows' lower-is-better contract (`benchmark:<suite>.recall_gap`, `benchmark:<suite>.qa_error`) and persist in `observability/tuner/benchmarks.json`. They carry forward through skipped/failed passes so a broken harness can never false-validate a learning through metric absence.
- **Tune step**: runs on benchmark evidence alone (cold start — a formation with zero users gets evidence on day one), sees scores with previous-run deltas as a prompt block, bound by an overfitting guard (benchmark answers/dataset specifics never enter MUXI.md; memory-tuning knobs stay human recommendations).
- **Steering seam**: bench runners accept `--muxi-md`; the file rides the QA answer prompt — the bench equivalent of the runtime injecting MUXI.md into every turn. The bench formation declares `tuning: false` (the measuring stick never tunes itself).
- **Observability**: new `tuning.benchmark` event per suite attempt; `tuning.run` enriched with `benchmark_suites_run`/`benchmark_skipped`; morning report shows scores when it fires.

## Testing

- 22 new unit tests (`test_tuning_benchmark.py`) against a fake harness speaking the real CLI surface: discovery opt-in, run policy, inversion, carry-forward, crash-after-report, timeout kill, MUXI.md plumbing.
- 4 new service wiring tests: cold-start tune on benchmark evidence, baseline freezing, fail-soft observe, no-evidence skip.
- e2e 27A8 (real harness: both fixture suites in one pass, live MUXI.md echoed by reports, fresh-score reuse) and 27A9 (deterministic retirement through a carried metric + failing-harness fail-soft) — both PASSED.
- Full unit suite: 3918 passed. 27A1/27A5 regression: PASSED. `validate_events`: 100%. black/isort/ruff/flake8/mypy clean. CodeRabbit: 0 findings.