### PR TITLE
feat: adopt anydoc as primary document converter with MarkItDown fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## [unreleased]
 
+### anydoc is now the primary document converter
+
+Office-document conversion (chat attachments and knowledge sources) now
+runs on Firecrawl's anydoc (Rust, `firecrawl-anydoc`) inside the same
+out-of-process sandbox that previously ran MarkItDown, extending the
+pdf-inspector-primary/MarkItDown-fallback pattern to every office format.
+
+- Coverage gained: legacy Office (.doc/.ppt/.pps/.pot/.xls), macro
+  variants (.docm/.pptm/.ppsm/.ppsx/.xlsm/.xlsb), OpenDocument
+  (.odt/.ods/.odp), RTF, and EPUB now convert -- formats MarkItDown never
+  handled. The chat-attachment gate and knowledge-source extension list
+  widened to match.
+- Per-file fallback: when anydoc fails on a file, conversion retries with
+  sandboxed MarkItDown for the formats MarkItDown supports
+  (docx/pptx/xlsx/xls/csv/epub) and emits
+  `document.conversion.fallback` with `primary`/`fallback` converter
+  names in the payload. Those events are the measurement story: when
+  fallbacks stop appearing in the field, MarkItDown can be dropped from
+  the office-document path entirely. anydoc-only formats quarantine
+  honestly as `parser_error` -- no fake fallback.
+- PDFs are unchanged: pdf-inspector stays primary (it classifies
+  native-text vs scanned pages, a signal anydoc's Python API does not
+  expose) with the existing MarkItDown fallback.
+- Mechanism swap only: no new configuration keys, same sandbox rlimits,
+  timeouts, and quarantine semantics.
+
 ### Inline credential collection no longer orphans its request
 
 Interactive turns are deliberately left PROCESSING, because the follow-up

