### PR TITLE
fix: return 2xx when request cancellation actually takes effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## [unreleased]
 
+### Request cancellation reports success for ordinary chat turns
+
+`DELETE /v1/requests/{request_id}` returned 400 `OPERATION_FAILED` for a
+normal chat turn even though the cancellation had taken effect. The route
+set the cooperative cancellation flag (which processing checkpoints honour,
+aborting the turn at the next safe point) but then keyed its status code off
+`Overlord.cancel_request`, which can only cancel an asyncio task when the
+request carries a `task_ref` -- and only background workflow executions do.
+Clients that check the status code concluded cancellation was unsupported.
+
+- 2xx whenever the request was found and the cancellation flag was set.
+- The response body now carries a `cancellation` field so callers can tell
+  how strong the guarantee is: `immediate` when the underlying task was
+  cancelled outright (background workflows), `cooperative` when the turn
+  will stop at its next checkpoint (ordinary chat turns).
+- 404 for unknown request ids is unchanged. A request that already
+  `completed` or `failed` still returns 400 `OPERATION_FAILED`, now with a
+  message naming the status -- that is the one case where neither
+  cancellation mechanism can apply. Re-cancelling an already-cancelled
+  request stays a successful no-op, as documented.
+
 ## v1.20260803.0
 
 ### Dependency security updates: pypdf 6.14.2, nltk held below 3.10

--- a/src/muxi/runtime/formation/background/request_tracker.py
+++ b/src/muxi/runtime/formation/background/request_tracker.py
@@ -74,6 +74,11 @@ _TERMINAL_STATUSES = frozenset(
     {RequestStatus.COMPLETED, RequestStatus.FAILED, RequestStatus.CANCELLED}
 )
 
+# A request in one of these states has already run to its end: neither the
+# cooperative cancellation flag nor asyncio task cancellation can affect it.
+# CANCELLED is deliberately absent -- re-cancelling is a no-op, not a failure.
+UNCANCELLABLE_STATUSES = frozenset({RequestStatus.COMPLETED, RequestStatus.FAILED})
+
 DEFAULT_COMPLETED_TTL_SECONDS = 300  # 5 minutes
 DEFAULT_STALE_REQUEST_TIMEOUT = 600  # 10 minutes -- matches StreamingManager.SUBSCRIBE_TIMEOUT
 
@@ -159,7 +164,7 @@ class RequestTracker:
         async with self._lock:
             return self._requests.get(request_id)
 
-    async def mark_cancelled(self, request_id: str) -> None:
+    async def mark_cancelled(self, request_id: str) -> bool:
         """
         Mark request as cancelled for cooperative cancellation.
 
@@ -167,11 +172,27 @@ class RequestTracker:
         will check. When a checkpoint detects cancellation, it will
         raise RequestCancelledException.
 
+        The status check and the mark happen atomically under the tracker
+        lock: if the tracked request has already finished (COMPLETED or
+        FAILED), the flag is NOT set and False is returned, so a cancel
+        racing a completion cannot leave a stale cancellation flag behind
+        a finished request. Marking an already-CANCELLED request stays a
+        harmless no-op success, and untracked ids are still markable
+        (callers gate existence separately).
+
         Args:
             request_id: Unique identifier for the request to cancel
+
+        Returns:
+            True if the cooperative flag was set, False if the request
+            had already reached COMPLETED/FAILED.
         """
         async with self._lock:
+            state = self._requests.get(request_id)
+            if state is not None and state.status in UNCANCELLABLE_STATUSES:
+                return False
             self._cancelled.add(request_id)
