### PR TITLE
feat(a2a): extended auth types — hmac, oauth2, openid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## [unreleased]
 
+### A2A extended auth types (hmac, oauth2, openid)
+
+Agent-to-agent authentication grows beyond shared static keys
+(A2A Extended Auth Types PRD), leaning entirely on existing plumbing --
+the strict-mode inbound authenticator, the outbound credential manager,
+and the secrets interpolation the current modes already use:
+
+- Inbound `hmac`: requests carry `X-Signature` (HMAC-SHA256 over the
+  `X-Timestamp` value) and are verified against the configured
+  `secret` with constant-time comparison, a timestamp tolerance
+  (default 300s, `timestamp_tolerance`), and a replay cache that
+  rejects reused signatures within the window.
+- Inbound `openid`: bearer JWTs are validated against the issuer's
+  JWKS (PyJWT + `jwks_url` or the issuer's well-known path) with
+  issuer/audience/algorithm/expiry checks and configurable clock skew;
+  callers authenticate as `openid:<sub>` with no shared key at rest.
+- Outbound `hmac`: each request to an external service is signed
+  fresh (timestamp + signature headers, names configurable), so
+  retries never reuse a stale signature.
+- Outbound `oauth2`: client_credentials tokens are fetched from the
+  service's `token_url`, cached per service, and refreshed 60s before
+  expiry; the token rides as a standard Bearer header.
+- Strict mode matching extends to the new types: an hmac server
+  rejects bearer/api-key attempts and vice versa. Formation validation
+  gains per-type field checks and directional hints (`oauth2` is
+  outbound-only, `openid` inbound-only). mTLS remains out of scope.
+
 ### Self-improving formation - meta-agent benchmark observation (Phase 3)
 
 The tuning loop gains a second evidence source (Self-Improving

--- a/src/muxi/runtime/datatypes/schema.py
+++ b/src/muxi/runtime/datatypes/schema.py
@@ -225,11 +225,19 @@ class A2AServiceSchema(BaseServiceSchema):
 
     # Security configuration
     require_auth: bool = Field(default=False, description="Require authentication for A2A requests")
-    auth_mode: Literal["none", "api_key", "bearer", "basic"] = Field(
-        default="none", description="Authentication mode (none, api_key, bearer, basic)"
+    auth_mode: Literal["none", "api_key", "bearer", "basic", "hmac", "openid"] = Field(
+        default="none",
+        description="Authentication mode (none, api_key, bearer, basic, hmac, openid)",
     )
     shared_key: Optional[str] = Field(
         default=None, description="Shared key for inbound authentication"
+    )
+    inbound_auth: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Full inbound auth configuration block with mode-specific settings "
+            "(e.g. hmac timestamp_tolerance, openid issuer/audience/jwks_url)"
+        ),
     )
     allowed_origins: Optional[List[str]] = Field(
         default=None, description="Allowed origins for CORS"
@@ -258,10 +266,14 @@ class A2AServiceSchema(BaseServiceSchema):
             raise ValueError("Server port must be >= 1024 for non-root operation")
 
         # Validate authentication configuration
-        if self.require_auth and self.auth_mode != "none" and not self.shared_key:
+        if self.require_auth and self.auth_mode not in ("none", "openid") and not self.shared_key:
             raise ValueError(
                 f"Shared key is required when auth is enabled with mode '{self.auth_mode}'. "
                 "Either provide a shared_key or set auth_mode to 'none'"
+            )
+        if self.auth_mode == "openid" and not (self.inbound_auth or {}).get("issuer"):
+            raise ValueError(
+                "OpenID auth mode requires an 'issuer' in the inbound auth configuration"
             )
 
         # Normalize registries to RegistryConfig objects

--- a/src/muxi/runtime/formation/config/validation.py
+++ b/src/muxi/runtime/formation/config/validation.py
@@ -3541,11 +3541,14 @@ class FormationValidator:
 
         # Validate auth type
         auth_type = auth_config.get("type", "none")
-        valid_auth_types = ["api_key", "bearer", "basic", "custom", "none"]
+        valid_auth_types = ["api_key", "bearer", "basic", "custom", "hmac", "oauth2", "none"]
 
         if auth_type not in valid_auth_types:
+            hint = ""
+            if auth_type == "openid":
+                hint = " ('openid' is inbound-only; use 'oauth2' for outbound services)"
             self.result.add_error(
-                f"{service_identifier} auth type '{auth_type}' invalid. "
+                f"{service_identifier} auth type '{auth_type}' invalid{hint}. "
                 f"Valid types are: {valid_auth_types}"
             )
             return
@@ -3577,6 +3580,24 @@ class FormationValidator:
                     f"{service_identifier} custom auth headers must be a dictionary"
                 )
 
+        elif auth_type == "hmac":
+            if "secret" not in auth_config:
+                self.result.add_error(f"{service_identifier} hmac auth requires 'secret' field")
+            for header_field in ["signature_header", "timestamp_header"]:
+                if header_field in auth_config and not isinstance(auth_config[header_field], str):
+                    self.result.add_error(
+                        f"{service_identifier} hmac auth '{header_field}' must be a string"
+                    )
+
+        elif auth_type == "oauth2":
+            for oauth2_field in ["client_id", "client_secret", "token_url"]:
+                if oauth2_field not in auth_config:
+                    self.result.add_error(
+                        f"{service_identifier} oauth2 auth requires '{oauth2_field}' field"
+                    )
+            if "scope" in auth_config and not isinstance(auth_config["scope"], str):
+                self.result.add_error(f"{service_identifier} oauth2 auth scope must be a string")
+
     def _validate_inbound_auth_config(self, auth_config: Dict[str, Any]) -> None:
         """Validate inbound authentication configuration."""
         if not isinstance(auth_config, dict):
@@ -3585,11 +3606,14 @@ class FormationValidator:
 
         # Validate auth type
         auth_type = auth_config.get("type", "none")
-        valid_auth_types = ["api_key", "bearer", "basic", "custom", "none"]
+        valid_auth_types = ["api_key", "bearer", "basic", "custom", "hmac", "openid", "none"]
 
         if auth_type not in valid_auth_types:
+            hint = ""
+            if auth_type == "oauth2":
+                hint = " ('oauth2' is outbound-only; use 'openid' to validate inbound JWTs)"
             self.result.add_error(
-                f"A2A inbound auth type '{auth_type}' invalid. "
+                f"A2A inbound auth type '{auth_type}' invalid{hint}. "
                 f"Valid types are: {valid_auth_types}"
             )
             return
@@ -3616,6 +3640,42 @@ class FormationValidator:
                 self.result.add_error("A2A inbound custom auth requires 'headers' field")
             elif not isinstance(auth_config["headers"], dict):
                 self.result.add_error("A2A inbound custom auth headers must be a dictionary")
+
+        elif auth_type == "hmac":
+            if "secret" not in auth_config:
+                self.result.add_error("A2A inbound hmac auth requires 'secret' field")
+            if "timestamp_tolerance" in auth_config:
+                tolerance = auth_config["timestamp_tolerance"]
+                if not isinstance(tolerance, int) or tolerance <= 0:
+                    self.result.add_error(
+                        "A2A inbound hmac auth 'timestamp_tolerance' must be a positive integer"
+                    )
+
+        elif auth_type == "openid":
+            if "issuer" not in auth_config:
+                self.result.add_error("A2A inbound openid auth requires 'issuer' field")
+            elif not isinstance(auth_config["issuer"], str) or not auth_config["issuer"].startswith(
+                ("http://", "https://")
+            ):
+                self.result.add_error("A2A inbound openid auth 'issuer' must be a URL string")
+            for str_field in ["audience", "jwks_url"]:
+                if str_field in auth_config and not isinstance(auth_config[str_field], str):
+                    self.result.add_error(f"A2A inbound openid auth '{str_field}' must be a string")
+            if "allowed_algorithms" in auth_config:
+                algorithms = auth_config["allowed_algorithms"]
+                if not isinstance(algorithms, list) or not all(
+                    isinstance(alg, str) for alg in algorithms
+                ):
+                    self.result.add_error(
+                        "A2A inbound openid auth 'allowed_algorithms' must be a list of strings"
+                    )
+            if "clock_skew_seconds" in auth_config:
+                skew = auth_config["clock_skew_seconds"]
+                if not isinstance(skew, int) or skew < 0:
+                    self.result.add_error(
+                        "A2A inbound openid auth 'clock_skew_seconds' must be a "
+                        "non-negative integer"
+                    )
 
     def _validate_scheduler_config(self, scheduler_config: Dict[str, Any]) -> None:
         """Validate scheduler configuration."""

--- a/src/muxi/runtime/formation/formation.py
+++ b/src/muxi/runtime/formation/formation.py
@@ -328,6 +328,11 @@ class Formation:
             return auth_config.get("token")
         elif auth_type == "api_key":
             return auth_config.get("key")
+        elif auth_type == "hmac":
+            return auth_config.get("secret")
+        elif auth_type == "openid":
+            # OpenID validates JWTs against the issuer's JWKS; no shared key
+            return None
         elif auth_type == "basic":
             # For basic auth, the server handles username/password separately
             return None
@@ -1223,6 +1228,7 @@ class Formation:
                     .get("auth", {})
                     .get("type", "none"),
                     shared_key=self._get_inbound_auth_key(self._a2a_config.get("inbound", {})),
+                    inbound_auth=self._a2a_config.get("inbound", {}).get("auth"),
                     allowed_origins=self._a2a_config.get("security", {}).get("allowed_origins"),
                     # Map outbound configuration
                     default_timeout_seconds=self._a2a_config.get("outbound", {}).get(

--- a/src/muxi/runtime/formation/overlord/a2a_coordinator.py
+++ b/src/muxi/runtime/formation/overlord/a2a_coordinator.py
@@ -223,6 +223,7 @@ class A2ACoordinator:
                     auth_mode=self.config.auth_mode if self.config.auth_mode else "none",
                     shared_key=self.config.shared_key,
                     formation_name=self.overlord.formation_id,
+                    auth_config=getattr(self.config, "inbound_auth", None),
                 )
 
             # Start the server

--- a/src/muxi/runtime/services/a2a/auth/inbound.py
+++ b/src/muxi/runtime/services/a2a/auth/inbound.py
@@ -6,8 +6,12 @@ Implements STRICT auth type validation to fix critical security vulnerability.
 Uses SDK security schemes for protocol compliance.
 """
 
+import asyncio
 import base64
+import hashlib
+import hmac as hmac_lib
 import os
+import time
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, Optional, Tuple
@@ -21,6 +25,10 @@ from ...secrets import SecretsManager
 # We implement SDK-style authentication without importing SDK modules
 # since they're not available on the server side
 
+DEFAULT_HMAC_TIMESTAMP_TOLERANCE = 300  # seconds
+DEFAULT_OPENID_CLOCK_SKEW = 30  # seconds
+DEFAULT_OPENID_ALGORITHMS = ["RS256"]
+
 
 class InboundAuthType(str, Enum):
     """Supported inbound authentication types"""
@@ -29,6 +37,8 @@ class InboundAuthType(str, Enum):
     API_KEY = "api_key"
     BEARER = "bearer"
     BASIC = "basic"
+    HMAC = "hmac"
+    OPENID = "openid"
 
 
 @dataclass
@@ -50,22 +60,36 @@ class A2AInboundAuthenticator:
     were incorrectly accepted.
     """
 
-    def __init__(self, auth_mode: str = "none", secrets_manager: Optional[SecretsManager] = None):
+    def __init__(
+        self,
+        auth_mode: str = "none",
+        secrets_manager: Optional[SecretsManager] = None,
+        auth_config: Optional[Dict[str, Any]] = None,
+    ):
         """
         Initialize the inbound authenticator
 
         Args:
             auth_mode: Authentication mode for the formation (strictly enforced)
             secrets_manager: Optional SecretsManager for credential access
+            auth_config: The formation's raw ``a2a.inbound.auth`` block (secrets
+                already interpolated); carries mode-specific settings such as
+                ``timestamp_tolerance`` (hmac) or ``issuer``/``audience`` (openid)
         """
         try:
             self.auth_mode = InboundAuthType(auth_mode)
             self.secrets_manager = secrets_manager
+            self.auth_config: Dict[str, Any] = auth_config or {}
             self.schemes: Dict[str, Any] = {}  # SDK schemes for validation
             self.credentials: Dict[str, InboundCredential] = {}
             self.api_keys: Dict[str, str] = {}  # api_key -> client_id mapping
             self.bearer_tokens: Dict[str, str] = {}  # token -> client_id mapping
             self.basic_auth: Dict[str, str] = {}  # username -> password mapping
+            self.hmac_secrets: Dict[str, str] = {}  # secret -> client_id mapping
+            # HMAC replay prevention: signature -> expiry timestamp
+            self._seen_signatures: Dict[str, float] = {}
+            # Lazily constructed PyJWKClient for openid mode
+            self._jwks_client: Optional[Any] = None
 
             # Emit initialization event
             observability.observe(
@@ -480,6 +504,11 @@ class A2AInboundAuthenticator:
                     raise ValueError("Basic authentication requires 'username' and 'password'")
                 self.basic_auth[credential_data["username"]] = credential_data["password"]
 
+            elif auth_type == InboundAuthType.HMAC:
+                if "secret" not in credential_data:
+                    raise ValueError("HMAC authentication requires 'secret' in credential_data")
+                self.hmac_secrets[credential_data["secret"]] = client_id
+
             # Store the credential
             self.credentials[client_id] = InboundCredential(
                 auth_type=auth_type,
@@ -576,6 +605,26 @@ class A2AInboundAuthenticator:
                 if not authorization or not authorization.startswith("Basic "):
                     return False, None, "Basic authentication required"
                 result = await self._authenticate_basic(authorization)
+
+            elif self.auth_mode == InboundAuthType.HMAC:
+                if x_api_key:
+                    return False, None, "Server requires HMAC authentication, not API key"
+                if authorization:
+                    return False, None, "Server requires HMAC authentication, not Authorization"
+                if not x_signature or not x_timestamp:
+                    return (
+                        False,
+                        None,
+                        "HMAC authentication requires X-Signature and X-Timestamp headers",
+                    )
+                result = await self._authenticate_hmac(x_signature, x_timestamp)
+
+            elif self.auth_mode == InboundAuthType.OPENID:
+                if x_api_key:
+                    return False, None, "Server requires OpenID authentication, not API key"
+                if not authorization or not authorization.startswith("Bearer "):
+                    return False, None, "OpenID authentication requires a Bearer JWT"
+                result = await self._authenticate_openid(authorization)
 
             else:
                 error_msg = f"Unsupported authentication mode: {self.auth_mode}"
@@ -751,6 +800,141 @@ class A2AInboundAuthenticator:
             )
             return False, None, f"Basic authentication error: {str(e)}"
 
+    async def _authenticate_hmac(
+        self, x_signature: str, x_timestamp: str
+    ) -> Tuple[bool, Optional[str], Optional[str]]:
+        """Authenticate using an HMAC-SHA256 signature over the request timestamp.
+
+        The signature proves possession of the shared secret; the timestamp
+        tolerance plus the replay cache bound reuse. Transport integrity is
+        TLS's job (the body is not signed).
+        """
+        try:
+            tolerance = int(
+                self.auth_config.get("timestamp_tolerance", DEFAULT_HMAC_TIMESTAMP_TOLERANCE)
+            )
+
+            try:
+                timestamp = int(x_timestamp)
+            except (TypeError, ValueError):
+                return False, None, "Invalid X-Timestamp header (expected unix seconds)"
+
+            now = time.time()
+            if abs(now - timestamp) > tolerance:
+                observability.observe(
+                    event_type=observability.SystemEvents.A2A_AUTH_VALIDATION_FAILED,
+                    level=observability.EventLevel.WARNING,
+                    description="HMAC authentication failed: timestamp outside tolerance",
+                    data={"auth_type": "hmac", "tolerance": tolerance},
+                )
+                return False, None, "Timestamp outside accepted tolerance"
+
+            # Replay prevention: a signature is single-use within the window
+            self._prune_seen_signatures(now)
+            if x_signature in self._seen_signatures:
+                observability.observe(
+                    event_type=observability.SystemEvents.A2A_AUTH_VALIDATION_FAILED,
+                    level=observability.EventLevel.WARNING,
+                    description="HMAC authentication failed: signature replay detected",
+                    data={"auth_type": "hmac"},
+                )
+                return False, None, "Signature already used (replay rejected)"
+
+            for secret, client_id in self.hmac_secrets.items():
+                expected = hmac_lib.new(
+                    secret.encode("utf-8"), x_timestamp.encode("utf-8"), hashlib.sha256
+                ).hexdigest()
+                if hmac_lib.compare_digest(expected, x_signature):
+                    self._seen_signatures[x_signature] = now + tolerance
+                    observability.observe(
+                        event_type=observability.SystemEvents.A2A_AUTH_VALIDATED,
+                        level=observability.EventLevel.INFO,
+                        description=f"HMAC authentication successful for client {client_id}",
+                        data={"client_id": client_id, "auth_type": "hmac"},
+                    )
+                    return True, client_id, None
+
+            observability.observe(
+                event_type=observability.SystemEvents.A2A_AUTH_VALIDATION_FAILED,
+                level=observability.EventLevel.WARNING,
+                description="HMAC authentication failed: invalid signature",
+                data={"auth_type": "hmac", "configured_secrets": len(self.hmac_secrets)},
+            )
+            return False, None, "Invalid HMAC signature"
+
+        except Exception as e:
+            observability.observe(
+                event_type=observability.ErrorEvents.AUTHENTICATION_FAILED,
+                level=observability.EventLevel.ERROR,
+                description=f"HMAC authentication error: {str(e)}",
+                data={"auth_type": "hmac", "error": str(e)},
+            )
+            return False, None, f"HMAC authentication error: {str(e)}"
+
+    def _prune_seen_signatures(self, now: float) -> None:
+        """Drop expired entries from the replay cache."""
+        if len(self._seen_signatures) > 1000:
+            self._seen_signatures = {
+                sig: expiry for sig, expiry in self._seen_signatures.items() if expiry > now
+            }
+
+    async def _authenticate_openid(
+        self, authorization: str
+    ) -> Tuple[bool, Optional[str], Optional[str]]:
+        """Authenticate using an OpenID Connect / OAuth2 JWT validated via JWKS."""
+        try:
+            import jwt as pyjwt
+
+            token = authorization[7:]  # Remove "Bearer " prefix
+
+            issuer = self.auth_config.get("issuer")
+            if not issuer:
+                return False, None, "OpenID authentication is not configured (missing issuer)"
+            audience = self.auth_config.get("audience")
+            algorithms = self.auth_config.get("allowed_algorithms", DEFAULT_OPENID_ALGORITHMS)
+            leeway = int(self.auth_config.get("clock_skew_seconds", DEFAULT_OPENID_CLOCK_SKEW))
+
+            if self._jwks_client is None:
+                jwks_url = self.auth_config.get("jwks_url") or (
+                    issuer.rstrip("/") + "/.well-known/jwks.json"
+                )
+                self._jwks_client = pyjwt.PyJWKClient(jwks_url, cache_keys=True)
+
+            # PyJWKClient performs blocking HTTP on first fetch
+            signing_key = await asyncio.to_thread(self._jwks_client.get_signing_key_from_jwt, token)
+            claims = pyjwt.decode(
+                token,
+                signing_key.key,
+                algorithms=algorithms,
+                audience=audience,
+                issuer=issuer,
+                leeway=leeway,
+                # Without this, PyJWT rejects any token carrying an aud claim
+                # when no audience is configured
+                options={"verify_aud": audience is not None},
+            )
+
+            client_id = claims.get("sub") or claims.get("azp") or claims.get("client_id")
+            if not client_id:
+                return False, None, "JWT is valid but carries no subject claim"
+
+            observability.observe(
+                event_type=observability.SystemEvents.A2A_AUTH_VALIDATED,
+                level=observability.EventLevel.INFO,
+                description=f"OpenID authentication successful for subject {client_id}",
+                data={"client_id": client_id, "auth_type": "openid", "issuer": issuer},
+            )
+            return True, f"openid:{client_id}", None
+
+        except Exception as e:
+            observability.observe(
+                event_type=observability.SystemEvents.A2A_AUTH_VALIDATION_FAILED,
+                level=observability.EventLevel.WARNING,
+                description=f"OpenID authentication failed: {str(e)}",
+                data={"auth_type": "openid", "error": str(e)},
+            )
+            return False, None, f"Invalid OpenID token: {str(e)}"
+
     def get_auth_requirements(self) -> Dict[str, Any]:
         """Get authentication requirements for API documentation"""
         try:
@@ -765,6 +949,10 @@ class A2AInboundAuthenticator:
             elif self.auth_mode == InboundAuthType.BEARER:
                 requirements["required_headers"] = ["Authorization"]
             elif self.auth_mode == InboundAuthType.BASIC:
+                requirements["required_headers"] = ["Authorization"]
+            elif self.auth_mode == InboundAuthType.HMAC:
+                requirements["required_headers"] = ["X-Signature", "X-Timestamp"]
+            elif self.auth_mode == InboundAuthType.OPENID:
                 requirements["required_headers"] = ["Authorization"]
 
             # Emit auth requirements request event
@@ -797,6 +985,11 @@ class A2AInboundAuthenticator:
             InboundAuthType.API_KEY: "API key required in X-API-Key header",
             InboundAuthType.BEARER: "Bearer token required in Authorization header",
             InboundAuthType.BASIC: "Basic authentication required in Authorization header",
+            InboundAuthType.HMAC: (
+                "HMAC-SHA256 signature required in X-Signature header "
+                "with unix timestamp in X-Timestamp header"
+            ),
+            InboundAuthType.OPENID: "OpenID Connect JWT required in Authorization header",
         }
         return descriptions.get(self.auth_mode, "Unknown authentication mode")
 

--- a/src/muxi/runtime/services/a2a/auth/outbound.py
+++ b/src/muxi/runtime/services/a2a/auth/outbound.py
@@ -6,15 +6,22 @@ Supports authentication types as defined in the A2A protocol:
 - API Key authentication
 - Bearer token authentication
 - Basic authentication
+- HMAC request signing (per-request timestamp signature)
+- OAuth2 client_credentials (token fetch + cache)
 - No authentication
 
 Now integrated with A2A SDK security schemes for protocol compliance.
 """
 
 import base64
+import hashlib
+import hmac as hmac_lib
+import time
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, Optional, Tuple
+
+import httpx
 
 # A2A SDK imports
 from a2a.types import (
@@ -26,6 +33,9 @@ from a2a.types import (
 from ... import observability
 from ...secrets import SecretsManager
 
+OAUTH2_TOKEN_REFRESH_MARGIN = 60  # seconds before expiry to refresh
+OAUTH2_DEFAULT_TOKEN_TTL = 3600  # seconds, when the server omits expires_in
+
 
 class AuthType(str, Enum):
     """Supported authentication types for A2A communication"""
@@ -34,6 +44,8 @@ class AuthType(str, Enum):
     API_KEY = "api_key"
     BEARER = "bearer"
     BASIC = "basic"
+    HMAC = "hmac"
+    OAUTH2 = "oauth2"
 
 
 @dataclass
@@ -95,6 +107,32 @@ class AuthCredentials:
                 raise ValueError(
                     "Basic authentication requires 'username' and 'password' " "credentials"
                 )
+        elif self.auth_type == AuthType.HMAC:
+            if "secret" not in self.credentials:
+                observability.observe(
+                    event_type=observability.SystemEvents.A2A_AUTH_VALIDATION_FAILED,
+                    level=observability.EventLevel.ERROR,
+                    description="HMAC authentication validation failed",
+                    data={"auth_type": self.auth_type.value, "missing_credential": "secret"},
+                )
+                raise ValueError("HMAC authentication requires 'secret' credential")
+        elif self.auth_type == AuthType.OAUTH2:
+            missing = [
+                cred
+                for cred in ["client_id", "client_secret", "token_url"]
+                if cred not in self.credentials
+            ]
+            if missing:
+                observability.observe(
+                    event_type=observability.SystemEvents.A2A_AUTH_VALIDATION_FAILED,
+                    level=observability.EventLevel.ERROR,
+                    description="OAuth2 authentication validation failed",
+                    data={"auth_type": self.auth_type.value, "missing_credentials": missing},
+                )
+                raise ValueError(
+                    "OAuth2 authentication requires 'client_id', 'client_secret' "
+                    "and 'token_url' credentials"
+                )
 
         # Log successful validation
         observability.observe(
@@ -127,6 +165,8 @@ class A2AAuthManager:
         self.schemes: Dict[str, SecurityScheme] = {}
         self._credentials: Dict[str, AuthCredentials] = {}
         self._credentials_loaded = False
+        # OAuth2 client_credentials token cache: service_id -> (token, expires_at)
+        self._oauth2_tokens: Dict[str, Tuple[str, float]] = {}
 
         # Log initialization
         observability.observe(
@@ -196,6 +236,19 @@ class A2AAuthManager:
         elif auth_type == "basic":
             return HTTPAuthSecurityScheme(
                 scheme="basic",
+                description=auth_config.get("description", ""),
+            )
+        elif auth_type == "hmac":
+            return APIKeySecurityScheme(
+                name=auth_config.get("signature_header", "X-Signature"),
+                location="header",
+                description=auth_config.get("description", ""),
+            )
+        elif auth_type == "oauth2":
+            # Token is ultimately applied as a Bearer credential
+            return HTTPAuthSecurityScheme(
+                scheme="bearer",
+                bearer_format="OAuth2",
                 description=auth_config.get("description", ""),
             )
 
@@ -486,6 +539,29 @@ class A2AAuthManager:
                                 "password": interpolated_config.get("password"),
                             },
                         )
+                    elif auth_type == AuthType.HMAC:
+                        self.add_credentials(
+                            service_id,
+                            auth_type,
+                            {
+                                "secret": interpolated_config.get("secret"),
+                                "signature_header": interpolated_config.get(
+                                    "signature_header", "X-Signature"
+                                ),
+                                "timestamp_header": interpolated_config.get(
+                                    "timestamp_header", "X-Timestamp"
+                                ),
+                            },
+                        )
+                    elif auth_type == AuthType.OAUTH2:
+                        oauth2_creds = {
+                            "client_id": interpolated_config.get("client_id"),
+                            "client_secret": interpolated_config.get("client_secret"),
+                            "token_url": interpolated_config.get("token_url"),
+                        }
+                        if interpolated_config.get("scope"):
+                            oauth2_creds["scope"] = interpolated_config["scope"]
+                        self.add_credentials(service_id, auth_type, oauth2_creds)
 
                     # Log successful service configuration processing
                     observability.observe(
@@ -600,7 +676,14 @@ class A2AAuthManager:
             # Apply SDK scheme authentication based on type
             updated_headers = headers.copy()
 
-            if isinstance(scheme, APIKeySecurityScheme):
+            creds = self.get_credentials(service_id)
+            if creds and creds.auth_type == AuthType.HMAC:
+                # Fresh signature per request: HMAC-SHA256(secret, timestamp)
+                updated_headers.update(self._build_hmac_headers(creds))
+            elif creds and creds.auth_type == AuthType.OAUTH2:
+                token = await self._get_oauth2_token(service_id, creds)
+                updated_headers["Authorization"] = f"Bearer {token}"
+            elif isinstance(scheme, APIKeySecurityScheme):
                 # APIKeySecurityScheme stores the actual values, not the spec
                 # Get api_key from the stored credentials instead
                 creds = self.get_credentials(service_id)
@@ -769,6 +852,25 @@ class A2AAuthManager:
                     data={"agent_id": agent_id, "auth_type": "basic", "username": username},
                 )
 
+            elif auth_type == AuthType.HMAC:
+                updated_headers.update(self._build_hmac_headers(creds))
+                observability.observe(
+                    event_type=observability.SystemEvents.A2A_AUTH_VALIDATED,
+                    level=observability.EventLevel.DEBUG,
+                    description="A2A HMAC authentication applied successfully",
+                    data={"agent_id": agent_id, "auth_type": "hmac"},
+                )
+
+            elif auth_type == AuthType.OAUTH2:
+                token = await self._get_oauth2_token(agent_id, creds)
+                updated_headers["Authorization"] = f"Bearer {token}"
+                observability.observe(
+                    event_type=observability.SystemEvents.A2A_AUTH_VALIDATED,
+                    level=observability.EventLevel.DEBUG,
+                    description="A2A OAuth2 authentication applied successfully",
+                    data={"agent_id": agent_id, "auth_type": "oauth2"},
+                )
+
             return True, updated_headers
 
         except Exception as e:
@@ -785,6 +887,56 @@ class A2AAuthManager:
                 },
             )
             return False, headers
+
+    def _build_hmac_headers(self, creds: AuthCredentials) -> Dict[str, str]:
+        """Build per-request HMAC signature headers.
+
+        Signs the current unix timestamp with HMAC-SHA256 so each request
+        carries a fresh, replay-bounded signature.
+        """
+        secret = creds.credentials["secret"]
+        timestamp = str(int(time.time()))
+        signature = hmac_lib.new(
+            secret.encode("utf-8"), timestamp.encode("utf-8"), hashlib.sha256
+        ).hexdigest()
+        return {
+            creds.credentials.get("signature_header", "X-Signature"): signature,
+            creds.credentials.get("timestamp_header", "X-Timestamp"): timestamp,
+        }
+
+    async def _get_oauth2_token(self, service_id: str, creds: AuthCredentials) -> str:
+        """Get an OAuth2 client_credentials access token, using the cache when fresh."""
+        cached = self._oauth2_tokens.get(service_id)
+        now = time.time()
+        if cached and cached[1] - OAUTH2_TOKEN_REFRESH_MARGIN > now:
+            return cached[0]
+
+        data = {
+            "grant_type": "client_credentials",
+            "client_id": creds.credentials["client_id"],
+            "client_secret": creds.credentials["client_secret"],
+        }
+        if creds.credentials.get("scope"):
+            data["scope"] = creds.credentials["scope"]
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(creds.credentials["token_url"], data=data)
+            response.raise_for_status()
+            payload = response.json()
+
+        token = payload.get("access_token")
+        if not token:
+            raise ValueError(f"OAuth2 token endpoint returned no access_token for {service_id}")
+        expires_in = int(payload.get("expires_in", OAUTH2_DEFAULT_TOKEN_TTL))
+        self._oauth2_tokens[service_id] = (token, now + expires_in)
+
+        observability.observe(
+            event_type=observability.SystemEvents.A2A_CREDENTIAL_LOADED,
+            level=observability.EventLevel.DEBUG,
+            description="OAuth2 access token obtained for A2A service",
+            data={"service_id": service_id, "expires_in": expires_in},
+        )
+        return token
 
     def remove_credentials(self, agent_id: str):
         """Remove credentials for an agent"""

--- a/src/muxi/runtime/services/a2a/server.py
+++ b/src/muxi/runtime/services/a2a/server.py
@@ -85,6 +85,7 @@ class A2AServer:
         auth_mode: str = "none",
         shared_key: Optional[str] = None,
         formation_name: str = "default",
+        auth_config: Optional[Dict[str, Any]] = None,
     ):
         """
         Initialize the SDK-compatible A2A Formation Server.
@@ -97,6 +98,8 @@ class A2AServer:
             auth_mode: Authentication mode ("none", "api_key", "bearer", etc.)
             shared_key: Shared key for authentication (if auth_mode requires it)
             formation_name: Name of the formation this server serves
+            auth_config: The formation's ``a2a.inbound.auth`` block (mode-specific
+                settings such as hmac tolerance or openid issuer/audience)
         """
         try:
             self.overlord = overlord
@@ -117,14 +120,18 @@ class A2AServer:
 
             # Pass SecretsManager from overlord if available
             secrets_manager = getattr(overlord, "secrets_manager", None)
-            self.authenticator = A2AInboundAuthenticator(auth_mode, secrets_manager)
+            self.authenticator = A2AInboundAuthenticator(
+                auth_mode, secrets_manager, auth_config=auth_config
+            )
 
             # If we have a shared key, add it to the authenticator
-            if self.shared_key and self.auth_mode in ["bearer", "api_key", "apiKey"]:
+            if self.shared_key and self.auth_mode in ["bearer", "api_key", "apiKey", "hmac"]:
                 if self.auth_mode == "bearer":
                     self.authenticator.bearer_tokens[self.shared_key] = "formation_client"
                 elif self.auth_mode in ["api_key", "apiKey"]:
                     self.authenticator.api_keys[self.shared_key] = "formation_client"
+                elif self.auth_mode == "hmac":
+                    self.authenticator.hmac_secrets[self.shared_key] = "formation_client"
 
             # Initialize FastAPI app
             self._create_app()

--- a/tests/unit/test_a2a_auth_inbound.py
+++ b/tests/unit/test_a2a_auth_inbound.py
@@ -1,0 +1,278 @@
+"""Unit tests for A2A inbound authentication (hmac and openid modes).
+
+Covers:
+  - HMAC signature validation: valid signature, wrong secret, timestamp
+    tolerance, replay rejection, malformed timestamp
+  - Strict mode enforcement: hmac/openid servers reject other auth types
+  - OpenID JWT validation against a real JWKS endpoint (local HTTP server,
+    RSA keypair generated in-test, token signed with PyJWT)
+"""
+
+import hashlib
+import hmac
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from muxi.runtime.services.a2a.auth.inbound import (
+    A2AInboundAuthenticator,
+    InboundAuthType,
+)
+
+
+def _sign(secret: str, timestamp: str) -> str:
+    return hmac.new(secret.encode(), timestamp.encode(), hashlib.sha256).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# HMAC mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def hmac_auth():
+    authenticator = A2AInboundAuthenticator("hmac")
+    authenticator.hmac_secrets["shh"] = "client-1"
+    return authenticator
+
+
+async def test_hmac_valid_signature_authenticates(hmac_auth):
+    timestamp = str(int(time.time()))
+    ok, client_id, error = await hmac_auth._authenticate_hmac(_sign("shh", timestamp), timestamp)
+    assert ok is True
+    assert client_id == "client-1"
+    assert error is None
+
+
+async def test_hmac_wrong_secret_rejected(hmac_auth):
+    timestamp = str(int(time.time()))
+    ok, client_id, error = await hmac_auth._authenticate_hmac(_sign("wrong", timestamp), timestamp)
+    assert ok is False
+    assert client_id is None
+    assert "signature" in error.lower()
+
+
+async def test_hmac_stale_timestamp_rejected(hmac_auth):
+    timestamp = str(int(time.time()) - 3600)
+    ok, _, error = await hmac_auth._authenticate_hmac(_sign("shh", timestamp), timestamp)
+    assert ok is False
+    assert "tolerance" in error.lower()
+
+
+async def test_hmac_malformed_timestamp_rejected(hmac_auth):
+    ok, _, error = await hmac_auth._authenticate_hmac("sig", "not-a-number")
+    assert ok is False
+    assert "timestamp" in error.lower()
+
+
+async def test_hmac_replayed_signature_rejected(hmac_auth):
+    timestamp = str(int(time.time()))
+    signature = _sign("shh", timestamp)
+
+    ok, _, _ = await hmac_auth._authenticate_hmac(signature, timestamp)
+    assert ok is True
+
+    ok, _, error = await hmac_auth._authenticate_hmac(signature, timestamp)
+    assert ok is False
+    assert "replay" in error.lower()
+
+
+async def test_hmac_custom_tolerance_from_auth_config():
+    authenticator = A2AInboundAuthenticator("hmac", auth_config={"timestamp_tolerance": 10})
+    authenticator.hmac_secrets["shh"] = "client-1"
+    timestamp = str(int(time.time()) - 60)
+    ok, _, error = await authenticator._authenticate_hmac(_sign("shh", timestamp), timestamp)
+    assert ok is False
+    assert "tolerance" in error.lower()
+
+
+async def test_hmac_mode_rejects_bearer_and_api_key_headers(hmac_auth):
+    ok, _, error = await hmac_auth.authenticate_request(
+        request=None, authorization="Bearer tok", x_api_key=None
+    )
+    assert ok is False
+    assert "HMAC" in error
+
+    ok, _, error = await hmac_auth.authenticate_request(
+        request=None, authorization=None, x_api_key="key"
+    )
+    assert ok is False
+    assert "HMAC" in error
+
+
+async def test_hmac_mode_requires_both_signature_and_timestamp(hmac_auth):
+    ok, _, error = await hmac_auth.authenticate_request(
+        request=None, authorization=None, x_api_key=None, x_signature="sig", x_timestamp=None
+    )
+    assert ok is False
+    assert "X-Timestamp" in error
+
+
+async def test_hmac_full_request_dispatch_authenticates(hmac_auth):
+    timestamp = str(int(time.time()))
+    ok, client_id, _ = await hmac_auth.authenticate_request(
+        request=None,
+        authorization=None,
+        x_api_key=None,
+        x_signature=_sign("shh", timestamp),
+        x_timestamp=timestamp,
+    )
+    assert ok is True
+    assert client_id == "client-1"
+
+
+def test_add_client_credential_hmac_requires_secret():
+    authenticator = A2AInboundAuthenticator("hmac")
+    with pytest.raises(ValueError, match="secret"):
+        authenticator.add_client_credential("client-2", InboundAuthType.HMAC, {})
+
+    authenticator.add_client_credential("client-2", InboundAuthType.HMAC, {"secret": "s2"})
+    assert authenticator.hmac_secrets["s2"] == "client-2"
+
+
+def test_hmac_auth_requirements_list_signature_headers():
+    authenticator = A2AInboundAuthenticator("hmac")
+    requirements = authenticator.get_auth_requirements()
+    assert requirements["required_headers"] == ["X-Signature", "X-Timestamp"]
+
+
+# ---------------------------------------------------------------------------
+# OpenID mode (real JWKS endpoint + RSA-signed JWT)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def rsa_keypair():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return key, private_pem
+
+
+@pytest.fixture
+def jwks_server(rsa_keypair):
+    key, _ = rsa_keypair
+    jwk = json.loads(jwt.algorithms.RSAAlgorithm.to_jwk(key.public_key()))
+    jwk.update({"kid": "test-key", "use": "sig", "alg": "RS256"})
+    jwks_body = json.dumps({"keys": [jwk]}).encode()
+
+    class JWKSHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(jwks_body)))
+            self.end_headers()
+            self.wfile.write(jwks_body)
+
+        def log_message(self, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), JWKSHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{server.server_port}/jwks.json"
+    server.shutdown()
+    server.server_close()
+
+
+def _make_token(private_pem, issuer, audience=None, sub="svc-42", expired=False):
+    now = int(time.time())
+    claims = {
+        "iss": issuer,
+        "sub": sub,
+        "iat": now - 10,
+        "exp": now - 3600 if expired else now + 3600,
+    }
+    if audience:
+        claims["aud"] = audience
+    return jwt.encode(claims, private_pem, algorithm="RS256", headers={"kid": "test-key"})
+
+
+ISSUER = "https://idp.example.com"
+
+
+@pytest.fixture
+def openid_auth(jwks_server):
+    return A2AInboundAuthenticator(
+        "openid", auth_config={"issuer": ISSUER, "jwks_url": jwks_server}
+    )
+
+
+async def test_openid_valid_jwt_authenticates(openid_auth, rsa_keypair):
+    _, private_pem = rsa_keypair
+    token = _make_token(private_pem, ISSUER)
+    ok, client_id, error = await openid_auth._authenticate_openid(f"Bearer {token}")
+    assert ok is True, error
+    assert client_id == "openid:svc-42"
+
+
+async def test_openid_expired_jwt_rejected(openid_auth, rsa_keypair):
+    _, private_pem = rsa_keypair
+    token = _make_token(private_pem, ISSUER, expired=True)
+    ok, _, error = await openid_auth._authenticate_openid(f"Bearer {token}")
+    assert ok is False
+    assert "expired" in error.lower()
+
+
+async def test_openid_wrong_issuer_rejected(openid_auth, rsa_keypair):
+    _, private_pem = rsa_keypair
+    token = _make_token(private_pem, "https://evil.example.com")
+    ok, _, error = await openid_auth._authenticate_openid(f"Bearer {token}")
+    assert ok is False
+    assert "issuer" in error.lower()
+
+
+async def test_openid_audience_enforced_when_configured(jwks_server, rsa_keypair):
+    _, private_pem = rsa_keypair
+    authenticator = A2AInboundAuthenticator(
+        "openid",
+        auth_config={"issuer": ISSUER, "jwks_url": jwks_server, "audience": "muxi-formation"},
+    )
+
+    token = _make_token(private_pem, ISSUER, audience="muxi-formation")
+    ok, client_id, error = await authenticator._authenticate_openid(f"Bearer {token}")
+    assert ok is True, error
+    assert client_id == "openid:svc-42"
+
+    token = _make_token(private_pem, ISSUER, audience="someone-else")
+    ok, _, error = await authenticator._authenticate_openid(f"Bearer {token}")
+    assert ok is False
+    assert "audience" in error.lower()
+
+
+async def test_openid_token_with_aud_accepted_when_no_audience_configured(openid_auth, rsa_keypair):
+    _, private_pem = rsa_keypair
+    token = _make_token(private_pem, ISSUER, audience="anything")
+    ok, client_id, error = await openid_auth._authenticate_openid(f"Bearer {token}")
+    assert ok is True, error
+    assert client_id == "openid:svc-42"
+
+
+async def test_openid_missing_issuer_config_rejected():
+    authenticator = A2AInboundAuthenticator("openid", auth_config={})
+    ok, _, error = await authenticator._authenticate_openid("Bearer whatever")
+    assert ok is False
+    assert "issuer" in error.lower()
+
+
+async def test_openid_mode_rejects_api_key_and_non_bearer(openid_auth):
+    ok, _, error = await openid_auth.authenticate_request(
+        request=None, authorization=None, x_api_key="key"
+    )
+    assert ok is False
+    assert "OpenID" in error
+
+    ok, _, error = await openid_auth.authenticate_request(
+        request=None, authorization="Basic abc", x_api_key=None
+    )
+    assert ok is False
+    assert "Bearer" in error

--- a/tests/unit/test_a2a_auth_outbound.py
+++ b/tests/unit/test_a2a_auth_outbound.py
@@ -13,6 +13,12 @@ marked xfail with a Phase-2 target; Phase 2 must clear them.
 """
 
 import base64
