### PR TITLE
fix: mark completed chat turns COMPLETED in the request tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## [unreleased]
 
+### Chat turns now reach a terminal request status
+
+Ordinary sync and streaming chat turns registered themselves in the
+request tracker as PROCESSING and never transitioned out of it. Only the
+overlord fast path and the async background path ever wrote COMPLETED
+back, so a turn that had already answered stayed "processing" until the
+stale request reaper rewrote it to FAILED 600s later -- recording
+successful turns as failures and leaving
+`GET /v1/requests/{request_id}` unable to return the result it holds.
+
+- New `RequestTracker.mark_completed_if_active()`: a compare-and-set that
+  moves a request from PENDING/PROCESSING/RUNNING to COMPLETED, stores
+  the result, and stamps `end_time` so the completed-entry TTL still
+  purges it. A request that already reached a terminal state keeps the
+  status it has, so a turn completing cannot clobber a cancellation.
+- Sync and streaming chat turns both mark themselves COMPLETED with their
+  response content once processing finishes, mirroring the fast path.
+  `GET /v1/requests/{request_id}` now reports "completed" and returns the
+  result for a finished turn.
+- The streaming generator waits for the producer task to unwind after the
+  stream's terminal event instead of cancelling it. The subscription ends
+  a beat before the producer returns, so a successful stream could
+  previously race into CANCELLED. Client disconnect (no terminal event)
+  still cancels and marks the request CANCELLED as before.
+- Async hand-offs (background execution, approved workflows) are left in
+  PROCESSING for the background task to finish, and cooperatively
+  cancelled turns are recorded CANCELLED rather than COMPLETED.
+- Covered by unit tests for both paths (including that the reaper leaves a
+  finished turn alone) and a new e2e test, `9_async/test_9b2_sync_turn_completion`.
+
 ## v1.20260803.0
 
 ### Dependency security updates: pypdf 6.14.2, nltk held below 3.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ successful turns as failures and leaving
 - Async hand-offs (background execution, approved workflows) are left in
   PROCESSING for the background task to finish, and cooperatively
   cancelled turns are recorded CANCELLED rather than COMPLETED.
+- Interactive turns -- clarification questions, workflow-approval prompts,
+  credential requests -- are left alone as well. They end awaiting a
+  further user response and reuse the same request_id on the follow-up
+  turn, so their question is not a final result.
 - Covered by unit tests for both paths (including that the reaper leaves a
   finished turn alone) and a new e2e test, `9_async/test_9b2_sync_turn_completion`.
 