+            return True
 
     def is_cancelled(self, request_id: str) -> bool:
         """

--- a/src/muxi/runtime/formation/server/routes/client/requests.py
+++ b/src/muxi/runtime/formation/server/routes/client/requests.py
@@ -23,6 +23,11 @@ from ...responses import (
 
 router = APIRouter(tags=["Requests"])
 
+# A request in one of these states has already run to its end: neither the
+# cooperative cancellation flag nor asyncio task cancellation can affect it.
+# CANCELLED is deliberately absent -- re-cancelling is a no-op, not a failure.
+_UNCANCELLABLE_STATUSES = frozenset({RequestStatus.COMPLETED, RequestStatus.FAILED})
+
 
 def _check_auth_and_user_id(
     request: Request,
@@ -285,22 +290,39 @@ async def cancel_request(
         )
         return JSONResponse(content=response.model_dump(), status_code=403)
 
+    # Nothing to cancel once the request has finished -- report that honestly
+    if request_state.status in _UNCANCELLABLE_STATUSES:
+        response = create_error_response(
+            "OPERATION_FAILED",
+            f"Cannot cancel request {request_id}: already {request_state.status.value}",
+            None,
+            api_request_id,
+        )
+        return JSONResponse(content=response.model_dump(), status_code=400)
+
     # Mark for cooperative cancellation (checkpoints will check this)
     await overlord.request_tracker.mark_cancelled(request_id)
 
-    # Also try asyncio task cancellation
+    # Also try asyncio task cancellation. Only background workflow executions
+    # carry a task_ref, so this succeeds for those alone -- a normal chat turn
+    # relies entirely on the cooperative flag set above and stops at its next
+    # checkpoint. Either way the cancellation has taken effect.
     result = await overlord.cancel_request(request_id)
+    immediate = bool(result.get("success"))
 
-    if result["success"]:
-        response = create_success_response(
-            APIObjectType.REQUEST_STATUS,
-            APIEventType.REQUEST_CANCELLED,
-            {"request_id": request_id, "status": "cancelled", "message": "Request cancelled"},
-            api_request_id,
-        )
-        return JSONResponse(content=response.model_dump(), status_code=200)
-    else:
-        response = create_error_response(
-            "OPERATION_FAILED", result["message"], None, api_request_id
-        )
-        return JSONResponse(content=response.model_dump(), status_code=400)
+    response = create_success_response(
+        APIObjectType.REQUEST_STATUS,
+        APIEventType.REQUEST_CANCELLED,
+        {
+            "request_id": request_id,
+            "status": "cancelled",
+            "cancellation": "immediate" if immediate else "cooperative",
+            "message": (
+                "Request cancelled"
+                if immediate
+                else "Request marked for cancellation; it will stop at the next checkpoint"
+            ),
+        },
+        api_request_id,
+    )
+    return JSONResponse(content=response.model_dump(), status_code=200)

--- a/src/muxi/runtime/formation/server/routes/client/requests.py
+++ b/src/muxi/runtime/formation/server/routes/client/requests.py
@@ -23,11 +23,6 @@ from ...responses import (
 
 router = APIRouter(tags=["Requests"])
 
-# A request in one of these states has already run to its end: neither the
-# cooperative cancellation flag nor asyncio task cancellation can affect it.
-# CANCELLED is deliberately absent -- re-cancelling is a no-op, not a failure.
-_UNCANCELLABLE_STATUSES = frozenset({RequestStatus.COMPLETED, RequestStatus.FAILED})
-
 
 def _check_auth_and_user_id(
     request: Request,
@@ -290,18 +285,21 @@ async def cancel_request(
         )
         return JSONResponse(content=response.model_dump(), status_code=403)
 
-    # Nothing to cancel once the request has finished -- report that honestly
-    if request_state.status in _UNCANCELLABLE_STATUSES:
+    # Mark for cooperative cancellation (checkpoints will check this). The
+    # status check and the mark are atomic inside the tracker: if the request
+    # reaches COMPLETED/FAILED before the mark lands, no flag is set and we
+    # report the terminal state honestly instead of promising a cancellation.
+    marked = await overlord.request_tracker.mark_cancelled(request_id)
+    if not marked:
+        current = await overlord.request_tracker.get_request(request_id)
+        final_status = (current or request_state).status.value
         response = create_error_response(
             "OPERATION_FAILED",
-            f"Cannot cancel request {request_id}: already {request_state.status.value}",
+            f"Cannot cancel request {request_id}: already {final_status}",
             None,
             api_request_id,
         )
         return JSONResponse(content=response.model_dump(), status_code=400)
-
-    # Mark for cooperative cancellation (checkpoints will check this)
-    await overlord.request_tracker.mark_cancelled(request_id)
 
     # Also try asyncio task cancellation. Only background workflow executions
     # carry a task_ref, so this succeeds for those alone -- a normal chat turn

--- a/tests/unit/test_request_cancel_route.py
+++ b/tests/unit/test_request_cancel_route.py
@@ -180,6 +180,42 @@ async def test_cancel_finished_request_still_fails(status: RequestStatus) -> Non
     assert not overlord.request_tracker.is_cancelled("req-done")
 
 
+@pytest.mark.parametrize("status", [RequestStatus.COMPLETED, RequestStatus.FAILED])
+async def test_cancel_racing_completion_reports_terminal_state(status: RequestStatus) -> None:
+    """Request reaches a terminal state between the route's existence check and
+    the cancellation mark: the mark must refuse atomically, the route must not
+    promise a cancellation, and no stale cancellation flag may remain."""
+    overlord = make_overlord()
+    await track(overlord, "req-race")
+
+    tracker = overlord.request_tracker
+    original_get = tracker.get_request
+    calls = {"count": 0}
+
+    async def get_then_finish(request_id: str) -> Optional[RequestState]:
+        state = await original_get(request_id)
+        calls["count"] += 1
+        if calls["count"] == 1:
+            # Simulate the request finishing right after the route's check,
+            # before mark_cancelled runs
+            await tracker.update_request(request_id, status, result="done")
+        return state
+
+    tracker.get_request = get_then_finish
+
+    async with client_for(make_app(overlord)) as client:
+        response = await client.delete("/requests/req-race")
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["success"] is False
+    assert body["error"]["code"] == "OPERATION_FAILED"
+    assert status.value in body["error"]["message"]
+
+    # The race must not leave a stale cancellation flag behind
+    assert not tracker.is_cancelled("req-race")
+
+
 async def test_cancelling_twice_is_idempotent() -> None:
     """Documented behaviour: re-cancelling is safe, not an error."""
     overlord = make_overlord()

--- a/tests/unit/test_request_cancel_route.py
+++ b/tests/unit/test_request_cancel_route.py
@@ -1,0 +1,194 @@
+"""DELETE /requests/{request_id} reports cancellation honestly.
+
+Cancellation has two mechanisms. ``RequestTracker.mark_cancelled`` sets a
+cooperative flag that processing checkpoints honour (they raise
+``RequestCancelledException`` at the next safe point), and
+``Overlord.cancel_request`` cancels the asyncio task directly. Only
+background workflow executions carry a ``task_ref``, so hard task
+cancellation is unavailable for an ordinary chat turn.
+
+The route used to key its status code off the hard-cancellation result
+alone, so cancelling a normal chat turn returned 400 OPERATION_FAILED even
+though the turn did abort at its next checkpoint. These tests pin the
+corrected contract: 2xx whenever the cancellation flag was set, with a
+``cancellation`` field distinguishing ``cooperative`` from ``immediate``,
+404 for unknown ids, and a genuine failure only when the request already
+finished.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import MethodType, SimpleNamespace
+from typing import Any, Optional
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from muxi.runtime.formation.background.request_tracker import (
+    RequestState,
+    RequestStatus,
+    RequestTracker,
+)
+from muxi.runtime.formation.overlord.overlord import Overlord
+from muxi.runtime.formation.server.routes.client.requests import router
+
+CLIENT_KEY = "client-key-for-tests"
+USER = "user123"
+
+
+class StubBufferMemory:
+    """Only ``kv_set`` is reached, and only on the hard-cancellation path."""
+
+    def __init__(self) -> None:
+        self.writes: list[tuple[str, Any]] = []
+
+    async def kv_set(self, key: str, value: Any, ttl: int, namespace: str) -> None:
+        self.writes.append((key, value))
+
+
+def make_overlord() -> SimpleNamespace:
+    """An overlord stub carrying the real ``cancel_request`` implementation.
+
+    Binding the real method (rather than faking its return value) is the
+    point of these tests: the no-``task_ref`` branch returning
+    ``success: False`` is exactly the behaviour the route has to stop
+    treating as an error.
+    """
+    overlord = SimpleNamespace(
+        request_tracker=RequestTracker(),
+        buffer_memory=StubBufferMemory(),
+        is_multi_user=False,
+    )
+    overlord.cancel_request = MethodType(Overlord.cancel_request, overlord)
+    return overlord
+
+
+def make_app(overlord: Optional[SimpleNamespace]) -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    app.state.formation = SimpleNamespace(
+        _overlord=overlord,
+        _api_keys={"client": CLIENT_KEY, "admin": "admin-key-for-tests"},
+    )
+    return app
+
+
+def client_for(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"X-Muxi-Client-Key": CLIENT_KEY, "X-Muxi-User-ID": USER},
+    )
+
+
+async def track(
+    overlord: SimpleNamespace,
+    request_id: str,
+    status: RequestStatus = RequestStatus.PROCESSING,
+    task_ref: Optional[asyncio.Task] = None,
+) -> RequestState:
+    """Track a request owned by the single-user id the route normalizes to."""
+    state = RequestState(
+        id=request_id,
+        status=status,
+        start_time=time.time(),
+        user_id="0",  # single-user mode: the route normalizes X-Muxi-User-ID to "0"
+        task_ref=task_ref,
+    )
+    await overlord.request_tracker.track_request(request_id, state)
+    return state
+
+
+async def test_cancel_in_flight_chat_turn_reports_cooperative_cancellation() -> None:
+    """A normal chat turn has no task_ref: 200 + cooperative, flag actually set."""
+    overlord = make_overlord()
+    await track(overlord, "req-chat")
+
+    async with client_for(make_app(overlord)) as client:
+        response = await client.delete("/requests/req-chat")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is True
+    assert body["data"]["request_id"] == "req-chat"
+    assert body["data"]["status"] == "cancelled"
+    assert body["data"]["cancellation"] == "cooperative"
+
+    # The guarantee the 2xx is claiming: checkpoints will see the flag.
+    assert overlord.request_tracker.is_cancelled("req-chat")
+
+
+async def test_cancel_unknown_request_returns_404() -> None:
+    overlord = make_overlord()
+
+    async with client_for(make_app(overlord)) as client:
+        response = await client.delete("/requests/req-missing")
+
+    assert response.status_code == 404
+    body = response.json()
+    assert body["success"] is False
+    assert body["error"]["code"] == "NOT_FOUND"
+    assert not overlord.request_tracker.is_cancelled("req-missing")
+
+
+async def test_cancel_background_workflow_reports_immediate_cancellation() -> None:
+    """A tracked task_ref still gets hard-cancelled, and says so."""
+    overlord = make_overlord()
+
+    started = asyncio.Event()
+
+    async def never_finishes() -> None:
+        started.set()
+        await asyncio.sleep(3600)
+
+    task = asyncio.create_task(never_finishes())
+    await started.wait()
+    await track(overlord, "req-workflow", status=RequestStatus.RUNNING, task_ref=task)
+
+    async with client_for(make_app(overlord)) as client:
+        response = await client.delete("/requests/req-workflow")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["cancellation"] == "immediate"
+    assert overlord.request_tracker.is_cancelled("req-workflow")
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert task.cancelled()
+
+
+@pytest.mark.parametrize("status", [RequestStatus.COMPLETED, RequestStatus.FAILED])
+async def test_cancel_finished_request_still_fails(status: RequestStatus) -> None:
+    """Neither mechanism applies once the request is done -- keep the error."""
+    overlord = make_overlord()
+    await track(overlord, "req-done", status=status)
+
+    async with client_for(make_app(overlord)) as client:
+        response = await client.delete("/requests/req-done")
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["success"] is False
+    assert body["error"]["code"] == "OPERATION_FAILED"
+    assert status.value in body["error"]["message"]
+
+    # A finished request must not be left carrying a cancellation flag.
+    assert not overlord.request_tracker.is_cancelled("req-done")
+
+
+async def test_cancelling_twice_is_idempotent() -> None:
+    """Documented behaviour: re-cancelling is safe, not an error."""
+    overlord = make_overlord()
+    await track(overlord, "req-twice")
+
+    async with client_for(make_app(overlord)) as client:
+        first = await client.delete("/requests/req-twice")
+        second = await client.delete("/requests/req-twice")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert second.json()["data"]["cancellation"] == "cooperative"