+import hashlib
+import hmac
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
 
@@ -163,7 +169,7 @@ def test_create_scheme_bearer_is_constructable(auth_manager):
 
 
 def test_create_scheme_unknown_type_returns_none(auth_manager):
-    assert auth_manager.create_scheme({"type": "oauth2"}) is None
+    assert auth_manager.create_scheme({"type": "kerberos"}) is None
 
 
 def test_create_scheme_missing_type_returns_none(auth_manager):
@@ -181,4 +187,124 @@ async def test_apply_sdk_authentication_noop_without_registered_scheme(auth_mana
 
 async def test_apply_sdk_authentication_missing_required_scheme_fails(auth_manager):
     ok, _ = await auth_manager.apply_sdk_authentication("unknown-agent", {}, required=True)
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# HMAC request signing
+# ---------------------------------------------------------------------------
+
+
+def test_auth_credentials_rejects_hmac_without_secret():
+    with pytest.raises(ValueError, match="secret"):
+        AuthCredentials(auth_type=AuthType.HMAC, credentials={})
+
+
+def test_create_scheme_hmac_is_constructable(auth_manager):
+    scheme = auth_manager.create_scheme({"type": "hmac", "secret": "s"})
+    assert scheme is not None
+
+
+async def test_apply_authentication_hmac_signs_current_timestamp(auth_manager):
+    auth_manager.add_credentials("agent-a", AuthType.HMAC, {"secret": "shh"})
+    ok, headers = await auth_manager.apply_authentication("agent-a", AuthType.HMAC, {})
+
+    assert ok is True
+    timestamp = headers["X-Timestamp"]
+    assert abs(int(timestamp) - int(time.time())) <= 5
+    expected = hmac.new(b"shh", timestamp.encode(), hashlib.sha256).hexdigest()
+    assert headers["X-Signature"] == expected
+
+
+async def test_apply_authentication_hmac_honors_custom_header_names(auth_manager):
+    auth_manager.add_credentials(
+        "agent-a",
+        AuthType.HMAC,
+        {"secret": "shh", "signature_header": "X-Sig", "timestamp_header": "X-Ts"},
+    )
+    ok, headers = await auth_manager.apply_authentication("agent-a", AuthType.HMAC, {})
+    assert ok is True
+    assert "X-Sig" in headers
+    assert "X-Ts" in headers
+
+
+async def test_apply_sdk_authentication_hmac_signs_per_request(auth_manager):
+    scheme = auth_manager.create_scheme({"type": "hmac", "secret": "shh"})
+    auth_manager.schemes["agent-a"] = scheme
+    auth_manager.add_credentials("agent-a", AuthType.HMAC, {"secret": "shh"})
+
+    ok, headers = await auth_manager.apply_sdk_authentication("agent-a", {})
+    assert ok is True
+    expected = hmac.new(b"shh", headers["X-Timestamp"].encode(), hashlib.sha256).hexdigest()
+    assert headers["X-Signature"] == expected
+
+
+# ---------------------------------------------------------------------------
+# OAuth2 client_credentials
+# ---------------------------------------------------------------------------
+
+
+def test_auth_credentials_rejects_oauth2_missing_fields():
+    with pytest.raises(ValueError, match="oauth2|OAuth2"):
+        AuthCredentials(auth_type=AuthType.OAUTH2, credentials={"client_id": "c"})
+
+
+def test_create_scheme_oauth2_is_bearer_scheme(auth_manager):
+    scheme = auth_manager.create_scheme(
+        {"type": "oauth2", "client_id": "c", "client_secret": "s", "token_url": "u"}
+    )
+    assert scheme is not None
+    assert getattr(scheme, "scheme", None) == "bearer"
+
+
+async def test_oauth2_token_fetched_from_real_endpoint_and_cached(auth_manager):
+    calls = {"count": 0}
+
+    class TokenHandler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            calls["count"] += 1
+            body = json.dumps({"access_token": "tok-oauth-1", "expires_in": 3600}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), TokenHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        token_url = f"http://127.0.0.1:{server.server_port}/token"
+        auth_manager.add_credentials(
+            "svc-oauth",
+            AuthType.OAUTH2,
+            {"client_id": "cid", "client_secret": "cs", "token_url": token_url},
+        )
+
+        ok, headers = await auth_manager.apply_authentication("svc-oauth", AuthType.OAUTH2, {})
+        assert ok is True
+        assert headers["Authorization"] == "Bearer tok-oauth-1"
+
+        # Second call must come from the cache, not the endpoint
+        ok, headers = await auth_manager.apply_authentication("svc-oauth", AuthType.OAUTH2, {})
+        assert ok is True
+        assert headers["Authorization"] == "Bearer tok-oauth-1"
+        assert calls["count"] == 1
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+async def test_oauth2_expired_cache_triggers_refresh(auth_manager):
+    auth_manager.add_credentials(
+        "svc-oauth",
+        AuthType.OAUTH2,
+        {"client_id": "cid", "client_secret": "cs", "token_url": "http://127.0.0.1:9/token"},
+    )
+    # Seed an expired token; refresh must hit the (unreachable) endpoint and fail
+    auth_manager._oauth2_tokens["svc-oauth"] = ("stale", time.time() - 10)
+    ok, _ = await auth_manager.apply_authentication("svc-oauth", AuthType.OAUTH2, {})
     assert ok is False


### PR DESCRIPTION
Completes the a2a-extended-auth-types PRD (scoped: mTLS excluded, leaning on existing plumbing).

## Inbound
- **hmac**: `X-Signature` = HMAC-SHA256(secret, `X-Timestamp`), constant-time comparison, timestamp tolerance (default 300s, `timestamp_tolerance`), replay cache rejecting reused signatures within the window
- **openid**: bearer JWTs validated against the issuer JWKS (PyJWT, `jwks_url` or well-known path) with issuer/audience/algorithm/expiry checks and configurable clock skew; callers authenticate as `openid:<sub>`, no shared key at rest
- Strict mode matching extends to both: an hmac server rejects bearer/api-key attempts and vice versa

## Outbound
- **hmac**: fresh signature per request (header names configurable), so retries never reuse a stale signature
- **oauth2**: client_credentials token fetched from `token_url`, cached per service, refreshed 60s before expiry, applied as a Bearer header

## Wiring
- `A2AServiceSchema` gains `inbound_auth` (mode-specific settings ride formation -> coordinator -> server -> authenticator)
- Formation validation: per-type field checks both directions, with hints (`oauth2` outbound-only, `openid` inbound-only)

## Tests
- New `tests/unit/test_a2a_auth_inbound.py` (hmac + openid against a real JWKS endpoint with an in-test RSA keypair)
- Extended `tests/unit/test_a2a_auth_outbound.py` (hmac signing, oauth2 fetch/cache against a real local token endpoint)
- Full unit suite: 3960 passed; event validation 100%; black/ruff/flake8 clean