--- a/e2e/tests/9_async/test_9b2_sync_turn_completion.py
+++ b/e2e/tests/9_async/test_9b2_sync_turn_completion.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Test 9B2: Sync/Streaming Turn Request Completion
+
+Ordinary chat turns register in the RequestTracker as PROCESSING. Only the
+overlord fast path and the async background path ever wrote COMPLETED back,
+so a turn that had already answered stayed "processing" until the stale
+request reaper rewrote it to FAILED 600s later.
+
+This test drives a real sync turn and a real streaming turn against a live
+formation and asserts both end up COMPLETED in the tracker with their
+response stored as the result -- the state GET /v1/requests/{id} reads.
+"""
+
+import sys
+from pathlib import Path
+
+from base_async_test import BaseAsyncTest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from muxi.runtime.formation.background.request_tracker import RequestStatus  # noqa: E402
+
+
+def main():
+    """Test terminal request status for sync and streaming turns."""
+    test = BaseAsyncTest(
+        "9b2_sync_turn_completion",
+        "Test sync and streaming turns reach COMPLETED in the request tracker",
+    )
+
+    async def check_terminal_status(request_id: str, label: str) -> bool:
+        """Assert the tracker holds a COMPLETED entry with a stored result."""
+        state = await test.overlord.request_tracker.get_request(request_id)
+
+        if state is None:
+            test.formatter.print_failure(f"{label}: request {request_id} not tracked")
+            return False
+
+        if state.status != RequestStatus.COMPLETED:
+            test.formatter.print_failure(f"{label}: expected COMPLETED, got {state.status.value}")
+            return False
+
+        if not state.result:
+            test.formatter.print_failure(f"{label}: COMPLETED but no result stored")
+            return False
+
+        if state.end_time is None:
+            test.formatter.print_failure(f"{label}: COMPLETED but end_time not stamped")
+            return False
+
+        test.formatter.print_success(f"{label}: COMPLETED with result stored")
+        return True
+
+    async def run_completion_test():
+        formation_path = Path(__file__).parent / "formations" / "formation-async"
+        await test.setup_formation(formation_path=str(formation_path))
+
+        message = "What is 2 + 2? Answer with just the number."
+
+        # --- Sync turn -------------------------------------------------
+        sync_request_id = "req_e2e_9b2_sync"
+        sync_response = await test.overlord.chat(
+            message,
+            user_id="test_user",
+            session_id="async_test_9b2_sync",
+            request_id=sync_request_id,
+            use_async=False,
+            stream=False,
+        )
+        sync_content = getattr(sync_response, "content", str(sync_response))
+        test.formatter.print_debug(f"Sync response: {sync_content}")
+
+        sync_ok = await check_terminal_status(sync_request_id, "Sync turn")
+        test.transcript.append((message, str(sync_content)))
+
+        # --- Streaming turn --------------------------------------------
+        stream_request_id = "req_e2e_9b2_stream"
+        stream_generator = await test.overlord.chat(
+            message,
+            user_id="test_user",
+            session_id="async_test_9b2_stream",
+            request_id=stream_request_id,
+            use_async=False,
+            stream=True,
+        )
+
+        events = []
+        async for event in stream_generator:
+            events.append(event)
+
+        event_types = [event.get("type") for event in events if isinstance(event, dict)]
+        test.formatter.print_debug(f"Stream events: {event_types}")
+
+        if "completed" not in event_types:
+            test.formatter.print_failure("Streaming turn never emitted a terminal event")
+            stream_ok = False
+        else:
+            stream_ok = await check_terminal_status(stream_request_id, "Streaming turn")
+
+        success = sync_ok and stream_ok
+        test.results.append(success)
+
+        test.print_async_summary()
+        await test.cleanup_formation()
+
+        return 0 if success else 1
+
+    import asyncio
+    import os
+
+    result = asyncio.run(run_completion_test())
+    os._exit(result)  # Force exit to avoid cleanup hangs
+
+
+if __name__ == "__main__":
+    import os
+
+    try:
+        main()
+        print("SUCCESS", flush=True)
+        os._exit(0)
+    except SystemExit as e:
+        if e.code == 0:
+            print("SUCCESS", flush=True)
+        os._exit(e.code or 0)
+    except Exception:
+        os._exit(1)

--- a/src/muxi/runtime/formation/background/request_tracker.py
+++ b/src/muxi/runtime/formation/background/request_tracker.py
@@ -74,6 +74,13 @@ _TERMINAL_STATUSES = frozenset(
     {RequestStatus.COMPLETED, RequestStatus.FAILED, RequestStatus.CANCELLED}
 )
 
+# Statuses a request can still be moved out of by the producer that owns it.
+# Used by ``mark_completed_if_active`` so a request that already reached a
+# terminal state keeps the status it has.
+_ACTIVE_STATUSES = frozenset(
+    {RequestStatus.PENDING, RequestStatus.PROCESSING, RequestStatus.RUNNING}
+)
+
 DEFAULT_COMPLETED_TTL_SECONDS = 300  # 5 minutes
 DEFAULT_STALE_REQUEST_TIMEOUT = 600  # 10 minutes -- matches StreamingManager.SUBSCRIBE_TIMEOUT
 
@@ -142,6 +149,41 @@ class RequestTracker:
                 request_state.error = error
 
             if status in _TERMINAL_STATUSES and request_state.end_time is None:
+                request_state.end_time = time.time()
+
+            return True
+
+    async def mark_completed_if_active(self, request_id: str, result: Any = None) -> bool:
+        """
+        Transition an in-flight request to COMPLETED.
+
+        Compare-and-set against the active statuses, so a request that already
+        reached a terminal state (cancelled on client disconnect, failed, or
+        completed by the async background path) keeps the status it has. This
+        is what lets a finished chat turn record itself without racing the
+        disconnect handler.
+
+        ``end_time`` is stamped like any other terminal transition, so the
+        entry is purged by ``cleanup_expired`` once ``completed_ttl`` elapses.
+
+        Args:
+            request_id: Unique identifier for the request
+            result: Result data to store alongside the COMPLETED status
+
+        Returns:
+            True if the request was found, still active, and transitioned
+        """
+        async with self._lock:
+            request_state = self._requests.get(request_id)
+            if request_state is None or request_state.status not in _ACTIVE_STATUSES:
+                return False
+
+            request_state.status = RequestStatus.COMPLETED
+
+            if result is not None:
+                request_state.result = result
+
+            if request_state.end_time is None:
                 request_state.end_time = time.time()
 
             return True

--- a/src/muxi/runtime/formation/overlord/chat_orchestrator.py
+++ b/src/muxi/runtime/formation/overlord/chat_orchestrator.py
@@ -48,6 +48,15 @@ class EnhancedMessage(NamedTuple):
 # ``_apply_scheduled_marker`` for the single-place rule.
 SCHEDULED_EXECUTION_MARKER = "[SCHEDULED] "
 
+# Stream event types that end a subscription (see StreamingManager.subscribe).
+# Seeing one means the stream closed because processing reached its own
+# terminal event -- not because the client hung up.
+TERMINAL_STREAM_EVENTS = frozenset({"completed", "failed", "cancelled"})
+
+# How long the streaming generator waits for the producer task to unwind
+# after it emitted its terminal event, before treating it as stuck.
+PRODUCER_DRAIN_TIMEOUT = 5.0
+
 
 def _apply_scheduled_marker(message: str, session_id: Optional[str]) -> str:
     """Return ``message`` with the scheduled-execution marker if and only