--- a/tests/unit/test_request_tracker.py
+++ b/tests/unit/test_request_tracker.py
@@ -128,6 +128,36 @@ async def test_cancelled_requests_retained_then_cleaned(tracker, make_state):
 
 
 @pytest.mark.asyncio
+async def test_mark_cancelled_sets_flag_for_active_request(tracker, make_state):
+    """A PROCESSING request accepts the cooperative flag."""
+    await tracker.track_request("req_active", make_state("req_active"))
+
+    assert await tracker.mark_cancelled("req_active") is True
+    assert tracker.is_cancelled("req_active")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [RequestStatus.COMPLETED, RequestStatus.FAILED])
+async def test_mark_cancelled_refuses_finished_request(tracker, make_state, status):
+    """A COMPLETED/FAILED request refuses the flag: no stale cancellation."""
+    await tracker.track_request("req_done", make_state("req_done"))
+    await tracker.update_request("req_done", status)
+
+    assert await tracker.mark_cancelled("req_done") is False
+    assert not tracker.is_cancelled("req_done")
+
+
+@pytest.mark.asyncio
+async def test_mark_cancelled_allows_already_cancelled_request(tracker, make_state):
+    """Re-marking an already-CANCELLED request stays a harmless no-op success."""
+    await tracker.track_request("req_recancel", make_state("req_recancel"))
+    await tracker.update_request("req_recancel", RequestStatus.CANCELLED)
+
+    assert await tracker.mark_cancelled("req_recancel") is True
+    assert tracker.is_cancelled("req_recancel")
+
+
+@pytest.mark.asyncio
 async def test_default_ttl():
     """Default TTL is 300 seconds."""
     tracker = RequestTracker()