--- a/e2e/tests/3_multimodal/test_3m1_anydoc_document_conversion.py
+++ b/e2e/tests/3_multimodal/test_3m1_anydoc_document_conversion.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""
+Test 3M1: anydoc document conversion -> RTF/ODT/CSV/DOCX attachments convert,
+corrupt anydoc-only file quarantines.
+
+Feature test for the anydoc-primary document conversion routing: office,
+OpenDocument, RTF, EPUB, and CSV attachments are converted out-of-process by
+anydoc (Firecrawl's Rust converter) inside the same sandbox that previously
+ran MarkItDown, with DOCUMENT_CONVERSION_COMPLETED events naming the engine.
+A deliberately-corrupt ODT (an anydoc-only format, so no MarkItDown fallback
+exists) must quarantine as parser_error while the chat degrades gracefully.
+
+Standalone script (per e2e conventions): run directly, not via pytest.
+"""
+
+import asyncio
+import io
+import sys
+import threading
+import time
+import zipfile
+from pathlib import Path
+
+# Add parent directories to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "src"))
+
+from muxi.runtime.formation import Formation  # noqa: E402
+from muxi.runtime.services import observability  # noqa: E402
+
+COMPLETED_EVENT = "document.conversion.completed"
+QUARANTINE_EVENT = "document.conversion.quarantined"
+
+# --- Real fixtures, built from scratch (no binary blobs in the repo) --------
+
+RTF_FIXTURE = (
+    rb"{\rtf1\ansi\deff0 {\fonttbl {\f0 Times New Roman;}}"
+    rb"\f0\fs24 Quarterly revenue grew {\b fourteen percent} in Q3.\par}"
+)
+
+CSV_FIXTURE = b"product,units\nwidget,3\ngadget,7\n"
+
+
+def make_odt_bytes(text: str) -> bytes:
+    """A minimal but valid ODT: a zip with the ODF mimetype and content.xml."""
+    content_xml = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        "<office:document-content"
+        ' xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"'
+        ' xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"'
+        ' office:version="1.2">'
+        f"<office:body><office:text><text:p>{text}</text:p></office:text></office:body>"
+        "</office:document-content>"
+    )
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr(
+            "mimetype",
+            "application/vnd.oasis.opendocument.text",
+            compress_type=zipfile.ZIP_STORED,
+        )
+        archive.writestr("content.xml", content_xml)
+    return buffer.getvalue()
+
+
+def make_docx_bytes(text: str) -> bytes:
+    import docx
+
+    document = docx.Document()
+    document.add_paragraph(text)
+    buffer = io.BytesIO()
+    document.save(buffer)
+    return buffer.getvalue()
+
+
+# Zip local-file magic followed by garbage: anydoc detects the ODT route but
+# cannot read the archive. ODT is anydoc-only (MarkItDown has no ODF support),
+# so there is no fallback and the file must quarantine as parser_error.
+CORRUPT_ODT = b"PK\x03\x04" + b"\x00\xff\xfe\x01" * 128
+
+
+class CapturingLogger:
+    """Event sink recording everything observe() emits (same shape as test 3L1)."""
+
+    def __init__(self):
+        self._events = []
+        self._lock = threading.Lock()
+
+    def should_emit(self, event_type, level):
+        return True
+
+    def emit_event(self, event_type=None, level=None, data=None, description=None, **kwargs):
+        with self._lock:
+            self._events.append(
+                {
+                    "event": getattr(event_type, "value", str(event_type)),
+                    "data": data,
+                    "description": description,
+                }
+            )
+        return ""
+
+    def snapshot(self):
+        with self._lock:
+            return list(self._events)
+
+
+async def wait_for_events(capturing, predicate, timeout=10):
+    deadline = time.time() + timeout
+    matches = []
+    while time.time() < deadline:
+        matches = [e for e in capturing.snapshot() if predicate(e)]
+        if matches:
+            break
+        await asyncio.sleep(0.25)
+    return matches
+
+
+async def run() -> bool:
+    print("=" * 70)
+    print("Test 3M1: anydoc document conversion (RTF/ODT/CSV/DOCX + corrupt quarantine)")
+    print("=" * 70)
+
+    formation_path = Path(__file__).parent / "formations" / "formation-multimodal"
+    formation = Formation()
+    await formation.load(str(formation_path))
+    overlord = await formation.start_overlord()
+    print("1. Overlord started")
+
+    capturing = CapturingLogger()
+    observability.set_runtime_event_logger(capturing)
+
+    good_files = [
+        {
+            "filename": "report.rtf",
+            "content": RTF_FIXTURE,
+            "content_type": "application/rtf",
+            "size": len(RTF_FIXTURE),
+        },
+        {
+            "filename": "letter.odt",
+            "content": make_odt_bytes("The onboarding letter mentions a purple giraffe."),
+            "content_type": "application/vnd.oasis.opendocument.text",
+            "size": 0,
+        },
+        {
+            "filename": "inventory.csv",
+            "content": CSV_FIXTURE,
+            "content_type": "text/csv",
+            "size": len(CSV_FIXTURE),
+        },
+        {
+            "filename": "memo.docx",
+            "content": make_docx_bytes("The memo approves the anydoc rollout."),
+            "content_type": (
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            ),
+            "size": 0,
+        },
+    ]
+    for f in good_files:
+        f["size"] = len(f["content"])
+
+    print(f"2. Sending chat with {len(good_files)} attachments (rtf/odt/csv/docx)...")
+    response = await overlord.chat(
+        user_id="test_user",
+        message="Please summarize the attached documents for me.",
+        files=good_files,
+        use_async=False,
+        stream=False,
+    )
+    result = response.content if hasattr(response, "content") else str(response)
+    print(f"3. Chat completed; response length: {len(result)} chars")
+    assert isinstance(result, str) and len(result) > 0, "chat did not return a response"
+
+    expected = {f["filename"] for f in good_files}
+    completed = await wait_for_events(
+        capturing,
+        lambda e: e["event"] == COMPLETED_EVENT and (e["data"] or {}).get("filename") in expected,
+    )
+    # Wait until all four completions arrive (events emit on background threads).
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        completed = [
+            e
+            for e in capturing.snapshot()
+            if e["event"] == COMPLETED_EVENT and (e["data"] or {}).get("filename") in expected
+        ]
+        if {(e["data"] or {}).get("filename") for e in completed} == expected:
+            break
+        await asyncio.sleep(0.25)
+
+    seen = {(e["data"] or {}).get("filename"): (e["data"] or {}).get("engine") for e in completed}
+    print(f"4. Conversion events captured: {seen}")
+    assert set(seen) == expected, f"missing conversion events; got {set(seen)}"
+    for filename, engine in seen.items():
+        assert engine == "anydoc", f"{filename} converted by {engine}, expected anydoc"
+
+    # --- Corrupt anydoc-only format: quarantine, no fallback, graceful chat ---
+    corrupt_file = [
+        {
+            "filename": "broken.odt",
+            "content": CORRUPT_ODT,
+            "content_type": "application/vnd.oasis.opendocument.text",
+            "size": len(CORRUPT_ODT),
+        }
+    ]
+    print(f"5. Sending chat with corrupt ODT attachment ({len(CORRUPT_ODT)} bytes)...")
+    response = await overlord.chat(
+        user_id="test_user",
+        message="Please summarize the attached document for me.",
+        files=corrupt_file,
+        use_async=False,
+        stream=False,
+    )
+    result = response.content if hasattr(response, "content") else str(response)
+    print(f"6. Chat completed; response length: {len(result)} chars")
+    assert isinstance(result, str) and len(result) > 0, "chat did not return a response"
+
+    quarantined = await wait_for_events(
+        capturing,
+        lambda e: e["event"] == QUARANTINE_EVENT
+        and (e["data"] or {}).get("filename") == "broken.odt",
+    )
+    assert quarantined, (
+        f"no {QUARANTINE_EVENT} event for broken.odt; "
+        f"captured events: {sorted({e['event'] for e in capturing.snapshot()})}"
+    )
+    data = quarantined[0]["data"] or {}
+    print(f"7. Quarantine event captured: reason={data.get('quarantine_reason')}")
+    assert data.get("quarantine_reason") == "parser_error", data
+    assert data.get("engine") == "anydoc", data
+
+    await formation.stop_overlord()
+    print("8. Overlord stopped cleanly")
+
+    print("\n" + "=" * 40 + "\n")
+    print("### Test Result:")
+    print("  🎉 SUCCESS: anydoc converted rtf/odt/csv/docx attachments end to end")
+    print("  ✓ document.conversion.completed emitted with engine=anydoc for all four")
+    print("  ✓ Corrupt ODT (anydoc-only, no fallback) quarantined as parser_error")
+    print("  ✓ Both chat requests completed with normal responses")
+    return True
+
+
+if __name__ == "__main__":
+    success = asyncio.run(run())
+    sys.exit(0 if success else 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,12 @@ dependencies = [
     # declares requires_python='<3.14' and blocks Python 3.14 installs even
     # though MUXI never imports it.
     "markitdown[docx,pdf,pptx,xls,xlsx]>=0.1.6",  # Convert various file formats to Markdown
+    # Primary office-document converter (Rust, imports as `anydoc`): Word
+    # (.doc/.docx/.docm), PowerPoint (.ppt/.pps/.pot/.pptx/.pptm/.ppsx/.ppsm),
+    # Excel (.xls/.xlsx/.xlsm/.xlsb), OpenDocument, RTF, EPUB, CSV. MarkItDown
+    # (above) remains the per-file fallback for the formats it supports and the
+    # converter for everything anydoc does not claim (HTML, images, ...).
+    "firecrawl-anydoc>=0.1.3",
     "pdf-inspector>=0.2.6",  # PDF classification + native-text markdown extraction (sandboxed)
     "pypdf>=6.14.2",  # PDF document processing (successor to PyPDF2); inline-image loop + xref DoS advisories fixed in 6.14.x
     "python-docx>=1.2.0",  # Word document processing

--- a/src/muxi/runtime/datatypes/observability.py
+++ b/src/muxi/runtime/datatypes/observability.py
@@ -711,14 +711,16 @@ class ConversationEvents(Enum):
     # When document processing fails
 
     DOCUMENT_CONVERSION_COMPLETED = "document.conversion.completed"
-    # When sandboxed document conversion (pdf-inspector/MarkItDown) succeeds
+    # When sandboxed document conversion (anydoc/pdf-inspector/MarkItDown) succeeds
 
     DOCUMENT_CONVERSION_QUARANTINED = "document.conversion.quarantined"
     # When sandboxed conversion is refused/killed (timeout, memory, oversize,
     # parser_error, encrypted, unsupported) and the document is quarantined
 
     DOCUMENT_CONVERSION_FALLBACK = "document.conversion.fallback"
-    # When pdf-inspector fails on a PDF and conversion falls back to MarkItDown
+    # When a primary converter (anydoc on office docs, pdf-inspector on PDFs)
+    # fails and conversion falls back to MarkItDown for that file; the payload
+    # carries primary/fallback converter names
 
     CONTENT_EXTRACTION_STARTED = "content.extraction.started"
     # When content extraction from media begins

--- a/src/muxi/runtime/formation/agents/knowledge/base.py
+++ b/src/muxi/runtime/formation/agents/knowledge/base.py
@@ -58,7 +58,11 @@ from typing import Any, Dict, List, Optional
 from ....services import observability
 
 # Sandboxed document conversion (out-of-process anydoc / pdf-inspector / MarkItDown)
-from ....services.multimodal.document_converter import convert_document
+from ....services.multimodal.document_converter import (
+    ANYDOC_EXTENSIONS,
+    ENGINE_ANYDOC,
+    convert_document,
+)
 
 # Import DocumentChunkManager for hybrid architecture integration
 from ...documents.storage.chunk_manager import DocumentChunk, DocumentChunkManager
@@ -544,7 +548,17 @@ class FileKnowledge(KnowledgeSource):
         return all_chunks
 
     def _get_processing_method(self, file_path: str) -> str:
-        """Get the processing method used for a file."""
+        """Get the processing method (converter engine) used for a file.
+
+        Mirrors the converter's actual routing: anydoc-claimed extensions
+        convert via anydoc (PDF stays on the pdf-inspector route), so chunk
+        metadata and diagnostics name the engine that really ran.
+        """
+        ext = os.path.splitext(file_path)[1].lower()
+        if ext == ".pdf":
+            return "pdf-inspector"
+        if ext in ANYDOC_EXTENSIONS:
+            return ENGINE_ANYDOC
         if self._is_markitdown_supported(file_path):
             return "markitdown"
         elif self._is_text_file(file_path):

--- a/src/muxi/runtime/formation/agents/knowledge/base.py
+++ b/src/muxi/runtime/formation/agents/knowledge/base.py
@@ -57,7 +57,7 @@ from typing import Any, Dict, List, Optional
 # Import observability
 from ....services import observability
 
-# Sandboxed document conversion (out-of-process MarkItDown / pdf-inspector)
+# Sandboxed document conversion (out-of-process anydoc / pdf-inspector / MarkItDown)
 from ....services.multimodal.document_converter import convert_document
 
 # Import DocumentChunkManager for hybrid architecture integration
@@ -100,8 +100,13 @@ class FileKnowledge(KnowledgeSource):
     with support for recursive scanning and file extension filtering.
     It supports the new configuration schema with path, description, and options.
 
-    Enhanced with markitdown support for comprehensive file format handling:
-    - Office documents: .docx, .pptx, .xlsx, .xls
+    Converted via the sandboxed conversion service (anydoc for office/
+    OpenDocument/RTF/EPUB/CSV, pdf-inspector for PDFs, MarkItDown for the
+    rest and as per-file fallback):
+    - Office documents: .doc, .docx, .docm, .ppt, .pps, .pot, .pptx, .pptm,
+      .ppsx, .ppsm, .xls, .xlsx, .xlsm, .xlsb
+    - OpenDocument: .odt, .ods, .odp
+    - Rich text: .rtf
     - PDFs: .pdf
     - Images: .jpg, .jpeg, .png, .gif, .bmp, .tiff
     - Audio: .wav, .mp3
@@ -112,13 +117,30 @@ class FileKnowledge(KnowledgeSource):
     - Plain text: .txt, .md
     """
 
-    # Extended list of supported file extensions via markitdown
+    # Extensions handled by the sandboxed conversion service (the name predates
+    # anydoc: routing inside document_converter picks the actual engine).
     _MARKITDOWN_EXTENSIONS = [
-        # Office documents
+        # Office documents (anydoc: legacy, OOXML, and macro variants)
+        ".doc",
         ".docx",
+        ".docm",
+        ".ppt",
+        ".pps",
+        ".pot",
         ".pptx",
-        ".xlsx",
+        ".pptm",
+        ".ppsx",
+        ".ppsm",
         ".xls",
+        ".xlsx",
+        ".xlsm",
+        ".xlsb",
+        # OpenDocument (anydoc)
+        ".odt",
+        ".ods",
+        ".odp",
+        # Rich Text Format (anydoc)
+        ".rtf",
         # PDFs
         ".pdf",
         # Images (with OCR support)
@@ -221,7 +243,8 @@ class FileKnowledge(KnowledgeSource):
         """
         Load and process file content using appropriate method.
 
-        Uses markitdown for supported formats, direct reading for text files.
+        Uses the sandboxed conversion service for supported formats, direct
+        reading for text files.
 
         Args:
             file_path: Path to the file to load
@@ -251,7 +274,8 @@ class FileKnowledge(KnowledgeSource):
                     return f"[Error loading file: {os.path.basename(file_path)}]"
 
                 # Convert supported file types in the sandboxed subprocess
-                # (pdf-inspector for PDFs, MarkItDown for everything else).
+                # (anydoc for office/OpenDocument/RTF/EPUB/CSV, pdf-inspector
+                # for PDFs, MarkItDown for everything else and as fallback).
                 with open(file_path, "rb") as f:
                     raw = f.read()
                 conversion = convert_document(

--- a/src/muxi/runtime/formation/overlord/overlord.py
+++ b/src/muxi/runtime/formation/overlord/overlord.py
@@ -134,7 +134,7 @@ from ...services.multimodal import (
     WorkflowMultiModalProcessor,
 )
 
-# Sandboxed document conversion (out-of-process MarkItDown / pdf-inspector)
+# Sandboxed document conversion (out-of-process anydoc / pdf-inspector / MarkItDown)
 from ...services.multimodal.document_converter import (
     ATTACHMENT_CONVERTIBLE_EXTENSIONS,
     convert_document_async,
@@ -5724,8 +5724,10 @@ Agent response: {raw_response}"""
 
                 else:
                     # Convertible documents go through the sandboxed out-of-process
-                    # conversion service (pdf-inspector for PDFs, MarkItDown for
-                    # the rest); hostile files are quarantined, never parsed here.
+                    # conversion service (pdf-inspector for PDFs, anydoc for office/
+                    # OpenDocument/RTF/EPUB/CSV, MarkItDown for the rest and as
+                    # per-file fallback); hostile files are quarantined, never
+                    # parsed here.
                     file_ext = os.path.splitext(filename)[1].lower()
                     should_convert = file_ext in ATTACHMENT_CONVERTIBLE_EXTENSIONS
 

--- a/src/muxi/runtime/services/multimodal/conversion_worker.py
+++ b/src/muxi/runtime/services/multimodal/conversion_worker.py
@@ -8,9 +8,9 @@
 # Author:       Muxi Framework Team
 #
 # This script is the *only* code that touches untrusted document bytes with a
-# parser (pdf-inspector or MarkItDown). It is executed by file path (never
-# imported) so the muxi package import chain is skipped and the process stays
-# small and fast to spawn.
+# parser (anydoc, pdf-inspector, or MarkItDown). It is executed by file path
+# (never imported) so the muxi package import chain is skipped and the process
+# stays small and fast to spawn.
 #
 # Isolation model (v1, honest limits):
 #   - Process boundary: parser crashes/hangs kill this process, not the runtime.
@@ -45,6 +45,7 @@ except ImportError:  # pragma: no cover - Windows
 
 ENGINE_PDF_INSPECTOR = "pdf_inspector"
 ENGINE_MARKITDOWN = "markitdown"
+ENGINE_ANYDOC = "anydoc"
 
 # QuarantineReason values (mirrored from document_converter.QuarantineReason;
 # this file cannot import muxi modules).
@@ -106,27 +107,43 @@ def _convert_with_pdf_inspector(input_path: str) -> str:
     return pdf_inspector.process_pdf(input_path).markdown
 
 
-def _convert(engine: str, input_path: str, max_output_bytes: int) -> dict:
+def _convert_with_anydoc(input_path: str) -> str:
+    import anydoc
+
+    # Format is detected from the file content; the temp file's sanitized
+    # extension is the fallback for signature-less formats (CSV).
+    return anydoc.to_markdown(input_path)
+
+
+_CONVERTERS = {
+    ENGINE_PDF_INSPECTOR: _convert_with_pdf_inspector,
+    ENGINE_MARKITDOWN: _convert_with_markitdown,
+    ENGINE_ANYDOC: _convert_with_anydoc,
+}
+
+
+def _convert(engine: str, fallback_engine, input_path: str, max_output_bytes: int) -> dict:
     """Run the conversion, returning a result dict (never raising for parser errors)."""
     fallback_from = None
     fallback_error = None
     engine_used = engine
 
     try:
-        if engine == ENGINE_PDF_INSPECTOR:
-            try:
-                text = _convert_with_pdf_inspector(input_path)
-            except MemoryError:
+        try:
+            text = _CONVERTERS[engine](input_path)
+        except MemoryError:
+            raise
+        except Exception as primary_exc:  # noqa: BLE001 - untrusted input boundary
+            if not fallback_engine:
+                # No converter can retry this format; classify the primary
+                # failure honestly instead of pretending a fallback ran.
                 raise
-            except Exception as pdf_exc:  # noqa: BLE001 - untrusted input boundary
-                # pdf-inspector could not handle this PDF; fall back to
-                # sandboxed MarkItDown so we never fail harder than before.
-                fallback_from = ENGINE_PDF_INSPECTOR
-                fallback_error = f"{type(pdf_exc).__name__}: {pdf_exc}"
-                engine_used = ENGINE_MARKITDOWN
-                text = _convert_with_markitdown(input_path)
-        else:
-            text = _convert_with_markitdown(input_path)
+            # The primary converter could not handle this file; fall back to
+            # the sandboxed secondary so we never fail harder than before.
+            fallback_from = engine
+            fallback_error = f"{type(primary_exc).__name__}: {primary_exc}"
+            engine_used = fallback_engine
+            text = _CONVERTERS[fallback_engine](input_path)
     except MemoryError:
         return {
             "ok": False,
@@ -181,8 +198,12 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Sandboxed document conversion worker")
     parser.add_argument("input_path")
     parser.add_argument("output_path")
+    parser.add_argument("--engine", choices=sorted(_CONVERTERS), required=True)
     parser.add_argument(
-        "--engine", choices=[ENGINE_PDF_INSPECTOR, ENGINE_MARKITDOWN], required=True
+        "--fallback-engine",
+        choices=sorted(_CONVERTERS),
+        default=None,
+        help="Converter to retry with in-process when the primary engine raises",
     )
     parser.add_argument("--cpu-seconds", type=int, required=True)
     parser.add_argument("--memory-bytes", type=int, required=True)
@@ -190,7 +211,7 @@ def main() -> int:
     args = parser.parse_args()
 
     _apply_rlimits(args.cpu_seconds, args.memory_bytes, args.max_output_bytes)
-    result = _convert(args.engine, args.input_path, args.max_output_bytes)
+    result = _convert(args.engine, args.fallback_engine, args.input_path, args.max_output_bytes)
 
     with open(args.output_path, "w", encoding="utf-8") as handle:
         json.dump(result, handle)

--- a/src/muxi/runtime/services/multimodal/document_converter.py
+++ b/src/muxi/runtime/services/multimodal/document_converter.py
@@ -28,10 +28,20 @@
 # explicit output-size check apply.
 #
 # Routing: application/pdf (or a .pdf extension) goes to pdf-inspector, whose
-# native-text path runs locally and emits structured markdown. Everything else
-# stays on MarkItDown - now inside the same sandbox. If pdf-inspector fails on
-# a given PDF the worker falls back to sandboxed MarkItDown for that file, so
-# PDFs never fail harder than they did before routing existed.
+# native-text path runs locally, emits structured markdown, AND classifies
+# native-text vs scanned pages - anydoc's Python API returns only a markdown
+# string for PDFs (its to_document() explicitly rejects them), so the direct
+# pdf-inspector route stays. Office/OpenDocument/RTF/EPUB/CSV formats go to
+# anydoc (Firecrawl's Rust converter, which also covers legacy .doc/.ppt/.xls
+# and macro variants MarkItDown never handled). Everything else convertible
+# (HTML, ...) stays on MarkItDown - all inside the same sandbox.
+#
+# Fallbacks (per file, inside the worker): when the primary converter fails,
+# the worker retries with sandboxed MarkItDown for the formats MarkItDown
+# supports, so no format fails harder than it did before anydoc was primary.
+# Formats only anydoc can read (odt/ods/odp, rtf, legacy .doc/.ppt, macro
+# variants) have no fallback: a failure quarantines as parser_error and the
+# events say so honestly.
 # =============================================================================
 
 import asyncio
@@ -63,12 +73,89 @@ DEFAULT_MEMORY_LIMIT_BYTES = 2 * 1024 * 1024 * 1024
 
 _WORKER_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "conversion_worker.py")
 
-# Extensions the chat-attachment path converts (unchanged from the previous
-# in-process MarkItDown gate in overlord.py).
-ATTACHMENT_CONVERTIBLE_EXTENSIONS = [".pdf", ".docx", ".pptx", ".xlsx", ".html"]
-
 ENGINE_PDF_INSPECTOR = "pdf_inspector"
 ENGINE_MARKITDOWN = "markitdown"
+ENGINE_ANYDOC = "anydoc"
+
+# Extensions anydoc converts (its full claimed surface minus PDF, which keeps
+# the dedicated pdf-inspector route below).
+ANYDOC_EXTENSIONS = frozenset(
+    {
+        # Word
+        ".doc",
+        ".docx",
+        ".docm",
+        # PowerPoint
+        ".ppt",
+        ".pps",
+        ".pot",
+        ".pptx",
+        ".pptm",
+        ".ppsx",
+        ".ppsm",
+        # Excel
+        ".xls",
+        ".xlsx",
+        ".xlsm",
+        ".xlsb",
+        # OpenDocument
+        ".odt",
+        ".ods",
+        ".odp",
+        # Rich Text Format
+        ".rtf",
+        # E-books
+        ".epub",
+        # Data
+        ".csv",
+    }
+)
+
+# MIME types that route to anydoc (compared lowercased, parameters stripped).
+_ANYDOC_MEDIA_TYPES = frozenset(
+    {
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.ms-word.document.macroenabled.12",
+        "application/vnd.ms-powerpoint",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
+        "application/vnd.ms-powerpoint.presentation.macroenabled.12",
+        "application/vnd.ms-powerpoint.slideshow.macroenabled.12",
+        "application/vnd.ms-excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.ms-excel.sheet.macroenabled.12",
+        "application/vnd.ms-excel.sheet.binary.macroenabled.12",
+        "application/vnd.oasis.opendocument.text",
+        "application/vnd.oasis.opendocument.spreadsheet",
+        "application/vnd.oasis.opendocument.presentation",
+        "application/rtf",
+        "text/rtf",
+        "application/epub+zip",
+        "text/csv",
+    }
+)
+
+# The subset of anydoc's surface that sandboxed MarkItDown can also read
+# (verified against the markitdown[docx,pdf,pptx,xls,xlsx] extras actually
+# installed: its CSV and EPUB converters are built in, so both keep the
+# fallback they effectively had when MarkItDown was primary). Legacy .doc/.ppt,
+# macro variants, .xlsb, OpenDocument, and RTF are anydoc-only: no fallback.
+_MARKITDOWN_FALLBACK_EXTENSIONS = frozenset({".docx", ".pptx", ".xlsx", ".xls", ".csv", ".epub"})
+_MARKITDOWN_FALLBACK_MEDIA_TYPES = frozenset(
+    {
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.ms-excel",
+        "text/csv",
+        "application/epub+zip",
+    }
+)
+
+# Extensions the chat-attachment path converts: the previous MarkItDown gate
+# (.pdf/.docx/.pptx/.xlsx/.html) widened to anydoc's full claimed surface.
+ATTACHMENT_CONVERTIBLE_EXTENSIONS = [".pdf", ".html"] + sorted(ANYDOC_EXTENSIONS)
 
 # Environment variables stripped from the worker (best-effort network hygiene).
 _PROXY_ENV_VARS = (
@@ -102,14 +189,45 @@ class ConversionResult:
     quarantine_reason: Optional[QuarantineReason] = None
     detail: str = ""
     fallback_used: bool = False
+    fallback_from: Optional[str] = None  # primary engine that failed, when fallback_used
+
+
+def _normalized_media_type(media_type: Optional[str]) -> str:
+    """Lowercased MIME type with parameters stripped ('' when absent)."""
+    return (media_type or "").lower().split(";")[0].strip()
 
 
 def _select_engine(filename: str, media_type: Optional[str]) -> str:
-    """Deterministic routing by media type / extension: PDFs to pdf-inspector."""
+    """Deterministic routing by media type / extension.
+
+    PDFs go to pdf-inspector (which classifies native-text vs scanned pages -
+    a signal anydoc's PDF path does not expose), anydoc's claimed formats go
+    to anydoc, and everything else stays on MarkItDown.
+    """
     ext = os.path.splitext(filename)[1].lower()
-    if ext == ".pdf" or (media_type or "").lower().split(";")[0].strip() == "application/pdf":
+    media = _normalized_media_type(media_type)
+    if ext == ".pdf" or media == "application/pdf":
         return ENGINE_PDF_INSPECTOR
+    if ext in ANYDOC_EXTENSIONS or media in _ANYDOC_MEDIA_TYPES:
+        return ENGINE_ANYDOC
     return ENGINE_MARKITDOWN
+
+
+def _select_fallback_engine(engine: str, filename: str, media_type: Optional[str]) -> Optional[str]:
+    """The converter to retry with when the primary fails, or None.
+
+    pdf-inspector always falls back to MarkItDown (PDFs must never fail harder
+    than before routing existed). anydoc falls back to MarkItDown only for the
+    formats MarkItDown supports; anydoc-only formats quarantine honestly.
+    """
+    if engine == ENGINE_PDF_INSPECTOR:
+        return ENGINE_MARKITDOWN
+    if engine == ENGINE_ANYDOC:
+        ext = os.path.splitext(filename)[1].lower()
+        media = _normalized_media_type(media_type)
+        if ext in _MARKITDOWN_FALLBACK_EXTENSIONS or media in _MARKITDOWN_FALLBACK_MEDIA_TYPES:
+            return ENGINE_MARKITDOWN
+    return None
 
 
 def _safe_suffix(filename: str) -> str:
@@ -150,6 +268,7 @@ def _run_worker(
     timeout: float,
     memory_limit_bytes: int,
     max_output_bytes: int,
+    fallback_engine: Optional[str] = None,
 ) -> ConversionResult:
     """Spawn one worker process and classify its outcome. Never raises."""
     cmd = [
@@ -166,6 +285,8 @@ def _run_worker(
         "--max-output-bytes",
         str(max_output_bytes),
     ]
+    if fallback_engine:
+        cmd += ["--fallback-engine", fallback_engine]
     # POSIX: give the worker its own process group so the timeout kill also
     # reaps any helpers it spawned. Windows has neither start_new_session nor
     # os.killpg; a plain kill() of the worker is the fallback there.
@@ -228,7 +349,8 @@ def _run_worker(
             detail=f"unreadable worker result: {exc}",
         )
 
-    fallback_used = payload.get("fallback_from") is not None
+    fallback_from = payload.get("fallback_from")
+    fallback_used = fallback_from is not None
     if payload.get("ok"):
         return ConversionResult(
             ok=True,
@@ -236,6 +358,7 @@ def _run_worker(
             engine=payload.get("engine", engine),
             detail=payload.get("fallback_error") or "",
             fallback_used=fallback_used,
+            fallback_from=fallback_from,
         )
 
     try:
@@ -248,6 +371,7 @@ def _run_worker(
         quarantine_reason=reason,
         detail=payload.get("detail", ""),
         fallback_used=fallback_used,
+        fallback_from=fallback_from,
     )
 
 
@@ -271,7 +395,8 @@ def convert_document(
     Args:
         content: Raw document bytes (untrusted).
         filename: Original filename; its extension drives parser selection.
-        media_type: Optional MIME type; application/pdf routes to pdf-inspector.
+        media_type: Optional MIME type; application/pdf routes to pdf-inspector,
+            office/OpenDocument/RTF/EPUB/CSV types route to anydoc.
         timeout: Wall-clock ceiling for the conversion.
         max_input_bytes: Inputs larger than this are rejected before spawning.
         max_output_bytes: Converted text larger than this is quarantined.
@@ -295,6 +420,7 @@ def convert_document(
         return result
 
     engine = _select_engine(filename, media_type)
+    fallback_engine = _select_fallback_engine(engine, filename, media_type)
 
     try:
         with tempfile.TemporaryDirectory(prefix="muxi_docconv_") as workdir:
@@ -310,27 +436,31 @@ def convert_document(
                 timeout,
                 memory_limit_bytes,
                 max_output_bytes,
+                fallback_engine=fallback_engine,
             )
 
-            # If pdf-inspector crashed the worker outright (signal death, so the
-            # in-worker MarkItDown fallback never ran), retry once with
-            # MarkItDown - PDFs must never fail harder than before routing.
+            # If the primary converter crashed the worker outright (signal
+            # death, so the in-worker fallback never ran), retry once with the
+            # fallback engine - the file must never fail harder than it did
+            # when that engine was primary.
             if (
                 not result.ok
-                and engine == ENGINE_PDF_INSPECTOR
+                and fallback_engine
                 and result.quarantine_reason == QuarantineReason.PARSER_ERROR
                 and not os.path.exists(output_path)
             ):
+                crash_detail = result.detail
                 retry = _run_worker(
                     input_path,
                     output_path,
-                    ENGINE_MARKITDOWN,
+                    fallback_engine,
                     timeout,
                     memory_limit_bytes,
                     max_output_bytes,
                 )
                 retry.fallback_used = True
-                retry.detail = f"pdf_inspector worker crashed ({result.detail}); {retry.detail}"
+                retry.fallback_from = engine
+                retry.detail = f"{engine} worker crashed ({crash_detail}); {retry.detail}"
                 result = retry
     except Exception as exc:  # noqa: BLE001 - service must never leak exceptions
         result = ConversionResult(
@@ -370,7 +500,7 @@ async def convert_document_async(
 def _observe_outcome(
     result: ConversionResult, filename: str, input_bytes: int, started: float
 ) -> None:
-    """Emit the conversion outcome (and any pdf-inspector fallback) as events."""
+    """Emit the conversion outcome (and any primary-converter fallback) as events."""
     duration_ms = int((time.monotonic() - started) * 1000)
     base_data = {
         "filename": filename,
@@ -380,11 +510,19 @@ def _observe_outcome(
     }
 
     if result.fallback_used:
+        primary = result.fallback_from or ENGINE_PDF_INSPECTOR
         observability.observe(
             event_type=observability.ConversationEvents.DOCUMENT_CONVERSION_FALLBACK,
             level=observability.EventLevel.WARNING,
-            data={**base_data, "fallback_from": ENGINE_PDF_INSPECTOR, "error": result.detail},
-            description=f"pdf-inspector failed for {filename}; fell back to MarkItDown",
+            data={
+                **base_data,
+                # fallback_from predates primary/fallback; kept for consumers.
+                "fallback_from": primary,
+                "primary": primary,
+                "fallback": result.engine,
+                "error": result.detail,
+            },
+            description=f"{primary} failed for {filename}; fell back to {result.engine}",
         )
 
     if result.ok:

--- a/tests/unit/test_document_converter.py
+++ b/tests/unit/test_document_converter.py
@@ -12,10 +12,11 @@ These tests use real converters and real hostile fixtures - no mocks:
   - a decompression-bomb .docx (tiny zip, enormous extracted text)
   - a huge HTML document that cannot finish inside the timeout
   - oversize input rejected before any subprocess is spawned
-  - well-formed .docx/.html producing byte-identical text to in-process
-    MarkItDown (the pre-sandbox behavior)
   - PDFs routed to pdf-inspector, with fallback to MarkItDown when
     pdf-inspector cannot parse the file
+  - office/OpenDocument/RTF/EPUB/CSV routed to anydoc, with fallback to
+    MarkItDown only for the formats MarkItDown supports; anydoc-only formats
+    quarantine honestly as parser_error
 """
 
 import asyncio
@@ -30,10 +31,15 @@ from pypdf import PdfReader, PdfWriter
 
 from muxi.runtime.services import observability
 from muxi.runtime.services.multimodal.document_converter import (
+    ANYDOC_EXTENSIONS,
+    ATTACHMENT_CONVERTIBLE_EXTENSIONS,
+    ENGINE_ANYDOC,
     ENGINE_MARKITDOWN,
     ENGINE_PDF_INSPECTOR,
     ConversionResult,
     QuarantineReason,
+    _select_engine,
+    _select_fallback_engine,
     convert_document,
     convert_document_async,
 )
@@ -128,12 +134,13 @@ def _in_process_markitdown(content: bytes, suffix: str, tmp_path) -> str:
     return MarkItDown().convert(str(path)).text_content
 
 
-def test_wellformed_docx_converts_identically_to_in_process(tmp_path):
+def test_wellformed_docx_converts_via_anydoc():
     content = make_docx_bytes("Quarterly revenue grew 14% in Q3.")
     result = convert_document(content, "report.docx")
     assert result.ok, result.detail
-    assert result.engine == ENGINE_MARKITDOWN
-    assert result.text == _in_process_markitdown(content, ".docx", tmp_path)
+    assert result.engine == ENGINE_ANYDOC
+    assert not result.fallback_used
+    assert "Quarterly revenue grew 14% in Q3." in result.text
 
 
 def test_wellformed_html_converts_identically_to_in_process(tmp_path):
@@ -188,6 +195,247 @@ def test_encrypted_pdf_quarantined_as_encrypted():
     result = convert_document(make_encrypted_pdf_bytes(), "locked.pdf")
     assert not result.ok
     assert result.quarantine_reason == QuarantineReason.ENCRYPTED
+
+
+# ---------------------------------------------------------------------------
+# Routing table: anydoc is primary for its full claimed surface
+# ---------------------------------------------------------------------------
+
+# Every extension anydoc claims (minus .pdf, which keeps its dedicated route).
+_ANYDOC_CLAIMED_EXTENSIONS = [
+    ".doc",
+    ".docx",
+    ".docm",
+    ".ppt",
+    ".pps",
+    ".pot",
+    ".pptx",
+    ".pptm",
+    ".ppsx",
+    ".ppsm",
+    ".xls",
+    ".xlsx",
+    ".xlsm",
+    ".xlsb",
+    ".odt",
+    ".ods",
+    ".odp",
+    ".rtf",
+    ".epub",
+    ".csv",
+]
+
+
+def test_anydoc_extension_set_matches_claimed_surface():
+    assert ANYDOC_EXTENSIONS == frozenset(_ANYDOC_CLAIMED_EXTENSIONS)
+
+
+@pytest.mark.parametrize("ext", _ANYDOC_CLAIMED_EXTENSIONS)
+def test_every_claimed_extension_routes_to_anydoc(ext):
+    assert _select_engine(f"file{ext}", None) == ENGINE_ANYDOC
+
+
+@pytest.mark.parametrize(
+    "media_type,expected",
+    [
+        ("application/pdf", ENGINE_PDF_INSPECTOR),
+        ("application/msword", ENGINE_ANYDOC),
+        (
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            ENGINE_ANYDOC,
+        ),
+        ("application/vnd.ms-word.document.macroEnabled.12", ENGINE_ANYDOC),
+        ("application/vnd.ms-powerpoint", ENGINE_ANYDOC),
+        (
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            ENGINE_ANYDOC,
+        ),
+        ("application/vnd.openxmlformats-officedocument.presentationml.slideshow", ENGINE_ANYDOC),
+        ("application/vnd.ms-excel", ENGINE_ANYDOC),
+        ("application/vnd.ms-excel.sheet.binary.macroEnabled.12", ENGINE_ANYDOC),
+        ("application/vnd.oasis.opendocument.text", ENGINE_ANYDOC),
+        ("application/vnd.oasis.opendocument.spreadsheet", ENGINE_ANYDOC),
+        ("application/vnd.oasis.opendocument.presentation", ENGINE_ANYDOC),
+        ("application/rtf", ENGINE_ANYDOC),
+        ("text/rtf", ENGINE_ANYDOC),
+        ("application/epub+zip", ENGINE_ANYDOC),
+        ("text/csv; charset=utf-8", ENGINE_ANYDOC),
+        ("text/html", ENGINE_MARKITDOWN),
+        ("application/octet-stream", ENGINE_MARKITDOWN),
+        (None, ENGINE_MARKITDOWN),
+    ],
+)
+def test_media_type_routing_without_extension(media_type, expected):
+    # Extension-less filename: the media type alone must drive routing.
+    assert _select_engine("attachment", media_type) == expected
+
+
+def test_unclaimed_types_still_route_to_markitdown():
+    assert _select_engine("page.html", None) == ENGINE_MARKITDOWN
+    assert _select_engine("data.json", None) == ENGINE_MARKITDOWN
+    assert _select_engine("mystery.bin", None) == ENGINE_MARKITDOWN
+    assert _select_engine("doc.pdf", None) == ENGINE_PDF_INSPECTOR
+
+
+@pytest.mark.parametrize(
+    "filename,media_type,expected",
+    [
+        # pdf-inspector always falls back to MarkItDown.
+        ("doc.pdf", "application/pdf", ENGINE_MARKITDOWN),
+        # anydoc formats MarkItDown also supports keep a per-file fallback.
+        ("a.docx", None, ENGINE_MARKITDOWN),
+        ("a.pptx", None, ENGINE_MARKITDOWN),
+        ("a.xlsx", None, ENGINE_MARKITDOWN),
+        ("a.xls", None, ENGINE_MARKITDOWN),
+        ("a.csv", None, ENGINE_MARKITDOWN),
+        ("a.epub", None, ENGINE_MARKITDOWN),
+        # Media type alone selects the fallback for extension-less files.
+        ("attachment", "text/csv", ENGINE_MARKITDOWN),
+        (
+            "attachment",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            ENGINE_MARKITDOWN,
+        ),
+        # anydoc-only formats have no fallback: failures quarantine honestly.
+        ("a.doc", None, None),
+        ("a.docm", None, None),
+        ("a.ppt", None, None),
+        ("a.pptm", None, None),
+        ("a.xlsm", None, None),
+        ("a.xlsb", None, None),
+        ("a.odt", None, None),
+        ("a.ods", None, None),
+        ("a.odp", None, None),
+        ("a.rtf", None, None),
+        ("attachment", "application/msword", None),
+        ("attachment", "application/vnd.oasis.opendocument.text", None),
+    ],
+)
+def test_fallback_selection(filename, media_type, expected):
+    engine = _select_engine(filename, media_type)
+    assert _select_fallback_engine(engine, filename, media_type) == expected
+
+
+def test_markitdown_route_has_no_fallback():
+    assert _select_fallback_engine(ENGINE_MARKITDOWN, "page.html", "text/html") is None
+
+
+def test_attachment_gate_covers_anydoc_surface():
+    # Chat attachments must admit every format anydoc converts, plus the
+    # pre-existing .pdf/.html routes.
+    assert set(ATTACHMENT_CONVERTIBLE_EXTENSIONS) == {".pdf", ".html"} | ANYDOC_EXTENSIONS
+
+
+# ---------------------------------------------------------------------------
+# anydoc conversions: real fixtures for RTF / ODT / CSV / DOCX
+# ---------------------------------------------------------------------------
+
+RTF_FIXTURE = (
+    rb"{\rtf1\ansi\deff0 {\fonttbl {\f0 Times New Roman;}}"
+    rb"\f0\fs24 Hello {\b RTF} sandbox test.\par}"
+)
+
+
+def make_odt_bytes(text: str = "Hello ODT sandbox test.") -> bytes:
+    """A minimal but valid ODT: a zip with the ODF mimetype and content.xml."""
+    content_xml = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        "<office:document-content"
+        ' xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"'
+        ' xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"'
+        ' office:version="1.2">'
+        f"<office:body><office:text><text:p>{text}</text:p></office:text></office:body>"
+        "</office:document-content>"
+    )
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr(
+            "mimetype",
+            "application/vnd.oasis.opendocument.text",
+            compress_type=zipfile.ZIP_STORED,
+        )
+        archive.writestr("content.xml", content_xml)
+    return buffer.getvalue()
+
+
+def test_rtf_converts_via_anydoc():
+    result = convert_document(RTF_FIXTURE, "note.rtf")
+    assert result.ok, result.detail
+    assert result.engine == ENGINE_ANYDOC
+    assert not result.fallback_used
+    # anydoc renders the bold run as markdown emphasis.
+    assert "Hello **RTF** sandbox test." in result.text
+
+
+def test_odt_converts_via_anydoc():
+    result = convert_document(make_odt_bytes(), "letter.odt")
+    assert result.ok, result.detail
+    assert result.engine == ENGINE_ANYDOC
+    assert "Hello ODT sandbox test." in result.text
+
+
+def test_csv_converts_via_anydoc_as_table():
+    result = convert_document(b"name,qty\nwidget,3\ngadget,7\n", "data.csv", media_type="text/csv")
+    assert result.ok, result.detail
+    assert result.engine == ENGINE_ANYDOC
+    # anydoc renders CSV as a markdown table.
+    assert "| widget | 3 |" in result.text
+
+
+def test_anydoc_failure_falls_back_to_markitdown_for_supported_format():
+    # CSV bytes wearing an .xls extension: anydoc detects no OLE/ZIP signature,
+    # trusts the extension, and its workbook parser rejects the file, while
+    # MarkItDown's content sniffing recovers the table. This mirrors the
+    # real-world servers-send-CSV-as-.xls case.
+    result = convert_document(b"name,qty\nwidget,3\n", "export.xls")
+    assert result.ok, result.detail
+    assert result.fallback_used
+    assert result.fallback_from == ENGINE_ANYDOC
+    assert result.engine == ENGINE_MARKITDOWN
+    assert "widget" in result.text
+    # The anydoc error is preserved for observability.
+    assert "ConvertError" in result.detail
+
+
+def test_corrupt_anydoc_only_format_quarantines_without_fallback():
+    # A structurally-broken ODT (zip local-file magic, no archive): odt is
+    # anydoc-only, so the failure must quarantine honestly - no fallback.
+    result = convert_document(b"PK\x03\x04 not really a zip archive", "broken.odt")
+    assert not result.ok
+    assert result.engine == ENGINE_ANYDOC
+    assert result.quarantine_reason == QuarantineReason.PARSER_ERROR
+    assert not result.fallback_used
+    assert result.fallback_from is None
+
+
+def test_fallback_event_payload_carries_primary_and_fallback_converters():
+    capturing = _CapturingLogger()
+    previous = observability.get_runtime_event_logger()
+    observability.set_runtime_event_logger(capturing)
+    observability.enable()
+    try:
+        convert_document(b"name,qty\nwidget,3\n", "export.xls")
+        import time
+
+        deadline = time.time() + 5
+        fallback_events = []
+        while time.time() < deadline:
+            fallback_events = [
+                e for e in capturing.snapshot() if e["event"] == "document.conversion.fallback"
+            ]
+            if fallback_events:
+                break
+            time.sleep(0.1)
+    finally:
+        observability.disable()
+        observability.set_runtime_event_logger(previous)
+
+    assert fallback_events, "no document.conversion.fallback event was emitted"
+    data = fallback_events[0]["data"]
+    assert data["primary"] == ENGINE_ANYDOC
+    assert data["fallback"] == ENGINE_MARKITDOWN
+    # Pre-anydoc field kept for existing consumers.
+    assert data["fallback_from"] == ENGINE_ANYDOC
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_document_converter.py
+++ b/tests/unit/test_document_converter.py
@@ -551,3 +551,24 @@ def test_quarantine_and_fallback_events_emitted():
     assert "document.conversion.completed" in names
     quarantined = next(e for e in events if e["event"] == "document.conversion.quarantined")
     assert quarantined["data"]["quarantine_reason"] == "oversize"
+
+
+class TestKnowledgeProcessingMethodLabel:
+    """The knowledge chunk metadata names the engine that actually converts."""
+
+    def _method(self, filename: str) -> str:
+        from muxi.runtime.formation.agents.knowledge.base import FileKnowledge
+
+        source = FileKnowledge.__new__(FileKnowledge)
+        source.enable_markitdown = True
+        return FileKnowledge._get_processing_method(source, filename)
+
+    def test_anydoc_formats_labeled_anydoc(self):
+        for name in ("a.odt", "b.rtf", "c.doc", "d.pptm", "e.xlsb", "f.epub"):
+            assert self._method(name) == "anydoc", name
+
+    def test_pdf_labeled_pdf_inspector(self):
+        assert self._method("report.pdf") == "pdf-inspector"
+
+    def test_text_still_text(self):
+        assert self._method("notes.md") == "text"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -1811,6 +1811,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
+]
+
+[[package]]
+name = "firecrawl-anydoc"
+version = "0.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/32/b3541611e080d42a3de26158e31165c61ad72e8dd0f53e68855b3220b91b/firecrawl_anydoc-0.1.3.tar.gz", hash = "sha256:e474b1fa1af5cc27549d81a27072cc5b6b7dbfe5aa262777e345a9817b181f44", size = 183093, upload-time = "2026-08-04T19:58:47.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/13/21c9a74e4880c2f1fc279cb2162ff99cbf517956a3d8bbfc3967a4bbbadc/firecrawl_anydoc-0.1.3-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:21230921d27d7e37d2ffd4a8b936c13420e097aa342fd69faeb5600260153535", size = 3510117, upload-time = "2026-08-04T19:58:37.396Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c7/c1c8bb05659030340bd98f9a180b1dce23c8a3f98a7a8f7920246cea0223/firecrawl_anydoc-0.1.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:fd05f1eba6152667f94511802d89d2259c0b2d02990717bced917b7b2c2f6eb6", size = 3299887, upload-time = "2026-08-04T19:58:38.807Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/00/6851b21cefbdcf62401f0c926eda45f3374bb12c172f39b4ca5956822433/firecrawl_anydoc-0.1.3-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:60001691c55dd9fb5a4a75118749324a4996ce07349046c50b97d8dbcad5935a", size = 3373411, upload-time = "2026-08-04T19:58:40.154Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0c/95e80e7c47c30a98a5563ac956a84908a6a65e0723a76da7fd6ecaef6406/firecrawl_anydoc-0.1.3-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aeac246432a6bb0d7c2137f0d4d7b73d4cce903398426001e29cc8db8c4c718d", size = 3604935, upload-time = "2026-08-04T19:58:41.828Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/af8e6b82120526312f23206445d0afbd76e8637064ed45d823e10ae48024/firecrawl_anydoc-0.1.3-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:64fe9313d9a0495545a9794b2cc988b4dc1b281753e1c23017aa7f0e6c12f0f3", size = 3555227, upload-time = "2026-08-04T19:58:43.281Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/6d/53244a665ef13d3c03b45d891ff61e8e320fa4edae0d837301d7323ee893/firecrawl_anydoc-0.1.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9bb09167b9500159124f8ba4c780be4d349e9e842a4683e88c2aaf39bd8096ca", size = 3845456, upload-time = "2026-08-04T19:58:44.603Z" },
+    { url = "https://files.pythonhosted.org/packages/05/18/556c5aeac352e125f9b4d766f5732fb6d4c16f9dc5b88e67eaa2cdc6640e/firecrawl_anydoc-0.1.3-cp310-abi3-win_amd64.whl", hash = "sha256:bf008a2fdfda84fcd625328ad71701b464e0ed222372913d36746e9a7b92e7e7", size = 3631477, upload-time = "2026-08-04T19:58:45.909Z" },
 ]
 
 [[package]]
@@ -3953,6 +3968,7 @@ dependencies = [
     { name = "faissx" },
     { name = "fastapi" },
     { name = "fastmcp" },
+    { name = "firecrawl-anydoc" },
     { name = "fpdf2" },
     { name = "google-cloud-aiplatform" },
     { name = "httpx" },
@@ -4084,6 +4100,7 @@ requires-dist = [
     { name = "faissx-gpu", marker = "extra == 'cuda'", specifier = ">=0.20260422.2" },
     { name = "fastapi", specifier = ">=0.137.1" },
     { name = "fastmcp", specifier = ">=3.4.2" },
+    { name = "firecrawl-anydoc", specifier = ">=0.1.3" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "fpdf2", specifier = ">=2.8.7" },
     { name = "google-cloud-aiplatform", specifier = ">=1.157.0" },


### PR DESCRIPTION
## Summary

Adopts Firecrawl's [anydoc](https://github.com/firecrawl/anydoc) (`firecrawl-anydoc>=0.1.3`, Rust core with abi3 Python wheels, imports as `anydoc`) as the primary office-document converter, extending the pattern #305 built for PDFs (pdf-inspector primary, sandboxed MarkItDown per-file fallback) to every office format. Conversion still runs inside the same out-of-process sandbox (rlimits, wall-clock kill, typed `QuarantineReason` outcomes) — anydoc is imported lazily inside `conversion_worker.py` exactly like MarkItDown/pdf-inspector. Mechanism swap only: no new AFS keys.

## Routing table

| Input | Primary | On failure |
|---|---|---|
| `.pdf` / `application/pdf` | pdf-inspector | MarkItDown fallback (unchanged) |
| `.docx` `.pptx` `.xlsx` `.xls` `.csv` `.epub` (+ MIME types) | **anydoc** | MarkItDown fallback, `document.conversion.fallback` emitted |
| `.doc` `.docm` `.ppt` `.pps` `.pot` `.pptm` `.ppsx` `.ppsm` `.xlsm` `.xlsb` `.odt` `.ods` `.odp` `.rtf` (+ MIME types) | **anydoc** | quarantine `parser_error` — no converter can retry these, and the event says so honestly |
| `.html` and everything else convertible | MarkItDown | quarantine |

Routing matches on extension **and** normalized MIME type (lowercased, parameters stripped), mirroring the existing PDF rule. The chat-attachment gate (`ATTACHMENT_CONVERTIBLE_EXTENSIONS`) and the knowledge-source extension list widened to anydoc's full claimed surface — that is the coverage gained: legacy Office, macro variants, OpenDocument, RTF, EPUB.

**Fallback-set note:** the design brief listed docx/pptx/xlsx/xls as MarkItDown's surface; verification against the installed `markitdown[docx,pdf,pptx,xls,xlsx]` showed its CSV and EPUB converters are built in (both converted real fixtures), and both formats routed to MarkItDown before this PR — so csv/epub keep the fallback rather than failing harder than the status quo.

## PDF-route decision: unchanged

pdf-inspector stays primary for PDFs. Evidence: anydoc's Python API (`python/anydoc/_anydoc.pyi` at v0.1.3) exposes only `to_markdown`/`to_markdown_bytes` returning a plain string for PDFs, and `to_document()` explicitly rejects PDF ("PDF conversion produces Markdown directly and has no document-model form"). It does not expose pdf-inspector's native-text-vs-scanned classification (`classify_pdf`, `PdfClassification`, per-page OCR reasons), so consolidating would lose that signal. The direct `pdf-inspector` dependency remains.

## Observability / measurement story

`document.conversion.fallback` now carries `primary` and `fallback` converter names (`fallback_from` kept for existing consumers). When those events stop appearing for anydoc routes in the field, MarkItDown can be dropped from the office-document path entirely.

## Fixture strategy

All fixtures are generated in-test from scratch — no binary blobs:
- **RTF**: hand-written minimal RTF (bold run renders as `**markdown**`)
- **ODT**: minimal zip built with `zipfile` (ODF mimetype entry + `content.xml`) — verified anydoc accepts it
- **CSV**: trivial; anydoc renders a markdown table
- **DOCX**: `python-docx` (existing dependency)
- **Fallback**: CSV bytes named `.xls` — anydoc raises `ConvertError` (no OLE/ZIP signature, extension names xls, workbook parser rejects), MarkItDown recovers the table via content sniffing; mirrors real-world servers-send-CSV-as-.xls
- **Quarantine**: zip local-file magic + garbage as `.odt` — anydoc-only format, quarantines `parser_error` with no fallback

Legacy `.doc`/`.ppt` fixtures are not fabricated; routing unit tests cover those extensions.

## Tests

- `tests/unit/test_document_converter.py`: 83 pass (was 14) — full routing-table parametrization (every claimed extension + MIME type), fallback-selection matrix, attachment-gate coverage, real anydoc conversions, fallback + quarantine paths, `primary`/`fallback` event payload fields
- e2e `test_3m1_anydoc_document_conversion.py` (new, 3l1-style standalone): rtf/odt/csv/docx attachments through a live formation chat — all four emit `document.conversion.completed` with `engine=anydoc`; corrupt ODT quarantines `parser_error`; both chats degrade gracefully — **passed**
- e2e `test_3l1_malformed_pdf_quarantine.py` regression, unchanged — **passed**
- Full unit suite: 4127 passed, 10 skipped
- black/isort/ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)