### PR TITLE
feat(server): idempotency-key support — chat, scheduler jobs, triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [unreleased]
 
+### Idempotency-Key support (chat, scheduler jobs, triggers)
+
+The `idempotency_key` envelope field comes alive: clients can send an
+`Idempotency-Key` header on POST `/chat`, POST `/scheduler/jobs`, and
+POST `/triggers/{name}`, and retries within 24h replay the original
+response instead of processing twice:
+
+- Keys are scoped per endpoint path and user, so different callers
+  (or different triggers) can reuse the same key safely.
+- Concurrent duplicates are single-flighted: the second request waits
+  for the first and receives its cached response -- a scheduled job
+  or trigger can never fire twice for one key.
+- Only successful (2xx) JSON responses are cached; errors stay
+  retryable, and SSE streaming responses pass through untouched.
+- The key echoes back in the response envelope (`request.idempotency_key`),
+  storage is in-process with TTL eviction, matching the runtime's
+  async request-state semantics.
+
 ### A2A extended auth types (hmac, oauth2, openid)
 
 Agent-to-agent authentication grows beyond shared static keys

--- a/src/muxi/runtime/formation/server/idempotency.py
+++ b/src/muxi/runtime/formation/server/idempotency.py
@@ -1,0 +1,183 @@
+"""
+In-memory idempotency-key support for Formation API endpoints.
+
+Clients send an ``Idempotency-Key`` header on mutating requests; retries with
+the same key within the TTL replay the original JSON response instead of
+processing the request again. Keys are scoped per endpoint and user so
+different callers (or different endpoints) can reuse the same key safely.
+
+Semantics:
+  - Only successful (2xx) JSON responses are cached; errors are retryable.
+  - Streaming (SSE) responses pass through untouched: a token stream cannot
+    be replayed from a response cache, and duplicate sync chats are harmless.
+  - Concurrent requests with the same key are single-flighted: the second
+    caller waits for the first to finish, then receives the cached response.
+  - Storage is in-process with a TTL, mirroring the RequestTracker precedent;
+    like async request state, cached responses do not survive a restart.
+"""
+
+import asyncio
+import functools
+import time
+from typing import Any, Dict, Optional, Tuple
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+from ...services import observability
+from ...utils.fastjson import json
+from .responses import APIResponse
+from .utils import get_header_case_insensitive
+
+IDEMPOTENCY_HEADER = "Idempotency-Key"
+DEFAULT_TTL_SECONDS = 24 * 60 * 60
+MAX_CACHE_ENTRIES = 10_000
+
+
+class IdempotencyCache:
+    """In-memory idempotency response cache with TTL and single-flight locks."""
+
+    def __init__(self, ttl_seconds: int = DEFAULT_TTL_SECONDS):
+        self.ttl_seconds = ttl_seconds
+        # scoped_key -> (expires_at, response_body, status_code)
+        self._responses: Dict[str, Tuple[float, Dict[str, Any], int]] = {}
+        self._locks: Dict[str, asyncio.Lock] = {}
+
+    @staticmethod
+    def scoped_key(endpoint: str, user_id: str, key: str) -> str:
+        return f"{endpoint}:{user_id}:{key}"
+
+    def lock_for(self, scoped_key: str) -> asyncio.Lock:
+        """Get (or create) the single-flight lock for a scoped key."""
+        lock = self._locks.get(scoped_key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[scoped_key] = lock
+        return lock
+
+    def get(self, scoped_key: str) -> Optional[Tuple[Dict[str, Any], int]]:
+        """Return the cached (body, status_code) if present and not expired."""
+        entry = self._responses.get(scoped_key)
+        if entry is None:
+            return None
+        expires_at, body, status_code = entry
+        if expires_at <= time.time():
+            self._responses.pop(scoped_key, None)
+            self._locks.pop(scoped_key, None)
+            return None
+        return body, status_code
+
+    def store(self, scoped_key: str, body: Dict[str, Any], status_code: int) -> None:
+        self._prune()
+        self._responses[scoped_key] = (time.time() + self.ttl_seconds, body, status_code)
+
+    def _prune(self) -> None:
+        if len(self._responses) < MAX_CACHE_ENTRIES:
+            return
+        now = time.time()
+        self._responses = {key: entry for key, entry in self._responses.items() if entry[0] > now}
+        self._locks = {
+            key: lock
+            for key, lock in self._locks.items()
+            if lock.locked() or key in self._responses
+        }
+        overflow = len(self._responses) - MAX_CACHE_ENTRIES + 1
+        if overflow > 0:
+            # Still full after dropping expired entries: evict the oldest
+            for key, _ in sorted(self._responses.items(), key=lambda item: item[1][0])[:overflow]:
+                self._responses.pop(key, None)
+
+
+def get_idempotency_cache(app) -> IdempotencyCache:
+    """Get (or lazily create) the app-scoped idempotency cache."""
+    cache = getattr(app.state, "idempotency_cache", None)
+    if cache is None:
+        cache = IdempotencyCache()
+        app.state.idempotency_cache = cache
+    return cache
+
+
+def _find_request(args, kwargs) -> Optional[Request]:
+    for value in list(args) + list(kwargs.values()):
+        if isinstance(value, Request):
+            return value
+    return None
+
+
+def _echo_key(body: Dict[str, Any], key: str) -> None:
+    """Echo the idempotency key into the response envelope, if present."""
+    request_info = body.get("request")
+    if isinstance(request_info, dict):
+        request_info["idempotency_key"] = key
+
+
+def _extract_cacheable_body(response: Any) -> Optional[Tuple[Dict[str, Any], int]]:
+    """Extract a JSON body + status from a handler result, if it is cacheable."""
+    if isinstance(response, APIResponse):
+        return response.model_dump(), 200
+    if isinstance(response, JSONResponse):
+        try:
+            body = json.loads(response.body)
+        except (ValueError, TypeError):
+            return None
+        if isinstance(body, dict):
+            return body, response.status_code
+    return None
+
+
+def idempotent(endpoint: str):
+    """Wrap a route handler with Idempotency-Key replay support.
+
+    Requests without the header run unchanged. FastAPI resolves dependencies
+    against the wrapped handler's signature (functools.wraps preserves it).
+    """
+
+    def decorator(handler):
+        @functools.wraps(handler)
+        async def wrapper(*args, **kwargs):
+            request = _find_request(args, kwargs)
+            key = (
+                get_header_case_insensitive(request.headers, IDEMPOTENCY_HEADER)
+                if request is not None
+                else None
+            )
+            if not key:
+                return await handler(*args, **kwargs)
+
+            user_id = get_header_case_insensitive(request.headers, "X-Muxi-User-Id") or "0"
+            cache = get_idempotency_cache(request.app)
+            # Scope by the concrete path so path parameters (e.g. trigger
+            # names) get independent key namespaces
+            scoped = cache.scoped_key(f"{request.method} {request.url.path}", user_id, key)
+
+            async with cache.lock_for(scoped):
+                cached = cache.get(scoped)
+                if cached is not None:
+                    body, status_code = cached
+                    observability.observe(
+                        event_type=observability.ConversationEvents.REQUEST_COMPLETED,
+                        level=observability.EventLevel.INFO,
+                        data={
+                            "service": "formation_api_server",
+                            "endpoint": endpoint,
+                            "user_id": user_id,
+                            "idempotency_replay": True,
+                        },
+                        description=(f"Replayed cached response for idempotency key on {endpoint}"),
+                    )
+                    return JSONResponse(content=body, status_code=status_code)
+
+                response = await handler(*args, **kwargs)
+
+                extracted = _extract_cacheable_body(response)
+                if extracted is not None:
+                    body, status_code = extracted
+                    if 200 <= status_code < 300:
+                        _echo_key(body, key)
+                        cache.store(scoped, body, status_code)
+                        return JSONResponse(content=body, status_code=status_code)
+                return response
+
+        return wrapper
+
+    return decorator

--- a/src/muxi/runtime/formation/server/routes/admin/scheduler.py
+++ b/src/muxi/runtime/formation/server/routes/admin/scheduler.py
@@ -17,6 +17,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from .....datatypes.api import APIEventType, APIObjectType
+from ...idempotency import idempotent
 from ...responses import (
     APIResponse,
     create_error_response,
@@ -232,6 +233,7 @@ async def list_scheduled_jobs(request: Request) -> JSONResponse:
 
 
 @router.post("/scheduler/jobs", response_model=APIResponse)
+@idempotent("scheduler_jobs_create")
 async def create_scheduled_job(request: Request, job: ScheduledJobCreate) -> JSONResponse:
     """
     Create a new scheduled job. AdminKey only.

--- a/src/muxi/runtime/formation/server/routes/client/chat.py
+++ b/src/muxi/runtime/formation/server/routes/client/chat.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 
 from .....services import observability
 from .....utils.fastjson import json
+from ...idempotency import idempotent
 from ...utils import get_header_case_insensitive
 
 router = APIRouter(tags=["Chat"])
@@ -138,6 +139,7 @@ class AudioChatRequest(BaseModel):
 
 
 @router.post("/chat", response_model=None, operation_id="chat")
+@idempotent("chat")
 async def chat(
     request: Request, chat_request: ChatRequest
 ) -> Union[StreamingResponse, JSONResponse]:

--- a/src/muxi/runtime/formation/server/routes/client/triggers.py
+++ b/src/muxi/runtime/formation/server/routes/client/triggers.py
@@ -25,6 +25,7 @@ from ....background.transformers import (
     parse_trigger_frontmatter,
     resolve_transformer_url,
 )
+from ...idempotency import idempotent
 from ...responses import (
     APIResponse,
     create_api_response,
@@ -211,6 +212,7 @@ async def get_trigger(request: Request, trigger_name: str) -> JSONResponse:
 
 
 @router.post("/triggers/{trigger_name}", operation_id="execute_trigger")
+@idempotent("execute_trigger")
 async def execute_trigger(
     trigger_name: str,
     request: Request,

--- a/tests/unit/test_idempotency.py
+++ b/tests/unit/test_idempotency.py
@@ -1,0 +1,219 @@
+"""Unit tests for Idempotency-Key support on Formation API endpoints.
+
+Covers:
+  - IdempotencyCache: TTL expiry, scoping, prune behavior
+  - The @idempotent decorator through a real FastAPI app: replay of cached
+    responses, envelope echo of the key, per-user and per-path scoping,
+    error responses staying retryable, streaming passthrough, and
+    single-flight coalescing of concurrent duplicates
+"""
+
+import asyncio
+import time
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.testclient import TestClient
+
+from muxi.runtime.datatypes.api import APIEventType, APIObjectType
+from muxi.runtime.formation.server.idempotency import (
+    IdempotencyCache,
+    get_idempotency_cache,
+    idempotent,
+)
+from muxi.runtime.formation.server.responses import create_success_response
+
+# ---------------------------------------------------------------------------
+# IdempotencyCache primitives
+# ---------------------------------------------------------------------------
+
+
+def test_cache_get_returns_stored_body():
+    cache = IdempotencyCache()
+    cache.store("k1", {"data": 1}, 200)
+    assert cache.get("k1") == ({"data": 1}, 200)
+
+
+def test_cache_miss_returns_none():
+    cache = IdempotencyCache()
+    assert cache.get("missing") is None
+
+
+def test_cache_entry_expires_after_ttl():
+    cache = IdempotencyCache(ttl_seconds=1)
+    cache.store("k1", {"data": 1}, 200)
+    cache._responses["k1"] = (time.time() - 1, {"data": 1}, 200)
+    assert cache.get("k1") is None
+
+
+def test_scoped_key_separates_endpoint_and_user():
+    assert IdempotencyCache.scoped_key("POST /chat", "u1", "abc") != IdempotencyCache.scoped_key(
+        "POST /chat", "u2", "abc"
+    )
+    assert IdempotencyCache.scoped_key("POST /chat", "u1", "abc") != IdempotencyCache.scoped_key(
+        "POST /triggers/t1", "u1", "abc"
+    )
+
+
+def test_prune_evicts_expired_entries_when_full():
+    cache = IdempotencyCache()
+    from muxi.runtime.formation.server import idempotency as idem_module
+
+    for i in range(idem_module.MAX_CACHE_ENTRIES):
+        cache._responses[f"k{i}"] = (time.time() - 1, {}, 200)
+    cache.store("fresh", {"data": 1}, 200)
+    assert cache.get("fresh") == ({"data": 1}, 200)
+    assert len(cache._responses) == 1
+
+
+# ---------------------------------------------------------------------------
+# @idempotent decorator through a real FastAPI app
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_and_calls():
+    app = FastAPI()
+    calls = {"count": 0}
+
+    @app.post("/v1/jobs")
+    @idempotent("jobs_create")
+    async def create_job(request: Request) -> JSONResponse:
+        calls["count"] += 1
+        envelope = create_success_response(
+            APIObjectType.REQUEST,
+            APIEventType.REQUEST_COMPLETED,
+            {"job_id": f"job-{calls['count']}"},
+        )
+        return JSONResponse(content=envelope.model_dump(), status_code=200)
+
+    @app.post("/v1/failing")
+    @idempotent("failing")
+    async def failing(request: Request) -> JSONResponse:
+        calls["count"] += 1
+        return JSONResponse(content={"error": "boom"}, status_code=500)
+
+    @app.post("/v1/stream")
+    @idempotent("stream")
+    async def stream(request: Request):
+        calls["count"] += 1
+
+        async def gen():
+            yield "data: x\n\n"
+
+        return StreamingResponse(gen(), media_type="text/event-stream")
+
+    return app, calls
+
+
+def test_requests_without_key_are_not_deduplicated(app_and_calls):
+    app, calls = app_and_calls
+    client = TestClient(app)
+    client.post("/v1/jobs")
+    client.post("/v1/jobs")
+    assert calls["count"] == 2
+
+
+def test_duplicate_key_replays_cached_response(app_and_calls):
+    app, calls = app_and_calls
+    client = TestClient(app)
+
+    first = client.post("/v1/jobs", headers={"Idempotency-Key": "abc"})
+    second = client.post("/v1/jobs", headers={"Idempotency-Key": "abc"})
+
+    assert calls["count"] == 1
+    assert first.json()["data"]["job_id"] == "job-1"
+    assert second.json() == first.json()
+
+
+def test_key_echoed_in_response_envelope(app_and_calls):
+    app, _ = app_and_calls
+    client = TestClient(app)
+    response = client.post("/v1/jobs", headers={"Idempotency-Key": "echo-me"})
+    assert response.json()["request"]["idempotency_key"] == "echo-me"
+
+
+def test_different_keys_process_independently(app_and_calls):
+    app, calls = app_and_calls
+    client = TestClient(app)
+    client.post("/v1/jobs", headers={"Idempotency-Key": "k1"})
+    client.post("/v1/jobs", headers={"Idempotency-Key": "k2"})
+    assert calls["count"] == 2
+
+
+def test_same_key_different_users_process_independently(app_and_calls):
+    app, calls = app_and_calls
+    client = TestClient(app)
+    client.post("/v1/jobs", headers={"Idempotency-Key": "k1", "X-Muxi-User-Id": "alice"})
+    client.post("/v1/jobs", headers={"Idempotency-Key": "k1", "X-Muxi-User-Id": "bob"})
+    assert calls["count"] == 2
+
+
+def test_header_is_case_insensitive(app_and_calls):
+    app, calls = app_and_calls
+    client = TestClient(app)
+    client.post("/v1/jobs", headers={"idempotency-key": "k1"})
+    client.post("/v1/jobs", headers={"IDEMPOTENCY-KEY": "k1"})
+    assert calls["count"] == 1
+
+
+def test_error_responses_are_not_cached(app_and_calls):
+    app, calls = app_and_calls
+    client = TestClient(app)
+    first = client.post("/v1/failing", headers={"Idempotency-Key": "k1"})
+    second = client.post("/v1/failing", headers={"Idempotency-Key": "k1"})
+    assert first.status_code == 500
+    assert second.status_code == 500
+    assert calls["count"] == 2
+
+
+def test_streaming_responses_pass_through_uncached(app_and_calls):
+    app, calls = app_and_calls
+    client = TestClient(app)
+    first = client.post("/v1/stream", headers={"Idempotency-Key": "k1"})
+    second = client.post("/v1/stream", headers={"Idempotency-Key": "k1"})
+    assert first.headers["content-type"].startswith("text/event-stream")
+    assert second.headers["content-type"].startswith("text/event-stream")
+    assert calls["count"] == 2
+
+
+def test_cache_is_app_scoped(app_and_calls):
+    app, _ = app_and_calls
+    client = TestClient(app)
+    client.post("/v1/jobs", headers={"Idempotency-Key": "k1"})
+    cache = get_idempotency_cache(app)
+    assert isinstance(cache, IdempotencyCache)
+    assert len(cache._responses) == 1
+
+
+async def test_concurrent_duplicates_are_single_flighted():
+    app = FastAPI()
+    calls = {"count": 0}
+    release = asyncio.Event()
+
+    @app.post("/v1/slow")
+    @idempotent("slow")
+    async def slow(request: Request) -> JSONResponse:
+        calls["count"] += 1
+        await release.wait()
+        envelope = create_success_response(
+            APIObjectType.REQUEST,
+            APIEventType.REQUEST_COMPLETED,
+            {"result": calls["count"]},
+        )
+        return JSONResponse(content=envelope.model_dump(), status_code=200)
+
+    import httpx
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        task1 = asyncio.create_task(client.post("/v1/slow", headers={"Idempotency-Key": "k1"}))
+        task2 = asyncio.create_task(client.post("/v1/slow", headers={"Idempotency-Key": "k1"}))
+        await asyncio.sleep(0.1)
+        release.set()
+        first, second = await asyncio.gather(task1, task2)
+
+    assert calls["count"] == 1
+    assert first.json()["data"] == {"result": 1}
+    assert second.json() == first.json()


### PR DESCRIPTION
Completes the idempotency-key PRD (scoped per discussion: in-memory storage; chat + scheduler jobs + triggers).

## What
- New `formation/server/idempotency.py`: `IdempotencyCache` (TTL 24h, max 10k entries, lazy prune + oldest-first eviction) and an `@idempotent` route decorator.
- Decorated endpoints: POST `/chat`, POST `/scheduler/jobs`, POST `/triggers/{name}`.

## Semantics
- Keys scope per `METHOD path` + user, so different callers (and different triggers) can reuse the same key safely.
- Concurrent duplicates are single-flighted via a per-key asyncio lock: the second request waits and receives the first request's cached response — a job or trigger can never fire twice for one key.
- Only successful (2xx) JSON responses are cached; errors stay retryable. SSE streaming responses pass through untouched (a token stream cannot be replayed from a response cache).
- The key echoes back in the response envelope (`request.idempotency_key`), bringing the long-dormant placeholder field to life.
- Storage is in-process with TTL, mirroring the RequestTracker precedent: like async request state, cached responses do not survive a restart.

## Tests
- `tests/unit/test_idempotency.py` (15 tests): cache primitives (TTL, scoping, prune), and the decorator through a real FastAPI app — replay, envelope echo, per-user/per-path scoping, case-insensitive header, error passthrough, streaming passthrough, and concurrent single-flight via httpx ASGITransport.
- Full unit suite green (3960 passed); black/ruff/flake8 clean.
