### PR TITLE
fix(distillery): durable DB-backed daily quotas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [unreleased]
 
+### Durable distillery daily quotas
+
+The distilled-batch daily quota guard moves from an in-process dict
+(reset on restart, wrong across replicas) to durable DB-backed counters:
+
+- New `distillery_quota_counters` table -- one row per (formation,
+  distillery, UTC day), created with the rest of the runtime tables on
+  both SQLite and PostgreSQL.
+- Check-and-consume is one atomic guarded upsert (`INSERT ... ON
+  CONFLICT ... DO UPDATE ... WHERE count + n <= limit`), so concurrent
+  batches -- across async tasks or replicas sharing the database --
+  can never overshoot `max_events_per_day`; a batch of N events
+  consumes N slots or is rejected as a whole (429 contract unchanged).
+- Counts survive restarts; per-day rollover comes free from the date
+  key; buckets older than 7 days are pruned on the consume path (no
+  maintenance loop needed).
+
 ## v0.20260713.0
 
 ### Idempotency-Key support (chat, scheduler jobs, triggers)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ The distilled-batch daily quota guard moves from an in-process dict
 - Counts survive restarts; per-day rollover comes free from the date
   key; buckets older than 7 days are pruned on the consume path (no
   maintenance loop needed).
+- The counter is a cache over ground truth: a reservation leaked by a
+  crash between reserve and settle is reconciled downward to the
+  substrate's actual accepted-event count on each process's first
+  consume of a day bucket, so a crashy period cannot starve a
+  distillery with 429s until rollover.
 
 ## v0.20260713.0
 

--- a/src/muxi/runtime/formation/initialization.py
+++ b/src/muxi/runtime/formation/initialization.py
@@ -1503,7 +1503,10 @@ def _create_all_database_tables(db_manager, embedding_dimension: int = 1536) -> 
         # Get Base from db module
         from ..services.db import Base
         from ..services.memory.artifacts.models import Artifact, SystemConfig  # noqa: F401
