### PR TITLE
feat(memory): persist request_id onto memory events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [unreleased]
 
+### Memory events carry their originating request_id
+
+Every memory event now records the observability request that produced
+it, seeding answer-to-evidence provenance (a provenance chain shows
+which request produced each hop) and the future event forwarder:
+
+- Additive nullable `request_id` column on `memory_events`; existing
+  rows read NULL and events with no originating request (maintenance,
+  synthesis, legacy backfill) record NULL.
+- Populated at `record()` time from the observability request context
+  (single choke point -- no caller changes), surfaced in event dicts
+  and provenance chain output.
+- Idempotency is unchanged: a duplicate (source, source_id) retried
+  from a different request still dedups to the original event.
+
 ## v0.20260713.0
 
 ### Idempotency-Key support (chat, scheduler jobs, triggers)

--- a/e2e/tests/2_memory/test_2s2_provenance_and_rebuild.py
+++ b/e2e/tests/2_memory/test_2s2_provenance_and_rebuild.py
@@ -82,8 +82,13 @@ class TestMemoryProvenanceAndRebuild(BaseMemoryTest):
                 "My name is Jordan and I live in London. I founded a company "
                 "called Automaze and we are building the MUXI project."
             )
+            chat_request_id = f"req_e2e_prov_{int(time.time())}"
             response = await self.overlord.chat(
-                user_msg, user_id=user_id, use_async=False, stream=False
+                user_msg,
+                user_id=user_id,
+                use_async=False,
+                stream=False,
+                request_id=chat_request_id,
             )
             response_text = response.content if hasattr(response, "content") else str(response)
             transcript.append((user_msg, response_text))
@@ -105,6 +110,20 @@ class TestMemoryProvenanceAndRebuild(BaseMemoryTest):
                 checks_passed.append("Graph extraction events recorded")
             else:
                 print("  ✗ No graph.extracted events recorded")
+                all_passed = False
+
+            # Answer-to-evidence: the extraction event(s) must carry the
+            # request_id of the chat turn that produced them (the same id
+            # the response envelope returns as request.id).
+            if graph_events and all(e.get("request_id") == chat_request_id for e in graph_events):
+                print(f"  ✓ Extraction event(s) carry the turn's request_id ({chat_request_id})")
+                checks_passed.append("Extraction events carry the turn's request_id")
+            else:
+                stamped_ids = [e.get("request_id") for e in graph_events]
+                print(
+                    f"  ✗ Extraction events missing the turn's request_id "
+                    f"(expected {chat_request_id}, got {stamped_ids})"
+                )
                 all_passed = False
 
             # Check 1: provenance query on a real conversation entity.

--- a/src/muxi/runtime/formation/initialization.py
+++ b/src/muxi/runtime/formation/initialization.py
@@ -1398,6 +1398,37 @@ def _migrate_add_derived_from_event_id_column(db_manager, table_name: str) -> No
         pass  # Table may not exist yet on first run; create_tables handles it
 
 
