### PR TITLE
feat: stream final response as incremental content SSE events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ pass) now runs in streaming mode and emits each provider chunk as a
   no resilience-wrapper retries: replaying a partially consumed stream
   would duplicate text; the overlord falls back to the non-streaming
   call on any stream failure so the turn always answers).
+- If that fallback regenerates AFTER deltas were already published, the
+  terminal `completed` event additionally carries
+  `stream_discontinuity: true` -- clients that render deltas should then
+  discard them and treat `completed.content` as authoritative (the flag
+  is absent on every normal turn).
 - Covered by unit tests (ordering, envelope, config off, rewrite-step
   gating, fallback) and a new e2e test,
   `10_streaming/test_10_a_7` (deltas before `completed`, concatenation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## [unreleased]
 
+### Streaming chat now streams the final response as content deltas
+
+During a streaming chat turn the final assistant text used to arrive
+only once, inside the terminal `completed` event -- clients could not
+render text as it generated. The final-response LLM call (the persona
+pass) now runs in streaming mode and emits each provider chunk as a
+`type: "content"` SSE event, so clients render tokens live.
+
+- Purely additive: the terminal `completed` event still carries the full
+  final text, so clients that only read the terminal event keep working,
+  and clients that render deltas (e.g. the ACP bridge) dedup it.
+- Deltas are emitted only when the generated text IS the delivered text:
+  the fast conversational path and the standard agent/workflow response
+  path stream; turns whose text is rewritten after generation
+  (`response.format: json` wrapping, `html` prettify, credential-option
+  formatting, error formatting) keep today's behavior.
+- Configurable via `overlord.config.response.stream_tokens` (default
+  `true`). Chunking is passed through as the provider yields it; clients
+  coalesce.
+- `content` events bypass the background emitter thread and are appended
+  synchronously, guaranteeing delta ordering; they carry the standard
+  event envelope (request_id, user_id, session_id, timestamp).
+- New `LLM.chat_stream()` async generator on the LLM service (text-only,
+  no resilience-wrapper retries: replaying a partially consumed stream
+  would duplicate text; the overlord falls back to the non-streaming
+  call on any stream failure so the turn always answers).
+- Covered by unit tests (ordering, envelope, config off, rewrite-step
+  gating, fallback) and a new e2e test,
+  `10_streaming/test_10_a_7` (deltas before `completed`, concatenation
+  equals the final text, clean stream termination).
+
 ### Chat turns now reach a terminal request status
 
 Ordinary sync and streaming chat turns registered themselves in the

--- a/e2e/tests/10_streaming/test_10_a_7.py
+++ b/e2e/tests/10_streaming/test_10_a_7.py
@@ -105,6 +105,13 @@ def main():
                 test.formatter.print_success(
                     f"completed event carries full text ({len(completed_content)} chars)"
                 )
+            # A clean streamed turn never carries the fallback-regeneration
+            # marker (stream_discontinuity is additive, absent-when-false)
+            if completed_events[0].get("stream_discontinuity"):
+                test.formatter.print_failure(
+                    "completed unexpectedly flagged stream_discontinuity on a clean turn"
+                )
+                success = False
 
         # --- (a) at least one content event, all before completed ---
         if not content_events:

--- a/e2e/tests/10_streaming/test_10_a_7.py
+++ b/e2e/tests/10_streaming/test_10_a_7.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+Test 10A7: Final-Response Token Streaming (content deltas)
+
+Tests that the final assistant response streams as incremental
+``type: "content"`` events during a streaming chat turn, while the
+terminal ``completed`` event still carries the full final text.
+
+Contract under test (feature: overlord.config.response.stream_tokens,
+default true):
+
+(a) at least one ``content`` event arrives BEFORE the terminal
+    ``completed`` event;
+(b) the concatenated ``content`` deltas equal the ``completed`` event's
+    content, modulo the deterministic output normalization the runtime
+    applies to the final text (strip + newline collapse in
+    ``clean_response_text`` -- no rewrite step ran on this turn);
+(c) the stream terminates cleanly right after ``completed`` (no events
+    follow it; the HTTP SSE framing's ``event: done`` is emitted by the
+    unchanged route layer on top of exactly this termination).
+"""
+
+import asyncio
+import re
+import sys
+from pathlib import Path
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent))
+
+from base_streaming_test import BaseStreamingTest
+
+
+def normalize_final_text(text: str) -> str:
+    """Mirror the runtime's deterministic final-text normalization.
+
+    The runtime cleans the accumulated persona output before putting it
+    in the ``completed`` event (``clean_response_text``: strip invisible
+    chars, drop separator-only lines, strip, collapse 3+ newlines).
+    Deltas are emitted raw as the provider chunks them, so we apply the
+    same normalization to both sides before comparing.
+    """
+    text = re.sub(r"^[─━═┄┅┈┉\-_]{3,}\s*$", "", text, flags=re.MULTILINE)
+    text = text.strip()
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text
+
+
+def main():
+    """Test final-response content delta streaming."""
+    test = BaseStreamingTest(
+        "10a7_content_delta_streaming",
+        "Test final response streams as incremental content events",
+    )
+
+    async def run_content_delta_test():
+        # Setup formation using the shared streaming formation
+        formation_path = Path(__file__).parent / "formations" / "formation-streaming"
+        await test.setup_formation(formation_path=str(formation_path))
+
+        # An actionable question: routed to an agent, then the persona
+        # pass produces the final text (the streamed LLM call under test).
+        response = await test.overlord.chat(
+            message="What are the key principles of quantum computing?",
+            user_id="test_user",
+            session_id="streaming_test_10a7",
+            use_async=False,
+            stream=True,
+        )
+
+        success = True
+
+        if not hasattr(response, "__aiter__"):
+            test.formatter.print_failure(f"Response is not a stream: {type(response)}")
+            test.results.append(False)
+            test.print_streaming_summary()
+            await test.cleanup_formation()
+            return 1
+
+        stream_result = await test.consume_stream(response, timeout=90.0)
+        events = stream_result["events"]
+
+        event_types = [e.get("type") for e in events if isinstance(e, dict)]
+        test.formatter.print_debug(f"Event sequence: {event_types}")
+
+        content_events = [e for e in events if isinstance(e, dict) and e.get("type") == "content"]
+        completed_events = [
+            e for e in events if isinstance(e, dict) and e.get("type") == "completed"
+        ]
+
+        # --- Terminal completed event still carries the full text ---
+        if len(completed_events) != 1:
+            test.formatter.print_failure(
+                f"Expected exactly one completed event, got {len(completed_events)}"
+            )
+            success = False
+            completed_content = ""
+        else:
+            completed_content = completed_events[0].get("content", "")
+            if not completed_content:
+                test.formatter.print_failure("completed event has empty content")
+                success = False
+            else:
+                test.formatter.print_success(
+                    f"completed event carries full text ({len(completed_content)} chars)"
+                )
+
+        # --- (a) at least one content event, all before completed ---
+        if not content_events:
+            test.formatter.print_failure("No content delta events received")
+            success = False
+        else:
+            test.formatter.print_success(f"Received {len(content_events)} content delta events")
+            completed_idx = next(
+                (
+                    i
+                    for i, e in enumerate(events)
+                    if isinstance(e, dict) and e.get("type") == "completed"
+                ),
+                len(events),
+            )
+            late = [
+                i
+                for i, e in enumerate(events)
+                if isinstance(e, dict) and e.get("type") == "content" and i > completed_idx
+            ]
+            if late:
+                test.formatter.print_failure(
+                    f"content events arrived AFTER completed at indexes {late}"
+                )
+                success = False
+            else:
+                test.formatter.print_success("All content deltas arrived before completed")
+
+            # Envelope fields ride every content event
+            first = content_events[0]
+            for field in ("request_id", "user_id", "session_id", "timestamp"):
+                if field not in first:
+                    test.formatter.print_failure(f"content event missing '{field}'")
+                    success = False
+
+        # --- (b) concatenated deltas == completed content (normalized) ---
+        if content_events and completed_content:
+            concatenated = "".join(e.get("content", "") for e in content_events)
+            if normalize_final_text(concatenated) == normalize_final_text(completed_content):
+                test.formatter.print_success("Concatenated deltas match completed content")
+            else:
+                test.formatter.print_failure(
+                    "Concatenated deltas do NOT match completed content\n"
+                    f"--- deltas ({len(concatenated)} chars): {concatenated[:200]}...\n"
+                    f"--- completed ({len(completed_content)} chars): "
+                    f"{completed_content[:200]}..."
+                )
+                success = False
+
+        # --- (c) stream terminates cleanly right after completed ---
+        if events and isinstance(events[-1], dict) and events[-1].get("type") == "completed":
+            test.formatter.print_success(
+                "Stream terminated cleanly after completed (SSE layer emits "
+                "event: done on this termination)"
+            )
+        else:
+            last_type = events[-1].get("type") if events else "none"
+            test.formatter.print_failure(
+                f"Stream did not end on completed (last event: {last_type})"
+            )
+            success = False
+
+        test.results.append(success)
+
+        if success:
+            test.formatter.print_success("Content delta streaming test passed")
+        else:
+            test.formatter.print_failure("Content delta streaming test failed")
+
+        test.print_streaming_summary()
+        await test.cleanup_formation()
+
+        return 0 if success else 1
+
+    return asyncio.run(run_content_delta_test())
+
+
+if __name__ == "__main__":
+    import os
+
+    exit_code = main()
+    if exit_code == 0:
+        print("SUCCESS", flush=True)
+    os._exit(exit_code)

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -3255,11 +3255,92 @@ class Overlord:
         except Exception:
             return ""
 
+    def _should_stream_response_deltas(self) -> bool:
+        """
+        Decide whether the final-response LLM call may stream incremental
+        ``content`` events to the client.
+
+        True only when ALL of the following hold:
+
+        - ``overlord.config.response.stream_tokens`` is enabled (default on);
+        - the response format is not post-processed AFTER persona generation.
+          ``json`` (wrapped in a JSON envelope) and ``html`` (BeautifulSoup
+          prettify) both rewrite the text after the LLM call, so streaming
+          the LLM output would show text the user never receives;
+        - the current request actually has a streaming subscriber (otherwise
+          a streaming LLM call buys nothing).
+        """
+        if not getattr(self, "stream_tokens", True):
+            return False
+        if getattr(self, "response_format", "markdown") in ("json", "html"):
+            return False
+        try:
+            from ...services.observability.context import get_current_request_context
+
+            request_context = get_current_request_context()
+            return bool(
+                request_context
+                and getattr(request_context, "id", None)
+                and streaming_manager.is_streaming_enabled(request_context.id)
+            )
+        except Exception:
+            return False
+
+    async def _persona_llm_call(
+        self,
+        llm,
+        messages: List[Dict[str, str]],
+        max_tokens: int,
+        stream_deltas: bool,
+    ) -> Any:
+        """
+        Run the persona LLM call, optionally streaming ``content`` deltas.
+
+        When ``stream_deltas`` is True, generation runs in streaming mode and
+        each provider chunk is emitted as a ``content`` streaming event
+        (passed through as-chunked; clients coalesce). The accumulated text
+        is returned so downstream handling (cleaning, the terminal
+        ``completed`` event) is identical to the non-streaming path.
+
+        On any streaming failure the call falls back to the regular
+        non-streaming request so the turn always produces a response; the
+        terminal ``completed`` event remains the authoritative content.
+        """
+        if stream_deltas:
+            try:
+                parts: List[str] = []
+                async for delta in llm.chat_stream(
+                    messages, max_tokens=max_tokens, temperature=0.7, caching=False
+                ):
+                    parts.append(delta)
+                    streaming.stream(
+                        "content",
+                        delta,
+                        stage="response_generation",
+                        skip_rephrase=True,
+                    )
+                if parts:
+                    return "".join(parts)
+            except Exception as e:
+                observability.observe(
+                    event_type=observability.ErrorEvents.INTERNAL_ERROR,
+                    level=observability.EventLevel.WARNING,
+                    data={"error": str(e), "stage": "persona_stream_deltas"},
+                    description=(
+                        f"Streaming persona generation failed, falling back "
+                        f"to non-streaming: {e}"
+                    ),
+                )
+        return await llm.chat(
+            messages, max_tokens=max_tokens, temperature=0.7, stream=False, caching=False
+        )
+
     async def _apply_persona(
         self,
         raw_response: Optional[str],
         user_message: str,
         session_id: Optional[str] = None,
+        stream_deltas: bool = False,
     ) -> str:
         """
         Apply the overlord persona to format a response.
@@ -3269,10 +3350,20 @@ class Overlord:
             user_message: The original user message for context
             session_id: The request's session id, when the call site has it
                 (used to recognize heartbeat-originated requests)
+            stream_deltas: Opt-in from call sites where the persona output IS
+                the final response text delivered to the user verbatim. When
+                enabled (and permitted by ``_should_stream_response_deltas``),
+                the persona LLM call streams and each chunk is emitted as a
+                ``content`` streaming event. Call sites that post-process the
+                persona output (e.g. credential-option formatting) must NOT
+                opt in, or clients would see text the user never receives.
 
         Returns:
             Formatted response with persona applied
         """
+        # Resolve delta streaming once: call-site opt-in AND runtime gates
+        # (config, response format, active streaming subscriber).
+        stream_deltas = stream_deltas and self._should_stream_response_deltas()
         # Heartbeat protocol guard (Proactiveness Phase 4): heartbeat
         # acknowledgments must survive persona formatting. Rephrasing
         # turns the suppression sentinel into friendly prose ("Everything
@@ -3418,9 +3509,10 @@ class Overlord:
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_content},
                 ]
-                # Force non-streaming for persona application, disable caching for varied responses
-                response = await llm.chat(
-                    messages, max_tokens=300, temperature=0.7, stream=False, caching=False
+                # Caching disabled for varied responses; streams content
+                # deltas when the call site opted in and gates allow it.
+                response = await self._persona_llm_call(
+                    llm, messages, max_tokens=300, stream_deltas=stream_deltas
                 )
 
                 if hasattr(response, "content"):
@@ -3494,10 +3586,11 @@ Agent response: {raw_response}"""
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_content},
                 ]