-        from ..services.memory.distillery.models import RegisteredDistillery  # noqa: F401
+        from ..services.memory.distillery.models import (  # noqa: F401
+            DistilleryQuotaCounter,
+            RegisteredDistillery,
+        )
         from ..services.memory.events.models import (  # noqa: F401
             MemoryEvent,
             ProjectionCheckpoint,

--- a/src/muxi/runtime/services/memory/distillery/__init__.py
+++ b/src/muxi/runtime/services/memory/distillery/__init__.py
@@ -12,13 +12,16 @@
 
 from .models import (
     PROVISIONAL_CONFIDENCE_CAP,
+    QUOTA_RETENTION_DAYS,
     STATUS_ACTIVE,
     STATUS_REVOKED,
     TRUST_LEVELS,
     TRUST_PROVISIONAL,
     TRUST_VERIFIED,
+    DistilleryQuotaCounter,
     RegisteredDistillery,
 )
+from .quotas import DistilleryQuotaStore
 from .registry import DistilleryRegistry
 from .service import (
     DISPOSITION_FAILED,
@@ -49,11 +52,14 @@ from .verification import (
 
 __all__ = [
     "PROVISIONAL_CONFIDENCE_CAP",
+    "QUOTA_RETENTION_DAYS",
     "STATUS_ACTIVE",
     "STATUS_REVOKED",
     "TRUST_LEVELS",
     "TRUST_PROVISIONAL",
     "TRUST_VERIFIED",
+    "DistilleryQuotaCounter",
+    "DistilleryQuotaStore",
     "RegisteredDistillery",
     "DistilleryRegistry",
     "DISPOSITION_FAILED",

--- a/src/muxi/runtime/services/memory/distillery/models.py
+++ b/src/muxi/runtime/services/memory/distillery/models.py
@@ -47,6 +47,9 @@ PROVISIONAL_CONFIDENCE_CAP = 0.7
 STATUS_ACTIVE = "active"
 STATUS_REVOKED = "revoked"
 
+# The substrate source every distilled event carries (PRD "Event Format").
+SOURCE_DISTILLERY = "distillery"
+
 # Quota counters older than this many days are pruned opportunistically on
 # the consume path (see DistilleryQuotaStore.try_consume) -- only today's
 # row is ever read, so the window is pure debugging headroom.

--- a/src/muxi/runtime/services/memory/distillery/models.py
+++ b/src/muxi/runtime/services/memory/distillery/models.py
@@ -27,7 +27,7 @@
 #   is the purge path, mirroring the substrate's forgetting model).
 # =============================================================================
 
-from sqlalchemy import Column, DateTime, Index, Integer, String
+from sqlalchemy import Column, DateTime, Index, Integer, String, UniqueConstraint
 
 from ....datatypes.json_type import JSONType
 from ....utils.datetime_utils import utc_now_naive
@@ -46,6 +46,11 @@ PROVISIONAL_CONFIDENCE_CAP = 0.7
 # Registration lifecycle states.
 STATUS_ACTIVE = "active"
 STATUS_REVOKED = "revoked"
+
+# Quota counters older than this many days are pruned opportunistically on
+# the consume path (see DistilleryQuotaStore.try_consume) -- only today's
+# row is ever read, so the window is pure debugging headroom.
+QUOTA_RETENTION_DAYS = 7
 
 
 class RegisteredDistillery(Base, AsyncModelMixin):
@@ -92,3 +97,35 @@ class RegisteredDistillery(Base, AsyncModelMixin):
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "revoked_at": self.revoked_at.isoformat() if self.revoked_at else None,
         }
+
+
+class DistilleryQuotaCounter(Base, AsyncModelMixin):
+    """One (distillery, UTC day) accepted-event counter.
+
+    Durable replacement for the old in-process daily-count dict: the quota
+    guard increments this row with a single guarded upsert
+    (increment-if-under-limit), so counts survive restarts and stay
+    correct across replicas sharing the database. Per-day rollover comes
+    free from the quota_date key; rows older than QUOTA_RETENTION_DAYS are
+    pruned opportunistically on the consume path.
+    """
+
+    __tablename__ = "distillery_quota_counters"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    formation_id = Column(String(255), nullable=False)
+    # The distillery's public id (the X-Distillery-ID header value).
+    distillery_id = Column(String(21), nullable=False)
+    # UTC day bucket, "YYYY-MM-DD".
+    quota_date = Column(String(10), nullable=False)
+    count = Column(Integer, nullable=False, default=0)
+    updated_at = Column(DateTime, nullable=False, default=utc_now_naive)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "formation_id",
+            "distillery_id",
+            "quota_date",
+            name="uq_distillery_quota_counters_day",
+        ),
+    )

--- a/src/muxi/runtime/services/memory/distillery/quotas.py
+++ b/src/muxi/runtime/services/memory/distillery/quotas.py
@@ -1,0 +1,164 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Distillery Quota Store - Durable Daily Counters
+# Description:  DB-backed increment-if-under-limit daily quota counters
+# Role:         Replica-safe quota enforcement for distilled-batch intake
+# Usage:        Used by MemoryDistilleryService's accept path
+# Author:       Muxi Framework Team
+#
+# Durable replacement for the old in-process daily-count dict. The whole
+# check-and-consume is ONE guarded upsert per backend:
+#
+#   INSERT ... ON CONFLICT (formation_id, distillery_id, quota_date)
+#   DO UPDATE SET count = count + n WHERE count + n <= limit
+#
+# - PostgreSQL: ON CONFLICT DO UPDATE takes a row lock on the conflicting
+#   counter row, so concurrent consumers (across replicas) serialize on it
+#   and re-evaluate the WHERE against the committed count. rowcount == 0
+#   means the guard rejected the increment.
+# - SQLite: writers are serialized at the database level, so the same
+#   statement is equally race-free; rowcount reporting matches.
+#
+# Either way there is no check-then-act window: a batch of N events
+# consumes N atomically or not at all. Per-day rollover comes free from
+# the quota_date key, and rows older than QUOTA_RETENTION_DAYS are pruned
+# in the same transaction as a successful consume (no maintenance loop).
+# =============================================================================
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import case, delete, select, update
+
+from ....utils.datetime_utils import utc_now_naive
+from .models import QUOTA_RETENTION_DAYS, DistilleryQuotaCounter
+
+
+class DistilleryQuotaStore:
+    """Durable per-(distillery, UTC day) quota counters."""
+
+    def __init__(self, db_manager, formation_id: str):
+        """
+        Initialize the store bound to a formation.
+
+        Args:
+            db_manager: Shared DatabaseManager (PostgreSQL or SQLite).
+            formation_id: Formation identifier scoping all rows.
+        """
+        self.db_manager = db_manager
+        self.formation_id = formation_id
+
+    @staticmethod
+    def today() -> str:
+        """The current UTC day bucket ("YYYY-MM-DD")."""
+        return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    def _insert(self):
+        """The dialect-specific INSERT construct (both support upserts)."""
+        if self.db_manager.database_type == "postgresql":
+            from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+            return pg_insert(DistilleryQuotaCounter)
+        from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+        return sqlite_insert(DistilleryQuotaCounter)
+
+    async def try_consume(
+        self, distillery_id: str, quota_date: str, count: int, limit: int
+    ) -> bool:
+        """Atomically consume ``count`` slots if the day stays within ``limit``.
+
+        The check and the increment are one guarded upsert (see module
+        docstring), so concurrent consumers -- other async tasks or other
+        replicas sharing the database -- can never overshoot the limit.
+
+        Returns:
+            True when the slots were consumed, False when consuming would
+            exceed the limit (nothing is consumed in that case).
+        """
+        if count <= 0:
+            return True
+        if count > limit:
+            return False
+        now = utc_now_naive()
+        # inline() suppresses the implicit RETURNING id, so rowcount comes
+        # from the plain command tag on both backends (0 when the guard
+        # rejects the increment, 1 when the insert or update lands).
+        stmt = (
+            self._insert()
+            .inline()
+            .values(
+                formation_id=self.formation_id,
+                distillery_id=distillery_id,
+                quota_date=quota_date,
+                count=count,
+                updated_at=now,
+            )
+        )
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["formation_id", "distillery_id", "quota_date"],
+            set_={
+                "count": DistilleryQuotaCounter.count + count,
+                "updated_at": now,
+            },
+            where=DistilleryQuotaCounter.count + count <= limit,
+        )
+        async with self.db_manager.get_async_session() as session:
+            result = await session.execute(stmt)
+            consumed = bool(result.rowcount)
+            if consumed:
+                # Retention rides the consume path: drop day buckets older
+                # than the retention window in the same transaction, so the
+                # table stays tiny without a dedicated maintenance loop.
+                cutoff = (
+                    datetime.now(timezone.utc) - timedelta(days=QUOTA_RETENTION_DAYS)
+                ).strftime("%Y-%m-%d")
+                await session.execute(
+                    delete(DistilleryQuotaCounter).where(
+                        DistilleryQuotaCounter.formation_id == self.formation_id,
+                        DistilleryQuotaCounter.quota_date < cutoff,
+                        # Never drop the bucket just consumed, whatever its date.
+                        DistilleryQuotaCounter.quota_date != quota_date,
+                    )
+                )
+            return consumed
+
+    async def release(self, distillery_id: str, quota_date: str, count: int) -> None:
+        """Return ``count`` reserved-but-unused slots (floored at zero).
+
+        Used when a reservation made for net-new events turns out larger
+        than the events actually created (append-time duplicates).
+        """
+        if count <= 0:
+            return
+        stmt = (
+            update(DistilleryQuotaCounter)
+            .where(
+                DistilleryQuotaCounter.formation_id == self.formation_id,
+                DistilleryQuotaCounter.distillery_id == distillery_id,
+                DistilleryQuotaCounter.quota_date == quota_date,
+            )
+            .values(
+                count=case(
+                    (
+                        DistilleryQuotaCounter.count > count,
+                        DistilleryQuotaCounter.count - count,
+                    ),
+                    else_=0,
+                ),
+                updated_at=utc_now_naive(),
+            )
+        )
+        async with self.db_manager.get_async_session() as session:
+            await session.execute(stmt)
+
+    async def used(self, distillery_id: str, quota_date: str) -> int:
+        """The consumed count for one (distillery, day), 0 when absent."""
+        stmt = select(DistilleryQuotaCounter.count).where(
+            DistilleryQuotaCounter.formation_id == self.formation_id,
+            DistilleryQuotaCounter.distillery_id == distillery_id,
+            DistilleryQuotaCounter.quota_date == quota_date,
+        )
+        async with self.db_manager.get_async_session() as session:
+            value = (await session.execute(stmt)).scalar_one_or_none()
+            return int(value or 0)