### PR DESCRIPTION
## Problem

`DELETE /v1/requests/{request_id}` returns **400 OPERATION_FAILED** for an ordinary chat turn even when the cancellation actually took effect.

The route does two things:

1. `overlord.request_tracker.mark_cancelled(request_id)` — sets the cooperative cancellation flag. This works: checkpoints throughout the overlord check it and raise `RequestCancelledException` (`overlord.py:3242`, `7746`, `8744`, `8974`, `9479`, `10803`).
2. `overlord.cancel_request(request_id)` — hard asyncio task cancellation, which requires `request_state.task_ref` (`overlord.py:10738`). `task_ref` is only assigned for background workflow execution (`overlord.py:10510-10513`), so for a normal chat turn it is `None`, `cancel_request` returns `{"success": False, ...}`, and the route returned 400.

Net effect: the turn *does* abort at its next checkpoint, but the caller is told the operation failed. Any client keying off the status code concludes cancellation is unsupported.

## Fix

Treat a successful cooperative mark as success, and say which guarantee the caller got:

| Situation | Before | After |
|-----------|--------|-------|
| In-flight normal chat turn | 400 `OPERATION_FAILED` | **200**, `data.cancellation: "cooperative"` |
| In-flight background workflow (has `task_ref`) | 200 | 200, `data.cancellation: "immediate"` |
| Already cancelled (re-cancel) | 400 | **200**, `cooperative` (idempotent, as documented) |
| Unknown request id | 404 `NOT_FOUND` | 404 `NOT_FOUND` (unchanged) |
| Already `completed` / `failed` | 400 `OPERATION_FAILED` | 400 `OPERATION_FAILED`, message now names the status |