@@ -200,6 +209,10 @@ class ChatOrchestrator:
             # - It disables streaming when finished
             # We don't need to duplicate that here.
 
+            # The turn answered -- record it so pollers see a result and the
+            # stale request reaper doesn't later rewrite it to FAILED.
+            await self._mark_turn_terminal(request_id, result)
+
             return result
 
         # Create task with context propagation (Python 3.10 compatible)
@@ -213,10 +226,23 @@ class ChatOrchestrator:
         current_context.run(create_task_with_context)
 
         # Yield events from the stream; cancel processing on client disconnect
+        terminal_event_seen = False
         try:
             async for event in self._stream_request(request_id, user_id, session_id):
+                if isinstance(event, dict) and event.get("type") in TERMINAL_STREAM_EVENTS:
+                    terminal_event_seen = True
                 yield event
         finally:
+            # The subscription ends as soon as the terminal event is emitted,
+            # which is a beat before ``delayed_process`` returns. Wait for the
+            # producer to unwind rather than cancelling a turn that already
+            # answered -- otherwise a successful stream races into CANCELLED.
+            if terminal_event_seen and processing_task and not processing_task.done():
+                with suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                    await asyncio.wait_for(
+                        asyncio.shield(processing_task), timeout=PRODUCER_DRAIN_TIMEOUT
+                    )
+
             # Client disconnected or stream ended -- cancel if still running
             if processing_task and not processing_task.done():
                 processing_task.cancel()
@@ -785,7 +811,44 @@ class ChatOrchestrator:
                         latency_ms = (time.time() - _framework_start_time) * 1000
                         telemetry.record_request(success, latency_ms, "framework")
 
+            # The turn answered -- record it so pollers see a result and the
+            # stale request reaper doesn't later rewrite it to FAILED.
+            await self._mark_turn_terminal(request_id, chat_result)
+
             return chat_result
+
+    async def _mark_turn_terminal(
+        self, request_id: str, result: Union[str, Dict[str, Any], MuxiResponse]
+    ) -> None:
+        """
+        Record the terminal state of a finished chat turn in the request tracker.
+
+        Ordinary sync/streaming turns used to be left in PROCESSING once the
+        response had been delivered, so ``GET /v1/requests/{id}`` reported
+        "processing" for a turn that had already answered, and the stale
+        request reaper eventually rewrote it to FAILED. Mirrors the
+        transition the early-heuristic fast path already performs.
+
+        Args:
+            request_id: The request being finished
+            result: Whatever the turn returned to the caller
+        """
+        # Async hand-off (background task or approved workflow): the
+        # background path owns the terminal transition for this request.
+        if isinstance(result, dict) and result.get("status") == "processing":
+            return
+
+        # Cooperative cancellation: the turn unwound because the client
+        # cancelled it, so it is cancelled -- not completed.
+        metadata = getattr(result, "metadata", None) or {}
+        if metadata.get("cancelled"):
+            await self.overlord.request_tracker.update_request(request_id, RequestStatus.CANCELLED)
+            return
+
+        content = getattr(result, "content", None)
+        await self.overlord.request_tracker.mark_completed_if_active(
+            request_id, result=content if content is not None else result
+        )
 
     async def _determine_async_mode(
         self,

--- a/src/muxi/runtime/formation/overlord/chat_orchestrator.py
+++ b/src/muxi/runtime/formation/overlord/chat_orchestrator.py
@@ -66,6 +66,8 @@ PENDING_INTERACTION_KEYS = (
     "clarification",
     "clarification_requested",
     "clarification_type",
+    "requires_clarification",
+    "needs_clarification",
     "approval_required",
     "requires_user_response",
 )

--- a/src/muxi/runtime/formation/overlord/chat_orchestrator.py
+++ b/src/muxi/runtime/formation/overlord/chat_orchestrator.py
@@ -57,6 +57,19 @@ TERMINAL_STREAM_EVENTS = frozenset({"completed", "failed", "cancelled"})
 # after it emitted its terminal event, before treating it as stuck.
 PRODUCER_DRAIN_TIMEOUT = 5.0
 
+# Response metadata set by turns that end awaiting a further user response:
+# clarification questions, workflow-approval prompts, and credential
+# requests. Those turns store pending interaction state and reuse the same
+# request_id on the follow-up turn, so they have not finished and their
+# question is not a final result. See ``_mark_turn_terminal``.
+PENDING_INTERACTION_KEYS = (
+    "clarification",
+    "clarification_requested",
+    "clarification_type",
+    "approval_required",
+    "requires_user_response",
+)
+
 
 def _apply_scheduled_marker(message: str, session_id: Optional[str]) -> str:
     """Return ``message`` with the scheduled-execution marker if and only
@@ -843,6 +856,13 @@ class ChatOrchestrator:
         metadata = getattr(result, "metadata", None) or {}
         if metadata.get("cancelled"):
             await self.overlord.request_tracker.update_request(request_id, RequestStatus.CANCELLED)
+            return
+
+        # Interactive turns end awaiting a further user response and reuse
+        # this request_id on the follow-up turn (which re-registers it as
+        # PROCESSING), so the turn is not finished and its question is not
+        # a final result. Left untouched, as before this transition existed.
+        if any(metadata.get(key) for key in PENDING_INTERACTION_KEYS):
             return
 
         content = getattr(result, "content", None)

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -8651,8 +8651,19 @@ Agent response: {raw_response}"""
                                     },
                                 )
 