+def _migrate_add_request_id_column(db_manager, table_name: str) -> None:
+    """Add the request_id column to memory_events from older schema versions.
+
+    Additive migration (answer-to-evidence provenance): existing rows read
+    NULL -- no backfill is issued. Rows written after this migration carry
+    the observability RequestContext.id of the request that produced them,
+    or NULL for events with no originating request (maintenance,
+    synthesis, legacy backfill).
+    """
+    from sqlalchemy import text
+
+    try:
+        with db_manager.engine.connect() as conn:
+            if db_manager.database_type == "postgresql":
+                conn.execute(
+                    text(
+                        f"ALTER TABLE {table_name} ADD COLUMN IF NOT EXISTS "
+                        f"request_id VARCHAR(255)"
+                    )
+                )
+            else:
+                # SQLite: check if column exists via PRAGMA, add if missing
+                result = conn.execute(text(f"PRAGMA table_info({table_name})"))
+                columns = [row[1] for row in result]
+                if "request_id" not in columns:
+                    conn.execute(text(f"ALTER TABLE {table_name} ADD COLUMN request_id TEXT"))
+            conn.commit()
+    except Exception:
+        pass  # Table may not exist yet on first run; create_tables handles it
+
+
 def _migrate_add_scope_columns(db_manager, table_name: str) -> None:
     """Add the memory-namespaces scope columns to memories tables from older schema versions.
 
@@ -1562,6 +1593,10 @@ def _create_all_database_tables(db_manager, embedding_dimension: int = 1536) -> 
         # artifacts table created before the artifact-metadata projection
         # shipped (Memory Substrate Phase 2c, additive)
         _migrate_add_derived_from_event_id_column(db_manager, "artifacts")
+        # Migrate: ensure the request_id provenance column exists on
+        # memory_events tables created before answer-to-evidence
+        # provenance shipped (additive; existing rows read NULL)
+        _migrate_add_request_id_column(db_manager, "memory_events")
         # Migrate: ensure the memory-namespaces scope columns exist on
         # memories tables created before the scope substrate shipped.
         # Covers ALL memories_{dim} tables, not just the active dimension's:

--- a/src/muxi/runtime/services/memory/events/models.py
+++ b/src/muxi/runtime/services/memory/events/models.py
@@ -346,6 +346,14 @@ class MemoryEvent(Base, AsyncModelMixin):
     agent_id = Column(String(255), nullable=True)
     conversation_id = Column(String(255), nullable=True)
 
+    # Observability request that produced this event (RequestContext.id),
+    # captured at record() time from the request-context ContextVar. NULL
+    # for events with no originating request (maintenance, synthesis,
+    # legacy backfill). Not indexed: no read path filters by request_id
+    # today -- provenance resolves event -> request, and the replay /
+    # forwarder paths scan by id cursor.
+    request_id = Column(String(255), nullable=True)
+
     __table_args__ = (
         # Idempotency: the same (source, source_id) cannot be written twice
         # for a scope while live. Partial unique index works on both
@@ -397,6 +405,7 @@ class MemoryEvent(Base, AsyncModelMixin):
             "deleted_reason": self.deleted_reason,
             "agent_id": self.agent_id,
             "conversation_id": self.conversation_id,
+            "request_id": self.request_id,
         }
 
 

--- a/src/muxi/runtime/services/memory/events/provenance.py
+++ b/src/muxi/runtime/services/memory/events/provenance.py
@@ -47,6 +47,7 @@ def render_event(event: Dict[str, Any], decay: Optional[DecaySettings] = None) -
         "occurred_at": event["occurred_at"],
         "agent_id": event["agent_id"],
         "conversation_id": event["conversation_id"],
+        "request_id": event["request_id"],
         "payload": event["payload"],
         "deleted_at": event["deleted_at"],
     }

--- a/src/muxi/runtime/services/memory/events/service.py
+++ b/src/muxi/runtime/services/memory/events/service.py
@@ -186,12 +186,21 @@ class MemoryEventService:
         Volatile events without an explicit ``expires_at`` default to
         occurred_at + memory.decay.volatile_default_ttl_hours.
 
+        The observability ``RequestContext.id`` active in the current
+        ContextVar is stamped onto the event as ``request_id`` (the
+        answer-to-evidence provenance link). This is the single choke
+        point: callers never pass a request id, and paths that run
+        outside a request (maintenance, synthesis, legacy backfill)
+        record NULL.
+
         Returns the event dict (existing one on an idempotent duplicate),
         or None when the substrate is disabled or the append failed. A
         None return must never affect the caller's own write path.
         """
         if not self.enabled:
             return None
+        request_context = observability.get_current_request_context()
+        request_id = request_context.id if request_context is not None else None
         if decay_rate == DECAY_VOLATILE and expires_at is None:
             from ....utils.datetime_utils import utc_now_naive
 
@@ -214,6 +223,7 @@ class MemoryEventService:
                 conversation_id=conversation_id,
                 scope_type=scope_type,
                 scope_id=scope_id,
