### PR TITLE
fix(tests): dispose async DB engines on unit-test teardown

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,6 +8,7 @@ test's tmp_path for the whole unit suite.
 
 import pytest
 
+from muxi.runtime.services import db as db_module
 from muxi.runtime.services.observability import spool as spool_module
 from muxi.runtime.services.observability.spool import reset_event_spool
 from muxi.runtime.services.tuning import experiments as experiments_module
@@ -22,3 +23,30 @@ def _isolated_event_spool(tmp_path, monkeypatch):
     reset_event_spool()
     yield
     reset_event_spool()
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_async_db_engines(monkeypatch):
+    """Dispose every async engine a DatabaseManager creates during a test.
+
+    DatabaseManager builds its async engine lazily, and each pooled
+    aiosqlite connection owns a dedicated worker thread. Test fixtures
+    dispose the sync engine on teardown but historically leaked the async
+    one, so those worker threads outlived their event loop -- spamming
+    "Event loop is closed" at GC time and accumulating threads across the
+    suite. Track engine creation here and dispose on teardown, while the
+    test's event loop is still open so connections close on the loop that
+    created them. Disposing an engine the test already closed is a no-op.
+    """
+    engines = []
+    original_create = db_module.DatabaseManager._create_async_engine
+
+    def _tracking_create(self):
+        engine = original_create(self)
+        engines.append(engine)
+        return engine
+
+    monkeypatch.setattr(db_module.DatabaseManager, "_create_async_engine", _tracking_create)
+    yield
+    for engine in engines:
+        await engine.dispose()

--- a/tests/unit/test_builtin_commands.py
+++ b/tests/unit/test_builtin_commands.py
@@ -17,6 +17,7 @@ for the scheduler and buffer memory.
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
+import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from muxi.runtime.datatypes.response import MuxiResponse
@@ -744,7 +745,10 @@ class _SqliteDBManager:
         return self._session_maker()
 
 
-async def _make_db_manager() -> _SqliteDBManager:
+@pytest.fixture
+async def sqlite_db_manager():
+    # Disposed on teardown: each pooled aiosqlite connection owns a worker
+    # thread that outlives the test's event loop otherwise.
     engine = create_async_engine("sqlite+aiosqlite://")
     async with engine.begin() as conn:
         await conn.run_sync(
@@ -752,7 +756,8 @@ async def _make_db_manager() -> _SqliteDBManager:
                 sync_conn, tables=[User.__table__, UserIdentifier.__table__]
             )
         )
-    return _SqliteDBManager(async_sessionmaker(engine, expire_on_commit=False))
+    yield _SqliteDBManager(async_sessionmaker(engine, expire_on_commit=False))
+    await engine.dispose()
 
 
 class TestIdentity:
@@ -766,9 +771,8 @@ class TestIdentity:
         response = await run_command(overlord, "/identity")
         assert "requires persistent memory" in response.content
 
-    async def test_link_list_unlink_roundtrip(self):
-        db_manager = await _make_db_manager()
-        overlord = make_overlord(multi_user=True, db_manager=db_manager)
+    async def test_link_list_unlink_roundtrip(self, sqlite_db_manager):
+        overlord = make_overlord(multi_user=True, db_manager=sqlite_db_manager)
 
         response = await run_command(overlord, "/identity", user_id="ran@example.com")
         assert "No other identifiers are linked yet" in response.content
@@ -788,9 +792,8 @@ class TestIdentity:
         response = await run_command(overlord, "/identity", user_id="ran@example.com")
         assert "u12345" not in response.content
 
-    async def test_link_normalizes_mixed_case_type(self):
-        db_manager = await _make_db_manager()
-        overlord = make_overlord(multi_user=True, db_manager=db_manager)
+    async def test_link_normalizes_mixed_case_type(self, sqlite_db_manager):
+        overlord = make_overlord(multi_user=True, db_manager=sqlite_db_manager)
         response = await run_command(
             overlord, "/identity link tg-1 Telegram", user_id="ran@example.com"
         )
