### PR TITLE
fix(a2a): normalize outbound service identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ and the secrets interpolation the current modes already use:
 - Outbound `oauth2`: client_credentials tokens are fetched from the
   service's `token_url`, cached per service, and refreshed 60s before
   expiry; the token rides as a standard Bearer header.
+- Outbound service auth now uses the canonical `id` for credential
+  registration and matches requests through the service `url`, removing
+  the previous need to duplicate identifiers in `id` and `service_id`.
+  Legacy `service_id` configurations remain accepted with a deprecation
+  warning.
 - Strict mode matching extends to the new types: an hmac server
   rejects bearer/api-key attempts and vice versa. Formation validation
   gains per-type field checks and directional hints (`oauth2` is

--- a/src/muxi/runtime/formation/config/validation.py
+++ b/src/muxi/runtime/formation/config/validation.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Union
 import yaml
 
 # Import the MCP registry to get valid MCP names dynamically
+from ...services.a2a.identifiers import get_service_identifier
 from ...services.mcp.built_in import BUILTIN_MCP_REGISTRY
 from ...utils.fastjson import json
 
@@ -136,7 +137,7 @@ class FormationValidator:
     REQUIRED_AGENT_FIELDS = ["schema", "id", "name", "description"]
     REQUIRED_MODEL_FIELDS = ["provider"]
     REQUIRED_MCP_SERVER_FIELDS = ["schema", "id", "description", "type"]
-    REQUIRED_A2A_SERVICE_FIELDS = ["schema", "id", "name", "description", "url"]
+    REQUIRED_A2A_SERVICE_FIELDS = ["schema", "name", "description", "url"]
 
     # Known model capabilities (also used to reject alias/capability collisions)
     KNOWN_MODEL_CAPABILITIES = {
@@ -1098,7 +1099,7 @@ class FormationValidator:
                         continue
 
                     # Check for service id and duplicates
-                    service_id = service_config.get("id")
+                    service_id = get_service_identifier(service_config)
                     if service_id:
                         if service_id in service_ids:
                             self.result.add_error(f"Duplicate A2A service id: {service_id}")
@@ -1974,7 +1975,7 @@ class FormationValidator:
                 self._validate_a2a_service_config(a2a_config, a2a_file.name)
 
                 # Check for duplicate service IDs
-                service_id = a2a_config.get("id")
+                service_id = get_service_identifier(a2a_config)
                 if service_id:
                     if service_id in service_ids:
                         self.result.add_error(f"Duplicate A2A service id: {service_id}")
@@ -3393,10 +3394,21 @@ class FormationValidator:
         if schema and not isinstance(schema, str):
             self.result.add_error(f"A2A service {filename} schema must be a string")
 
-        # Validate id
+        # Validate canonical id and deprecated alias
         service_id = service_config.get("id")
-        if service_id and not isinstance(service_id, str):
-            self.result.add_error(f"A2A service {filename} id must be a string")
+        legacy_service_id = service_config.get("service_id")
+        if service_id is None and legacy_service_id is None:
+            self.result.add_error(f"A2A service {filename} missing required field: id")
+        if service_id is not None and (not isinstance(service_id, str) or not service_id.strip()):
+            self.result.add_error(f"A2A service {filename} id must be a non-empty string")
+        if legacy_service_id is not None and (
+            not isinstance(legacy_service_id, str) or not legacy_service_id.strip()
+        ):
+            self.result.add_error(f"A2A service {filename} service_id must be a non-empty string")
+        if service_id is None and legacy_service_id is not None:
+            self.result.add_warning(
+                f"A2A service {filename} uses deprecated service_id; rename it to id"
+            )
 
         # Validate name
         name = service_config.get("name")
@@ -3518,14 +3530,20 @@ class FormationValidator:
             self.result.add_error(f"{service_identifier} configuration must be a dictionary")
             return
 
-        # Check required field: service_id
-        if "service_id" not in service_config:
-            self.result.add_error(f"{service_identifier} missing required field: service_id")
-
-        # Validate service_id
-        service_id = service_config.get("service_id")
-        if service_id and not isinstance(service_id, str):
-            self.result.add_error(f"{service_identifier} service_id must be a string")
+        service_id = service_config.get("id")
+        legacy_service_id = service_config.get("service_id")
+        if service_id is None and legacy_service_id is None:
+            self.result.add_error(f"{service_identifier} missing required field: id")
+        if service_id is not None and (not isinstance(service_id, str) or not service_id.strip()):
+            self.result.add_error(f"{service_identifier} id must be a non-empty string")
+        if legacy_service_id is not None and (
+            not isinstance(legacy_service_id, str) or not legacy_service_id.strip()
+        ):
+            self.result.add_error(f"{service_identifier} service_id must be a non-empty string")
+        if service_id is None and legacy_service_id is not None:
+            self.result.add_warning(
+                f"{service_identifier} uses deprecated service_id; rename it to id"
+            )
 
         # Validate authentication configuration if present
         if "auth" in service_config:

--- a/src/muxi/runtime/formation/overlord/a2a_messaging.py
+++ b/src/muxi/runtime/formation/overlord/a2a_messaging.py
@@ -26,6 +26,7 @@ from a2a.client import ClientCallContext
 from a2a.types import Message, SendMessageRequest
 
 from ...services.a2a import _sdk_helpers as sdk
+from ...services.a2a.identifiers import get_service_identifier
 from ...utils.id_generator import generate_nanoid
 
 
@@ -36,6 +37,73 @@ class UnifiedA2AMessaging:
         """Initialize with overlord instance that has ClientFactory."""
         self.overlord = overlord
         self._last_was_external: bool = False
+
+    @staticmethod
+    def _match_outbound_service(
+        service: Dict[str, Any],
+        target_agent_url: str,
+    ) -> Optional[tuple[int, int, str]]:
+        credential_id = get_service_identifier(service)
+        if credential_id is None:
+            return None
+
+        target = urlparse(target_agent_url)
+        target_host = target.hostname
+        try:
+            target_port = target.port or (443 if target.scheme == "https" else 80)
+        except ValueError:
+            return None
+        path_parts = target.path.strip("/").split("/")
+        target_agent_id = (
+            path_parts[1]
+            if len(path_parts) >= 3 and path_parts[0] == "agents" and path_parts[2] == "message"
+            else None
+        )
+
+        selector = service.get("service_id")
+        if not isinstance(selector, str) or not selector.strip():
+            selector = credential_id if "url" not in service else None
+        if selector:
+            selector = selector.strip()
+            if (
+                target_agent_id
+                and target_host
+                and selector == f"{target_agent_id}@{target_host}:{target_port}"
+            ):
+                return 0, 0, credential_id
+            if target_host and selector == f"{target_host}:{target_port}":
+                return 2, 0, credential_id
+            if (
+                target_host in ("localhost", "127.0.0.1", "0.0.0.0")
+                and selector == f"localhost:{target_port}"
+            ):
+                return 2, 0, credential_id
+            if target_host and selector == target_host:
+                return 3, 0, credential_id
+            if selector == str(target_port):
+                return 4, 0, credential_id
+
+        configured_url = service.get("url")
+        if not isinstance(configured_url, str) or not configured_url.strip():
+            return None
+        configured = urlparse(configured_url)
+        try:
+            configured_port = configured.port or (443 if configured.scheme == "https" else 80)
+        except ValueError:
+            return None
+        if (
+            configured.scheme != target.scheme
+            or configured.hostname != target_host
+            or configured_port != target_port
+        ):
+            return None
+
+        configured_path = configured.path.rstrip("/")
+        if configured_path and not (
+            target.path == configured_path or target.path.startswith(f"{configured_path}/")
+        ):
+            return None
+        return 1, -len(configured_path), credential_id
 
     async def send_a2a_message(
         self,
@@ -203,47 +271,17 @@ class UnifiedA2AMessaging:
             .get("services", [])
         )
 
-        parsed_url = urlparse(target_agent_url)
-        target_host = parsed_url.hostname
-        target_port = parsed_url.port
-
-        # URL format: http://hostname:port/agents/{agent-id}/message
-        target_agent_id = None
-        if parsed_url.path:
-            path_parts = parsed_url.path.strip("/").split("/")
-            if len(path_parts) >= 3 and path_parts[0] == "agents" and path_parts[2] == "message":
-                target_agent_id = path_parts[1]
-
         matches = []
         for service in outbound_services:
-            service_id = service.get("service_id", "")
-            if not service_id:
-                continue
-            if (
-                target_agent_id
-                and target_host
-                and target_port
-                and service_id == f"{target_agent_id}@{target_host}:{target_port}"
-            ):
-                matches.append((1, service_id))
-            elif target_host and target_port and service_id == f"{target_host}:{target_port}":
-                matches.append((2, service_id))
-            elif target_host and service_id == target_host:
-                matches.append((3, service_id))
-            elif target_port:
-                if service_id == str(target_port):
-                    matches.append((4, service_id))
-                elif (
-                    target_host in ("localhost", "127.0.0.1", "0.0.0.0")
-                    and service_id == f"localhost:{target_port}"
-                ):
-                    matches.append((2, service_id))
+            match = self._match_outbound_service(service, target_agent_url)
+            if match is not None:
+                matches.append(match)
 
         if not matches:
             return {}
-        matches.sort(key=lambda x: x[0])
+        matches.sort()
         success, headers = await auth_manager.apply_sdk_authentication(
-            matches[0][1], {}, required=False
+            matches[0][2], {}, required=False
         )
         return headers if success else {}
 

--- a/src/muxi/runtime/services/a2a/auth/outbound.py
+++ b/src/muxi/runtime/services/a2a/auth/outbound.py
@@ -32,6 +32,7 @@ from a2a.types import (
 
 from ... import observability
 from ...secrets import SecretsManager
+from ..identifiers import get_service_identifier
 
 OAUTH2_TOKEN_REFRESH_MARGIN = 60  # seconds before expiry to refresh
 OAUTH2_DEFAULT_TOKEN_TTL = 3600  # seconds, when the server omits expires_in
@@ -489,8 +490,9 @@ class A2AAuthManager:
         services = outbound_config.get("services", [])
 
         for service_config in services:
+            service_id = None
             try:
-                service_id = service_config.get("id")
+                service_id = get_service_identifier(service_config)
                 auth_config = service_config.get("auth", {})
 
                 if not service_id or not auth_config:

--- a/src/muxi/runtime/services/a2a/identifiers.py
+++ b/src/muxi/runtime/services/a2a/identifiers.py
@@ -1,0 +1,10 @@
+from typing import Any, Dict, Optional
+
+
+def get_service_identifier(service_config: Dict[str, Any]) -> Optional[str]:
+    """Return the canonical service identifier, accepting the legacy alias."""
+    for key in ("id", "service_id"):
+        value = service_config.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None

--- a/tests/unit/test_a2a_auth_outbound.py
+++ b/tests/unit/test_a2a_auth_outbound.py
@@ -190,6 +190,49 @@ async def test_apply_sdk_authentication_missing_required_scheme_fails(auth_manag
     assert ok is False
 
 
+async def test_load_credentials_uses_canonical_service_id(auth_manager):
+    await auth_manager.load_credentials_from_formation_config(
+        {
+            "a2a": {
+                "outbound": {
+                    "services": [
+                        {
+                            "id": "analytics",
+                            "url": "https://analytics.example.com",
+                            "auth": {"type": "bearer", "token": "token-123"},
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    ok, headers = await auth_manager.apply_sdk_authentication("analytics", {})
+    assert ok is True
+    assert headers["Authorization"] == "Bearer token-123"
+
+
+async def test_load_credentials_accepts_legacy_service_id(auth_manager):
+    await auth_manager.load_credentials_from_formation_config(
+        {
+            "a2a": {
+                "outbound": {
+                    "services": [
+                        {
+                            "service_id": "analytics.example.com",
+                            "auth": {"type": "bearer", "token": "token-123"},
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    ok, headers = await auth_manager.apply_sdk_authentication("analytics.example.com", {})
+    assert ok is True
+    assert headers["Authorization"] == "Bearer token-123"
+
+
 # ---------------------------------------------------------------------------
 # HMAC request signing
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_a2a_messaging.py
+++ b/tests/unit/test_a2a_messaging.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 import pytest
 
 from muxi.runtime.formation.overlord.a2a_messaging import UnifiedA2AMessaging
+from muxi.runtime.services.a2a.auth.outbound import A2AAuthManager
 
 
 @pytest.fixture
@@ -160,3 +161,88 @@ def test_convert_from_external_empty_response_is_error(messaging):
     out = messaging._convert_from_a2a_message(sdk)
 
     assert out.get("status") == "error"
+
+
+class _SecretsManager:
+    async def interpolate_secrets(self, value):
+        return value
+
+
+async def _messaging_with_services(services):
+    config = {"a2a": {"outbound": {"services": services}}}
+    auth_manager = A2AAuthManager(_SecretsManager())
+    await auth_manager.load_credentials_from_formation_config(config)
+    overlord = SimpleNamespace(
+        client_factory=None,
+        secrets_manager=_SecretsManager(),
+        formation_config=config,
+        _a2a_auth_manager=auth_manager,
+    )
+    return UnifiedA2AMessaging(overlord)
+
+
+async def test_outbound_auth_matches_canonical_id_by_url():
+    messaging = await _messaging_with_services(
+        [
+            {
+                "id": "analytics",
+                "url": "https://analytics.example.com",
+                "auth": {"type": "bearer", "token": "canonical-token"},
+            }
+        ]
+    )
+
+    headers = await messaging._resolve_outbound_auth_headers(
+        "https://analytics.example.com/agents/reporter/message"
+    )
+
+    assert headers["Authorization"] == "Bearer canonical-token"
+
+
+async def test_outbound_auth_prefers_the_most_specific_url_path():
+    messaging = await _messaging_with_services(
+        [
+            {
+                "id": "generic",
+                "url": "https://agents.example.com",
+                "auth": {"type": "bearer", "token": "generic-token"},
+            },
+            {
+                "id": "analytics",
+                "url": "https://agents.example.com/analytics",
+                "auth": {"type": "bearer", "token": "analytics-token"},
+            },
+        ]
+    )
+
+    headers = await messaging._resolve_outbound_auth_headers(
+        "https://agents.example.com/analytics/agents/reporter/message"
+    )
+
+    assert headers["Authorization"] == "Bearer analytics-token"
+
+
+async def test_outbound_auth_accepts_legacy_service_id_selector():
+    messaging = await _messaging_with_services(
+        [
+            {
+                "service_id": "analytics.example.com",
+                "auth": {"type": "bearer", "token": "legacy-token"},
+            }
+        ]
+    )
+
+    headers = await messaging._resolve_outbound_auth_headers(
+        "https://analytics.example.com/agents/reporter/message"
+    )
+
+    assert headers["Authorization"] == "Bearer legacy-token"
+
+
+def test_outbound_service_match_ignores_invalid_configured_port():
+    match = UnifiedA2AMessaging._match_outbound_service(
+        {"id": "analytics", "url": "https://analytics.example.com:invalid"},
+        "https://analytics.example.com/agents/reporter/message",
+    )
+
+    assert match is None

--- a/tests/unit/test_a2a_service_identifiers.py
+++ b/tests/unit/test_a2a_service_identifiers.py
@@ -1,0 +1,78 @@
+from muxi.runtime.formation.config.validation import FormationValidator
+from muxi.runtime.services.a2a.identifiers import get_service_identifier
+
+
+def _validate(services):
+    validator = FormationValidator()
+    validator._validate_a2a_config({"outbound": {"services": services}})
+    return validator.result
+
+
+def test_service_identifier_falls_back_when_canonical_id_is_blank():
+    assert (
+        get_service_identifier({"id": "  ", "service_id": " legacy-service "}) == "legacy-service"
+    )
+
+
+def test_outbound_service_accepts_canonical_id():
+    result = _validate(
+        [
+            {
+                "id": "analytics",
+                "url": "https://analytics.example.com",
+                "auth": {"type": "bearer", "token": "token"},
+            }
+        ]
+    )
+
+    assert not result.errors
+    assert not result.warnings
+
+
+def test_outbound_service_accepts_legacy_service_id_with_warning():
+    result = _validate(
+        [
+            {
+                "service_id": "analytics.example.com",
+                "auth": {"type": "bearer", "token": "token"},
+            }
+        ]
+    )
+
+    assert not result.errors
+    assert any("deprecated service_id" in warning for warning in result.warnings)
+
+
+def test_outbound_service_requires_an_identifier():
+    result = _validate([{"auth": {"type": "bearer", "token": "token"}}])
+
+    assert any("missing required field: id" in error for error in result.errors)
+
+
+def test_outbound_service_rejects_duplicate_legacy_identifiers():
+    result = _validate(
+        [
+            {"service_id": "analytics.example.com"},
+            {"service_id": "analytics.example.com"},
+        ]
+    )
+
+    assert any("Duplicate A2A service id" in error for error in result.errors)
+
+
+def test_service_file_accepts_legacy_service_id_with_warning():
+    validator = FormationValidator()
+    validator._validate_a2a_service_config(
+        {
+            "schema": "1.0.0",
+            "service_id": "analytics.example.com",
+            "name": "Analytics",
+            "description": "Analytics service",
+            "url": "https://analytics.example.com",
+            "auth": {"type": "bearer", "token": "token"},
+        },
+        "analytics.afs",
+    )
+
+    assert not validator.result.errors
+    assert any("deprecated service_id" in warning for warning in validator.result.warnings)


### PR DESCRIPTION
## Summary
- use `id` as the canonical outbound A2A credential identifier
- match outbound authentication through each service `url`, preferring the most specific path
- retain deprecated `service_id` compatibility with validation warnings
- add canonical, legacy, URL matching, and duplicate validation coverage

## Validation
- `3971 passed, 10 skipped` in the full unit suite
- `6 passed` in `test_a2a_server_roundtrip.py`
- Ruff and Black pass for all changed files
- CodeRabbit final review: 0 findings