+                            # Self-describing metadata, matching the vocabulary
+                            # the other credential producers use. This response
+                            # asks the user for credentials, so the turn is not
+                            # finished -- ``_mark_turn_terminal`` reads these
+                            # keys to keep the request out of COMPLETED.
                             credential_request_response = MuxiResponse(
-                                role="assistant", content=result["message"]
+                                role="assistant",
+                                content=result["message"],
+                                metadata={
+                                    "clarification_type": "credential",
+                                    "credential_mode": result.get("action"),
+                                    "service": service,
+                                },
                             )
                             if result.get("action") == "redirect":
                                 # Declared credential portal (Response Envelope

--- a/tests/unit/test_chat_turn_request_completion.py
+++ b/tests/unit/test_chat_turn_request_completion.py
@@ -264,6 +264,13 @@ async def test_cancelled_turn_is_not_marked_completed(tracker):
         {"requires_clarification": True, "clarification_source": "agent_request"},
         # Agent response flagged as needing more information
         {"needs_clarification": True, "clarification_type": "information_request"},
+        # Direct credential request (overlord.py:8654), which used to return
+        # a response with no metadata at all and so could not be recognised
+        {
+            "clarification_type": "credential",
+            "credential_mode": "redirect",
+            "service": "github",
+        },
     ],
     ids=[
         "clarification",
@@ -271,6 +278,7 @@ async def test_cancelled_turn_is_not_marked_completed(tracker):
         "credential_redirect",
         "agent_request",
         "agent_needs_info",
+        "credential_request",
     ],
 )
 async def test_interactive_turn_is_not_marked_completed(tracker, metadata):

