### PR TITLE
fix(deps): bump pypdf to 6.14.2, hold nltk below 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [unreleased]
 
+### Dependency security updates: pypdf 6.14.2, nltk held below 3.10
+
+- `pypdf` bumped to `>=6.14.2`, clearing four open advisories (two
+  infinite-loop DoS bugs on unterminated inline images, long runtimes on
+  repeated malformed xref entries, and unbounded memory on wrong image
+  dimensions). Defense in depth on top of the new conversion sandbox --
+  a malicious PDF now has to beat both the patched parser and the
+  subprocess resource limits.
+- `nltk` deliberately pinned `>=3.9.4,<3.10`: the 3.10 line's new
+  `inisec` import guard blocks any nltk-initiated import whose resolved
+  path is inside the current working directory, which breaks every
+  in-project `.venv` layout outright (`import nltk` fails from the repo
+  root, and the `-P` remedy it suggests does not help). MUXI's nltk
+  surface is punkt tokenization plus a fixed-URL `nltk.download("punkt")`;
+  the 3.10.0 advisories (corpus reader traversal/ReDoS, ENFORCE-mode
+  download filtering) are not reachable from that surface. Revisit when
+  upstream fixes the cwd check.
+
 ### Sandboxed document conversion + PDF routing to pdf-inspector
 
 Untrusted documents (chat attachments and knowledge source files) are no

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,11 +76,17 @@ dependencies = [
     # though MUXI never imports it.
     "markitdown[docx,pdf,pptx,xls,xlsx]>=0.1.6",  # Convert various file formats to Markdown
     "pdf-inspector>=0.2.6",  # PDF classification + native-text markdown extraction (sandboxed)
-    "pypdf>=6.13.2",  # PDF document processing (successor to PyPDF2); CVE-2026-33123 fixed in 6.9.1
+    "pypdf>=6.14.2",  # PDF document processing (successor to PyPDF2); inline-image loop + xref DoS advisories fixed in 6.14.x
     "python-docx>=1.2.0",  # Word document processing
     "markdownify>=1.2.2",  # HTML to Markdown conversion
     "beautifulsoup4>=4.15.0",  # HTML parsing and validation
-    "nltk>=3.9.4",  # Natural language processing for chunking
+    # nltk held below 3.10: its new inisec guard blocks nltk-initiated imports whose
+    # resolved path sits inside cwd, which breaks any in-project .venv layout outright
+    # (import nltk fails from the repo root, even with -P). The 3.10.0 advisories cover
+    # corpus readers (Framenet/NKJP/Reviews) and pathsec ENFORCE-mode download filtering,
+    # none of which MUXI exercises: our only surface is punkt tokenization plus a
+    # fixed-URL nltk.download("punkt"). Revisit when upstream fixes the cwd check.
+    "nltk>=3.9.4,<3.10",  # Natural language processing for chunking
     "spacy>=3.8.14",  # Advanced NLP for semantic chunking (compatible with NumPy 2.x)
 
     # PII entity redaction (names/addresses/orgs/DOB/financial) for logs,

--- a/uv.lock
+++ b/uv.lock
@@ -4102,7 +4102,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "nanoid", specifier = ">=2.0.0" },
     { name = "networkx", specifier = ">=3.4" },
-    { name = "nltk", specifier = ">=3.9.4" },
+    { name = "nltk", specifier = ">=3.9.4,<3.10" },
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "onellm", extras = ["cache"], specifier = ">=0.20260514.0" },
     { name = "onellm", extras = ["cache", "local-pytorch"], marker = "extra == 'pytorch'", specifier = ">=0.20260514.0" },
@@ -4126,7 +4126,7 @@ requires-dist = [
     { name = "pyasn1", specifier = ">=0.6.3" },
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "pyjwt", specifier = ">=2.13.0" },
-    { name = "pypdf", specifier = ">=6.13.2" },
+    { name = "pypdf", specifier = ">=6.14.2" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
@@ -5983,14 +5983,14 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.13.3"
+version = "6.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/18/9947cc201af9ccf76720fd3347bf4f70eb882ce3fcf4cb05f7443e4cf871/pypdf-6.13.3.tar.gz", hash = "sha256:f3cb822769725f1bac658c406cfc9460399043f3750c2d3e4650e0a85eacabd7", size = 6484063, upload-time = "2026-06-17T15:22:00.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/56/2967e621598987905fb8cdfadd8f8de6b5c68c9351f0523c4df8409f28f1/pypdf-6.13.3-py3-none-any.whl", hash = "sha256:c6e3f86afb625791510b02ad5480e94b63970bb957df75d44657c282ecc52224", size = 347288, upload-time = "2026-06-17T15:21:59.512Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Clears the 4 open **pypdf** dependabot advisories (2 high: infinite loops on unterminated inline images; 2 medium: malformed-xref long runtimes, oversized-image memory) by bumping to `>=6.14.2`. Defense in depth on top of #305's conversion sandbox.

**nltk is deliberately held at `>=3.9.4,<3.10`** rather than bumped to 3.10.x for its 4 advisories:

- nltk 3.10's new `inisec` import guard blocks any nltk-initiated import whose *resolved path* sits inside the current working directory. With the standard in-project `.venv` layout, site-packages is inside the repo root, so `import nltk` itself fails from the project directory — and the `-P`/`PYTHONSAFEPATH` remedy its error message suggests does not help (the check is about file location, not `sys.path`). Verified locally on 3.10.1.
- Our exposure to the 3.10.0 advisories is nil: they cover `FramenetCorpusReader`/`NKJPCorpusReader` path traversal, `ReviewsCorpusReader` ReDoS, and DNS-rebinding bypass of ENFORCE-mode `pathsec` download filtering. MUXI's entire nltk surface is punkt tokenization plus a fixed-URL `nltk.download("punkt")` (`chunk_manager.py`) — no corpus readers, no attacker-controlled download URLs.

Rationale is recorded in `pyproject.toml` and the changelog; revisit when upstream fixes the cwd check.

## Testing
- `uv lock` resolves cleanly (pypdf 6.13.3 → 6.14.2, nltk stays 3.9.4)
- 43 chunking/pdf/document/multimodal unit tests pass on the new pypdf

🤖 Generated with [Claude Code](https://claude.com/claude-code)