### PR TITLE
fix(security): sandbox document conversion + route PDFs to pdf-inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## [unreleased]
 
+### Sandboxed document conversion + PDF routing to pdf-inspector
+
+Untrusted documents (chat attachments and knowledge source files) are no
+longer parsed in-process: a hostile PDF/DOCX/HTML file could previously
+hang, crash, or balloon the runtime via MarkItDown. Conversion now runs
+in a spawned subprocess with resource limits and typed quarantine
+outcomes (`services/multimodal/document_converter.py`):
+
+- Out-of-process sandbox: bounded input size checked before spawning,
+  `resource.setrlimit` in the worker (CPU seconds everywhere, address
+  space on Linux, output file size on all platforms), and a hard
+  wall-clock timeout that kills the whole process group. Network
+  isolation is best-effort only (proxy env stripped); the containment
+  win is crash/hang/memory isolation, not egress control.
+- Typed `QuarantineReason` (`timeout`, `memory`, `oversize`,
+  `parser_error`, `encrypted`, `unsupported`) returned to callers --
+  never an unhandled exception into the chat path. Existing graceful
+  degradation is preserved: the attachment fails, the chat continues.
+- `application/pdf` / `.pdf` now routes to `pdf-inspector` (new
+  dependency): local native-text classification and structured markdown
+  extraction. If pdf-inspector cannot parse a given PDF, that file
+  falls back to sandboxed MarkItDown -- PDFs never fail harder than
+  before. All other convertible types stay on MarkItDown, now inside
+  the same sandbox.
+- Both call sites converted: the overlord chat-attachment path and the
+  `FileKnowledge` loader (reused by the knowledge handler and the
+  reasoning tree builder). Well-formed files produce identical text to
+  the previous in-process path.
+- New observability events: `document.conversion.completed`,
+  `document.conversion.quarantined` (with reason), and
+  `document.conversion.fallback`.
+
 ## v0.20260713.0
 
 ### Idempotency-Key support (chat, scheduler jobs, triggers)

--- a/e2e/tests/3_multimodal/test_3l1_malformed_pdf_quarantine.py
+++ b/e2e/tests/3_multimodal/test_3l1_malformed_pdf_quarantine.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+Test 3L1: Malformed PDF attachment -> quarantine + graceful degradation.
+
+Security regression test for the sandboxed document conversion service:
+a hostile/malformed PDF attachment must NOT crash or hang the runtime.
+The conversion runs out-of-process (pdf-inspector with MarkItDown fallback),
+gets quarantined with a typed reason, a DOCUMENT_CONVERSION_QUARANTINED
+event is emitted, and the chat request still completes normally.
+
+Standalone script (per e2e conventions): run directly, not via pytest.
+"""
+
+import asyncio
+import sys
+import threading
+import time
+from pathlib import Path
+
+# Add parent directories to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from muxi.runtime.formation import Formation  # noqa: E402
+from muxi.runtime.services import observability  # noqa: E402
+
+QUARANTINE_EVENT = "document.conversion.quarantined"
+
+# A "PDF" that neither pdf-inspector nor MarkItDown can parse: valid magic
+# bytes followed by binary garbage. Routing sends it to pdf-inspector, which
+# fails; the sandboxed MarkItDown fallback also fails; the file is quarantined
+# with reason parser_error and the chat continues without the attachment.
+MALFORMED_PDF = b"%PDF-1.7\n" + b"\x00\xff\xfe\x01" * 512 + b"\n%%EOF"
+
+
+class CapturingLogger:
+    """Event sink recording everything observe() emits (same shape as test 18c)."""
+
+    def __init__(self):
+        self._events = []
+        self._lock = threading.Lock()
+
+    def should_emit(self, event_type, level):
+        return True
+
+    def emit_event(self, event_type=None, level=None, data=None, description=None, **kwargs):
+        with self._lock:
+            self._events.append(
+                {
+                    "event": getattr(event_type, "value", str(event_type)),
+                    "data": data,
+                    "description": description,
+                }
+            )
+        return ""
+
+    def snapshot(self):
+        with self._lock:
+            return list(self._events)
+
+
+async def run() -> bool:
+    print("=" * 70)
+    print("Test 3L1: Malformed PDF attachment -> quarantine + graceful degradation")
+    print("=" * 70)
+
+    formation_path = Path(__file__).parent / "formations" / "formation-multimodal"
+    formation = Formation()
+    await formation.load(str(formation_path))
+    overlord = await formation.start_overlord()
+    print("1. Overlord started")
+
+    capturing = CapturingLogger()
+    observability.set_runtime_event_logger(capturing)
+
+    files = [
+        {
+            "filename": "malformed.pdf",
+            "content": MALFORMED_PDF,
+            "content_type": "application/pdf",
+            "size": len(MALFORMED_PDF),
+        }
+    ]
+    user_message = "Please summarize the attached document for me."
+
+    print(f"2. Sending chat with malformed PDF attachment ({len(MALFORMED_PDF)} bytes)...")
+    response = await overlord.chat(
+        user_id="test_user",
+        message=user_message,
+        files=files,
+        use_async=False,
+        stream=False,
+    )
+    result = response.content if hasattr(response, "content") else str(response)
+    print(f"3. Chat completed; response length: {len(result)} chars")
+    print(f"   Response preview: {result[:200]}")
+
+    # Graceful degradation: the runtime survived and the chat produced a reply.
+    assert isinstance(result, str) and len(result) > 0, "chat did not return a response"
+
+    # observe() emits on background threads; wait for the quarantine event.
+    quarantine_events = []
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        quarantine_events = [e for e in capturing.snapshot() if e["event"] == QUARANTINE_EVENT]
+        if quarantine_events:
+            break
+        await asyncio.sleep(0.25)
+
+    assert quarantine_events, (
+        f"no {QUARANTINE_EVENT} event was emitted; "
+        f"captured events: {sorted({e['event'] for e in capturing.snapshot()})}"
+    )
+    event = quarantine_events[0]
+    reason = (event["data"] or {}).get("quarantine_reason")
+    filename = (event["data"] or {}).get("filename")
+    print(f"4. Quarantine event captured: reason={reason} filename={filename}")
+    assert reason == "parser_error", f"expected parser_error, got {reason}"
+    assert filename == "malformed.pdf", f"unexpected filename in event: {filename}"
+
+    await formation.stop_overlord()
+    print("5. Overlord stopped cleanly")
+
+    print("\n" + "=" * 40 + "\n")
+    print("### Test Result:")
+    print("  🎉 SUCCESS: Malformed PDF was quarantined and chat degraded gracefully")
+    print("  ✓ Runtime survived a hostile PDF (no crash, no hang)")
+    print("  ✓ document.conversion.quarantined emitted with reason parser_error")
+    print("  ✓ Chat request completed with a normal response")
+    print("\n" + "=" * 40 + "\n")
+    print("### Chat transcript:")
+    print(f"\nUser: {user_message} [attachment: malformed.pdf]")
+    print(f"System: {result[:500]}")
+    return True
+
+
+if __name__ == "__main__":
+    success = asyncio.run(run())
+    sys.exit(0 if success else 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ dependencies = [
     # declares requires_python='<3.14' and blocks Python 3.14 installs even
     # though MUXI never imports it.
     "markitdown[docx,pdf,pptx,xls,xlsx]>=0.1.6",  # Convert various file formats to Markdown
+    "pdf-inspector>=0.2.6",  # PDF classification + native-text markdown extraction (sandboxed)
     "pypdf>=6.13.2",  # PDF document processing (successor to PyPDF2); CVE-2026-33123 fixed in 6.9.1
     "python-docx>=1.2.0",  # Word document processing
     "markdownify>=1.2.2",  # HTML to Markdown conversion

--- a/src/muxi/runtime/datatypes/observability.py
+++ b/src/muxi/runtime/datatypes/observability.py
@@ -710,6 +710,16 @@ class ConversationEvents(Enum):
     DOCUMENT_PROCESSING_FAILED = "document.processing.failed"
     # When document processing fails
 
+    DOCUMENT_CONVERSION_COMPLETED = "document.conversion.completed"
+    # When sandboxed document conversion (pdf-inspector/MarkItDown) succeeds
+
+    DOCUMENT_CONVERSION_QUARANTINED = "document.conversion.quarantined"
+    # When sandboxed conversion is refused/killed (timeout, memory, oversize,
+    # parser_error, encrypted, unsupported) and the document is quarantined
+
+    DOCUMENT_CONVERSION_FALLBACK = "document.conversion.fallback"
+    # When pdf-inspector fails on a PDF and conversion falls back to MarkItDown
+
     CONTENT_EXTRACTION_STARTED = "content.extraction.started"
     # When content extraction from media begins
 

--- a/src/muxi/runtime/formation/agents/knowledge/base.py
+++ b/src/muxi/runtime/formation/agents/knowledge/base.py
@@ -231,6 +231,25 @@ class FileKnowledge(KnowledgeSource):
         """
         try:
             if self._is_markitdown_supported(file_path):