--- a/tests/unit/test_chat_turn_request_completion.py
+++ b/tests/unit/test_chat_turn_request_completion.py
@@ -1,0 +1,278 @@
+"""
+Tests for the terminal request-tracker transition of ordinary chat turns.
+
+Background
+----------
+Every chat turn registers itself in the ``RequestTracker`` as PROCESSING.
+Only the overlord fast path and the async background path ever wrote
+COMPLETED back, so an ordinary sync or streaming turn stayed "processing"
+after it had already answered:
+
+* ``GET /v1/requests/{request_id}`` reported "processing" forever, and its
+  result-return branch never fired (status was not COMPLETED and result
+  was None).
+* 600s later the stale request reaper rewrote the finished turn to FAILED
+  with "Request timed out (stale request reaper)", so successful turns were
+  recorded as failures.
+
+These tests pin:
+
+* a completed sync turn reports COMPLETED with its content as the result
+* a completed streaming turn does the same once the stream reaches its
+  terminal event (and is not raced into CANCELLED by the disconnect path)
+* the stale reaper leaves both alone
+* the completed entry still honours the tracker's completed-entry TTL
+* async hand-offs and cooperatively cancelled turns are not mislabelled
+"""
+
+import time
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from muxi.runtime.datatypes.response import MuxiResponse
+from muxi.runtime.formation.background.request_tracker import (
+    RequestState,
+    RequestStatus,
+    RequestTracker,
+)
+from muxi.runtime.formation.overlord.chat_orchestrator import (
+    ChatOrchestrator,
+    EnhancedMessage,
+)
+from muxi.runtime.services import streaming
+from muxi.runtime.services.streaming import streaming_manager
+
+REQUEST_ID = "req_completion_test"
+USER_ID = "0"
+SESSION_ID = "sess_completion_test"
+STREAM_ANSWER = "Revenue grew 12%."
+
+
+def _processing_state() -> RequestState:
+    """The initial tracker state the orchestrator registers for a chat turn."""
+    return RequestState(
+        id=REQUEST_ID,
+        status=RequestStatus.PROCESSING,
+        start_time=time.time(),
+        user_id=USER_ID,
+        session_id=SESSION_ID,
+    )
+
+
+def _make_orchestrator(tracker: RequestTracker) -> ChatOrchestrator:
+    """Build an orchestrator whose overlord is stubbed down to the tracker."""
+    orch = ChatOrchestrator.__new__(ChatOrchestrator)
+
+    overlord = MagicMock()
+    overlord.request_tracker = tracker
+    overlord.formation_id = "test-formation"
+    overlord.is_multi_user = False
+    overlord.streaming = False
+    overlord.agents = {}
+    # No database / persistent memory -> user resolution and background user
+    # info extraction are skipped entirely.
+    overlord.db_manager = None
+    overlord.long_term_memory = None
+    overlord.buffer_memory_manager = None
+    overlord.auto_extract_user_info = False
+    overlord.async_webhook_url = None
+    overlord.async_threshold_seconds = 30
+    overlord.mcp_service = None
+    overlord._get_pending_clarification = AsyncMock(return_value=None)
+
+    def _create_tracked_task(coro, name: Optional[str] = None):
+        # Fire-and-forget storage tasks are irrelevant here; close the
+        # coroutine so it never warns about never being awaited.
+        coro.close()
+        return None
+
+    overlord._create_tracked_task = MagicMock(side_effect=_create_tracked_task)
+
+    orch.overlord = overlord
+    return orch
+
+
+def _stub_context_enrichment(orch: ChatOrchestrator, message: str) -> None:
+    """Skip the memory-backed enrichment hops the turn does not exercise."""
+    enhanced = f"=== CURRENT REQUEST ===\n{message}"
+    orch._enhance_message_with_context = AsyncMock(
+        return_value=EnhancedMessage(original=message, enhanced=enhanced)
+    )
+    orch._build_clean_chat_context = AsyncMock(return_value={"current_user_message": message})
+
+
+async def _run_sync_turn(
+    orch: ChatOrchestrator,
+    result: Any,
+    message: str = "What is the weather in Tel Aviv?",
+) -> Any:
+    """Drive ``chat()`` through the plain (non-streaming) sync path."""
+    _stub_context_enrichment(orch, message)
+    orch._process_sync_chat = AsyncMock(return_value=result)
+
+    return await orch.chat(
+        message=message,
+        user_id=USER_ID,
+        session_id=SESSION_ID,
+        request_id=REQUEST_ID,
+        stream=False,
+    )
+
+
+async def _drain_stream(orch: ChatOrchestrator) -> List[Dict[str, Any]]:
+    """Consume the streaming generator to exhaustion, the way a client does."""
+    message = "Summarize the quarterly report."
+    events: List[Dict[str, Any]] = []
+    generator = orch._create_stream_generator(
+        enhanced_message=f"=== CURRENT REQUEST ===\n{message}",
+        original_message=message,
+        agent_name=None,
+        user_id=USER_ID,
+        session_id=SESSION_ID,
+        request_id=REQUEST_ID,
+        use_async=None,
+        webhook_url=None,
+    )
+    async for event in generator:
+        events.append(event)
+    return events
+
+
+def _start_streaming_turn(orch: ChatOrchestrator, tracker: RequestTracker) -> None:
+    """Register the turn and stand in for the streaming producer."""
+
+    async def _emit_and_answer(**kwargs):
+        # Mirrors overlord._process_sync_chat, which emits its own terminal
+        # "completed" event before returning.
+        streaming_manager.emit_event(REQUEST_ID, "content", STREAM_ANSWER)
+        streaming_manager.emit_event(REQUEST_ID, "completed", STREAM_ANSWER)
+        return MuxiResponse(role="assistant", content=STREAM_ANSWER)
+
+    orch._process_sync_chat = AsyncMock(side_effect=_emit_and_answer)
+
+
+@pytest.fixture
+def tracker() -> RequestTracker:
+    # Short stale timeout so the reaper can be exercised without waiting 600s.
+    return RequestTracker(completed_ttl=1.0, stale_timeout=0.01)
+
+
+@pytest.fixture
+def streaming_turn(tracker):
+    """A request registered as PROCESSING with streaming enabled."""
+    streaming.enable_streaming(REQUEST_ID, USER_ID, SESSION_ID)
+    yield
+    streaming.disable_streaming(REQUEST_ID)
+
+
+async def test_sync_chat_turn_marks_request_completed(tracker):
+    """A finished sync turn reports COMPLETED with its content as the result."""
+    orch = _make_orchestrator(tracker)
+
+    await _run_sync_turn(orch, MuxiResponse(role="assistant", content="It is 29C and sunny."))
+
+    state = await tracker.get_request(REQUEST_ID)
+    assert state is not None
+    assert state.status == RequestStatus.COMPLETED
+    assert state.result == "It is 29C and sunny."
+    assert state.end_time is not None
+
+
+async def test_stale_reaper_leaves_completed_sync_turn_alone(tracker):
+    """The stale reaper no longer rewrites a finished sync turn to FAILED."""
+    orch = _make_orchestrator(tracker)
+
+    await _run_sync_turn(orch, MuxiResponse(role="assistant", content="Done."))
+
+    # Backdate well past the stale timeout -- before the fix, a turn still
+    # sitting in PROCESSING was flipped to FAILED at this point.
+    state = await tracker.get_request(REQUEST_ID)
+    state.start_time = time.time() - 3600
+
+    await tracker.cleanup_expired()
+
+    state = await tracker.get_request(REQUEST_ID)
+    assert state.status == RequestStatus.COMPLETED
+    assert state.error is None
+
+
+async def test_completed_sync_turn_respects_completed_ttl(tracker):
+    """The completed entry is purged once the completed-entry TTL elapses."""
+    orch = _make_orchestrator(tracker)
+
+    await _run_sync_turn(orch, MuxiResponse(role="assistant", content="Done."))
+
+    state = await tracker.get_request(REQUEST_ID)
+    state.end_time = time.time() - (tracker.completed_ttl + 1.0)
+
+    purged = await tracker.cleanup_expired()
+
+    assert purged == 1
+    assert await tracker.get_request(REQUEST_ID) is None
+
+
+async def test_async_handoff_is_not_marked_completed(tracker):
+    """A turn handed off to the background path keeps its PROCESSING status."""
+    orch = _make_orchestrator(tracker)
+
+    await _run_sync_turn(
+        orch,
+        {"status": "processing", "request_id": REQUEST_ID, "workflow_id": "wf_1"},
+    )
+
+    state = await tracker.get_request(REQUEST_ID)
+    assert state.status == RequestStatus.PROCESSING
+
+
+async def test_cancelled_turn_is_not_marked_completed(tracker):
+    """A cooperatively cancelled turn is recorded CANCELLED, not COMPLETED."""
+    orch = _make_orchestrator(tracker)
+
+    await _run_sync_turn(
+        orch,
+        MuxiResponse(
+            role="assistant",
+            content="",
+            metadata={"cancelled": True, "request_id": REQUEST_ID},
+        ),
+    )
+
+    state = await tracker.get_request(REQUEST_ID)
+    assert state.status == RequestStatus.CANCELLED
+
+
+async def test_streaming_chat_turn_marks_request_completed(tracker, streaming_turn):
+    """A finished streaming turn reports COMPLETED once the stream terminates."""
+    orch = _make_orchestrator(tracker)
+    await tracker.track_request(REQUEST_ID, _processing_state())
+    _start_streaming_turn(orch, tracker)
+
+    events = await _drain_stream(orch)
+
+    assert "completed" in [event["type"] for event in events]
+
+    state = await tracker.get_request(REQUEST_ID)
+    assert state is not None
+    assert state.status == RequestStatus.COMPLETED
+    assert state.result == STREAM_ANSWER
+    assert state.end_time is not None
+
+
+async def test_stale_reaper_leaves_completed_streaming_turn_alone(tracker, streaming_turn):
+    """The stale reaper no longer rewrites a finished streaming turn to FAILED."""
+    orch = _make_orchestrator(tracker)
+    await tracker.track_request(REQUEST_ID, _processing_state())
+    _start_streaming_turn(orch, tracker)
+
+    await _drain_stream(orch)
+
+    state = await tracker.get_request(REQUEST_ID)
+    state.start_time = time.time() - 3600
+
+    await tracker.cleanup_expired()
+
+    state = await tracker.get_request(REQUEST_ID)
+    assert state.status == RequestStatus.COMPLETED
+    assert state.error is None

