### PR TITLE
fix: scope idempotency keys by response mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [unreleased]
 
+### Idempotency keys are scoped by response mode
+
+Reusing an idempotency key across streaming and non-streaming calls could
+hand a stream consumer a JSON body. `POST /v1/chat` with `stream: false`
+caches its envelope; a later call with the same key and `stream: true`
+matched the same cache entry and replayed `application/json` to a client
+waiting on `text/event-stream` -- which typically fails to parse or hangs.
+
+The scope key now includes the effective response mode derived from the
+parsed request body (`stream` present and `false` -> `json`, otherwise
+`stream`), so the two modes occupy separate namespaces and can never
+collide. Streaming responses are still never cached: a stream-mode key
+simply has nothing stored under it, and each streaming call runs fresh.
+Single-flight locks are scoped the same way. Endpoints whose body has no
+`stream` field are unaffected.
+
 ## v1.20260803.0
 
 ### Dependency security updates: pypdf 6.14.2, nltk held below 3.10

--- a/e2e/tests/19_api/test_19y1_idempotency.py
+++ b/e2e/tests/19_api/test_19y1_idempotency.py
@@ -124,6 +124,24 @@ class TestIdempotency(BaseE2ETest):
                 print("✅ No-header passthrough unchanged")
                 checks.append("No-header passthrough")
 