+                # Enforce max_file_size BEFORE reading the file into memory
+                # (same pre-read guard as process_with_chunk_manager), so the
+                # reasoning-tree path cannot allocate an oversize file either.
+                file_size = os.path.getsize(file_path)
+                if file_size > self.max_file_size:
+                    observability.observe(
+                        event_type=observability.ErrorEvents.RESOURCE_EXHAUSTED,
+                        level=observability.EventLevel.WARNING,
+                        description=(
+                            f"Skipping large file ({file_size} bytes > {self.max_file_size})"
+                        ),
+                        data={
+                            "file_path": file_path,
+                            "file_size": file_size,
+                            "limit": self.max_file_size,
+                        },
+                    )
+                    return f"[Error loading file: {os.path.basename(file_path)}]"
+
                 # Convert supported file types in the sandboxed subprocess
                 # (pdf-inspector for PDFs, MarkItDown for everything else).
                 with open(file_path, "rb") as f:

--- a/src/muxi/runtime/formation/agents/knowledge/base.py
+++ b/src/muxi/runtime/formation/agents/knowledge/base.py
@@ -54,11 +54,11 @@ import glob
 import os
 from typing import Any, Dict, List, Optional
 
-# Import markitdown for document conversion
-from markitdown import MarkItDown
-
 # Import observability
 from ....services import observability
+
+# Sandboxed document conversion (out-of-process MarkItDown / pdf-inspector)
+from ....services.multimodal.document_converter import convert_document
 
 # Import DocumentChunkManager for hybrid architecture integration
 from ...documents.storage.chunk_manager import DocumentChunk, DocumentChunkManager
@@ -205,20 +205,6 @@ class FileKnowledge(KnowledgeSource):
 
         self._files: Optional[List[str]] = None
 
-        # Initialize markitdown converter if available
-        self._markitdown = None
-        if self.enable_markitdown:
-            try:
-                self._markitdown = MarkItDown()
-            except Exception as e:
-                observability.observe(
-                    event_type=observability.ErrorEvents.MARKITDOWN_INITIALIZATION_FAILED,
-                    level=observability.EventLevel.WARNING,
-                    description="Failed to initialize MarkItDown",
-                    data={"error": str(e)},
-                )
-                self.enable_markitdown = False
-
     def _is_markitdown_supported(self, file_path: str) -> bool:
         """Check if file extension is supported by markitdown."""
         if not self.enable_markitdown:
@@ -245,9 +231,36 @@ class FileKnowledge(KnowledgeSource):
         """
         try:
             if self._is_markitdown_supported(file_path):
-                # Use markitdown for supported file types
-                result = self._markitdown.convert(file_path)
-                return result.text_content
+                # Convert supported file types in the sandboxed subprocess
+                # (pdf-inspector for PDFs, MarkItDown for everything else).
+                with open(file_path, "rb") as f:
+                    raw = f.read()
+                conversion = convert_document(
+                    raw,
+                    os.path.basename(file_path),
+                    max_input_bytes=self.max_file_size,
+                )
+                if conversion.ok:
+                    return conversion.text
+                # Quarantined: the conversion service already emitted a
+                # DOCUMENT_CONVERSION_QUARANTINED event; degrade exactly like
+                # the previous in-process failure path.
+                reason = (
+                    conversion.quarantine_reason.value
+                    if conversion.quarantine_reason
+                    else "unknown"
+                )
+                observability.observe(
+                    event_type=observability.ConversationEvents.DOCUMENT_PROCESSING_FAILED,
+                    level=observability.EventLevel.ERROR,
+                    description=f"Error processing file {os.path.basename(file_path)}",
+                    data={
+                        "file_path": file_path,
+                        "quarantine_reason": reason,
+                        "error": conversion.detail,
+                    },
+                )
+                return f"[Error loading file: {os.path.basename(file_path)}]"
 
             elif self._is_text_file(file_path):
                 # Direct reading for plain text files

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -5711,9 +5711,7 @@ Agent response: {raw_response}"""
 
                     chunk_content = chunk.get("content", "")
 