--- a/tests/unit/test_chat_turn_request_completion.py
+++ b/tests/unit/test_chat_turn_request_completion.py
@@ -252,8 +252,13 @@ async def test_cancelled_turn_is_not_marked_completed(tracker):
         {"workflow_id": "wf_1", "approval_required": True, "requires_user_response": True},
         # Credential request awaiting the user
         {"clarification_type": "missing_credential", "service": "github"},
+        # Agent-initiated clarification (overlord.py:11823) -- carries neither
+        # "clarification" nor "clarification_type"
+        {"requires_clarification": True, "clarification_source": "agent_request"},
+        # Agent response flagged as needing more information
+        {"needs_clarification": True, "clarification_type": "information_request"},
     ],
-    ids=["clarification", "approval", "credential"],
+    ids=["clarification", "approval", "credential", "agent_request", "agent_needs_info"],
 )
 async def test_interactive_turn_is_not_marked_completed(tracker, metadata):
     """A turn awaiting a further user response is not a completed turn.

--- a/tests/unit/test_chat_turn_request_completion.py
+++ b/tests/unit/test_chat_turn_request_completion.py
@@ -243,6 +243,37 @@ async def test_cancelled_turn_is_not_marked_completed(tracker):
     assert state.status == RequestStatus.CANCELLED
 
 
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        # Clarification question (overlord clarification system)
+        {"clarification": True, "mode": "ambiguous"},
+        # Workflow plan awaiting approval
+        {"workflow_id": "wf_1", "approval_required": True, "requires_user_response": True},
+        # Credential request awaiting the user
+        {"clarification_type": "missing_credential", "service": "github"},
+    ],
+    ids=["clarification", "approval", "credential"],
+)
+async def test_interactive_turn_is_not_marked_completed(tracker, metadata):
+    """A turn awaiting a further user response is not a completed turn.
+
+    These turns store pending interaction state and reuse the same
+    request_id on the follow-up turn, so reporting the question as a
+    final result would be wrong.
+    """
+    orch = _make_orchestrator(tracker)
+
+    await _run_sync_turn(
+        orch,
+        MuxiResponse(role="assistant", content="Which repository?", metadata=metadata),
+    )
+
+    state = await tracker.get_request(REQUEST_ID)
+    assert state.status == RequestStatus.PROCESSING
+    assert state.result is None
+
+
 async def test_streaming_chat_turn_marks_request_completed(tracker, streaming_turn):
     """A finished streaming turn reports COMPLETED once the stream terminates."""
     orch = _make_orchestrator(tracker)

--- a/tests/unit/test_chat_turn_request_completion.py
+++ b/tests/unit/test_chat_turn_request_completion.py
@@ -250,15 +250,28 @@ async def test_cancelled_turn_is_not_marked_completed(tracker):
         {"clarification": True, "mode": "ambiguous"},
         # Workflow plan awaiting approval
         {"workflow_id": "wf_1", "approval_required": True, "requires_user_response": True},
-        # Credential request awaiting the user
-        {"clarification_type": "missing_credential", "service": "github"},
+        # Missing-credential redirect (overlord.py:9642). The default
+        # "redirect" mode sets clarification_requested to False, so the
+        # guard has to catch it on the sibling clarification_type key.
+        {
+            "clarification_requested": False,
+            "clarification_type": "missing_credential",
+            "credential_mode": "redirect",
+            "service": "github",
+        },
         # Agent-initiated clarification (overlord.py:11823) -- carries neither
         # "clarification" nor "clarification_type"
         {"requires_clarification": True, "clarification_source": "agent_request"},
         # Agent response flagged as needing more information
         {"needs_clarification": True, "clarification_type": "information_request"},
     ],
-    ids=["clarification", "approval", "credential", "agent_request", "agent_needs_info"],
+    ids=[
+        "clarification",
+        "approval",
+        "credential_redirect",
+        "agent_request",
+        "agent_needs_info",
+    ],
 )
 async def test_interactive_turn_is_not_marked_completed(tracker, metadata):
     """A turn awaiting a further user response is not a completed turn.