+                print("\n7. Reusing a cached key with stream=true still streams...")
+                async with client.stream(
+                    "POST",
+                    f"{self.base_url}/chat",
+                    json={**payload, "stream": True},
+                    headers=self._headers("e2e-key-1"),
+                ) as r6:
+                    assert r6.status_code == 200
+                    content_type = r6.headers.get("content-type", "")
+                    assert content_type.startswith("text/event-stream"), (
+                        f"stream retry got {content_type!r} -- cached JSON leaked "
+                        "across response modes"
+                    )
+                    async for _ in r6.aiter_bytes():
+                        break
+                print("✅ Stream retry not served from the JSON cache")
+                checks.append("Response-mode key scoping")
+
             formatter.print_test_result(
                 test_name="test_19y1_idempotency",
                 success=True,

--- a/src/muxi/runtime/formation/server/idempotency.py
+++ b/src/muxi/runtime/formation/server/idempotency.py
@@ -3,13 +3,16 @@ In-memory idempotency-key support for Formation API endpoints.
 
 Clients send an ``X-Muxi-Idempotency-Key`` header on mutating requests; retries with
 the same key within the TTL replay the original JSON response instead of
-processing the request again. Keys are scoped per endpoint and user so
-different callers (or different endpoints) can reuse the same key safely.
+processing the request again. Keys are scoped per endpoint, user, and response
+mode so different callers (or different endpoints) can reuse the same key safely.
 
 Semantics:
   - Only successful (2xx) JSON responses are cached; errors are retryable.
   - Streaming (SSE) responses pass through untouched: a token stream cannot
     be replayed from a response cache, and duplicate sync chats are harmless.
+  - Streaming and non-streaming calls never share a cache entry: the scope
+    includes the response mode, so reusing a key with ``stream: true`` after a
+    ``stream: false`` call cannot hand a JSON body to a stream consumer.
   - Concurrent requests with the same key are single-flighted: the second
     caller waits for the first to finish, then receives the cached response.
   - Storage is in-process with a TTL, mirroring the RequestTracker precedent;
@@ -23,6 +26,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from fastapi import Request
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 
 from ...services import observability
 from ...utils.fastjson import json
@@ -32,6 +36,9 @@ from .utils import get_header_case_insensitive
 IDEMPOTENCY_HEADER = "X-Muxi-Idempotency-Key"
 DEFAULT_TTL_SECONDS = 24 * 60 * 60
 MAX_CACHE_ENTRIES = 10_000
+
+# Sentinel: distinguishes "body has no stream field" from "stream is None"
+_NO_STREAM_FIELD = object()
 
 
 class IdempotencyCache:
@@ -44,8 +51,8 @@ class IdempotencyCache:
         self._locks: Dict[str, asyncio.Lock] = {}
 
     @staticmethod
-    def scoped_key(endpoint: str, user_id: str, key: str) -> str:
-        return f"{endpoint}:{user_id}:{key}"
+    def scoped_key(endpoint: str, user_id: str, key: str, mode: str = "json") -> str:
+        return f"{endpoint}:{user_id}:{mode}:{key}"
 
     def lock_for(self, scoped_key: str) -> asyncio.Lock:
         """Get (or create) the single-flight lock for a scoped key."""
@@ -104,6 +111,21 @@ def _find_request(args, kwargs) -> Optional[Request]:
     return None
 
 
+def _response_mode(args, kwargs) -> str:
+    """Derive the response mode a request is asking for from its parsed body.
+
+    Handlers treat ``stream is False`` as the only non-streaming case, so this
+    mirrors that check. Bodies with no ``stream`` field (and handlers with no
+    body model at all) are JSON-only endpoints.
+    """
+    for value in list(args) + list(kwargs.values()):
+        if isinstance(value, BaseModel):
+            stream = getattr(value, "stream", _NO_STREAM_FIELD)
+            if stream is not _NO_STREAM_FIELD:
+                return "json" if stream is False else "stream"
+    return "json"
+
+
 def _echo_key(body: Dict[str, Any], key: str) -> None:
     """Echo the idempotency key into the response envelope, if present."""
     request_info = body.get("request")
@@ -147,8 +169,14 @@ def idempotent(endpoint: str):
             user_id = get_header_case_insensitive(request.headers, "X-Muxi-User-Id") or "0"
             cache = get_idempotency_cache(request.app)
             # Scope by the concrete path so path parameters (e.g. trigger
-            # names) get independent key namespaces
-            scoped = cache.scoped_key(f"{request.method} {request.url.path}", user_id, key)
+            # names) get independent key namespaces, and by the response mode
+            # so a stream=true retry never replays a cached JSON body
+            scoped = cache.scoped_key(
+                f"{request.method} {request.url.path}",
+                user_id,
+                key,
+                _response_mode(args, kwargs),
+            )
 
             async with cache.lock_for(scoped):
                 cached = cache.get(scoped)

--- a/src/muxi/runtime/formation/server/idempotency.py
+++ b/src/muxi/runtime/formation/server/idempotency.py
@@ -52,7 +52,11 @@ class IdempotencyCache:
 
     @staticmethod
     def scoped_key(endpoint: str, user_id: str, key: str, mode: str = "json") -> str:
-        return f"{endpoint}:{user_id}:{mode}:{key}"
+        # JSON-serialize the components rather than colon-joining them: a
+        # delimiter that can also appear inside a component (e.g. a user id or
+        # idempotency key containing ":") would let distinct tuples collide on
+        # the same scope key, enabling cross-user/cross-mode replay.
+        return json.dumps([endpoint, user_id, mode, key])
 
     def lock_for(self, scoped_key: str) -> asyncio.Lock:
         """Get (or create) the single-flight lock for a scoped key."""

--- a/tests/unit/test_idempotency.py
+++ b/tests/unit/test_idempotency.py
@@ -63,6 +63,29 @@ def test_scoped_key_separates_response_mode():
     ) != IdempotencyCache.scoped_key("POST /chat", "u1", "abc", "stream")
 
 
+def test_scoped_key_is_unambiguous_for_colon_containing_components():
+    # Colon-joining would make these distinct tuples collide:
+    #   ("alice", "stream", "json:k") vs ("alice:stream", "json", "k")
+    ambiguous_pairs = [
+        (("POST /chat", "alice", "json:k", "stream"), ("POST /chat", "alice:stream", "k", "json")),
+        (("POST /chat", "alice", "k", "json"), ("POST /chat:alice", "k", "json", "json")),
+        (("POST /chat", "u1", "k:json", "json"), ("POST /chat", "u1:k", "json", "json")),
+    ]
+    for (e1, u1, k1, m1), (e2, u2, k2, m2) in ambiguous_pairs:
+        key_a = IdempotencyCache.scoped_key(e1, u1, k1, m1)
+        key_b = IdempotencyCache.scoped_key(e2, u2, k2, m2)
+        assert key_a != key_b
+
+        # Distinct scope keys must not share cache entries...
+        cache = IdempotencyCache()
+        cache.store(key_a, {"owner": "a"}, 200)
+        assert cache.get(key_b) is None
+        assert cache.get(key_a) == ({"owner": "a"}, 200)
+
+        # ...nor single-flight locks
+        assert cache.lock_for(key_a) is not cache.lock_for(key_b)
+
+
 def test_prune_evicts_expired_entries_when_full():
     cache = IdempotencyCache()
     from muxi.runtime.formation.server import idempotency as idem_module