-                # Force non-streaming for persona application
-                # Disable caching to ensure varied responses (persona is final stage)
-                response = await llm.chat(
-                    messages, max_tokens=2000, temperature=0.7, stream=False, caching=False
+                # Caching disabled to ensure varied responses (persona is
+                # the final stage); streams content deltas when the call
+                # site opted in and gates allow it.
+                response = await self._persona_llm_call(
+                    llm, messages, max_tokens=2000, stream_deltas=stream_deltas
                 )
 
                 # Check cancellation after LLM call returns
@@ -3830,6 +3923,10 @@ Agent response: {raw_response}"""
             response_config = overlord_config.get("response", {})
             self.response_format = response_config.get("format", "markdown")
             self.streaming = response_config.get("streaming", False)
+            # Stream final-response tokens as incremental `content` SSE
+            # events during streaming chat (the terminal `completed`
+            # event still carries the full text, so this is additive).
+            self.stream_tokens = response_config.get("stream_tokens", True)
 
             # Resilience is handled by the resilient workflow executor
 
@@ -8905,7 +9002,9 @@ Agent response: {raw_response}"""
                 stage="response_preparation",
                 skip_rephrase=True,
             )
-            response = await self._apply_persona(None, message)
+            # stream_deltas: the persona output IS the final text on this
+            # path (returned and completed-emitted verbatim below)
+            response = await self._apply_persona(None, message, stream_deltas=True)
 
             # NOTE: Assistant response buffer storage is handled by
             # chat_orchestrator._process_sync_chat() after this returns.