--- a/tests/unit/test_request_tracker.py
+++ b/tests/unit/test_request_tracker.py
@@ -136,6 +136,54 @@ async def test_default_ttl():
 
 
 @pytest.mark.asyncio
+async def test_mark_completed_if_active_transitions_processing(tracker, make_state):
+    """An in-flight request is completed and stamped with an end_time."""
+    await tracker.track_request("req_active_done", make_state("req_active_done"))
+
+    assert await tracker.mark_completed_if_active("req_active_done", result="answer") is True
+
+    got = await tracker.get_request("req_active_done")
+    assert got.status == RequestStatus.COMPLETED
+    assert got.result == "answer"
+    assert got.end_time is not None
+
+
+@pytest.mark.asyncio
+async def test_mark_completed_if_active_keeps_terminal_status(tracker, make_state):
+    """A request that already reached a terminal state is left untouched."""
+    await tracker.track_request("req_cancelled", make_state("req_cancelled"))
+    await tracker.update_request("req_cancelled", RequestStatus.CANCELLED)
+
+    assert await tracker.mark_completed_if_active("req_cancelled", result="answer") is False
+
+    got = await tracker.get_request("req_cancelled")
+    assert got.status == RequestStatus.CANCELLED
+    assert got.result is None
+
+
+@pytest.mark.asyncio
+async def test_mark_completed_if_active_unknown_request(tracker):
+    """Completing an unknown request is a no-op."""
+    assert await tracker.mark_completed_if_active("req_missing", result="answer") is False
+
+
+@pytest.mark.asyncio
+async def test_mark_completed_if_active_stops_stale_reaper(make_state):
+    """A request completed this way is not reaped as stale."""
+    tracker = RequestTracker(completed_ttl=60.0, stale_timeout=0.01)
+    state = make_state("req_reap")
+    await tracker.track_request("req_reap", state)
+    await tracker.mark_completed_if_active("req_reap", result="answer")
+
+    state.start_time = time.time() - 3600
+    await tracker.cleanup_expired()
+
+    got = await tracker.get_request("req_reap")
+    assert got.status == RequestStatus.COMPLETED
+    assert got.error is None
+
+
+@pytest.mark.asyncio
 async def test_result_stored_on_completed(tracker, make_state):
     """Result payload is stored and retrievable for completed requests."""
     state = make_state("req_result")