--- a/tests/unit/test_idempotency.py
+++ b/tests/unit/test_idempotency.py
@@ -3,9 +3,9 @@
 Covers:
   - IdempotencyCache: TTL expiry, scoping, prune behavior
   - The @idempotent decorator through a real FastAPI app: replay of cached
-    responses, envelope echo of the key, per-user and per-path scoping,
-    error responses staying retryable, streaming passthrough, and
-    single-flight coalescing of concurrent duplicates
+    responses, envelope echo of the key, per-user, per-path and per-response-
+    mode scoping, error responses staying retryable, streaming passthrough,
+    and single-flight coalescing of concurrent duplicates
 """
 
 import asyncio
@@ -15,6 +15,7 @@ import pytest
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.testclient import TestClient
+from pydantic import BaseModel
 
 from muxi.runtime.datatypes.api import APIEventType, APIObjectType
 from muxi.runtime.formation.server.idempotency import (
@@ -56,6 +57,12 @@ def test_scoped_key_separates_endpoint_and_user():
     )
 
 
+def test_scoped_key_separates_response_mode():
+    assert IdempotencyCache.scoped_key(
+        "POST /chat", "u1", "abc", "json"
+    ) != IdempotencyCache.scoped_key("POST /chat", "u1", "abc", "stream")
+
+
 def test_prune_evicts_expired_entries_when_full():
     cache = IdempotencyCache()
     from muxi.runtime.formation.server import idempotency as idem_module
@@ -70,6 +77,13 @@ def test_prune_evicts_expired_entries_when_full():
 # ---------------------------------------------------------------------------
 # @idempotent decorator through a real FastAPI app
 # ---------------------------------------------------------------------------
+
+
+class _ChatBody(BaseModel):
+    """Minimal stand-in for ChatRequest: streaming is the default."""
+
+    message: str
+    stream: bool = True
 
 
 @pytest.fixture
@@ -101,6 +115,25 @@ def app_and_calls():
 
         async def gen():
             yield "data: x\n\n"
+
+        return StreamingResponse(gen(), media_type="text/event-stream")
+
+    # Mirrors the real /v1/chat contract: one endpoint, two response shapes
+    # selected by the body's `stream` flag
+    @app.post("/v1/chat")
+    @idempotent("chat")
+    async def chat(request: Request, chat_request: _ChatBody):
+        calls["count"] += 1
+        if chat_request.stream is False:
+            envelope = create_success_response(
+                APIObjectType.REQUEST,
+                APIEventType.REQUEST_COMPLETED,
+                {"reply": f"reply-{calls['count']}"},
+            )
+            return JSONResponse(content=envelope.model_dump(), status_code=200)
+
+        async def gen():
+            yield "data: token\n\n"
 
         return StreamingResponse(gen(), media_type="text/event-stream")
 
@@ -175,6 +208,48 @@ def test_streaming_responses_pass_through_uncached(app_and_calls):
     second = client.post("/v1/stream", headers={"X-Muxi-Idempotency-Key": "k1"})
     assert first.headers["content-type"].startswith("text/event-stream")
     assert second.headers["content-type"].startswith("text/event-stream")
+    assert calls["count"] == 2
+
+
+def test_stream_retry_does_not_replay_cached_json(app_and_calls):
+    """A stream:true retry of a cached stream:false key must not get JSON."""
+    app, calls = app_and_calls
+    client = TestClient(app)
+    headers = {"X-Muxi-Idempotency-Key": "k1"}
+
+    first = client.post("/v1/chat", json={"message": "hi", "stream": False}, headers=headers)
+    second = client.post("/v1/chat", json={"message": "hi", "stream": True}, headers=headers)
+
+    assert first.headers["content-type"].startswith("application/json")
+    assert second.headers["content-type"].startswith("text/event-stream")
+    assert second.text == "data: token\n\n"
+    assert calls["count"] == 2
+
+
+def test_json_retry_still_replays_within_same_mode(app_and_calls):
+    app, calls = app_and_calls
+    client = TestClient(app)
+    headers = {"X-Muxi-Idempotency-Key": "k1"}
+    body = {"message": "hi", "stream": False}
+
+    first = client.post("/v1/chat", json=body, headers=headers)
+    second = client.post("/v1/chat", json=body, headers=headers)
+
+    assert calls["count"] == 1
+    assert second.json() == first.json()
+
+
+def test_json_retry_after_stream_is_not_served_from_stream_scope(app_and_calls):
+    """The reverse order: streaming is never cached, so the JSON call runs."""
+    app, calls = app_and_calls
+    client = TestClient(app)
+    headers = {"X-Muxi-Idempotency-Key": "k1"}
+
+    client.post("/v1/chat", json={"message": "hi", "stream": True}, headers=headers)
+    second = client.post("/v1/chat", json={"message": "hi", "stream": False}, headers=headers)
+
+    assert second.headers["content-type"].startswith("application/json")
+    assert second.json()["data"]["reply"] == "reply-2"
     assert calls["count"] == 2
 
 


### PR DESCRIPTION
## Problem

The idempotency scope key was built from method + path, the `X-Muxi-User-Id` header, and the key itself — it did not incorporate the request's `stream` flag.

`POST /v1/chat` with `stream: false` returns a JSON envelope, which **is** cached (`_extract_cacheable_body`). A client that later reuses the same idempotency key with `stream: true` matched that same cache entry and received the cached JSON body with `Content-Type: application/json`, while its SSE consumer was waiting on `text/event-stream`. In practice that fails to parse or hangs.

## Fix

`IdempotencyCache.scoped_key` takes a `mode` discriminator, and the `@idempotent` wrapper derives it from the parsed request body:

- a body model whose `stream` is `False` → `"json"`
- any other value of `stream` → `"stream"` (mirrors the handlers' own `chat_request.stream is False` check, so `stream: null` and the `True` default both stay streaming)
- a body with no `stream` field, or a handler with no body model → `"json"`

The lookup is restricted to `pydantic.BaseModel` instances, deliberately: Starlette's `Request` has a `.stream()` *method*, so a naive `getattr(value, "stream", None)` over all arguments would classify every request as streaming.

Single-flight locks are keyed off the same scoped key, so they are now per-mode too.

Existing behavior is preserved:
- Streaming responses are still never cached. A stream-mode key simply never has an entry stored under it, so each streaming call runs fresh.
- Endpoints whose body model has no `stream` field (triggers, scheduler jobs) keep a single namespace.
- The cache is in-process and non-persistent, so the key-format change needs no migration.

## Tests

`tests/unit/test_idempotency.py` gains a `/v1/chat` fixture route mirroring the real contract (one endpoint, two response shapes selected by the body's `stream` flag) and:

- `test_stream_retry_does_not_replay_cached_json` — the regression: `stream: false` then `stream: true` on the same key returns `text/event-stream` with real stream bytes, and the handler ran twice
- `test_json_retry_after_stream_is_not_served_from_stream_scope` — the reverse order
- `test_json_retry_still_replays_within_same_mode` — same-mode replay is unchanged
- `test_scoped_key_separates_response_mode`

Both new decorator tests fail against the unfixed code (verified) and pass with the fix.

`e2e/tests/19_api/test_19y1_idempotency.py` gains step 7, reusing the already-cached `e2e-key-1` with `stream: true` and asserting the response is `text/event-stream`.

## Verification

```
tests/unit/test_idempotency.py                     19 passed
tests/unit -k "idempot or chat or trigger or scheduler"  271 passed
black --check / isort --check / ruff / flake8       clean
```

The e2e step was not executed here (needs a live formation and provider keys); it runs in the e2e job.