@@ -9819,9 +9918,13 @@ Agent response: {raw_response}"""
         # Apply persona to format the response (except for clarifications)
         if result and hasattr(result, "content"):
             if isinstance(result.content, str):
-                # Simple string content - apply persona directly
+                # Simple string content - apply persona directly.
+                # stream_deltas: this persona output becomes result.content
+                # and is emitted verbatim in the terminal `completed` event
+                # below (json/html post-wrapping is excluded by the gate in
+                # _should_stream_response_deltas).
                 formatted_content = await self._apply_persona(
-                    result.content, message, session_id=session_id
+                    result.content, message, session_id=session_id, stream_deltas=True
                 )
                 result.content = formatted_content
             elif isinstance(result.content, dict):
@@ -9869,9 +9972,11 @@ Agent response: {raw_response}"""
                         # Last resort - format as JSON
                         extracted_text = json_lib.dumps(result.content, indent=2)
 
-                # Apply persona to the extracted text
+                # Apply persona to the extracted text.
+                # stream_deltas: same terminal path as the string branch
+                # above -- persona output is the final `completed` content.
                 formatted_content = await self._apply_persona(
-                    extracted_text, message, session_id=session_id
+                    extracted_text, message, session_id=session_id, stream_deltas=True
                 )
                 result.content = formatted_content
 

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -3322,10 +3322,24 @@ class Overlord:
                 if parts:
                     return "".join(parts)
             except Exception as e:
+                # If deltas were already published, the fallback below runs a
+                # FRESH generation whose text will differ from the streamed
+                # prefix. Mark the discontinuity so the terminal `completed`
+                # event carries `stream_discontinuity: true` and
+                # delta-rendering clients (which normally dedup/suppress
+                # completed.content) know to discard their partial text and
+                # use the authoritative completed.content instead. With zero
+                # deltas published there is nothing to invalidate.
+                if parts:
+                    streaming.mark_stream_discontinuity()
                 observability.observe(
                     event_type=observability.ErrorEvents.INTERNAL_ERROR,
                     level=observability.EventLevel.WARNING,
-                    data={"error": str(e), "stage": "persona_stream_deltas"},
+                    data={
+                        "error": str(e),
+                        "stage": "persona_stream_deltas",
+                        "deltas_published": len(parts),
+                    },
                     description=(
                         f"Streaming persona generation failed, falling back "
                         f"to non-streaming: {e}"

--- a/src/muxi/runtime/services/llm/llm.py
+++ b/src/muxi/runtime/services/llm/llm.py
@@ -1498,6 +1498,63 @@ class LLM:
                 **kwargs,
             )
 
+    async def chat_stream(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        **kwargs: Any,
+    ):
+        """
+        Stream a text-only chat completion, yielding text deltas as they arrive.
+
+        Deltas are passed through exactly as the provider chunks them — no
+        coalescing or re-chunking happens here (consumers coalesce if needed).
+
+        Notes:
+            - Text-only: files/multimodal are not supported on this path.
+            - Bypasses the resilience wrapper: retrying a partially consumed
+              stream would replay text the consumer already handled, so errors
+              propagate and the caller decides how to fall back.
+            - Token accounting is unavailable for streamed responses (chunks
+              carry no usage block), so MODEL_REQUEST_COMPLETED is not emitted.
+
+        Args:
+            messages: A list of messages in the conversation.
+            temperature: Controls randomness. Overrides the instance setting.
+            max_tokens: The maximum number of tokens to generate.
+            **kwargs: Additional provider-specific parameters (e.g. caching).
+
+        Yields:
+            Non-empty text deltas (str) in generation order.
+        """
+        params = await self._prepare_chat_request(
+            messages,
+            None,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs,
+        )
+        params["stream"] = True
+
+        response = await ChatCompletion.acreate(**params)
+
+        # Record telemetry for the streamed LLM request (parity with chat())
+        from ...services.telemetry import get_telemetry
+
+        telemetry = get_telemetry()
+        if telemetry:
+            telemetry.record_llm_request(self._provider, self._model, cache_hit=False)
+
+        async for chunk in response:
+            choices = getattr(chunk, "choices", None)
+            if not choices:
+                continue
+            delta = getattr(choices[0], "delta", None)
+            text = getattr(delta, "content", None) if delta is not None else None
+            if text:
+                yield text
+
     async def _advanced_multimodal_processing(
         self,
         messages: List[Dict[str, str]],

--- a/src/muxi/runtime/services/streaming.py
+++ b/src/muxi/runtime/services/streaming.py
@@ -321,6 +321,16 @@ def stream(event_type: str, content: str, **metadata):
             if event_type not in terminal_events:
                 return  # Skip all progress/thinking/planning events to save on LLM costs
 
+        # Content deltas (incremental final-response tokens) are emitted
+        # synchronously: they are high-frequency, strictly order-sensitive,
+        # and never LLM-rephrased. Routing them through the background
+        # thread pool could reorder chunks under thread scheduling, which
+        # would scramble the streamed text. emit_event is a cheap in-memory
+        # append, so the synchronous path adds no meaningful latency.
+        if event_type == "content":
+            streaming_manager.emit_event(request_context.id, event_type, content, **metadata)
+            return
+
         @multitasking.task
         def _emit_in_background(manager, req_id, evt_type, evt_content, evt_metadata, config):
             try:

--- a/src/muxi/runtime/services/streaming.py
+++ b/src/muxi/runtime/services/streaming.py
@@ -47,6 +47,21 @@ class StreamingManager:
             if request_id not in self.event_streams:
                 self.event_streams[request_id] = {"owner": (user_id, session_id), "events": []}
 
+    def mark_discontinuity(self, request_id: str):
+        """
+        Mark this request's published content deltas as invalidated.
+
+        Called when a fallback regeneration runs AFTER content deltas were
+        already published: the deltas belong to an abandoned generation, so
+        the terminal ``completed`` event for this request will carry
+        ``stream_discontinuity: true`` telling delta-rendering clients to
+        discard their accumulated deltas and use ``completed.content``
+        (which stays the full authoritative text) instead.
+        """
+        with self._lock:
+            if request_id in self.event_streams:
+                self.event_streams[request_id]["discontinuity"] = True
+
     def emit_event(self, request_id: str, event_type: str, content: str, **metadata):
         """Simple event storage - just in-memory dict/list operations"""
         with self._lock:
@@ -55,6 +70,11 @@ class StreamingManager:
 
             stream_data = self.event_streams[request_id]
             user_id, session_id = stream_data["owner"]
+
+            # Additive, absent-when-false: only a marked request's terminal
+            # completed event carries the flag (see mark_discontinuity).
+            if event_type == "completed" and stream_data.get("discontinuity"):
+                metadata.setdefault("stream_discontinuity", True)
 
             event = {
                 "request_id": request_id,
@@ -409,6 +429,29 @@ def stream(event_type: str, content: str, **metadata):
 
 
 # Helper functions
+def mark_stream_discontinuity():
+    """
+    Flag the current request's published content deltas as invalidated.
+
+    Used by the final-response fallback path: when a streaming generation
+    fails AFTER deltas were published and a fresh non-streaming generation
+    replaces it, the already-streamed text no longer matches the final
+    text. The terminal ``completed`` event then carries
+    ``stream_discontinuity: true`` so delta-rendering clients know to
+    treat ``completed.content`` as authoritative. No-op when the request
+    is not streaming-enabled.
+    """
+    try:
+        from .observability.context import get_current_request_context
+
+        request_context = get_current_request_context()
+        if request_context and getattr(request_context, "id", None):
+            streaming_manager.mark_discontinuity(request_context.id)
+    except Exception:
+        # Silent failure like the rest of the streaming API
+        pass
+
+
 def enable_streaming(request_id: str, user_id: str, session_id: str):
     """Enable streaming for a request"""
     streaming_manager.enable_streaming(request_id, user_id, session_id)

--- a/tests/unit/test_stream_content_deltas.py
+++ b/tests/unit/test_stream_content_deltas.py
@@ -1,0 +1,280 @@
+"""Tests for final-response token streaming (``content`` delta events).
+
+Feature contract
+----------------
+During a streaming chat turn the FINAL response LLM call (the persona
+pass in ``Overlord._apply_persona``) may stream its output as
+incremental ``type: "content"`` events so clients can render text as it
+generates. The feature is strictly additive:
+
+- the terminal ``completed`` event still carries the full final text;
+- deltas are emitted only when the persona output IS the final text --
+  call sites that post-process the output (json wrapping, html
+  prettify, credential-option formatting) never stream;
+- ``overlord.config.response.stream_tokens: false`` disables deltas;
+- delta chunking is passed through as the provider yields it (clients
+  coalesce); ordering is guaranteed by synchronous emission.
+"""
+
+import asyncio
+
+import pytest
+
+from muxi.runtime.datatypes.observability import RequestContext
+from muxi.runtime.formation.overlord.overlord import Overlord
+from muxi.runtime.services.observability.context import set_request_context
+from muxi.runtime.services.streaming import streaming_manager
+
+REQUEST_ID = "req_stream_deltas_test"
+USER_ID = "user_1"
+SESSION_ID = "sess_1"
+
+CHUNKS = ["Hel", "lo ", "wor", "ld!"]
+
+
+class _FakeStreamingLLM:
+    """Persona model stub with both streaming and non-streaming APIs."""
+
+    def __init__(self, chunks=None, stream_error_after=None):
+        self.chunks = chunks if chunks is not None else list(CHUNKS)
+        self.stream_error_after = stream_error_after
+        self.chat_called = False
+        self.chat_stream_called = False
+
+    async def chat_stream(self, messages, **kwargs):
+        self.chat_stream_called = True
+        for i, chunk in enumerate(self.chunks):
+            if self.stream_error_after is not None and i >= self.stream_error_after:
+                raise RuntimeError("provider stream broke")
+            yield chunk
+
+    async def chat(self, messages, **kwargs):
+        self.chat_called = True
+
+        class _Response:
+            content = "".join(CHUNKS)
+
+        return _Response()
+
+
+class _NoCancelTracker:
+    """Request tracker stub: nothing is ever cancelled."""
+
+    def is_cancelled(self, request_id):
+        return False
+
+    async def clear_cancelled(self, request_id):
+        pass
+
+
+def _make_overlord(llm, stream_tokens=True, response_format="markdown"):
+    overlord = Overlord.__new__(Overlord)
+    overlord.routing_model = llm
+    overlord._default_persona = "You are a helpful assistant."
+    overlord.request_tracker = _NoCancelTracker()
+    overlord.stream_tokens = stream_tokens
+    overlord.response_format = response_format
+    return overlord
+
+
+@pytest.fixture(autouse=True)
+def _reset_request_context():
+    """Never leak the request-context ContextVar into other tests."""
+    yield
+    set_request_context(None)
+
+
+@pytest.fixture()
+def streaming_request():
+    """Set a request context and enable streaming for it; clean up after."""
+    set_request_context(RequestContext(id=REQUEST_ID, user_id=USER_ID, session_id=SESSION_ID))
+    streaming_manager.enable_streaming(REQUEST_ID, USER_ID, SESSION_ID)
+    yield REQUEST_ID
+    streaming_manager.disable_streaming(REQUEST_ID)
+
+
+def _recorded_events(request_id=REQUEST_ID):
+    with streaming_manager._lock:
+        stream_data = streaming_manager.event_streams.get(request_id)
+        return list(stream_data["events"]) if stream_data else []
+
+
+def _content_events(request_id=REQUEST_ID):
+    return [e for e in _recorded_events(request_id) if e["type"] == "content"]
+
+
+def test_deltas_emitted_in_order_and_returned_text_matches(streaming_request):
+    """Streaming persona call emits one content event per chunk, in order."""
+    llm = _FakeStreamingLLM()
+    overlord = _make_overlord(llm)
+
+    result = asyncio.run(
+        overlord._apply_persona("agent says hi", "hello there", stream_deltas=True)
+    )
+
+    assert llm.chat_stream_called, "persona call should use the streaming API"
+    assert not llm.chat_called, "non-streaming fallback should not fire"
+
+    deltas = [e["content"] for e in _content_events()]
+    assert deltas == CHUNKS, "deltas must pass through as chunked, in order"
+    # The returned (final) text is the concatenation of the deltas --
+    # the terminal completed event downstream carries exactly this text.
+    assert result == "".join(CHUNKS)
+
+
+def test_content_events_carry_standard_envelope(streaming_request):
+    """content events ride the standard envelope (ids + timestamp)."""
+    overlord = _make_overlord(_FakeStreamingLLM())
+    asyncio.run(overlord._apply_persona("raw", "msg", stream_deltas=True))
+
+    events = _content_events()
+    assert events, "expected at least one content event"
+    for event in events:
+        assert event["request_id"] == REQUEST_ID
+        assert event["user_id"] == USER_ID
+        assert event["session_id"] == SESSION_ID
+        assert "timestamp" in event
+        assert event["stage"] == "response_generation"
+
+
+def test_config_off_no_deltas(streaming_request):
+    """stream_tokens: false disables deltas; non-streaming call is used."""
+    llm = _FakeStreamingLLM()
+    overlord = _make_overlord(llm, stream_tokens=False)
+
+    result = asyncio.run(overlord._apply_persona("raw", "msg", stream_deltas=True))
+
+    assert not llm.chat_stream_called
+    assert llm.chat_called
+    assert _content_events() == []
+    assert result == "".join(CHUNKS)
+
+
+@pytest.mark.parametrize("response_format", ["json", "html"])
+def test_rewrite_step_present_no_deltas(streaming_request, response_format):
+    """Formats post-processed AFTER persona (json wrap, html prettify) never
+    stream: the generated text is not the text the user receives."""
+    llm = _FakeStreamingLLM()
+    overlord = _make_overlord(llm, response_format=response_format)
+
+    asyncio.run(overlord._apply_persona("raw", "msg", stream_deltas=True))
+
+    assert not llm.chat_stream_called
+    assert llm.chat_called
+    assert _content_events() == []
+
+
+def test_no_opt_in_no_deltas(streaming_request):
+    """Call sites that don't opt in (error paths, credential formatting)
+    keep today's behavior even when all runtime gates would allow it."""
+    llm = _FakeStreamingLLM()
+    overlord = _make_overlord(llm)
+
+    asyncio.run(overlord._apply_persona("raw", "msg"))
+
+    assert not llm.chat_stream_called
+    assert llm.chat_called
+    assert _content_events() == []
+
+
+def test_not_streaming_request_no_deltas():
+    """Without a streaming subscriber the persona call stays non-streaming."""
+    set_request_context(
+        RequestContext(id="req_not_streaming", user_id=USER_ID, session_id=SESSION_ID)
+    )
+    llm = _FakeStreamingLLM()
+    overlord = _make_overlord(llm)
+
+    asyncio.run(overlord._apply_persona("raw", "msg", stream_deltas=True))
+
+    assert not llm.chat_stream_called
+    assert llm.chat_called
+
+
+def test_stream_failure_falls_back_to_non_streaming(streaming_request):
+    """A broken provider stream falls back to the regular call so the turn
+    still produces a full response (completed stays authoritative)."""
+    llm = _FakeStreamingLLM(stream_error_after=2)
+    overlord = _make_overlord(llm)
+
+    result = asyncio.run(overlord._apply_persona("raw", "msg", stream_deltas=True))
+
+    assert llm.chat_stream_called
+    assert llm.chat_called, "must fall back after the stream errors"
+    assert result == "".join(CHUNKS), "fallback must return the full text"
+
+
+def test_empty_stream_falls_back_to_non_streaming(streaming_request):
+    """Zero yielded deltas (empty stream) must not produce an empty reply."""
+    llm = _FakeStreamingLLM(chunks=[])
+    overlord = _make_overlord(llm)
+
+    result = asyncio.run(overlord._apply_persona("raw", "msg", stream_deltas=True))
+
+    assert llm.chat_called
+    assert result == "".join(CHUNKS)
+
+
+def test_content_events_emitted_synchronously():
+    """content events bypass the background emitter thread: they must be
+    visible in the event list immediately after stream() returns, or thread
+    scheduling could reorder deltas."""
+    from muxi.runtime.services import streaming
+
+    request_id = "req_sync_emit"
+    set_request_context(RequestContext(id=request_id, user_id=USER_ID, session_id=SESSION_ID))
+    streaming_manager.enable_streaming(request_id, USER_ID, SESSION_ID)
+    try:
+        for i in range(50):
+            streaming.stream("content", f"delta-{i}", stage="response_generation")
+        deltas = [e["content"] for e in _content_events(request_id)]
+        assert deltas == [f"delta-{i}" for i in range(50)]
+    finally:
+        streaming_manager.disable_streaming(request_id)
+
+
+def test_llm_chat_stream_passes_provider_chunks_through(monkeypatch):
+    """LLM.chat_stream yields provider deltas verbatim -- no coalescing,
+    empty chunks skipped."""
+    from muxi.runtime.services.llm import llm as llm_module
+
+    class _Delta:
+        def __init__(self, content):
+            self.content = content
+
+    class _Choice:
+        def __init__(self, content):
+            self.delta = _Delta(content)
+
+    class _Chunk:
+        def __init__(self, content):
+            self.choices = [_Choice(content)]
+
+    async def _fake_acreate(**params):
+        assert params["stream"] is True
+
+        async def _gen():
+            for text in ["a", "", None, "bc", "d"]:
+                yield _Chunk(text)
+
+        return _gen()
+
+    monkeypatch.setattr(llm_module.ChatCompletion, "acreate", staticmethod(_fake_acreate))
+
+    llm = llm_module.LLM.__new__(llm_module.LLM)
+    llm.model_name = "openai/gpt-test"
+    llm._provider = "openai"
+    llm._model = "gpt-test"
+    llm.temperature = 0.7
+    llm.max_tokens = None
+    llm.additional_params = {}
+
+    async def _collect():
+        return [
+            d
+            async for d in llm.chat_stream(
+                [{"role": "user", "content": "hi"}], max_tokens=100, caching=False
+            )
+        ]
+
+    assert asyncio.run(_collect()) == ["a", "bc", "d"]

--- a/tests/unit/test_stream_content_deltas.py
+++ b/tests/unit/test_stream_content_deltas.py
@@ -215,6 +215,71 @@ def test_empty_stream_falls_back_to_non_streaming(streaming_request):
     assert result == "".join(CHUNKS)
 
 
+def _emit_completed(content, request_id=REQUEST_ID):
+    """Emit a terminal completed event the way the overlord does and
+    return it (content events are synchronous; completed rides the same
+    emit_event path, called directly here for determinism)."""
+    streaming_manager.emit_event(request_id, "completed", content, status="success")
+    events = _recorded_events(request_id)
+    assert events and events[-1]["type"] == "completed"
+    return events[-1]
+
+
+def test_mid_stream_failure_flags_discontinuity_on_completed(streaming_request):
+    """Fallback regeneration AFTER published deltas: completed must carry
+    stream_discontinuity: true (deltas belong to the abandoned generation)
+    while still carrying the full authoritative text."""
+    llm = _FakeStreamingLLM(stream_error_after=2)
+    overlord = _make_overlord(llm)
+
+    result = asyncio.run(overlord._apply_persona("raw", "msg", stream_deltas=True))
+
+    assert len(_content_events()) == 2, "two deltas published before the failure"
+
+    completed = _emit_completed(result)
+    assert completed["stream_discontinuity"] is True
+    assert completed["content"] == "".join(CHUNKS), "full text stays authoritative"
+
+
+def test_failure_before_first_delta_no_discontinuity_flag(streaming_request):
+    """Zero deltas published before the failure: nothing to invalidate, so
+    the completed event carries no flag (absent, not false)."""
+    llm = _FakeStreamingLLM(stream_error_after=0)
+    overlord = _make_overlord(llm)
+
+    result = asyncio.run(overlord._apply_persona("raw", "msg", stream_deltas=True))
+
+    assert llm.chat_called, "must fall back after the stream errors"
+    assert _content_events() == []
+
+    completed = _emit_completed(result)
+    assert "stream_discontinuity" not in completed
+
+
+def test_empty_stream_fallback_no_discontinuity_flag(streaming_request):
+    """The empty-stream fallback (no error, no deltas) is not a
+    discontinuity either."""
+    llm = _FakeStreamingLLM(chunks=[])
+    overlord = _make_overlord(llm)
+
+    result = asyncio.run(overlord._apply_persona("raw", "msg", stream_deltas=True))
+
+    completed = _emit_completed(result)
+    assert "stream_discontinuity" not in completed
+
+
+def test_normal_path_no_discontinuity_flag(streaming_request):
+    """A clean streamed generation never flags: additive, absent-when-false."""
+    llm = _FakeStreamingLLM()
+    overlord = _make_overlord(llm)
+
+    result = asyncio.run(overlord._apply_persona("raw", "msg", stream_deltas=True))
+
+    assert [e["content"] for e in _content_events()] == CHUNKS
+    completed = _emit_completed(result)
+    assert "stream_discontinuity" not in completed
+
+
 def test_content_events_emitted_synchronously():
     """content events bypass the background emitter thread: they must be
     visible in the event list immediately after stream() returns, or thread


### PR DESCRIPTION
## Summary

During a streaming chat turn, the final assistant text used to arrive only once — inside the terminal `completed` event. Clients (e.g. the ACP bridge) could not render text as it generated. This PR streams the final-response LLM call and emits each provider chunk as a `type: "content"` SSE event.

## How it works

- The persona pass (`Overlord._apply_persona`) is the single final-response LLM call for both the fast conversational path and the standard agent/workflow path. When the turn has a streaming subscriber, that call now runs via a new `LLM.chat_stream()` async generator and emits every chunk as a `content` event with the standard envelope (request_id, user_id, session_id, timestamp).
- **Strictly additive**: the terminal `completed` event still carries the full final text. Clients that only read the terminal event keep working; delta-rendering clients dedup it.
- **Rewrite-step safety**: deltas are emitted only when the generated text IS the delivered text. Turns whose text is rewritten after generation are gated off and keep today's behavior:
  - `response.format: json` (JSON envelope wrapping) and `html` (BeautifulSoup prettify) — gated in `_should_stream_response_deltas()`
  - credential-option formatting and error-path persona calls — never opt in (call-site opt-in via `stream_deltas=True` is limited to the three sites whose output flows verbatim into `completed`)
- **Ordering**: `content` events bypass the background emitter thread (which could reorder chunks under thread scheduling) and are appended synchronously — a cheap in-memory append.
- **Failure**: any mid-stream provider failure falls back to the regular non-streaming call, so the turn always answers; `completed` remains authoritative. `chat_stream` deliberately skips the resilience/retry wrapper — replaying a partially consumed stream would duplicate text.
- **Config**: `overlord.config.response.stream_tokens` (default `true`). Chunking is passed through as the provider yields it; clients coalesce.

## Testing

- Unit (`tests/unit/test_stream_content_deltas.py`, 11 tests): deltas in order, envelope fields, config off → no deltas, json/html rewrite → no deltas, no opt-in → no deltas, non-streaming request → no deltas, mid-stream failure and empty-stream fallback, synchronous emission ordering (50 deltas), `chat_stream` chunk pass-through.
- Unit breadth: 169 passed (`-k "streaming or chat_orchestrator or overlord or persona or llm"`).
- E2E: new `10_streaming/test_10_a_7.py` passed live (395 content deltas, all before `completed`, concatenation matches `completed.content`, clean termination). Regression: `test_10_a_1` and `test_10_a_5` (progress-disabled formation) both pass.
- Lint: black/isort/ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)