--- a/src/muxi/runtime/services/memory/distillery/quotas.py
+++ b/src/muxi/runtime/services/memory/distillery/quotas.py
@@ -24,14 +24,23 @@
 # consumes N atomically or not at all. Per-day rollover comes free from
 # the quota_date key, and rows older than QUOTA_RETENTION_DAYS are pruned
 # in the same transaction as a successful consume (no maintenance loop).
+#
+# Crash healing: a process that dies between reserve and settle leaves the
+# counter durably inflated. The counter is a cache over ground truth (the
+# memory_events table IS the count of accepted distilled events), so each
+# process reconciles a (distillery, day) bucket downward to that truth
+# before its first consume of the bucket (ensure_reconciled).
 # =============================================================================
 
+import asyncio
 from datetime import datetime, timedelta, timezone
+from typing import Set, Tuple
 
-from sqlalchemy import case, delete, select, update
+from sqlalchemy import case, delete, func, select, update
 
 from ....utils.datetime_utils import utc_now_naive
-from .models import QUOTA_RETENTION_DAYS, DistilleryQuotaCounter
+from ..events.models import MemoryEvent
+from .models import QUOTA_RETENTION_DAYS, SOURCE_DISTILLERY, DistilleryQuotaCounter
 
 
 class DistilleryQuotaStore:
@@ -47,6 +56,11 @@ class DistilleryQuotaStore:
         """
         self.db_manager = db_manager
         self.formation_id = formation_id
+        # Buckets this process has already reconciled against ground truth
+        # (crash healing runs once per bucket per process; see
+        # ensure_reconciled).
+        self._reconciled: Set[Tuple[str, str]] = set()
+        self._reconcile_lock = asyncio.Lock()
 
     @staticmethod
     def today() -> str:
@@ -62,6 +76,65 @@ class DistilleryQuotaStore:
         from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
         return sqlite_insert(DistilleryQuotaCounter)
+
+    async def ensure_reconciled(self, distillery_id: str, quota_date: str) -> None:
+        """Heal crash-leaked reservations, once per bucket per process.
+
+        A process that dies after reserving but before settling leaves the
+        counter durably inflated, which would starve the distillery with
+        429s until day rollover. The memory_events table is ground truth
+        for accepted distilled events, so before this process's first
+        consume of a bucket the counter is capped at the day's actual
+        live distilled-event count (a downward-only conditional update:
+        it can shrink a leaked counter, never invent headroom beyond the
+        real accepted count).
+
+        Ordering makes this safe against in-flight reservations: it runs
+        before this process's first consume of the bucket (so this process
+        has none), and later calls are no-ops.
+
+        Distilled rows do not record which distillery shipped them, so
+        ground truth is the formation-wide distilled count: exact for the
+        common single-distillery formation, a conservative upper bound
+        (leak may persist) when several distilleries share a formation.
+        """
+        key = (distillery_id, quota_date)
+        if key in self._reconciled:
+            return
+        async with self._reconcile_lock:
+            if key in self._reconciled:
+                return
+            truth = await self._accepted_on_day(quota_date)
+            async with self.db_manager.get_async_session() as session:
+                await session.execute(
+                    update(DistilleryQuotaCounter)
+                    .where(
+                        DistilleryQuotaCounter.formation_id == self.formation_id,
+                        DistilleryQuotaCounter.distillery_id == distillery_id,
+                        DistilleryQuotaCounter.quota_date == quota_date,
+                        DistilleryQuotaCounter.count > truth,
+                    )
+                    .values(count=truth, updated_at=utc_now_naive())
+                )
+            self._reconciled.add(key)
+
+    async def _accepted_on_day(self, quota_date: str) -> int:
+        """Ground truth: live distilled events accepted on one UTC day."""
+        day_start = datetime.strptime(quota_date, "%Y-%m-%d")
+        day_end = day_start + timedelta(days=1)
+        stmt = (
+            select(func.count())
+            .select_from(MemoryEvent)
+            .where(
+                MemoryEvent.formation_id == self.formation_id,
+                MemoryEvent.source == SOURCE_DISTILLERY,
+                MemoryEvent.deleted_at.is_(None),
+                MemoryEvent.ingested_at >= day_start,
+                MemoryEvent.ingested_at < day_end,
+            )
+        )
+        async with self.db_manager.get_async_session() as session:
+            return int((await session.execute(stmt)).scalar_one() or 0)
 
     async def try_consume(
         self, distillery_id: str, quota_date: str, count: int, limit: int

--- a/src/muxi/runtime/services/memory/distillery/service.py
+++ b/src/muxi/runtime/services/memory/distillery/service.py
@@ -63,6 +63,7 @@ from ..events.models import (
 )
 from ..events.projectors import apply_fact_event
 from .models import PROVISIONAL_CONFIDENCE_CAP, STATUS_ACTIVE, TRUST_PROVISIONAL, TRUST_VERIFIED
+from .quotas import DistilleryQuotaStore
 from .registry import DistilleryRegistry
 from .verification import (
     DEFAULT_SIGNATURE_MAX_AGE_SECONDS,
@@ -349,11 +350,10 @@ class MemoryDistilleryService:
         )
 
         self._registry: Optional[DistilleryRegistry] = None
-        # Per-(distillery, UTC day) accepted-event counters. Process-local
-        # by design (matches the ingestion in-flight cap posture): the
-        # smallest viable quota guard, documented as per-node.
-        self._daily_counts: Dict[Tuple[str, str], int] = {}
-        self._daily_lock = asyncio.Lock()
+        # Per-(distillery, UTC day) accepted-event counters, DB-backed via
+        # DistilleryQuotaStore: durable across restarts and correct across
+        # replicas sharing the database (guarded-upsert consume).
+        self._quota_store: Optional[DistilleryQuotaStore] = None
 
     @staticmethod
     def _int_config(config: Dict[str, Any], key: str, default: int) -> int:
@@ -392,6 +392,16 @@ class MemoryDistilleryService:
                 memory_events.db_manager, memory_events.formation_id
             )
         return self._registry
+
+    @property
+    def quota_store(self) -> DistilleryQuotaStore:
+        """The durable daily quota counters (requires the substrate's DB)."""
+        if self._quota_store is None:
+            memory_events = self._require_substrate()
+            self._quota_store = DistilleryQuotaStore(
+                memory_events.db_manager, memory_events.formation_id
+            )
+        return self._quota_store
 
     def scope_defaults(self, scope: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         """Fill a registration scope with the formation-level defaults."""
@@ -523,29 +533,51 @@ class MemoryDistilleryService:
         )
 
     # ------------------------------------------------------------------
-    # Daily quota (process-local, per UTC day)
+    # Daily quota (durable, per UTC day; see quotas.py)
     # ------------------------------------------------------------------
 
-    async def _check_quota(self, distillery: Dict[str, Any], incoming: int) -> None:
+    async def _reserve_quota(
+        self, distillery: Dict[str, Any], incoming: int
+    ) -> Optional[Tuple[str, int]]:
+        """Atomically reserve quota slots for ``incoming`` net-new events.
+
+        All-or-nothing: the whole batch's net-new count is consumed in one
+        guarded upsert or the batch is rejected as a whole. Raising happens
+        before anything is appended, so the batch stays safely retryable.
+
+        Returns:
+            The (quota_date, reserved) reservation to settle after the
+            append pass, or None when nothing needed reserving.
+
+        Raises:
+            DistilleryRateLimitError: The day's limit would be exceeded.
+        """
+        if incoming <= 0:
+            return None
         scope = distillery.get("scope") or {}
         max_per_day = int(scope.get("max_events_per_day", self.default_max_events_per_day))
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-        key = (distillery["distillery_id"], today)
-        async with self._daily_lock:
-            # Prune counters from previous days so the map stays tiny.
-            stale = [k for k in self._daily_counts if k[1] != today]
-            for k in stale:
-                del self._daily_counts[k]
-            if self._daily_counts.get(key, 0) + incoming > max_per_day:
-                raise DistilleryRateLimitError(max_per_day)
+        quota_date = DistilleryQuotaStore.today()
+        consumed = await self.quota_store.try_consume(
+            distillery["distillery_id"], quota_date, incoming, max_per_day
+        )
+        if not consumed:
+            raise DistilleryRateLimitError(max_per_day)
+        return (quota_date, incoming)
 
-    async def _consume_quota(self, distillery: Dict[str, Any], count: int) -> None:
-        if count <= 0:
+    async def _settle_quota(
+        self,
+        distillery: Dict[str, Any],
+        reservation: Optional[Tuple[str, int]],
+        created: int,
+    ) -> None:
+        """Return reserved-but-unused slots (append-time duplicates)."""
+        if reservation is None:
             return
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-        key = (distillery["distillery_id"], today)
-        async with self._daily_lock:
-            self._daily_counts[key] = self._daily_counts.get(key, 0) + count
+        quota_date, reserved = reservation
+        if created < reserved:
+            await self.quota_store.release(
+                distillery["distillery_id"], quota_date, reserved - created
+            )
 
     # ------------------------------------------------------------------
     # Accept path (event-first, partial acceptance)
@@ -592,40 +624,47 @@ class MemoryDistilleryService:
         # Quota gates the NET-NEW event count only: a full-duplicate retry
         # must always succeed regardless of quota state (the idempotent
         # retry guarantee), and mixed batches only need headroom for the
-        # events they would actually create. Raising here appends nothing
-        # and consumes nothing, so the whole batch stays safely retryable.
-        await self._check_quota(distillery, len(net_new))
+        # events they would actually create. The reservation is one atomic
+        # increment-if-under-limit in the database (durable, replica-safe);
+        # raising here appends nothing and consumes nothing, so the whole
+        # batch stays safely retryable.
+        reservation = await self._reserve_quota(distillery, len(net_new))
 
         # Pass 2: append the net-new events. An append can still resolve
         # to an existing event (a concurrent writer, or the same source_id
-        # appearing twice within this batch) -- those count as duplicates.
+        # appearing twice within this batch) -- those count as duplicates,
+        # and their reserved quota slots are returned when settling.
         to_process: List[Tuple[int, DistilledEvent, Dict[str, Any]]] = []
-        for index, event in net_new:
-            try:
-                stored, created = await memory_events.storage.append(
-                    user_id=event.user_id,
-                    event_type=event.event_type,
-                    payload=event.payload,
-                    source=SOURCE_DISTILLERY,
-                    source_id=event.source_id,
-                    source_confidence=event.source_confidence,
-                    event_version=event.event_version,
-                    occurred_at=event.occurred_at,
-                    decay_rate=event.decay_rate,
-                    expires_at=event.expires_at,
-                    conversation_id=event.conversation_id,
-                )
-            except ValueError as exc:
-                # Defensive: validate_distilled_event mirrors the substrate
-                # checks, so this only fires on drift between the two.
-                rejections.append({"index": index, "reason": str(exc)})
-                continue
-            if created:
-                to_process.append((index, event, stored))
-            else:
-                duplicates += 1
-
-        await self._consume_quota(distillery, len(to_process))
+        try:
+            for index, event in net_new:
+                try:
+                    stored, created = await memory_events.storage.append(
+                        user_id=event.user_id,
+                        event_type=event.event_type,
+                        payload=event.payload,
+                        source=SOURCE_DISTILLERY,
+                        source_id=event.source_id,
+                        source_confidence=event.source_confidence,
+                        event_version=event.event_version,
+                        occurred_at=event.occurred_at,
+                        decay_rate=event.decay_rate,
+                        expires_at=event.expires_at,
+                        conversation_id=event.conversation_id,
+                    )
+                except ValueError as exc:
+                    # Defensive: validate_distilled_event mirrors the substrate
+                    # checks, so this only fires on drift between the two.
+                    rejections.append({"index": index, "reason": str(exc)})
+                    continue
+                if created:
+                    to_process.append((index, event, stored))
+                else:
+                    duplicates += 1
+        finally:
+            # Settle even on a mid-append failure: created events stay
+            # consumed (they exist; a retry sees them as duplicates), the
+            # rest of the reservation is returned.
+            await self._settle_quota(distillery, reservation, len(to_process))
 
         processing_id = None
         if to_process:

--- a/src/muxi/runtime/services/memory/distillery/service.py
+++ b/src/muxi/runtime/services/memory/distillery/service.py
@@ -62,7 +62,13 @@ from ..events.models import (
     validate_event_payload,
 )
 from ..events.projectors import apply_fact_event
-from .models import PROVISIONAL_CONFIDENCE_CAP, STATUS_ACTIVE, TRUST_PROVISIONAL, TRUST_VERIFIED
+from .models import (
+    PROVISIONAL_CONFIDENCE_CAP,
+    SOURCE_DISTILLERY,
+    STATUS_ACTIVE,
+    TRUST_PROVISIONAL,
+    TRUST_VERIFIED,
+)
 from .quotas import DistilleryQuotaStore
 from .registry import DistilleryRegistry
 from .verification import (
@@ -71,9 +77,6 @@ from .verification import (
     check_timestamp,
     verify_signature,
 )
-
-# The substrate source every distilled event carries (PRD "Event Format").
-SOURCE_DISTILLERY = "distillery"
 
 # Event types a distillery may ship: the intersection of the PRD's batch
 # vocabulary and the event types the substrate supports today. The PRD also
@@ -557,6 +560,12 @@ class MemoryDistilleryService:
         scope = distillery.get("scope") or {}
         max_per_day = int(scope.get("max_events_per_day", self.default_max_events_per_day))
         quota_date = DistilleryQuotaStore.today()
+        # Crash healing: cap the counter at the day's actual accepted-event
+        # count before this process's first consume of the bucket, so a
+        # reservation leaked by a crash between reserve and settle cannot
+        # starve the distillery until day rollover (no-op after the first
+        # call; see DistilleryQuotaStore.ensure_reconciled).
+        await self.quota_store.ensure_reconciled(distillery["distillery_id"], quota_date)
         consumed = await self.quota_store.try_consume(
             distillery["distillery_id"], quota_date, incoming, max_per_day
         )

--- a/tests/unit/test_memory_distillery.py
+++ b/tests/unit/test_memory_distillery.py
@@ -33,6 +33,7 @@ Covers the distillery surface at the unit level:
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import time
 from types import SimpleNamespace
@@ -49,6 +50,8 @@ from muxi.runtime.services.memory.distillery import (
     PROVISIONAL_CONFIDENCE_CAP,
     SOURCE_DISTILLERY,
     DistilleryAuthError,
+    DistilleryQuotaCounter,
+    DistilleryQuotaStore,
     DistilleryRateLimitError,
     DistilleryRevokedError,
     DistilleryUnavailableError,
@@ -76,6 +79,7 @@ TABLES = [
     MemoryEvent.__table__,
     ProjectionCheckpoint.__table__,
     RegisteredDistillery.__table__,
+    DistilleryQuotaCounter.__table__,
 ]
 
 
@@ -830,3 +834,131 @@ class TestQuotaOrdering:
         # The 429 fired before any append: the substrate is untouched and
         # the full batch remains retryable.
         assert await memory_events.list_events("alice@acme.com") == []
+
+
+# ----------------------------------------------------------------------
+# Durable quota counters (DB-backed; restart-proof, replica-safe)
+# ----------------------------------------------------------------------
+
+
+class TestDurableQuota:
+    async def test_quota_survives_service_restart(self, memory_events, keypair):
+        # Exhaust the quota with one service instance...
+        first_overlord = make_overlord(memory_events)
+        first_service = MemoryDistilleryService(first_overlord)
+        record = await register(first_service, keypair, scope={"max_events_per_day": 2})
+        outcome = await accept(
+            first_service,
+            record,
+            make_batch([fact_event(source_id="s1"), fact_event(source_id="s2")]),
+        )
+        await finish_job(first_overlord, outcome["processing_id"])
+
+        # ...then "restart": a brand-new service instance over the same
+        # database must still see the day as exhausted (the old in-process
+        # dict reset to zero here; the DB counter must not).
+        restarted = MemoryDistilleryService(make_overlord(memory_events))
+        with pytest.raises(DistilleryRateLimitError):
+            await accept(restarted, record, make_batch([fact_event(source_id="s3")]))
+
+    async def test_quota_resets_across_days(self, memory_events, keypair, monkeypatch):
+        overlord = make_overlord(memory_events)
+        service = MemoryDistilleryService(overlord)
+        record = await register(service, keypair, scope={"max_events_per_day": 1})
+
+        outcome = await accept(service, record, make_batch([fact_event(source_id="s1")]))
+        await finish_job(overlord, outcome["processing_id"])
+        with pytest.raises(DistilleryRateLimitError):
+            await accept(service, record, make_batch([fact_event(source_id="s2")]))
+
+        # UTC day rollover: the date key changes, so the quota is fresh.
+        monkeypatch.setattr(DistilleryQuotaStore, "today", staticmethod(lambda: "2999-01-01"))
+        rolled = await accept(service, record, make_batch([fact_event(source_id="s2")]))
+        assert rolled["accepted"] == 1
+        await finish_job(overlord, rolled["processing_id"])
+
+    async def test_concurrent_consumes_never_overshoot(self, memory_events):
+        # Hammer the guarded upsert directly: 40 concurrent single-slot
+        # consumers against a limit of 15 -- exactly 15 may win, and the
+        # stored counter must equal the limit (no lost updates, no
+        # overshoot from a check-then-act window).
+        store = DistilleryQuotaStore(memory_events.db_manager, FORMATION_ID)
+        day = DistilleryQuotaStore.today()
+        results = await asyncio.gather(
+            *(store.try_consume("dst-hammer", day, 1, 15) for _ in range(40))
+        )
+        assert sum(results) == 15
+        assert await store.used("dst-hammer", day) == 15
+
+    async def test_concurrent_batches_respect_limit_end_to_end(self, memory_events, keypair):
+        overlord = make_overlord(memory_events)
+        service = MemoryDistilleryService(overlord)
+        record = await register(service, keypair, scope={"max_events_per_day": 3})
+
+        async def submit_one(i):
+            return await accept(service, record, make_batch([fact_event(source_id=f"c{i}")]))
+
+        outcomes = await asyncio.gather(*(submit_one(i) for i in range(6)), return_exceptions=True)
+        accepted = [o for o in outcomes if isinstance(o, dict)]
+        limited = [o for o in outcomes if isinstance(o, DistilleryRateLimitError)]
+        unexpected = [o for o in outcomes if not isinstance(o, (dict, DistilleryRateLimitError))]
+        assert unexpected == []
+        assert len(accepted) == 3 and len(limited) == 3
+        for outcome in accepted:
+            await finish_job(overlord, outcome["processing_id"])
+        assert sum(o["accepted"] for o in accepted) == 3
+
+    async def test_batch_is_all_or_nothing(self, memory_events, keypair):
+        overlord = make_overlord(memory_events)
+        service = MemoryDistilleryService(overlord)
+        record = await register(service, keypair, scope={"max_events_per_day": 2})
+
+        # A 3-event batch against a 2/day limit: rejected as a whole, and
+        # the rejection consumed zero slots.
+        with pytest.raises(DistilleryRateLimitError):
+            await accept(
+                service,
+                record,
+                make_batch([fact_event(source_id=f"s{i}") for i in range(3)]),
+            )
+        used = await service.quota_store.used(record["distillery_id"], DistilleryQuotaStore.today())
+        assert used == 0
+
+        # The full limit is still available for a fitting batch.
+        fits = await accept(
+            service,
+            record,
+            make_batch([fact_event(source_id="s0"), fact_event(source_id="s1")]),
+        )
+        assert fits["accepted"] == 2
+        await finish_job(overlord, fits["processing_id"])
+
+    async def test_within_batch_duplicates_release_reserved_slots(self, memory_events, keypair):
+        overlord = make_overlord(memory_events)
+        service = MemoryDistilleryService(overlord)
+        record = await register(service, keypair, scope={"max_events_per_day": 2})
+
+        # Two events sharing one source_id: pass 1 sees both as net-new
+        # (the key isn't in the DB yet), pass 2 creates one and resolves
+        # the other as a duplicate -- its reserved slot must be returned.
+        outcome = await accept(
+            service,
+            record,
+            make_batch([fact_event(source_id="dup"), fact_event(source_id="dup")]),
+        )
+        assert outcome["accepted"] == 1
+        assert outcome["duplicates"] == 1
+        await finish_job(overlord, outcome["processing_id"])
+        used = await service.quota_store.used(record["distillery_id"], DistilleryQuotaStore.today())
+        assert used == 1
+
+    async def test_old_day_counters_are_pruned_on_consume(self, memory_events):
+        store = DistilleryQuotaStore(memory_events.db_manager, FORMATION_ID)
+        await store.try_consume("dst-old", "2020-01-01", 5, 10)
+        assert await store.used("dst-old", "2020-01-01") == 5
+
+        # A consume for today prunes day buckets past the retention window.
+        day = DistilleryQuotaStore.today()
+        assert await store.try_consume("dst-new", day, 1, 10)
+        assert await store.used("dst-old", "2020-01-01") == 0
+        assert await store.used("dst-new", day) == 1

--- a/tests/unit/test_memory_distillery.py
+++ b/tests/unit/test_memory_distillery.py
@@ -952,6 +952,78 @@ class TestDurableQuota:
         used = await service.quota_store.used(record["distillery_id"], DistilleryQuotaStore.today())
         assert used == 1
 
+    async def test_crash_leaked_reservation_heals_on_restart(self, memory_events, keypair):
+        overlord = make_overlord(memory_events)
+        service = MemoryDistilleryService(overlord)
+        record = await register(service, keypair, scope={"max_events_per_day": 3})
+
+        # One real accepted event (ground truth = 1)...
+        outcome = await accept(service, record, make_batch([fact_event(source_id="s1")]))
+        await finish_job(overlord, outcome["processing_id"])
+
+        # ...then simulate a crash between reserve and settle: two slots
+        # consumed durably with no events ever appended.
+        day = DistilleryQuotaStore.today()
+        assert await service.quota_store.try_consume(record["distillery_id"], day, 2, 3)
+        assert await service.quota_store.used(record["distillery_id"], day) == 3
+
+        # A restarted process reconciles the counter down to ground truth
+        # (1 accepted event) on first touch, so a submission within the
+        # real headroom succeeds instead of 429ing until day rollover.
+        restarted_overlord = make_overlord(memory_events)
+        restarted = MemoryDistilleryService(restarted_overlord)
+        healed = await accept(restarted, record, make_batch([fact_event(source_id="s2")]))
+        assert healed["accepted"] == 1
+        await finish_job(restarted_overlord, healed["processing_id"])
+        # Counter reflects truth again: 1 healed + 1 newly accepted.
+        assert await restarted.quota_store.used(record["distillery_id"], day) == 2
+
+        # The limit itself still holds against real events (2/3 used).
+        final = await accept(restarted, record, make_batch([fact_event(source_id="s3")]))
+        assert final["accepted"] == 1
+        await finish_job(restarted_overlord, final["processing_id"])
+        with pytest.raises(DistilleryRateLimitError):
+            await accept(restarted, record, make_batch([fact_event(source_id="s4")]))
+
+    async def test_reconcile_never_undercuts_inflight_consumes(self, memory_events):
+        # Old process leaked 5 slots (no events behind them), then died.
+        leaked = DistilleryQuotaStore(memory_events.db_manager, FORMATION_ID)
+        day = DistilleryQuotaStore.today()
+        assert await leaked.try_consume("dst-heal", day, 5, 100)
+
+        # New process: 30 concurrent consumers, each taking the real
+        # reserve path (reconcile-then-consume). Reconcile must run once,
+        # before any of this process's consumes, and never again -- if it
+        # re-ran mid-hammer it would erase in-flight consumes and let more
+        # than the limit through.
+        store = DistilleryQuotaStore(memory_events.db_manager, FORMATION_ID)
+
+        async def one_consume():
+            await store.ensure_reconciled("dst-heal", day)
+            return await store.try_consume("dst-heal", day, 1, 10)
+
+        results = await asyncio.gather(*(one_consume() for _ in range(30)))
+        assert sum(results) == 10  # healed 5 -> 0, then exactly the limit
+        assert await store.used("dst-heal", day) == 10
+
+    async def test_reconcile_never_invents_headroom(self, memory_events, keypair):
+        # Normal path: counter equals ground truth, reconcile is a no-op
+        # -- an exhausted quota backed by real events stays exhausted
+        # across restarts (this is the durable-counter guarantee).
+        overlord = make_overlord(memory_events)
+        service = MemoryDistilleryService(overlord)
+        record = await register(service, keypair, scope={"max_events_per_day": 2})
+        outcome = await accept(
+            service,
+            record,
+            make_batch([fact_event(source_id="s1"), fact_event(source_id="s2")]),
+        )
+        await finish_job(overlord, outcome["processing_id"])
+
+        restarted = MemoryDistilleryService(make_overlord(memory_events))
+        with pytest.raises(DistilleryRateLimitError):
+            await accept(restarted, record, make_batch([fact_event(source_id="s3")]))
+
     async def test_old_day_counters_are_pruned_on_consume(self, memory_events):
         store = DistilleryQuotaStore(memory_events.db_manager, FORMATION_ID)
         await store.try_consume("dst-old", "2020-01-01", 5, 10)


### PR DESCRIPTION
## Summary

The distillery daily quota guard was an in-process dict (`self._daily_counts`), explicitly documented as "smallest viable, per-node": it reset on every restart and was wrong across replicas. This PR replaces it with durable DB-backed counters (Acropolis M0b).

## Schema

New `distillery_quota_counters` table (registered with the shared `Base` metadata, created by `_create_all_database_tables` on both SQLite and PostgreSQL):

| column | type | notes |
|---|---|---|
| id | Integer PK | autoincrement |
| formation_id | String(255) | scoping, matches repo convention |
| distillery_id | String(21) | the X-Distillery-ID public id |
| quota_date | String(10) | UTC day bucket "YYYY-MM-DD" |
| count | Integer | accepted-event count |
| updated_at | DateTime | |

Unique on `(formation_id, distillery_id, quota_date)`.

## Atomicity

Check-and-consume is ONE guarded upsert on both backends:

```sql
INSERT ... ON CONFLICT (formation_id, distillery_id, quota_date)
DO UPDATE SET count = count + :n WHERE count + :n <= :limit
```

- **PostgreSQL**: `ON CONFLICT DO UPDATE` row-locks the counter, so concurrent consumers (across replicas) serialize on it and re-evaluate the guard against the committed count; `rowcount == 0` means rejected.
- **SQLite**: writers serialize at the database level; same statement, same rowcount semantics.
- `.inline()` suppresses the implicit `RETURNING id` so rowcount comes from the plain command tag on both drivers.

Batch semantics preserved: quota still gates the net-new event count only, reserved as a whole before any append (all-or-nothing; a rejected batch consumes nothing and stays retryable). Append-time duplicates return their reserved slots when settling. The 429 error shape, `max_events_per_day` / `max_batch_size` scope semantics, and the batch-size check location are unchanged.

Retention: buckets older than 7 days are pruned in the same transaction as a successful consume — no maintenance loop needed. Rollover comes free from the date key.

## Tests

- Unit (`tests/unit/test_memory_distillery.py`): quota enforced within a day; resets across days; survives service restart (new instance, same DB); concurrent consumes never overshoot (40-task `asyncio.gather` hammer, exactly 15/15 wins at limit 15); batch all-or-nothing; within-batch duplicate refund; old-bucket pruning. All existing quota-ordering tests pass unchanged.
- Live PostgreSQL verification: 60 concurrent consumers against limit 15 -> exactly 15 wins, counter == 15; release floors at zero.

## Gates

- Full unit suite: 3979 passed, 10 skipped, 0 failed
- E2E `2_memory/test_2w1_memory_distillery.py`: ALL TESTS PASSED (endpoint contract unchanged, incl. 401/410/429 semantics and idempotent replay)
- `run_random_tests.py 5`: 5/5 passed
- `validate_events.py`: 1464/1464 (100%)
- black / isort / ruff: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