### PR DESCRIPTION
## Problem

Every chat turn registers in the `RequestTracker` as `PROCESSING` ([chat_orchestrator.py:404-413](src/muxi/runtime/formation/overlord/chat_orchestrator.py#L404-L413)), but `COMPLETED` was only ever written for:

- the overlord fast-path / early-heuristic branch (`chat_orchestrator.py:587-589`)
- the async path (`overlord.py:7092-7093`), which the HTTP API rejects with 501 ([chat.py:195-201](src/muxi/runtime/formation/server/routes/client/chat.py#L195-L201))
- unrelated memory-ingest / distillery jobs

So an ordinary sync or streaming turn stayed `PROCESSING` after it had already answered:

1. `GET /v1/requests/{request_id}` reported `"processing"` for a finished turn, and its result-return branch ([requests.py:221-228](src/muxi/runtime/formation/server/routes/client/requests.py#L221-L228)) never fired — status was not `COMPLETED` and `result` was `None`.
2. 600s later the stale request reaper (`request_tracker.py:264-282`) rewrote the turn to `FAILED` with `"Request timed out (stale request reaper)"`, so successful turns were recorded as failures.

## Fix

**`RequestTracker.mark_completed_if_active()`** — a compare-and-set under the tracker lock that moves a request from `PENDING`/`PROCESSING`/`RUNNING` to `COMPLETED`, stores the result, and stamps `end_time` so the completed-entry TTL (`request_tracker.py:77`) still purges it. A request that already reached a terminal state keeps the status it has, so a turn completing can never clobber a cancellation.

**Sync and streaming turns both mark themselves terminal** via a shared `ChatOrchestrator._mark_turn_terminal()`, mirroring the transition the fast path already performs. The response content is stored as the result, so the poll endpoint can return it.

**The streaming generator no longer cancels a producer that already finished.** `StreamingManager.subscribe` ends as soon as the terminal event is emitted, which is a beat *before* `delayed_process` returns — so the disconnect branch could race a successful stream into `CANCELLED`. The generator now tracks whether it saw a terminal event and, if so, waits (bounded, 5s) for the producer to unwind before falling through to the existing cancel path. **Client disconnect — no terminal event — still cancels and marks `CANCELLED` exactly as before** (`chat_orchestrator.py:214-233` semantics unchanged).

Two cases are deliberately excluded from the `COMPLETED` transition:

- **async hand-offs** (background execution, approved workflows — a dict with `status: "processing"`) stay `PROCESSING`; the background task owns the terminal transition.
- **cooperatively cancelled turns** (`RequestCancelledException` → `metadata.cancelled`) are recorded `CANCELLED`, not `COMPLETED`.

## Tests

`tests/unit/test_chat_turn_request_completion.py` (new) drives `chat()` and `_create_stream_generator` end to end with a stubbed overlord:

- a completed sync turn reports `COMPLETED` with its content as the result
- a completed streaming turn does the same once the stream terminates
- the stale reaper leaves both alone (this is the regression that previously produced `FAILED`)
- the completed entry still honours the completed-entry TTL
- async hand-offs and cancelled turns are not mislabelled

`tests/unit/test_request_tracker.py` gains four cases for the new compare-and-set.

Against the **unfixed** source, 6 of the 7 new orchestrator tests fail — including `assert <RequestStatus.FAILED> == <RequestStatus.COMPLETED>` with `Reaped stale request req_completion_test (stuck in PROCESSING for 3600s)` in the captured log — reproducing the reported bug exactly.

Verification run:

- `tests/unit`: **4014 passed**, 10 skipped
- new e2e `e2e/tests/9_async/test_9b2_sync_turn_completion.py` against a live formation: **pass** (sync turn and streaming turn both `COMPLETED` with result stored)
- random-5 e2e regression: **5/5 passed** (19_api, 20_mcp_server, 27_tuning, 3_multimodal ×2)
- black / isort / ruff / flake8 clean on changed files

## Follow-up (not in this PR)

Failed turns still reach `FAILED` only via the 600s reaper, and its generic "stale request reaper" message masks the real error. Marking `FAILED` at the point the turn raises would be the natural next step; left out here to keep this change scoped to the reported bug.