The genuine-failure path is preserved for the one case where neither mechanism can apply — a request that already finished. That check now happens *before* `mark_cancelled`, so a finished request is no longer left carrying a stale cancellation flag.

Success body:

```json
{
  "object": "request_status",
  "type": "request.cancelled",
  "success": true,
  "data": {
    "request_id": "req_123",
    "status": "cancelled",
    "cancellation": "cooperative",
    "message": "Request marked for cancellation; it will stop at the next checkpoint"
  }
}
```

## Docs discrepancy

`muxi/docs/runtime/request-cancellation.md:346-352` documented the cancelled response as `{"content": "", "status": "cancelled", "request_id": "..."}`, which the endpoint has never produced — it returns the standard API envelope. The docs were wrong, and are fixed in a companion PR against `muxi-ai/muxi`: muxi-ai/muxi#76 (real response body, the new `cancellation` field, and the status-code table).

## Tests

New `tests/unit/test_request_cancel_route.py` (6 cases), driving the real router over ASGI with `Overlord.cancel_request` bound to a stub overlord — so the no-`task_ref` branch under test is the real implementation, not a mock's return value:

- in-flight chat turn → 200 + `cooperative`, and `request_tracker.is_cancelled()` is actually true
- unknown id → 404, no flag set
- background workflow with a live task → 200 + `immediate`, and the asyncio task is really cancelled
- already `completed` / `failed` (parametrized) → 400, no flag left behind
- cancelling twice → 200 both times

```
PYTHONPATH=$PWD/src pytest tests/unit/test_request_cancel_route.py -q
6 passed in 1.92s
```

The suite fails against `develop` (`assert 400 == 200`), so it pins the regression.

Full unit suite: `4009 passed, 10 skipped in 163.48s` (exit 0).

Lint: `black --line-length 100`, `isort --profile black`, `ruff check`, `flake8` all clean on the touched files.

## Not fixed here

`create_error_response("NOT_FOUND", ...)` maps to `type: "error.internal"` rather than `error.not_found` — the event-type mapping in `server/responses.py:127-138` only lists `AGENT_NOT_FOUND` / `RESOURCE_NOT_FOUND` / `METHOD_NOT_FOUND`. Cosmetic, affects the observability event type only, and out of scope for this fix.