-                    await self.add_to_buffer_memory(
-                        message=chunk_content, metadata=chunk_metadata
-                    )
+                    await self.add_to_buffer_memory(message=chunk_content, metadata=chunk_metadata)
 
                 # Add to processed docs list with actual content
                 processed_docs.append(

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -84,16 +84,12 @@ import os
 import re
 import signal
 import sys
-import threading
 import time
 from collections import OrderedDict
 from contextlib import contextmanager, suppress
 from datetime import datetime
 from pathlib import Path
 from typing import Any, AsyncGenerator, Dict, List, Optional, Set, Tuple, Union
-
-# Import MarkItDown - required dependency
-from markitdown import MarkItDown
 
 # Unified Response Components
 from ...datatypes.clarification import (
@@ -136,6 +132,12 @@ from ...services.multimodal import (
     TaskInputProcessor,
     TaskOutputProcessor,
     WorkflowMultiModalProcessor,
+)
+
+# Sandboxed document conversion (out-of-process MarkItDown / pdf-inspector)
+from ...services.multimodal.document_converter import (
+    ATTACHMENT_CONVERTIBLE_EXTENSIONS,
+    convert_document_async,
 )
 from ...services.scheduler.service import SchedulerService
 
@@ -235,9 +237,6 @@ from .secrets_manager import SecretsInterpolator
 #     ResilienceConfig,
 # )
 
-
-_MARKITDOWN_INSTANCE = None
-_MARKITDOWN_LOCK = threading.Lock()
 
 # Memory collections that should be created for each user/formation
 MEMORY_COLLECTIONS = {
@@ -5602,47 +5601,20 @@ Agent response: {raw_response}"""
                     ]
 
                 else:
-                    # Check if we should use MarkItDown for conversion
-                    should_use_markitdown = False
-                    markitdown_extensions = [".pdf", ".docx", ".pptx", ".xlsx", ".html"]
+                    # Convertible documents go through the sandboxed out-of-process
+                    # conversion service (pdf-inspector for PDFs, MarkItDown for
+                    # the rest); hostile files are quarantined, never parsed here.
                     file_ext = os.path.splitext(filename)[1].lower()
+                    should_convert = file_ext in ATTACHMENT_CONVERTIBLE_EXTENSIONS
 
-                    if file_ext in markitdown_extensions:
-                        global _MARKITDOWN_INSTANCE
-
-                        # Thread-safe singleton initialization
-                        if _MARKITDOWN_INSTANCE is None:
-                            with _MARKITDOWN_LOCK:
-                                # Double-check pattern: check again inside the lock
-                                if _MARKITDOWN_INSTANCE is None:
-                                    _MARKITDOWN_INSTANCE = MarkItDown()
-
-                        markitdown = _MARKITDOWN_INSTANCE
-                        should_use_markitdown = True
-
-                    if should_use_markitdown:
-                        try:
-                            # Convert document to markdown using MarkItDown
-                            # Create a temporary file for binary content
-                            import tempfile
-
-                            tmp_path = None
-                            try:
-                                with tempfile.NamedTemporaryFile(
-                                    suffix=file_ext, delete=False
-                                ) as tmp:
-                                    tmp.write(
-                                        content if isinstance(content, bytes) else content.encode()
-                                    )
-                                    tmp_path = tmp.name
-
-                                # Convert with MarkItDown
-                                result = markitdown.convert(tmp_path)
-                                extracted_content = result.text_content
-                            finally:
-                                # Always clean up temp file
-                                if tmp_path and os.path.exists(tmp_path):
-                                    os.unlink(tmp_path)
+                    if should_convert:
+                        conversion = await convert_document_async(
+                            content if isinstance(content, bytes) else content.encode(),
+                            filename,
+                            media_type=content_type,
+                        )
+                        if conversion.ok:
+                            extracted_content = conversion.text
                             # Now chunk the extracted text
                             if self.document_chunker:
                                 doc_chunks = await self.document_chunker.chunk_document(
@@ -5663,10 +5635,16 @@ Agent response: {raw_response}"""
                                         "metadata": {"filename": filename, "converted": True},
                                     }
                                 ]
-
-                            # REMOVE - line 4148 (DEBUG runtime trace: file processing)
-
-                        except Exception as e:
+                        else:
+                            # Quarantined (timeout/memory/oversize/parser_error/
+                            # encrypted/unsupported). The conversion service already
+                            # emitted DOCUMENT_CONVERSION_QUARANTINED; keep the
+                            # pre-existing graceful degradation for this call site.
+                            quarantine_reason = (
+                                conversion.quarantine_reason.value
+                                if conversion.quarantine_reason
+                                else "unknown"
+                            )
                             observability.observe(
                                 event_type=observability.ErrorEvents.GENERIC_ERROR,
                                 level=observability.EventLevel.WARNING,
@@ -5674,10 +5652,14 @@ Agent response: {raw_response}"""
                                     "service": "document_processing",
                                     "filename": filename,
                                     "file_extension": file_ext,
-                                    "error": str(e),
+                                    "quarantine_reason": quarantine_reason,
+                                    "error": conversion.detail,
                                     "fallback": "binary_chunking",
                                 },
-                                description=f"MarkItDown conversion failed for {filename}: {e}",
+                                description=(
+                                    f"Document conversion quarantined for {filename}: "
+                                    f"{quarantine_reason}"
+                                ),
                             )
                             # Fall back to binary chunking
                             chunks = [{"content": content, "metadata": {"filename": filename}}]
@@ -5729,7 +5711,7 @@ Agent response: {raw_response}"""
 
                     chunk_content = chunk.get("content", "")
 
-                    result = await self.add_to_buffer_memory(
+                    await self.add_to_buffer_memory(
                         message=chunk_content, metadata=chunk_metadata
                     )
 

--- a/src/muxi/runtime/services/multimodal/conversion_worker.py
+++ b/src/muxi/runtime/services/multimodal/conversion_worker.py
@@ -14,9 +14,13 @@
 #
 # Isolation model (v1, honest limits):
 #   - Process boundary: parser crashes/hangs kill this process, not the runtime.
-#   - resource.setrlimit: CPU seconds, address space (Linux only - RLIMIT_AS is
-#     unreliable on macOS), and output file size (RLIMIT_FSIZE, all platforms).
-#   - The parent enforces a hard wall-clock timeout and kills the process group.
+#   - resource.setrlimit (POSIX only): CPU seconds, address space (Linux only -
+#     RLIMIT_AS is unreliable on macOS), and output file size (RLIMIT_FSIZE).
+#     On Windows the resource module does not exist, so no rlimits apply; the
+#     parent's wall-clock timeout and the explicit output-length check are the
+#     enforced limits there.
+#   - The parent enforces a hard wall-clock timeout and kills the process group
+#     (plain kill on platforms without process groups).
 #   - Network isolation is best-effort only: proxy env vars are stripped by the
 #     parent, but there is no network namespace/seccomp on a plain POSIX host.
 #     The subprocess CAN technically open sockets; the win at this layer is
@@ -32,8 +36,12 @@
 
 import argparse
 import json
-import resource
 import sys
+
+try:
+    import resource  # POSIX only; unavailable on Windows
+except ImportError:  # pragma: no cover - Windows
+    resource = None
 
 ENGINE_PDF_INSPECTOR = "pdf_inspector"
 ENGINE_MARKITDOWN = "markitdown"
@@ -49,6 +57,10 @@ REASON_UNSUPPORTED = "unsupported"
 
 def _apply_rlimits(cpu_seconds: int, memory_bytes: int, max_output_bytes: int) -> None:
     """Apply resource limits to this process before any parsing happens."""
+    if resource is None:
+        # Windows: no rlimits available. The parent's wall-clock timeout and
+        # the explicit output-length check below are the only limits enforced.
+        return
     # CPU time: hard backstop against parser infinite loops even if the parent
     # dies before its wall-clock timeout fires. SIGXCPU at soft, SIGKILL at hard.
     try:

--- a/src/muxi/runtime/services/multimodal/conversion_worker.py
+++ b/src/muxi/runtime/services/multimodal/conversion_worker.py
@@ -1,0 +1,189 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Document Conversion Worker - Sandboxed Subprocess Entry Point
+# Description:  Converts one untrusted document inside a resource-limited process
+# Role:         Executed by document_converter.py in a spawned subprocess
+# Usage:        python conversion_worker.py <input> <output> --engine ... (internal)
+# Author:       Muxi Framework Team
+#
+# This script is the *only* code that touches untrusted document bytes with a
+# parser (pdf-inspector or MarkItDown). It is executed by file path (never
+# imported) so the muxi package import chain is skipped and the process stays
+# small and fast to spawn.
+#
+# Isolation model (v1, honest limits):
+#   - Process boundary: parser crashes/hangs kill this process, not the runtime.
+#   - resource.setrlimit: CPU seconds, address space (Linux only - RLIMIT_AS is
+#     unreliable on macOS), and output file size (RLIMIT_FSIZE, all platforms).
+#   - The parent enforces a hard wall-clock timeout and kills the process group.
+#   - Network isolation is best-effort only: proxy env vars are stripped by the
+#     parent, but there is no network namespace/seccomp on a plain POSIX host.
+#     The subprocess CAN technically open sockets; the win at this layer is
+#     crash/hang/memory containment, not egress control.
+#
+# Every handled outcome - success or quarantine - is written as JSON to the
+# output path and the process exits 0. Unhandled deaths (signals, rlimit kills)
+# are classified by the parent from the exit status.
+#
+# IMPORTANT: stdlib-only imports at module level. Parser libraries are imported
+# lazily so import failures are reported as structured quarantine results.
+# =============================================================================
+
+import argparse
+import json
+import resource
+import sys
+
+ENGINE_PDF_INSPECTOR = "pdf_inspector"
+ENGINE_MARKITDOWN = "markitdown"
+
+# QuarantineReason values (mirrored from document_converter.QuarantineReason;
+# this file cannot import muxi modules).
+REASON_MEMORY = "memory"
+REASON_OVERSIZE = "oversize"
+REASON_PARSER_ERROR = "parser_error"
+REASON_ENCRYPTED = "encrypted"
+REASON_UNSUPPORTED = "unsupported"
+
+
+def _apply_rlimits(cpu_seconds: int, memory_bytes: int, max_output_bytes: int) -> None:
+    """Apply resource limits to this process before any parsing happens."""
+    # CPU time: hard backstop against parser infinite loops even if the parent
+    # dies before its wall-clock timeout fires. SIGXCPU at soft, SIGKILL at hard.
+    try:
+        resource.setrlimit(resource.RLIMIT_CPU, (cpu_seconds, cpu_seconds + 5))
+    except (ValueError, OSError):
+        pass
+    # Address space: Linux only. On macOS RLIMIT_AS is not reliably enforced,
+    # and the artifact sandbox learned the hard way that pretending otherwise
+    # just produces confusing hangs (see AGENTS.md troubleshooting notes).
+    if sys.platform.startswith("linux"):
+        try:
+            resource.setrlimit(resource.RLIMIT_AS, (memory_bytes, memory_bytes))
+        except (ValueError, OSError):
+            pass
+    # Output file size: enforced on all platforms. A decompression bomb that
+    # slips past the explicit length check below dies on SIGXFSZ.
+    try:
+        fsize = max_output_bytes * 2  # JSON escaping overhead
+        resource.setrlimit(resource.RLIMIT_FSIZE, (fsize, fsize))
+    except (ValueError, OSError):
+        pass
+
+
+def _classify_exception(exc: Exception) -> str:
+    """Map a parser exception to a quarantine reason string."""
+    text = f"{type(exc).__name__}: {exc}".lower()
+    if "encrypt" in text or "password" in text:
+        return REASON_ENCRYPTED
+    if "unsupported" in text:
+        return REASON_UNSUPPORTED
+    return REASON_PARSER_ERROR
+
+
+def _convert_with_markitdown(input_path: str) -> str:
+    from markitdown import MarkItDown
+
+    return MarkItDown().convert(input_path).text_content
+
+
+def _convert_with_pdf_inspector(input_path: str) -> str:
+    import pdf_inspector
+
+    return pdf_inspector.process_pdf(input_path).markdown
+
+
+def _convert(engine: str, input_path: str, max_output_bytes: int) -> dict:
+    """Run the conversion, returning a result dict (never raising for parser errors)."""
+    fallback_from = None
+    fallback_error = None
+    engine_used = engine
+
+    try:
+        if engine == ENGINE_PDF_INSPECTOR:
+            try:
+                text = _convert_with_pdf_inspector(input_path)
+            except MemoryError:
+                raise
+            except Exception as pdf_exc:  # noqa: BLE001 - untrusted input boundary
+                # pdf-inspector could not handle this PDF; fall back to
+                # sandboxed MarkItDown so we never fail harder than before.
+                fallback_from = ENGINE_PDF_INSPECTOR
+                fallback_error = f"{type(pdf_exc).__name__}: {pdf_exc}"
+                engine_used = ENGINE_MARKITDOWN
+                text = _convert_with_markitdown(input_path)
+        else:
+            text = _convert_with_markitdown(input_path)
+    except MemoryError:
+        return {
+            "ok": False,
+            "reason": REASON_MEMORY,
+            "detail": "parser exhausted the memory limit",
+            "engine": engine_used,
+            "fallback_from": fallback_from,
+            "fallback_error": fallback_error,
+        }
+    except Exception as exc:  # noqa: BLE001 - untrusted input boundary
+        return {
+            "ok": False,
+            "reason": _classify_exception(exc),
+            "detail": f"{type(exc).__name__}: {exc}"[:2000],
+            "engine": engine_used,
+            "fallback_from": fallback_from,
+            "fallback_error": fallback_error,
+        }
+
+    if text is None:
+        # MarkItDown returns None text_content when it cannot extract anything
+        # from a malformed file; that is a parse failure, not an empty document.
+        return {
+            "ok": False,
+            "reason": REASON_PARSER_ERROR,
+            "detail": "converter produced no text",
+            "engine": engine_used,
+            "fallback_from": fallback_from,
+            "fallback_error": fallback_error,
+        }
+    text = text if isinstance(text, str) else str(text)
+    if len(text.encode("utf-8", errors="replace")) > max_output_bytes:
+        return {
+            "ok": False,
+            "reason": REASON_OVERSIZE,
+            "detail": f"converted output exceeds {max_output_bytes} bytes",
+            "engine": engine_used,
+            "fallback_from": fallback_from,
+            "fallback_error": fallback_error,
+        }
+
+    return {
+        "ok": True,
+        "text": text,
+        "engine": engine_used,
+        "fallback_from": fallback_from,
+        "fallback_error": fallback_error,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Sandboxed document conversion worker")
+    parser.add_argument("input_path")
+    parser.add_argument("output_path")
+    parser.add_argument(
+        "--engine", choices=[ENGINE_PDF_INSPECTOR, ENGINE_MARKITDOWN], required=True
+    )
+    parser.add_argument("--cpu-seconds", type=int, required=True)
+    parser.add_argument("--memory-bytes", type=int, required=True)
+    parser.add_argument("--max-output-bytes", type=int, required=True)
+    args = parser.parse_args()
+
+    _apply_rlimits(args.cpu_seconds, args.memory_bytes, args.max_output_bytes)
+    result = _convert(args.engine, args.input_path, args.max_output_bytes)
+
+    with open(args.output_path, "w", encoding="utf-8") as handle:
+        json.dump(result, handle)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/muxi/runtime/services/multimodal/document_converter.py
+++ b/src/muxi/runtime/services/multimodal/document_converter.py
@@ -22,7 +22,10 @@
 # Honest limits (v1): there is no network namespace or seccomp on a plain POSIX
 # host. Proxy environment variables are stripped from the worker env as a
 # best-effort measure, but the subprocess boundary + rlimits + timeout is the
-# actual containment win; egress control is not claimed.
+# actual containment win; egress control is not claimed. On Windows the
+# resource module does not exist, so only the process boundary, the pre-spawn
+# input cap, the wall-clock timeout (plain kill - no process groups), and the
+# explicit output-size check apply.
 #
 # Routing: application/pdf (or a .pdf extension) goes to pdf-inspector, whose
 # native-text path runs locally and emits structured markdown. Everything else
@@ -127,9 +130,11 @@ def _worker_env() -> dict:
 
 def _classify_signal(sig: int) -> QuarantineReason:
     """Classify a worker killed by a signal (rlimit kills and parser crashes)."""
-    if sig == signal.SIGXCPU:
+    # getattr: SIGXCPU/SIGKILL/SIGXFSZ do not exist on Windows, where negative
+    # return codes cannot occur anyway (no signal deaths).
+    if sig == getattr(signal, "SIGXCPU", -1):
         return QuarantineReason.TIMEOUT
-    if sig == signal.SIGKILL:
+    if sig == getattr(signal, "SIGKILL", -1):
         # RLIMIT_AS hard kill / OOM killer.
         return QuarantineReason.MEMORY
     if sig == getattr(signal, "SIGXFSZ", -1):
@@ -161,6 +166,10 @@ def _run_worker(
         "--max-output-bytes",
         str(max_output_bytes),
     ]
+    # POSIX: give the worker its own process group so the timeout kill also
+    # reaps any helpers it spawned. Windows has neither start_new_session nor
+    # os.killpg; a plain kill() of the worker is the fallback there.
+    posix = os.name == "posix"
     process = subprocess.Popen(  # noqa: S603 - fixed argv, no shell
         cmd,
         stdin=subprocess.DEVNULL,
@@ -168,15 +177,19 @@ def _run_worker(
         stderr=subprocess.PIPE,
         env=_worker_env(),
         cwd=os.path.dirname(input_path),
-        start_new_session=True,  # own process group so we can kill descendants
+        start_new_session=posix,
     )
     try:
         _, stderr = process.communicate(timeout=timeout)
     except subprocess.TimeoutExpired:
-        # Kill the entire process group; the worker may have spawned helpers.
-        try:
-            os.killpg(process.pid, signal.SIGKILL)
-        except (ProcessLookupError, PermissionError):
+        # Kill the entire process group where available; the worker may have
+        # spawned helpers. Fall back to killing just the worker.
+        if posix:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                process.kill()
+        else:
             process.kill()
         process.wait()
         return ConversionResult(

--- a/src/muxi/runtime/services/multimodal/document_converter.py
+++ b/src/muxi/runtime/services/multimodal/document_converter.py
@@ -1,0 +1,391 @@
+# =============================================================================
+# FRONTMATTER
+# =============================================================================
+# Title:        Document Converter - Out-of-Process Document Conversion Service
+# Description:  Converts untrusted documents (PDF/Office/HTML/...) to markdown text
+# Role:         Security boundary between untrusted document bytes and the runtime
+# Usage:        result = convert_document(content, filename) / await convert_document_async(...)
+# Author:       Muxi Framework Team
+#
+# Untrusted documents (chat attachments, knowledge source files) were previously
+# parsed in-process by MarkItDown: a malformed or hostile file could crash, hang,
+# or balloon the runtime process. This service moves every conversion into a
+# spawned subprocess (conversion_worker.py) with:
+#
+#   - bounded input size, checked BEFORE spawning anything
+#   - resource.setrlimit in the worker: CPU seconds, address space (Linux only),
+#     and output file size (all platforms)
+#   - a hard wall-clock timeout; on expiry the whole process group is killed
+#   - typed QuarantineReason outcomes - callers NEVER see an unhandled parser
+#     exception, they get a ConversionResult and degrade gracefully
+#
+# Honest limits (v1): there is no network namespace or seccomp on a plain POSIX
+# host. Proxy environment variables are stripped from the worker env as a
+# best-effort measure, but the subprocess boundary + rlimits + timeout is the
+# actual containment win; egress control is not claimed.
+#
+# Routing: application/pdf (or a .pdf extension) goes to pdf-inspector, whose
+# native-text path runs locally and emits structured markdown. Everything else
+# stays on MarkItDown - now inside the same sandbox. If pdf-inspector fails on
+# a given PDF the worker falls back to sandboxed MarkItDown for that file, so
+# PDFs never fail harder than they did before routing existed.
+# =============================================================================
+
+import asyncio
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from .. import observability
+
+# Wall-clock ceiling for a single conversion (parent-enforced; the worker also
+# gets an RLIMIT_CPU backstop derived from it).
+DEFAULT_TIMEOUT_SECONDS = 60.0
+# Rejected before spawning: nothing this large belongs in a chat attachment or
+# knowledge file, and refusing pre-spawn keeps hostile inputs cheap.
+DEFAULT_MAX_INPUT_BYTES = 50 * 1024 * 1024
+# Cap on converted text; protects against decompression bombs whose tiny input
+# passes the pre-spawn check but expands enormously.
+DEFAULT_MAX_OUTPUT_BYTES = 10 * 1024 * 1024
+# Address-space limit for the worker (enforced on Linux only; matches the
+# artifact sandbox's 2GB figure - parsers map a lot of virtual memory).
+DEFAULT_MEMORY_LIMIT_BYTES = 2 * 1024 * 1024 * 1024
+
+_WORKER_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "conversion_worker.py")
+
+# Extensions the chat-attachment path converts (unchanged from the previous
+# in-process MarkItDown gate in overlord.py).
+ATTACHMENT_CONVERTIBLE_EXTENSIONS = [".pdf", ".docx", ".pptx", ".xlsx", ".html"]
+
+ENGINE_PDF_INSPECTOR = "pdf_inspector"
+ENGINE_MARKITDOWN = "markitdown"
+
+# Environment variables stripped from the worker (best-effort network hygiene).
+_PROXY_ENV_VARS = (
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+)
+
+
+class QuarantineReason(str, Enum):
+    """Why a document conversion was refused or killed instead of completing."""
+
+    TIMEOUT = "timeout"  # wall-clock or CPU limit exceeded
+    MEMORY = "memory"  # memory limit exhausted
+    OVERSIZE = "oversize"  # input too large (pre-spawn) or output too large
+    PARSER_ERROR = "parser_error"  # parser raised or crashed on malformed input
+    ENCRYPTED = "encrypted"  # password-protected document
+    UNSUPPORTED = "unsupported"  # format the converters cannot handle
+
+
+@dataclass
+class ConversionResult:
+    """Outcome of one sandboxed document conversion."""
+
+    ok: bool
+    text: Optional[str] = None
+    engine: Optional[str] = None
+    quarantine_reason: Optional[QuarantineReason] = None
+    detail: str = ""
+    fallback_used: bool = False
+
+
+def _select_engine(filename: str, media_type: Optional[str]) -> str:
+    """Deterministic routing by media type / extension: PDFs to pdf-inspector."""
+    ext = os.path.splitext(filename)[1].lower()
+    if ext == ".pdf" or (media_type or "").lower().split(";")[0].strip() == "application/pdf":
+        return ENGINE_PDF_INSPECTOR
+    return ENGINE_MARKITDOWN
+
+
+def _safe_suffix(filename: str) -> str:
+    """Extension for the temp input file (parsers key off it); sanitized."""
+    ext = os.path.splitext(filename)[1].lower()
+    if ext and len(ext) <= 10 and all(c.isalnum() or c == "." for c in ext[1:]):
+        return ext
+    return ".bin"
+
+
+def _worker_env() -> dict:
+    env = {k: v for k, v in os.environ.items() if k not in _PROXY_ENV_VARS}
+    # Best-effort: libraries that honor no_proxy will not tunnel through one.
+    env["no_proxy"] = "*"
+    env["NO_PROXY"] = "*"
+    return env
+
+
+def _classify_signal(sig: int) -> QuarantineReason:
+    """Classify a worker killed by a signal (rlimit kills and parser crashes)."""
+    if sig == signal.SIGXCPU:
+        return QuarantineReason.TIMEOUT
+    if sig == signal.SIGKILL:
+        # RLIMIT_AS hard kill / OOM killer.
+        return QuarantineReason.MEMORY
+    if sig == getattr(signal, "SIGXFSZ", -1):
+        return QuarantineReason.OVERSIZE
+    # SIGSEGV/SIGABRT/SIGBUS/...: the parser crashed on hostile input.
+    return QuarantineReason.PARSER_ERROR
+
+
+def _run_worker(
+    input_path: str,
+    output_path: str,
+    engine: str,
+    timeout: float,
+    memory_limit_bytes: int,
+    max_output_bytes: int,
+) -> ConversionResult:
+    """Spawn one worker process and classify its outcome. Never raises."""
+    cmd = [
+        sys.executable,
+        _WORKER_PATH,
+        input_path,
+        output_path,
+        "--engine",
+        engine,
+        "--cpu-seconds",
+        str(max(1, int(timeout))),
+        "--memory-bytes",
+        str(memory_limit_bytes),
+        "--max-output-bytes",
+        str(max_output_bytes),
+    ]
+    process = subprocess.Popen(  # noqa: S603 - fixed argv, no shell
+        cmd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        env=_worker_env(),
+        cwd=os.path.dirname(input_path),
+        start_new_session=True,  # own process group so we can kill descendants
+    )
+    try:
+        _, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        # Kill the entire process group; the worker may have spawned helpers.
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            process.kill()
+        process.wait()
+        return ConversionResult(
+            ok=False,
+            engine=engine,
+            quarantine_reason=QuarantineReason.TIMEOUT,
+            detail=f"conversion exceeded {timeout}s wall-clock limit",
+        )
+
+    if process.returncode < 0:
+        sig = -process.returncode
+        return ConversionResult(
+            ok=False,
+            engine=engine,
+            quarantine_reason=_classify_signal(sig),
+            detail=f"worker killed by signal {sig}",
+        )
+
+    stderr_text = (stderr or b"").decode("utf-8", errors="replace")[-1000:]
+    if process.returncode != 0 or not os.path.exists(output_path):
+        return ConversionResult(
+            ok=False,
+            engine=engine,
+            quarantine_reason=QuarantineReason.PARSER_ERROR,
+            detail=f"worker exited {process.returncode} without a result: {stderr_text}",
+        )
+
+    try:
+        with open(output_path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, ValueError) as exc:
+        return ConversionResult(
+            ok=False,
+            engine=engine,
+            quarantine_reason=QuarantineReason.PARSER_ERROR,
+            detail=f"unreadable worker result: {exc}",
+        )
+
+    fallback_used = payload.get("fallback_from") is not None
+    if payload.get("ok"):
+        return ConversionResult(
+            ok=True,
+            text=payload.get("text", ""),
+            engine=payload.get("engine", engine),
+            detail=payload.get("fallback_error") or "",
+            fallback_used=fallback_used,
+        )
+
+    try:
+        reason = QuarantineReason(payload.get("reason", "parser_error"))
+    except ValueError:
+        reason = QuarantineReason.PARSER_ERROR
+    return ConversionResult(
+        ok=False,
+        engine=payload.get("engine", engine),
+        quarantine_reason=reason,
+        detail=payload.get("detail", ""),
+        fallback_used=fallback_used,
+    )
+
+
+def convert_document(
+    content: bytes,
+    filename: str,
+    media_type: Optional[str] = None,
+    *,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    max_input_bytes: int = DEFAULT_MAX_INPUT_BYTES,
+    max_output_bytes: int = DEFAULT_MAX_OUTPUT_BYTES,
+    memory_limit_bytes: int = DEFAULT_MEMORY_LIMIT_BYTES,
+) -> ConversionResult:
+    """
+    Convert an untrusted document to markdown-ish text in a sandboxed subprocess.
+
+    Never raises for bad input: every failure mode is returned as a
+    ConversionResult with a QuarantineReason so callers keep their existing
+    graceful-degradation behavior.
+
+    Args:
+        content: Raw document bytes (untrusted).
+        filename: Original filename; its extension drives parser selection.
+        media_type: Optional MIME type; application/pdf routes to pdf-inspector.
+        timeout: Wall-clock ceiling for the conversion.
+        max_input_bytes: Inputs larger than this are rejected before spawning.
+        max_output_bytes: Converted text larger than this is quarantined.
+        memory_limit_bytes: Worker address-space limit (enforced on Linux).
+
+    Returns:
+        ConversionResult with the converted text or a quarantine reason.
+    """
+    if isinstance(content, str):
+        content = content.encode("utf-8")
+
+    started = time.monotonic()
+    if len(content) > max_input_bytes:
+        result = ConversionResult(
+            ok=False,
+            engine=None,
+            quarantine_reason=QuarantineReason.OVERSIZE,
+            detail=f"input is {len(content)} bytes; limit is {max_input_bytes}",
+        )
+        _observe_outcome(result, filename, len(content), started)
+        return result
+
+    engine = _select_engine(filename, media_type)
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="muxi_docconv_") as workdir:
+            input_path = os.path.join(workdir, f"input{_safe_suffix(filename)}")
+            output_path = os.path.join(workdir, "result.json")
+            with open(input_path, "wb") as handle:
+                handle.write(content)
+
+            result = _run_worker(
+                input_path,
+                output_path,
+                engine,
+                timeout,
+                memory_limit_bytes,
+                max_output_bytes,
+            )
+
+            # If pdf-inspector crashed the worker outright (signal death, so the
+            # in-worker MarkItDown fallback never ran), retry once with
+            # MarkItDown - PDFs must never fail harder than before routing.
+            if (
+                not result.ok
+                and engine == ENGINE_PDF_INSPECTOR
+                and result.quarantine_reason == QuarantineReason.PARSER_ERROR
+                and not os.path.exists(output_path)
+            ):
+                retry = _run_worker(
+                    input_path,
+                    output_path,
+                    ENGINE_MARKITDOWN,
+                    timeout,
+                    memory_limit_bytes,
+                    max_output_bytes,
+                )
+                retry.fallback_used = True
+                retry.detail = f"pdf_inspector worker crashed ({result.detail}); {retry.detail}"
+                result = retry
+    except Exception as exc:  # noqa: BLE001 - service must never leak exceptions
+        result = ConversionResult(
+            ok=False,
+            engine=engine,
+            quarantine_reason=QuarantineReason.PARSER_ERROR,
+            detail=f"conversion service error: {type(exc).__name__}: {exc}",
+        )
+
+    _observe_outcome(result, filename, len(content), started)
+    return result
+
+
+async def convert_document_async(
+    content: bytes,
+    filename: str,
+    media_type: Optional[str] = None,
+    *,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    max_input_bytes: int = DEFAULT_MAX_INPUT_BYTES,
+    max_output_bytes: int = DEFAULT_MAX_OUTPUT_BYTES,
+    memory_limit_bytes: int = DEFAULT_MEMORY_LIMIT_BYTES,
+) -> ConversionResult:
+    """Async wrapper around convert_document; runs the blocking wait off-loop."""
+    return await asyncio.to_thread(
+        convert_document,
+        content,
+        filename,
+        media_type,
+        timeout=timeout,
+        max_input_bytes=max_input_bytes,
+        max_output_bytes=max_output_bytes,
+        memory_limit_bytes=memory_limit_bytes,
+    )
+
+
+def _observe_outcome(
+    result: ConversionResult, filename: str, input_bytes: int, started: float
+) -> None:
+    """Emit the conversion outcome (and any pdf-inspector fallback) as events."""
+    duration_ms = int((time.monotonic() - started) * 1000)
+    base_data = {
+        "filename": filename,
+        "engine": result.engine,
+        "input_bytes": input_bytes,
+        "duration_ms": duration_ms,
+    }
+
+    if result.fallback_used:
+        observability.observe(
+            event_type=observability.ConversationEvents.DOCUMENT_CONVERSION_FALLBACK,
+            level=observability.EventLevel.WARNING,
+            data={**base_data, "fallback_from": ENGINE_PDF_INSPECTOR, "error": result.detail},
+            description=f"pdf-inspector failed for {filename}; fell back to MarkItDown",
+        )
+
+    if result.ok:
+        observability.observe(
+            event_type=observability.ConversationEvents.DOCUMENT_CONVERSION_COMPLETED,
+            level=observability.EventLevel.INFO,
+            data={**base_data, "output_chars": len(result.text or "")},
+            description=f"Converted {filename} via {result.engine}",
+        )
+    else:
+        reason = result.quarantine_reason.value if result.quarantine_reason else "unknown"
+        observability.observe(
+            event_type=observability.ConversationEvents.DOCUMENT_CONVERSION_QUARANTINED,
+            level=observability.EventLevel.WARNING,
+            data={**base_data, "quarantine_reason": reason, "detail": result.detail},
+            description=f"Quarantined {filename} ({reason})",
+        )

--- a/tests/unit/test_document_converter.py
+++ b/tests/unit/test_document_converter.py
@@ -227,6 +227,22 @@ def test_runaway_parse_killed_at_wall_clock_timeout():
 # ---------------------------------------------------------------------------
 
 
+def test_knowledge_loader_skips_oversize_file_before_reading(tmp_path):
+    """FileKnowledge enforces max_file_size by stat BEFORE reading the bytes.
+
+    The vector-ingestion path always had a pre-read size gate; the direct
+    _load_file_content path (used by the reasoning tree builder) must apply
+    the same guard instead of allocating the whole file first.
+    """
+    from muxi.runtime.formation.agents.knowledge.base import FileKnowledge
+
+    big = tmp_path / "big.docx"
+    big.write_bytes(b"x" * 4096)
+    source = FileKnowledge(path=str(big), max_file_size=1024)
+    content = source._load_file_content(str(big))
+    assert content == "[Error loading file: big.docx]"
+
+
 def test_async_wrapper_converts():
     result = asyncio.run(convert_document_async(make_pdf_bytes(), "hello.pdf"))
     assert result.ok

--- a/tests/unit/test_document_converter.py
+++ b/tests/unit/test_document_converter.py
@@ -1,0 +1,289 @@
+"""
+Tests for the sandboxed out-of-process document conversion service.
+
+MarkItDown used to parse untrusted documents in-process (chat attachments in
+overlord.py and knowledge sources in agents/knowledge/base.py): a hostile file
+could hang, crash, or balloon the runtime. document_converter now runs every
+conversion in a spawned subprocess with rlimits and a wall-clock kill, routes
+PDFs to pdf-inspector, and returns typed QuarantineReason outcomes instead of
+raising.
+
+These tests use real converters and real hostile fixtures - no mocks:
+  - a decompression-bomb .docx (tiny zip, enormous extracted text)
+  - a huge HTML document that cannot finish inside the timeout
+  - oversize input rejected before any subprocess is spawned
+  - well-formed .docx/.html producing byte-identical text to in-process
+    MarkItDown (the pre-sandbox behavior)
+  - PDFs routed to pdf-inspector, with fallback to MarkItDown when
+    pdf-inspector cannot parse the file
+"""
+
+import asyncio
+import io
+import threading
+import zipfile
+
+import pytest
+from fpdf import FPDF
+from markitdown import MarkItDown
+from pypdf import PdfReader, PdfWriter
+
+from muxi.runtime.services import observability
+from muxi.runtime.services.multimodal.document_converter import (
+    ENGINE_MARKITDOWN,
+    ENGINE_PDF_INSPECTOR,
+    ConversionResult,
+    QuarantineReason,
+    convert_document,
+    convert_document_async,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture builders (deterministic, generated in-test from real libraries)
+# ---------------------------------------------------------------------------
+
+
+def make_pdf_bytes(text: str = "Hello PDF World") -> bytes:
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Helvetica", size=14)
+    pdf.cell(text=text)
+    return bytes(pdf.output())
+
+
+def make_docx_bytes(text: str = "Hello DOCX World") -> bytes:
+    import docx
+
+    document = docx.Document()
+    document.add_paragraph(text)
+    buffer = io.BytesIO()
+    document.save(buffer)
+    return buffer.getvalue()
+
+
+def make_bomb_docx_bytes(expanded_mb: int = 40) -> bytes:
+    """A valid .docx whose document.xml holds enormous highly-compressible text."""
+    base = make_docx_bytes("SEED")
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(io.BytesIO(base)) as zin:
+        with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zout:
+            for item in zin.namelist():
+                data = zin.read(item)
+                if item == "word/document.xml":
+                    data = data.replace(b"SEED", b"A" * (expanded_mb * 1024 * 1024))
+                zout.writestr(item, data)
+    return buffer.getvalue()
+
+
+def make_encrypted_pdf_bytes() -> bytes:
+    reader = PdfReader(io.BytesIO(make_pdf_bytes("secret contents")))
+    writer = PdfWriter()
+    for page in reader.pages:
+        writer.add_page(page)
+    writer.encrypt("secret123")
+    buffer = io.BytesIO()
+    writer.write(buffer)
+    return buffer.getvalue()
+
+
+# A structurally-broken PDF (invalid xref table): pdf-inspector's strict parser
+# rejects it, while MarkItDown's pdfminer backend recovers the text - the
+# natural fixture for the pdf-inspector -> MarkItDown fallback path.
+BROKEN_XREF_PDF = (
+    b"%PDF-1.4\n"
+    b"1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+    b"2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
+    b"3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Contents 4 0 R"
+    b"/Resources<</Font<</F1 5 0 R>>>>>>endobj\n"
+    b"4 0 obj<</Length 44>>stream\n"
+    b"BT /F1 24 Tf 72 700 Td (Hello Broken Xref) Tj ET\nendstream\nendobj\n"
+    b"5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj\n"
+    b"xref\n0 6\ntrailer<</Size 6/Root 1 0 R>>\nstartxref\n0\n%%EOF"
+)
+
+
+# ---------------------------------------------------------------------------
+# Oversize input: rejected before any subprocess is spawned
+# ---------------------------------------------------------------------------
+
+
+def test_oversize_input_rejected_pre_spawn():
+    result = convert_document(b"x" * 2048, "big.pdf", max_input_bytes=1024)
+    assert not result.ok
+    assert result.quarantine_reason == QuarantineReason.OVERSIZE
+    # engine is only assigned when a worker is spawned; None proves the input
+    # was refused before routing/spawning.
+    assert result.engine is None
+    assert "limit" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# Well-formed documents: identical output to the previous in-process path
+# ---------------------------------------------------------------------------
+
+
+def _in_process_markitdown(content: bytes, suffix: str, tmp_path) -> str:
+    path = tmp_path / f"reference{suffix}"
+    path.write_bytes(content)
+    return MarkItDown().convert(str(path)).text_content
+
+
+def test_wellformed_docx_converts_identically_to_in_process(tmp_path):
+    content = make_docx_bytes("Quarterly revenue grew 14% in Q3.")
+    result = convert_document(content, "report.docx")
+    assert result.ok, result.detail
+    assert result.engine == ENGINE_MARKITDOWN
+    assert result.text == _in_process_markitdown(content, ".docx", tmp_path)
+
+
+def test_wellformed_html_converts_identically_to_in_process(tmp_path):
+    content = b"<html><body><h1>Title</h1><p>hello sandboxed html</p></body></html>"
+    result = convert_document(content, "page.html")
+    assert result.ok, result.detail
+    assert result.engine == ENGINE_MARKITDOWN
+    assert result.text == _in_process_markitdown(content, ".html", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# PDF routing: pdf-inspector first, sandboxed MarkItDown as fallback
+# ---------------------------------------------------------------------------
+
+
+def test_pdf_routes_to_pdf_inspector():
+    result = convert_document(make_pdf_bytes(), "hello.pdf", media_type="application/pdf")
+    assert result.ok, result.detail
+    assert result.engine == ENGINE_PDF_INSPECTOR
+    assert not result.fallback_used
+    assert "Hello PDF World" in result.text
+    # Implementation marker: pdf-inspector emits structured markdown (heading
+    # syntax); plain MarkItDown/pdfminer output for this file has no markdown.
+    assert result.text.lstrip().startswith("#")
+
+
+def test_pdf_media_type_routes_even_without_extension():
+    result = convert_document(make_pdf_bytes(), "attachment", media_type="application/pdf")
+    assert result.ok, result.detail
+    assert result.engine == ENGINE_PDF_INSPECTOR
+
+
+def test_pdf_inspector_failure_falls_back_to_markitdown():
+    result = convert_document(BROKEN_XREF_PDF, "broken.pdf", media_type="application/pdf")
+    assert result.ok, result.detail
+    assert result.fallback_used
+    assert result.engine == ENGINE_MARKITDOWN
+    assert "Hello Broken Xref" in result.text
+    # The pdf-inspector error is preserved for observability.
+    assert "PDF parsing error" in result.detail
+
+
+def test_garbage_pdf_quarantined_as_parser_error():
+    result = convert_document(b"%PDF-1.7\n" + b"\x00\xff" * 200, "garbage.pdf")
+    assert not result.ok
+    assert result.quarantine_reason == QuarantineReason.PARSER_ERROR
+    # Both engines were given a chance before quarantining.
+    assert result.fallback_used
+
+
+def test_encrypted_pdf_quarantined_as_encrypted():
+    result = convert_document(make_encrypted_pdf_bytes(), "locked.pdf")
+    assert not result.ok
+    assert result.quarantine_reason == QuarantineReason.ENCRYPTED
+
+
+# ---------------------------------------------------------------------------
+# Hostile fixtures: bombs and runaway parses are killed cleanly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(180)
+def test_decompression_bomb_docx_quarantined():
+    """Tiny zip expanding to tens of MB of text must not reach the caller."""
+    bomb = make_bomb_docx_bytes(expanded_mb=40)
+    # The bomb passes the input-size gate easily (it is ~100KB on disk) ...
+    assert len(bomb) < 1024 * 1024
+    result = convert_document(bomb, "bomb.docx", max_output_bytes=1024 * 1024)
+    # ... but the expanded output trips the sandbox: the explicit output cap
+    # (oversize) or, on memory-limited platforms, the address-space limit.
+    assert not result.ok
+    assert result.quarantine_reason in (QuarantineReason.OVERSIZE, QuarantineReason.MEMORY)
+    assert isinstance(result, ConversionResult)
+
+
+@pytest.mark.timeout(120)
+def test_runaway_parse_killed_at_wall_clock_timeout():
+    """A parse that cannot finish in time is killed cleanly with TIMEOUT."""
+    huge_html = b"<html><body>" + b"<div><p>word one two</p></div>" * 1_000_000 + b"</body></html>"
+    result = convert_document(huge_html, "huge.html", timeout=1.5)
+    assert not result.ok
+    # Either kill mechanism is a valid clean kill: the parent's wall-clock
+    # deadline ("exceeded ... wall-clock limit") or the worker's RLIMIT_CPU
+    # backstop (SIGXCPU), whichever fires first. Both classify as TIMEOUT.
+    assert result.quarantine_reason == QuarantineReason.TIMEOUT
+    assert "wall-clock" in result.detail or "signal" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# Service contract: never raises, async wrapper, quarantine event emission
+# ---------------------------------------------------------------------------
+
+
+def test_async_wrapper_converts():
+    result = asyncio.run(convert_document_async(make_pdf_bytes(), "hello.pdf"))
+    assert result.ok
+    assert result.engine == ENGINE_PDF_INSPECTOR
+
+
+class _CapturingLogger:
+    """Minimal event sink capturing what observe() emits (same shape as e2e 18c)."""
+
+    def __init__(self):
+        self.events = []
+        self._lock = threading.Lock()
+
+    def should_emit(self, event_type, level):
+        return True
+
+    def emit_event(self, event_type=None, level=None, data=None, description=None, **kwargs):
+        with self._lock:
+            self.events.append(
+                {"event": getattr(event_type, "value", str(event_type)), "data": data}
+            )
+        return ""
+
+    def snapshot(self):
+        with self._lock:
+            return list(self.events)
+
+
+def test_quarantine_and_fallback_events_emitted():
+    capturing = _CapturingLogger()
+    previous = observability.get_runtime_event_logger()
+    observability.set_runtime_event_logger(capturing)
+    observability.enable()
+    try:
+        convert_document(b"x" * 2048, "big.pdf", max_input_bytes=1024)
+        convert_document(BROKEN_XREF_PDF, "broken.pdf")
+        # observe() emits on a short-lived background thread; give it time.
+        import time
+
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            names = [e["event"] for e in capturing.snapshot()]
+            if (
+                "document.conversion.quarantined" in names
+                and "document.conversion.fallback" in names
+                and "document.conversion.completed" in names
+            ):
+                break
+            time.sleep(0.1)
+    finally:
+        observability.disable()
+        observability.set_runtime_event_logger(previous)
+
+    events = capturing.snapshot()
+    names = [e["event"] for e in events]
+    assert "document.conversion.quarantined" in names
+    assert "document.conversion.fallback" in names
+    assert "document.conversion.completed" in names
+    quarantined = next(e for e in events if e["event"] == "document.conversion.quarantined")
+    assert quarantined["data"]["quarantine_reason"] == "oversize"

--- a/uv.lock
+++ b/uv.lock
@@ -3977,6 +3977,7 @@ dependencies = [
     { name = "orjson" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pdf-inspector" },
     { name = "pdf2image" },
     { name = "pgvector" },
     { name = "pillow" },
@@ -4112,6 +4113,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "paramiko", marker = "extra == 'dev'", specifier = ">=3.4.0" },
     { name = "paramiko", marker = "extra == 'sftp'", specifier = ">=3.4.0" },
+    { name = "pdf-inspector", specifier = ">=0.2.6" },
     { name = "pdf2image", specifier = ">=1.17.0" },
     { name = "pgvector", specifier = ">=0.4.2" },
     { name = "pillow", specifier = ">=12.2.0" },
@@ -5138,6 +5140,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/be/44/ed13eccdd0519eff265f44b670d46fbb0ec813e2274932dc1c0e48520f7d/patsy-1.0.2.tar.gz", hash = "sha256:cdc995455f6233e90e22de72c37fcadb344e7586fb83f06696f54d92f8ce74c0", size = 399942, upload-time = "2025-10-20T16:17:37.535Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/70/ba4b949bdc0490ab78d545459acd7702b211dfccf7eb89bbc1060f52818d/patsy-1.0.2-py2.py3-none-any.whl", hash = "sha256:37bfddbc58fcf0362febb5f54f10743f8b21dd2aa73dec7e7ef59d1b02ae668a", size = 233301, upload-time = "2025-10-20T16:17:36.563Z" },
+]
+
+[[package]]
+name = "pdf-inspector"
+version = "0.2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/7a/525ee06cad5c46d8aa7357c15b8f72c60e803246f3b7e24523e602f01f6d/pdf_inspector-0.2.6.tar.gz", hash = "sha256:5bb387f39bf7a93b02b49188b670b9798f8ccc7e58f68eee5883a512aa05ceb2", size = 1481660, upload-time = "2026-07-31T23:16:55.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/dc/9963c292151dd82678dddb63e1c640ec420e37d400f304dca2780c6d11a3/pdf_inspector-0.2.6-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c935a354facbfb935e88cb4f3f60fd158402f2af661c1a25a3da328eb21f19fb", size = 2719559, upload-time = "2026-07-31T23:16:46.721Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/2049766fec20c2ee6c01776cc2b7b8599fc9cf2d48e8940419600f65d4a0/pdf_inspector-0.2.6-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:d2b2aaa95b242da38630bbd0644ffe9a929466f9c4e6406d6f1957b59b413d08", size = 2630319, upload-time = "2026-07-31T23:16:48.871Z" },
+    { url = "https://files.pythonhosted.org/packages/45/f3/be670e07df2eb57a1adaeb63b1011d17061fd3036370d9f903984eda94e4/pdf_inspector-0.2.6-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79ba33b224029b68edbd30e7f6dc034f730663749ba0bea12e5873b31435ca28", size = 2808903, upload-time = "2026-07-31T23:16:50.368Z" },
+    { url = "https://files.pythonhosted.org/packages/59/af/be72ab2bd310b6532e4311cf06175eb722802ccea29dbd9281f66c645bd8/pdf_inspector-0.2.6-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df76dd100504b705ce92ef2c668f152f05277d942abd94a7d3f252cb5448d56d", size = 2903593, upload-time = "2026-07-31T23:16:51.906Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8a/22e2bf7413444036138f55a0c9f2b6420f7ef54b6a044755f4dbb3a7395b/pdf_inspector-0.2.6-cp38-abi3-win_amd64.whl", hash = "sha256:89814af887c5ff90f013702ba285ec8a4c5ae4e2ccbdb948f3e421f7c4b4f89d", size = 2550798, upload-time = "2026-07-31T23:16:53.64Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

MarkItDown previously parsed untrusted documents **in-process** at two call sites (the overlord chat-attachment path and the `FileKnowledge` knowledge-source loader). A hostile or malformed PDF/DOCX/PPTX/XLSX/HTML file could hang, crash, or balloon the runtime process. This PR closes that gap and adds pdf-inspector routing (Acropolis M0a).

### Out-of-process conversion sandbox

New service: `src/muxi/runtime/services/multimodal/document_converter.py` + subprocess entry point `conversion_worker.py` (executed by file path, stdlib-only at module level, so no muxi import chain in the worker).

- **Bounded input** checked before spawning anything (default 50MB; the knowledge loader passes its own `max_file_size`).
- **`resource.setrlimit` in the worker**: CPU seconds (all platforms, backstops the wall clock), address space (Linux only — RLIMIT_AS is unreliable on macOS, same lesson as the artifact sandbox), output file size via RLIMIT_FSIZE (all platforms).
- **Hard wall-clock timeout** in the parent (default 60s); on expiry the whole process group is SIGKILLed (`start_new_session=True`).
- **Honest network isolation**: proxy env vars stripped and `no_proxy=*` set — best effort only. There is no network namespace/seccomp on a plain POSIX host; the v1 win is crash/hang/memory containment, documented as such in the module frontmatter.

### Quarantine taxonomy

Typed `QuarantineReason` returned to callers — never an unhandled exception into the chat path:

| Reason | Trigger |
|---|---|
| `timeout` | wall-clock expiry or RLIMIT_CPU (SIGXCPU) |
| `memory` | MemoryError in worker, RLIMIT_AS/OOM SIGKILL |
| `oversize` | input too large (pre-spawn) or converted output over cap / SIGXFSZ |
| `parser_error` | parser exception, crash signal (SIGSEGV/SIGABRT), or no extractable text |
| `encrypted` | password-protected documents |
| `unsupported` | formats the converters reject |

Graceful degradation preserved at both call sites: attachment falls back to binary chunking (chat continues, warning event emitted); knowledge files return the same `[Error loading file: ...]` placeholder as before.

### PDF routing to pdf-inspector

- `application/pdf` / `.pdf` deterministically routes to `pdf-inspector` (new dependency, `>=0.2.6`): local native-text classification + structured markdown extraction, inside the same sandbox.
- If pdf-inspector fails on a given PDF (exception → in-worker fallback; worker crash → one parent-side respawn), that file falls back to sandboxed MarkItDown with a `document.conversion.fallback` event. PDFs never fail harder than before.
- All other convertible types stay on MarkItDown — now sandboxed.

### Observability

Three new enum events (validate_events.py stays 100%): `document.conversion.completed`, `document.conversion.quarantined` (with reason), `document.conversion.fallback`.

## Tests

- **Unit** (`tests/unit/test_document_converter.py`, 12 tests, no mocks): decompression-bomb .docx killed with `oversize`/`memory`; runaway huge-HTML parse killed with `timeout`; oversize rejected pre-spawn (no worker spawned); well-formed .docx/.html byte-identical to in-process MarkItDown; PDFs route to pdf-inspector (structured-markdown marker asserted); broken-xref PDF falls back to MarkItDown; garbage PDF → `parser_error`; encrypted PDF → `encrypted`; quarantine/fallback/completed events asserted via captured logger.
- **E2E**: new standalone `e2e/tests/3_multimodal/test_3l1_malformed_pdf_quarantine.py` — malformed PDF attachment through real chat → graceful reply + `document.conversion.quarantined` (parser_error) event, SUCCESS + exit 0. Re-ran existing document-area tests 3a1, 3a3, 3d1, 3d2, 3d3 — all pass.

## Gates

- Full unit suite: 3984 passed, 10 skipped
- `scripts/validate_events.py`: 100% (0 missing)
- `run_random_tests.py 5`: pass (see report)
- black / isort / ruff: clean on all touched files
- CHANGELOG.md updated under [unreleased]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