+                request_id=request_id,
             )
         except Exception as e:
             observability.observe(

--- a/src/muxi/runtime/services/memory/events/storage.py
+++ b/src/muxi/runtime/services/memory/events/storage.py
@@ -77,6 +77,7 @@ class MemoryEventStorage:
         conversation_id: Optional[str] = None,
         scope_type: Optional[str] = None,
         scope_id: Optional[str] = None,
+        request_id: Optional[str] = None,
     ) -> Tuple[Dict[str, Any], bool]:
         """
         Append one event to the log after validating its payload.
@@ -87,6 +88,12 @@ class MemoryEventStorage:
         rows. Default (None) is the implicit user scope with scope_id
         mirroring user_id -- byte-identical to the substrate's Phase 1
         shape.
+
+        ``request_id`` links the event to the observability request that
+        produced it (``RequestContext.id``); None for events with no
+        originating request. It is not part of the idempotency key: a
+        duplicate (source, source_id) append returns the existing event
+        regardless of the request that retried it.
 
         Returns:
             (event dict, created) -- created is False when an idempotent
@@ -134,6 +141,7 @@ class MemoryEventStorage:
                 conversation_id=conversation_id,
                 scope_type=scope_type,
                 scope_id=scope_id,
+                request_id=request_id,
             )
         except IntegrityError:
             # Lost an idempotency race: another appender inserted the same

--- a/src/muxi/runtime/services/tuning/benchmark.py
+++ b/src/muxi/runtime/services/tuning/benchmark.py
@@ -236,15 +236,25 @@ class BenchmarkStep:
             "previous_scores": previous.get("previous_scores"),
             "error": None,
         }
-        # A harness checkout carries the runtime under src/; putting it
-        # first lets the benchmark measure that checkout's code and
-        # keeps the subprocess importable when muxi is not installed
-        # into the interpreter.
+        # The child's import path is explicit, never an accident of cwd:
+        # ``-m bench...`` only resolves through the interpreter's
+        # implicit-cwd sys.path entry, which safe-path environments
+        # (PYTHONSAFEPATH, seen on CI runners) and any deployment
+        # launching from elsewhere do not provide. The bench root goes
+        # on PYTHONPATH explicitly, merged in front of any existing
+        # entries. A harness checkout carries the runtime under src/;
+        # putting it first lets the benchmark measure that checkout's
+        # code and keeps the subprocess importable when muxi is not
+        # installed into the interpreter.
         env = os.environ.copy()
+        path_entries = [str(bench_root)]
         src_dir = bench_root / "src"
         if src_dir.is_dir():
-            existing = env.get("PYTHONPATH", "")
-            env["PYTHONPATH"] = str(src_dir) + (os.pathsep + existing if existing else "")
+            path_entries.insert(0, str(src_dir))
+        existing = env.get("PYTHONPATH", "")
+        if existing:
+            path_entries.append(existing)
+        env["PYTHONPATH"] = os.pathsep.join(path_entries)
 
         process = None
         try:

--- a/tests/unit/test_memory_events_provenance.py
+++ b/tests/unit/test_memory_events_provenance.py
@@ -11,10 +11,12 @@ from __future__ import annotations
 
 import pytest
 
+from muxi.runtime.datatypes.observability import RequestContext
 from muxi.runtime.services.db import Base, DatabaseManager
 from muxi.runtime.services.memory.events import KnowledgeGraphProjector, MemoryEventService
 from muxi.runtime.services.memory.events.provenance import entity_provenance, event_provenance
 from muxi.runtime.services.memory.graph.service import KnowledgeGraphService
+from muxi.runtime.services.observability.context import _current_request_context
 
 FORMATION_ID = "provenance-test-formation"
 USER = "u1"
@@ -101,6 +103,29 @@ class TestProvenanceChain:
 
     async def test_unknown_event_returns_empty_chain(self, events):
         assert await events.provenance_chain(USER, 424242) == []
+
+    async def test_chain_surfaces_originating_request_id(self, events, graph):
+        # Every hop recorded inside a request carries that request's id,
+        # so a chain answers "which request produced this?".
+        token = _current_request_context.set(RequestContext(id="req_prov1"))
+        try:
+            await seed_conversation(events, graph)
+        finally:
+            _current_request_context.reset(token)
+        graph_events = await events.list_events(USER, event_types=["graph.extracted"])
+        chain = await events.provenance_chain(USER, graph_events[0]["id"])
+        assert [e["request_id"] for e in chain] == ["req_prov1", "req_prov1"]
+
+    async def test_event_provenance_renders_request_id(self, events, graph):
+        token = _current_request_context.set(RequestContext(id="req_prov2"))
+        try:
+            await seed_conversation(events, graph)
+        finally:
+            _current_request_context.reset(token)
+        graph_events = await events.list_events(USER, event_types=["graph.extracted"])
+        result = await event_provenance(events, USER, graph_events[0]["public_id"])
+        assert result["event"]["request_id"] == "req_prov2"
+        assert [e["request_id"] for e in result["chain"]] == ["req_prov2", "req_prov2"]
 
 
 class TestEntityProvenance:

--- a/tests/unit/test_memory_events_schema.py
+++ b/tests/unit/test_memory_events_schema.py
@@ -109,6 +109,7 @@ class TestTableCreation:
             "deleted_reason",
             "agent_id",
             "conversation_id",
+            "request_id",
         }
 
     def test_checkpoint_columns(self, engine):
@@ -162,6 +163,17 @@ class TestIdempotencyIndex:
         session.add(make_event(source_id="turn/1"))
         session.commit()
         session.add(make_event(source_id="turn/1"))
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+    def test_duplicate_source_id_rejected_across_request_ids(self, session):
+        # request_id is not part of the idempotency key: the same
+        # (formation, user, source, source_id) conflicts even when the
+        # duplicate arrives from a different request.
+        session.add(make_event(source_id="turn/1", request_id="req_a"))
+        session.commit()
+        session.add(make_event(source_id="turn/1", request_id="req_b"))
         with pytest.raises(IntegrityError):
             session.commit()
         session.rollback()

--- a/tests/unit/test_memory_events_service.py
+++ b/tests/unit/test_memory_events_service.py
@@ -9,8 +9,11 @@ hard-purge lifecycle.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
+
 import pytest
 
+from muxi.runtime.datatypes.observability import RequestContext
 from muxi.runtime.services.db import Base, DatabaseManager
 from muxi.runtime.services.memory.events.models import (
     EVENT_FACT_EXTRACTED,
@@ -18,6 +21,7 @@ from muxi.runtime.services.memory.events.models import (
     EVENT_USER_DELETION,
 )
 from muxi.runtime.services.memory.events.service import MemoryEventService
+from muxi.runtime.services.observability.context import _current_request_context
 
 FORMATION_ID = "events-test-formation"
 
@@ -49,6 +53,16 @@ class RecordingProjector:
     async def reset(self, user_id):
         self.resets.append(str(user_id))
         self.applied = []
+
+
+@contextmanager
+def request_context(request_id: str):
+    """Activate an observability RequestContext for the enclosed block."""
+    token = _current_request_context.set(RequestContext(id=request_id))
+    try:
+        yield
+    finally:
+        _current_request_context.reset(token)
 
 
 async def record_fact(service, memory="Likes tea", **kwargs):
@@ -96,6 +110,27 @@ class TestRecord:
         service.enabled = True
         assert await service.list_events("u1") == []
 
+    async def test_record_inside_request_context_stamps_request_id(self, service):
+        with request_context("req_abc123"):
+            event = await record_fact(service)
+        assert event["request_id"] == "req_abc123"
+        assert (await service.list_events("u1"))[0]["request_id"] == "req_abc123"
+
+    async def test_record_outside_request_context_stores_null(self, service):
+        event = await record_fact(service)
+        assert event["request_id"] is None
+
+    async def test_idempotency_unaffected_by_differing_request_ids(self, service):
+        # Same (source, source_id) retried from a different request must
+        # still dedup; the original event's request_id is preserved.
+        with request_context("req_first"):
+            first = await record_fact(service, source_id="conv/1")
+        with request_context("req_retry"):
+            second = await record_fact(service, memory="other", source_id="conv/1")
+        assert second["id"] == first["id"]
+        assert second["request_id"] == "req_first"
+        assert len(await service.list_events("u1")) == 1
+
 
 class TestRebuild:
     async def test_rebuild_resets_replays_and_checkpoints(self, service):
@@ -119,6 +154,19 @@ class TestRebuild:
 
         checkpoint = await service.storage.get_checkpoint("test_projection", "u1")
         assert checkpoint["last_event_id"] == second["id"]
+
+    async def test_rebuild_preserves_request_id(self, service):
+        # Rebuild replays the log read-only: the request_id recorded at
+        # append time survives, and the replayed event carries it.
+        projector = RecordingProjector()
+        service.register_projector(projector)
+        with request_context("req_rebuild"):
+            event = await record_fact(service)
+
+        await service.rebuild("u1")
+        assert projector.applied == [event["id"]]
+        replayed = (await service.list_events("u1"))[0]
+        assert replayed["request_id"] == "req_rebuild"
 
     async def test_rebuild_specific_projection_only(self, service):
         target = RecordingProjector(name="target")

--- a/tests/unit/test_tuning_benchmark.py
+++ b/tests/unit/test_tuning_benchmark.py
@@ -83,7 +83,10 @@ def build_harness(root: Path, runner_source: str = FAKE_RUNNER) -> Path:
 @pytest.fixture
 def step(tmp_path):
     step = BenchmarkStep(base_dir=str(tmp_path / "tuner"))
-    step.suite_timeout_seconds = 30.0
+    # Generous: hosted CI runners have been seen taking far longer than
+    # local hardware to spawn interpreters. The timeout test overrides
+    # this with its own tight value.
+    step.suite_timeout_seconds = 120.0
     return step
 
 
@@ -155,6 +158,19 @@ class TestObserve:
 
         assert sorted(result["suites_run"]) == sorted(s["name"] for s in SUITES)
         assert result["skipped"] is None
+
+        # The observe path degrades to carried-forward scores by design,
+        # so a broken environment (e.g. a CI runner failing the
+        # subprocess spawn) would otherwise surface as an opaque KeyError
+        # on the metrics. Fail loudly with the attempt's real error first.
+        sidecar = json.loads((tmp_path / "tuner" / "benchmarks.json").read_text())
+        for suite in SUITES:
+            record = sidecar["suites"][suite["name"]]
+            assert record["succeeded"] is True, (
+                f"benchmark suite {suite['name']} soft-failed "
+                f"(exit_code={record.get('exit_code')}): {record.get('error')}"
+            )
+
         for suite in SUITES:
             name = suite["name"]
             assert result["metrics"][f"benchmark:{name}.recall_gap"] == pytest.approx(0.2)
@@ -163,10 +179,8 @@ class TestObserve:
                 result["report_block"]
             )
 
-        sidecar = json.loads((tmp_path / "tuner" / "benchmarks.json").read_text())
         for suite in SUITES:
             record = sidecar["suites"][suite["name"]]
-            assert record["succeeded"] is True
             assert record["scores"]["recall_at_k"] == 0.8
             assert record["previous_scores"] is None
 

--- a/tests/unit/test_tuning_benchmark.py
+++ b/tests/unit/test_tuning_benchmark.py
@@ -184,6 +184,28 @@ class TestObserve:
             assert record["scores"]["recall_at_k"] == 0.8
             assert record["previous_scores"] is None
 
+    def test_run_resolves_harness_under_safe_path_mode(self, step, tmp_path, monkeypatch):
+        # Pins the CI condition behind the longmemeval flake: with
+        # PYTHONSAFEPATH in the inherited environment the child
+        # interpreter drops the implicit-cwd sys.path entry, so
+        # ``-m bench...`` must resolve through the explicit PYTHONPATH
+        # the step builds, not through the subprocess cwd by accident.
+        # A pre-existing PYTHONPATH must be merged, not clobbered.
+        build_harness(tmp_path / "harness")
+        monkeypatch.setenv(BENCH_ROOT_ENV, str(tmp_path / "harness"))
+        monkeypatch.setenv("PYTHONSAFEPATH", "1")
+        monkeypatch.setenv("PYTHONPATH", str(tmp_path / "unrelated"))
+        result = asyncio.run(step.observe())
+
+        sidecar = json.loads((tmp_path / "tuner" / "benchmarks.json").read_text())
+        for suite in SUITES:
+            record = sidecar["suites"][suite["name"]]
+            assert record["succeeded"] is True, (
+                f"benchmark suite {suite['name']} soft-failed "
+                f"(exit_code={record.get('exit_code')}): {record.get('error')}"
+            )
+            assert result["metrics"][f"benchmark:{suite['name']}.qa_error"] == pytest.approx(0.25)
+
     def test_fresh_scores_are_reused_not_rerun(self, step, tmp_path, monkeypatch):
         build_harness(tmp_path / "harness")
         monkeypatch.setenv(BENCH_ROOT_ENV, str(tmp_path / "harness"))


### PR DESCRIPTION
## Summary

Every memory event now records the observability request that produced it (Acropolis M0c). This is the seed of answer-to-evidence provenance -- any memory event, and any provenance chain hop, is traceable to the originating request -- and feeds the future event forwarder.

### Column / migration

- Additive nullable `request_id` (`String(255)`) on `memory_events`. Nullable because maintenance, synthesis, and legacy-backfill events have no originating request.
- Not indexed: no read path filters by `request_id` today -- provenance resolves event -> request, and replay/forwarder paths scan by id cursor. An index would only add write cost on every append.
- Migration follows the established additive pattern in `initialization.py` (`_migrate_add_request_id_column`, mirroring `_migrate_add_derived_from_event_id_column`): `ADD COLUMN IF NOT EXISTS` on PostgreSQL, PRAGMA-guarded `ALTER TABLE` on SQLite. Existing rows read NULL; no backfill.
- The idempotency partial unique index, schema registry (payload validation is orthogonal -- this is a column, not a payload key), checkpoints, and rebuild machinery are untouched; tests pin this.

### Population (single choke point)

`MemoryEventService.record()` reads the current `RequestContext` from the observability ContextVar itself -- no parameter threaded through callers. Absent context -> NULL.

ContextVar visibility, confirmed:
- Sync chat path: `track_request()` sets the context (chat_orchestrator.py:396).
- Streaming/async path: `delayed_process` sets it explicitly in the background task (chat_orchestrator.py:121-131).
- Fire-and-forget extraction: `asyncio.create_task` copies the context, so post-turn extraction events carry the turn's request id (verified end-to-end).
- Maintenance/synthesis loops are started at formation init (startup context) -> NULL, as intended.

### Surfacing

- `MemoryEvent.to_dict()` includes `request_id`, so every event dict and `provenance_chain()` hop carries it.
- `render_event()` (the provenance-facing view used by GET /v1/memories/provenance) exposes it.

No API changes, no event-first semantics changes, no backfill of old rows.

## Tests

Unit (all in existing memory-events suites):
- Event recorded inside a request context carries its id; outside -> NULL.
- Idempotency unaffected by differing request_ids: same (source, source_id) still dedups and the original event's request_id is preserved; the partial unique index semantics are pinned at the schema level too.
- `provenance_chain()` and `event_provenance()` surface the request id on every hop.
- Rebuild/replay preserves the column.
- Exact `memory_events` column-set assertion updated.

E2E: `test_2s2_provenance_and_rebuild` extended -- a real chat turn's `graph.extracted` event(s) must carry the turn's request_id (the same id the response envelope returns as `request.id`).

## Gates

- Full unit suite: 3979 passed, 10 skipped
- E2E 2s2: SUCCESS, exit 0 (new request_id check passing)
- `run_random_tests.py 5`: all passed
- `validate_events.py`: 1464/1464 (100%)
- black / isort / ruff clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