@@ -799,9 +802,8 @@ class TestIdentity:
         assert "tg-1 (telegram)" in response.content
         assert "Telegram" not in response.content
 
-    async def test_link_conflict_with_other_user(self):
-        db_manager = await _make_db_manager()
-        overlord = make_overlord(multi_user=True, db_manager=db_manager)
+    async def test_link_conflict_with_other_user(self, sqlite_db_manager):
+        overlord = make_overlord(multi_user=True, db_manager=sqlite_db_manager)
 
         # bob links an identifier to his own account first
         await run_command(overlord, "/identity link shared-handle", user_id="bob@example.com")
@@ -810,17 +812,15 @@ class TestIdentity:
         )
         assert "already linked to a different user" in response.content
 
-    async def test_cannot_unlink_current_identity(self):
-        db_manager = await _make_db_manager()
-        overlord = make_overlord(multi_user=True, db_manager=db_manager)
+    async def test_cannot_unlink_current_identity(self, sqlite_db_manager):
+        overlord = make_overlord(multi_user=True, db_manager=sqlite_db_manager)
         response = await run_command(
             overlord, "/identity unlink ran@example.com", user_id="ran@example.com"
         )
         assert "cannot unlink" in response.content.lower()
 
-    async def test_usage_on_bad_args(self):
-        db_manager = await _make_db_manager()
-        overlord = make_overlord(multi_user=True, db_manager=db_manager)
+    async def test_usage_on_bad_args(self, sqlite_db_manager):
+        overlord = make_overlord(multi_user=True, db_manager=sqlite_db_manager)
         response = await run_command(overlord, "/identity frobnicate", user_id="ran@example.com")
         assert "Usage: /identity" in response.content
 


### PR DESCRIPTION
## Summary

The unit suite leaked aiosqlite `_connection_worker_thread` threads: test fixtures dispose only the sync engine (`manager.engine.dispose()`, ~47 fixtures) and never `DatabaseManager._async_engine`, which is created lazily on first async use. Each pooled aiosqlite connection owns a dedicated worker thread, so those threads outlived their event loop -- producing "Event loop is closed" noise in CI stderr at GC time (visible around `tests/unit/test_tuning_benchmark.py` in recent failed CI logs) and, on thread/pid-constrained runners, risking late-suite subprocess spawn failures (asyncio's ThreadedChildWatcher needs a thread per child).

## Fix

One conftest-level cleanup instead of touching ~40 test files:

- **`tests/unit/conftest.py`**: new autouse async fixture `_dispose_async_db_engines` wraps `DatabaseManager._create_async_engine` to track every async engine created during a test, and disposes them all on teardown -- while the test's event loop is still open, so connections close on the loop that created them. Disposing an engine the test already closed is a no-op (SQLAlchemy replaces the pool on dispose).
- **`tests/unit/test_builtin_commands.py`**: the `_make_db_manager()` helper created raw in-memory `sqlite+aiosqlite://` engines (outside `DatabaseManager`, so the conftest hook can't see them) and never disposed them. Converted it to a `sqlite_db_manager` fixture that disposes the engine on teardown; the five `/identity` tests now take the fixture.

## Verification

Full unit suite (`uv run --extra dev python -m pytest tests/unit -q`) with a session-end thread probe, stderr captured:

| | before (develop) | after |
|---|---|---|
| result | 3972 passed, 10 skipped | 3972 passed, 10 skipped |
| leaked `_connection_worker_thread` at session end | 3 | **0** |
| wall time | 1:53 | 2:04 |

Remaining session-end threads are unrelated daemons (`muxi-buffer-fifo-cleanup`, `muxi-event-writer`). The "Event loop is closed" GC noise did not reproduce locally on macOS (it is timing-dependent), but it comes from exactly these orphaned connections being finalized against a closed loop; CI on this PR is the confirming run.

Black (line length 100), isort, and ruff pass on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
