### PR TITLE
fix: route SOP file attachments through the sandboxed document converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## [unreleased]
 
+### SOP file attachments now use the sandboxed document converter
+
+SOP `[file:...]` references were the last document intake path still
+parsing untrusted bytes inside the runtime process: it built its own
+`MarkItDown()` and called it directly -- no subprocess boundary, no
+rlimits, no wall-clock kill, no quarantine handling. Chat attachments
+and knowledge files had gone through the out-of-process conversion
+service since it was introduced, and the docs said conversion was
+sandboxed, which was untrue for this one path. SOP attachments now call
+the same `convert_document()` service, so a malformed or hostile
+document can no longer crash, hang, or balloon the runtime.
+
+- Conversion failures degrade exactly as before -- an attachment that
+  cannot be converted yields `[Unable to extract: <name>]` and the SOP
+  keeps running. What changed is that every failure mode is now a typed
+  `QuarantineReason` (timeout / memory / oversize / parser_error /
+  encrypted / unsupported) carried on the existing observability event,
+  instead of a parser exception caught after the fact.
+- The extension gate is now the converter's own supported-extension set
+  rather than a hand-maintained list. That list advertised `.doc` and
+  `.ppt`, which MarkItDown cannot read at all -- those files failed
+  confusingly. anydoc reads them, so they now convert, and OpenDocument,
+  RTF, EPUB, and HTML attachments work for the first time.
+
 ### Failed sync tasks now escalate to bounded async retries
 
 When a synchronous chat turn fails terminally (its in-request retry

--- a/src/muxi/runtime/formation/workflow/sops.py
+++ b/src/muxi/runtime/formation/workflow/sops.py
@@ -13,10 +13,13 @@ import yaml
 
 from ...services import observability
 from ...services.memory.embedding import embed
-from ...utils.user_dirs import get_cache_dir
 
-# Lazy import DocumentChunkManager to avoid initialization issues
-# from ..documents.storage.chunk_manager import DocumentChunkManager
+# Sandboxed document conversion (out-of-process anydoc / pdf-inspector / MarkItDown)
+from ...services.multimodal.document_converter import (
+    ATTACHMENT_CONVERTIBLE_EXTENSIONS,
+    convert_document_async,
+)
+from ...utils.user_dirs import get_cache_dir
 
 
 class OneLLMEmbeddingAdapter:
@@ -115,7 +118,6 @@ class SOPSystem:
         # LAZY-LOADED SERVICES
         # ===================================================================
         # These will be initialized on first use
-        self._document_processor = None
         self._faiss_service = None
         self._embedding_model = None
 
@@ -567,68 +569,6 @@ class SOPSystem:
                 pass
         return self._embedding_model
 
-    def _get_document_processor(self):
-        """Lazily get document processor and chunk manager."""
-        if self._document_processor is None:
-            try:
-                # Use both MarkItDown for extraction and DocumentChunkManager for chunking
-                from markitdown import MarkItDown
-
-                self._document_processor = {
-                    "markitdown": MarkItDown(),
-                    "chunk_manager": self._get_chunk_manager(),
-                }
-            except Exception:
-                pass
-        return self._document_processor
-
-    def _get_chunk_manager(self):
-        """Get DocumentChunkManager from formation or create one using formation's config."""
-        try:
-            # Lazy import DocumentChunkManager to avoid initialization issues
-            # Try to get from formation's configured services
-            from ...formation import Formation  # noqa: E402
-            from ..documents.storage.chunk_manager import DocumentChunkManager
-
-            formation = Formation.get_instance()
-
-            # First try to get existing chunk manager
-            if formation and hasattr(formation, "_configured_services"):
-                chunk_manager = formation._configured_services.get("document_chunk_manager")
-                if chunk_manager:
-                    return chunk_manager
-
-            # If not available, try to get the document processing config from formation
-            if formation:
-                # Try to get document processing config from formation
-                if hasattr(formation, "_document_processing_config"):
-                    # Use the formation's document processing configuration
-                    return DocumentChunkManager(
-                        document_config=formation._document_processing_config
-                    )
-
-                # Try to get from _configured_services as well
-                if hasattr(formation, "_configured_services"):
-                    doc_config = formation._configured_services.get("document_processing_config")
-                    if doc_config:
-                        return DocumentChunkManager(document_config=doc_config)
-
-            # Last resort: Create using the formation's LLM config if available
-            if formation and hasattr(formation, "_llm_config"):
-                from ...formation.config.document_processing import DocumentProcessingConfig
-
-                # This will extract document settings from llm.models.documents
-                config = DocumentProcessingConfig(formation._llm_config)
-                return DocumentChunkManager(document_config=config)
-
-            # Final fallback: Create with defaults (will use formation defaults internally)
-            from ...formation.config.document_processing import DocumentProcessingConfig
-
-            config = DocumentProcessingConfig({})
-            return DocumentChunkManager(document_config=config)
-        except Exception:
-            return None
-
     # ========================================================================
     # INDEXING AND SEARCH
     # ========================================================================
@@ -925,28 +865,17 @@ class SOPSystem:
             # In the future, we could use vision models to describe the image
             return f"[Image file: {file_path.name}]"
 
-        # Use MarkItDown for document files (PDFs, Word docs, spreadsheets, presentations)
-        document_processor = self._get_document_processor()
-        if document_processor and file_path.suffix.lower() in [
-            ".pdf",
-            ".docx",
-            ".doc",
-            ".pptx",
-            ".ppt",
-            ".xlsx",
-            ".xls",
-        ]:
+        # Convertible documents (PDFs, Word docs, spreadsheets, presentations,
+        # OpenDocument, RTF, EPUB, HTML) go through the sandboxed out-of-process
+        # conversion service - the same boundary chat attachments and knowledge
+        # files use. The gate is the converter's own supported-extension set, so
+        # it cannot drift from what the converters actually read (legacy binary
+        # .doc/.ppt included, via anydoc). Untrusted document bytes are never
+        # parsed in the runtime process.
+        if file_path.suffix.lower() in ATTACHMENT_CONVERTIBLE_EXTENSIONS:
             try:
-                markitdown = document_processor.get("markitdown")
-                if markitdown:
-                    # Extract complete content with MarkItDown
-                    result = markitdown.convert(str(file_path))
-                    content = (
-                        result.text_content if hasattr(result, "text_content") else str(result)
-                    )
-                    return content
+                raw = file_path.read_bytes()
             except Exception as e:
-                # Log extraction failure but continue
                 observability.observe(
                     event_type=observability.ErrorEvents.WARNING,
                     level=observability.EventLevel.WARNING,
@@ -955,10 +884,39 @@ class SOPSystem:
                         "error": str(e),
                         "file_type": file_path.suffix,
                     },
-                    description=f"Failed to extract content from {file_path.name}",
+                    description=f"Failed to read {file_path.name}",
                 )
-                # Return reference placeholder
-                return f"[Unable to extract: {file_path.name}]"
+                return f"[Unable to read: {file_path.name}]"
+
+            conversion = await convert_document_async(
+                raw,
+                file_path.name,
+                max_input_bytes=max_file_size_mb * 1024 * 1024,
+            )
+            if conversion.ok:
+                return conversion.text
+
+            # Quarantined (timeout/memory/oversize/parser_error/encrypted/
+            # unsupported). The conversion service already emitted
+            # DOCUMENT_CONVERSION_QUARANTINED; keep this call site's existing
+            # graceful degradation - an unconvertible attachment must never
+            # abort the SOP.
+            reason = (
+                conversion.quarantine_reason.value if conversion.quarantine_reason else "unknown"
+            )
+            observability.observe(
+                event_type=observability.ErrorEvents.WARNING,
+                level=observability.EventLevel.WARNING,
+                data={
+                    "file": str(file_path),
+                    "error": conversion.detail,
+                    "file_type": file_path.suffix,
+                    "quarantine_reason": reason,
+                },
+                description=f"Failed to extract content from {file_path.name}",
+            )
+            # Return reference placeholder
+            return f"[Unable to extract: {file_path.name}]"
 
         # For unsupported file types, return a reference
         return f"[Unsupported file type: {file_path.name}]"

--- a/tests/unit/test_sops_document_conversion.py
+++ b/tests/unit/test_sops_document_conversion.py
@@ -1,0 +1,281 @@
+"""
+Unit tests for SOP attachment conversion (``SOPSystem.get_resource_content``).
+
+The SOP ``[file:...]`` path used to instantiate ``MarkItDown()`` and parse
+untrusted document bytes *in the runtime process* — no subprocess isolation,
+no rlimits, no wall-clock kill, no ``QuarantineReason`` handling — while every
+other document intake path (chat attachments, knowledge files) went through
+the sandboxed ``convert_document()`` service built in PR #305.
+
+Three layers of coverage:
+
+1. **Sandbox guard** — the SOP path must call the out-of-process converter and
+   must never construct ``MarkItDown`` in-process. A poisoned ``markitdown``
+   module makes an in-process regression fail loudly instead of silently
+   re-opening the hole.
+
+2. **Graceful degradation** — a quarantined document (timeout / memory /
+   oversize / parser_error / encrypted / unsupported) returns the existing
+   placeholder string rather than raising into SOP execution.
+
+3. **Extension gate** — the gate is the converter's own supported-extension
+   set, not a hand-maintained list. The old list advertised ``.doc``/``.ppt``,
+   which MarkItDown cannot read at all; anydoc (PR #318) does, so those files
+   now convert instead of failing confusingly.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+
+from muxi.runtime.formation.workflow import sops as sops_module
+from muxi.runtime.formation.workflow.sops import SOPSystem
+from muxi.runtime.services.multimodal import document_converter
+from muxi.runtime.services.multimodal.document_converter import (
+    ConversionResult,
+    QuarantineReason,
+)
+
+
+@pytest.fixture
+def sop_system(tmp_path):
+    """An SOPSystem with no ``sops/`` directory, so __init__ stays inert."""
+    return SOPSystem(formation_path=tmp_path)
+
+
+@pytest.fixture
+def poisoned_markitdown(monkeypatch):
+    """Make any in-process ``MarkItDown()`` construction fail the test."""
+
+    class _Exploding:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError(
+                "MarkItDown was constructed in-process; document conversion must "
+                "go through the sandboxed convert_document() service"
+            )
+
+    module = types.ModuleType("markitdown")
+    module.MarkItDown = _Exploding
+    monkeypatch.setitem(sys.modules, "markitdown", module)
+    return module
+
+
+def _register(sop_system: SOPSystem, tmp_path, name: str, payload: bytes = b"\x00binary"):
+    """Write a fixture file and register it as a resolvable SOP resource."""
+    path = tmp_path / name
+    path.write_bytes(payload)
+    sop_system.resource_map[name] = path
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — the SOP path uses the sandboxed converter, not MarkItDown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pdf_resource_goes_through_sandboxed_converter(
+    sop_system, tmp_path, monkeypatch, poisoned_markitdown
+):
+    """A PDF attachment is converted out-of-process, with its raw bytes."""
+    path = _register(sop_system, tmp_path, "report.pdf", b"%PDF-1.7 fake")
+
+    convert = AsyncMock(
+        return_value=ConversionResult(ok=True, text="# Report", engine="pdf_inspector")
+    )
+    monkeypatch.setattr(sops_module, "convert_document_async", convert)
+
+    assert await sop_system.get_resource_content("report.pdf") == "# Report"
+
+    convert.assert_awaited_once()
+    args, kwargs = convert.call_args
+    assert args[0] == b"%PDF-1.7 fake"
+    assert args[1] == "report.pdf"
+    # The caller's size budget is handed to the sandbox's pre-spawn input cap.
+    assert kwargs["max_input_bytes"] == 10 * 1024 * 1024
+    # No path handle is leaked to the parser; only bytes cross the boundary.
+    assert str(path) not in [a for a in args if isinstance(a, str)]
+
+
+@pytest.mark.asyncio
+async def test_max_file_size_mb_flows_into_converter_input_cap(sop_system, tmp_path, monkeypatch):
+    """A caller-tightened size budget reaches the sandbox, not just the pre-check."""
+    _register(sop_system, tmp_path, "small.docx")
+
+    convert = AsyncMock(return_value=ConversionResult(ok=True, text="ok", engine="anydoc"))
+    monkeypatch.setattr(sops_module, "convert_document_async", convert)
+
+    await sop_system.get_resource_content("small.docx", max_file_size_mb=2)
+
+    assert convert.call_args.kwargs["max_input_bytes"] == 2 * 1024 * 1024
+
+
+@pytest.mark.asyncio
+async def test_text_and_image_resources_never_reach_the_converter(
+    sop_system, tmp_path, monkeypatch
+):
+    """Plain text is read directly and images stay references — no subprocess spawn."""
+    (tmp_path / "notes.md").write_text("hello")
+    sop_system.resource_map["notes.md"] = tmp_path / "notes.md"
+    _register(sop_system, tmp_path, "shot.png")
+
+    convert = AsyncMock()
+    monkeypatch.setattr(sops_module, "convert_document_async", convert)
+
+    assert await sop_system.get_resource_content("notes.md") == "hello"
+    assert await sop_system.get_resource_content("shot.png") == "[Image file: shot.png]"
+    convert.assert_not_awaited()
+
+
+def test_sop_system_no_longer_holds_an_in_process_document_processor(sop_system):
+    """The MarkItDown-holding lazy service is gone, not merely bypassed."""
+    assert not hasattr(sop_system, "_get_document_processor")
+    assert not hasattr(sop_system, "_document_processor")
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — quarantined documents degrade, never abort the SOP
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        QuarantineReason.TIMEOUT,
+        QuarantineReason.MEMORY,
+        QuarantineReason.OVERSIZE,
+        QuarantineReason.PARSER_ERROR,
+        QuarantineReason.ENCRYPTED,
+        QuarantineReason.UNSUPPORTED,
+    ],
+)
+@pytest.mark.asyncio
+async def test_quarantined_document_degrades_gracefully(sop_system, tmp_path, monkeypatch, reason):
+    """Every quarantine reason yields the placeholder, not an exception."""
+    _register(sop_system, tmp_path, "hostile.pdf")
+
+    monkeypatch.setattr(
+        sops_module,
+        "convert_document_async",
+        AsyncMock(
+            return_value=ConversionResult(
+                ok=False,
+                engine="pdf_inspector",
+                quarantine_reason=reason,
+                detail="worker killed",
+            )
+        ),
+    )
+
+    assert (
+        await sop_system.get_resource_content("hostile.pdf") == "[Unable to extract: hostile.pdf]"
+    )
+
+
+@pytest.mark.asyncio
+async def test_quarantine_emits_observability_event(sop_system, tmp_path, monkeypatch):
+    """The degradation is observable, carrying the quarantine reason."""
+    _register(sop_system, tmp_path, "hostile.pdf")
+
+    monkeypatch.setattr(
+        sops_module,
+        "convert_document_async",
+        AsyncMock(
+            return_value=ConversionResult(
+                ok=False,
+                engine="pdf_inspector",
+                quarantine_reason=QuarantineReason.TIMEOUT,
+                detail="conversion exceeded 60.0s wall-clock limit",
+            )
+        ),
+    )
+
+    events = []
+    monkeypatch.setattr(
+        sops_module.observability,
+        "observe",
+        lambda **kwargs: events.append(kwargs),
+    )
+
+    await sop_system.get_resource_content("hostile.pdf")
+
+    quarantine_events = [e for e in events if e["data"].get("quarantine_reason")]
+    assert len(quarantine_events) == 1
+    assert quarantine_events[0]["data"]["quarantine_reason"] == "timeout"
+    assert quarantine_events[0]["data"]["file_type"] == ".pdf"
+
+
+@pytest.mark.asyncio
+async def test_unreadable_file_degrades_instead_of_raising(sop_system, tmp_path, monkeypatch):
+    """An unreadable resource degrades before any conversion is attempted."""
+    path = _register(sop_system, tmp_path, "locked.docx")
+    path.unlink()
+
+    convert = AsyncMock()
+    monkeypatch.setattr(sops_module, "convert_document_async", convert)
+
+    assert await sop_system.get_resource_content("locked.docx") == "[Unable to read: locked.docx]"
+    convert.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — the extension gate tracks the converter, not a hand-kept list
+# ---------------------------------------------------------------------------
+
+
+def test_gate_is_the_converters_own_supported_set(sop_system):
+    """SOPs share the converter's constant, so the gate cannot drift from it."""
+    assert (
+        sops_module.ATTACHMENT_CONVERTIBLE_EXTENSIONS
+        is document_converter.ATTACHMENT_CONVERTIBLE_EXTENSIONS
+    )
+
+
+@pytest.mark.parametrize("filename", ["legacy.doc", "deck.ppt", "book.xls"])
+@pytest.mark.asyncio
+async def test_legacy_binary_office_attachments_now_convert(
+    sop_system, tmp_path, monkeypatch, filename
+):
+    """Legacy .doc/.ppt/.xls route to anydoc instead of failing on MarkItDown."""
+    _register(sop_system, tmp_path, filename, b"\xd0\xcf\x11\xe0 ole2")
+
+    convert = AsyncMock(
+        return_value=ConversionResult(ok=True, text="converted body", engine="anydoc")
+    )
+    monkeypatch.setattr(sops_module, "convert_document_async", convert)
+
+    assert await sop_system.get_resource_content(filename) == "converted body"
+    assert convert.await_count == 1
+
+
+@pytest.mark.parametrize("filename", ["notes.odt", "memo.rtf", "manual.epub", "page.html"])
+@pytest.mark.asyncio
+async def test_formats_the_old_gate_rejected_now_convert(
+    sop_system, tmp_path, monkeypatch, filename
+):
+    """OpenDocument/RTF/EPUB/HTML were unreachable under the old hand-kept list."""
+    _register(sop_system, tmp_path, filename)
+
+    convert = AsyncMock(return_value=ConversionResult(ok=True, text="body", engine="anydoc"))
+    monkeypatch.setattr(sops_module, "convert_document_async", convert)
+
+    assert await sop_system.get_resource_content(filename) == "body"
+
+
+@pytest.mark.asyncio
+async def test_genuinely_unsupported_type_still_reports_unsupported(
+    sop_system, tmp_path, monkeypatch
+):
+    """Formats no converter claims keep the pre-existing placeholder."""
+    _register(sop_system, tmp_path, "archive.zip")
+
+    convert = AsyncMock()
+    monkeypatch.setattr(sops_module, "convert_document_async", convert)
+
+    result = await sop_system.get_resource_content("archive.zip")
+    assert result == "[Unsupported file type: archive.zip]"
+    convert.assert_not_awaited()


### PR DESCRIPTION
## Problem

The SOP attachment path was the last document intake path still parsing untrusted bytes **inside the runtime process**.

[`sops.py`](src/muxi/runtime/formation/workflow/sops.py) built its own `MarkItDown()` in `_get_document_processor()` and called `.convert()` on it directly from `get_resource_content()`. No subprocess isolation, no rlimits, no wall-clock kill, no `QuarantineReason` handling, no anydoc routing. Every other path — chat attachments via overlord, knowledge files via `FileKnowledge` — has gone through `services/multimodal/document_converter.convert_document()` since PR #305, which exists precisely so untrusted documents are not parsed in the runtime process. The public docs state flatly that document conversion is sandboxed; that was untrue for this path.

Second defect in the same block: the extension gate listed `.doc` and `.ppt`, which MarkItDown cannot read at all. Those attachments failed with a confusing parser error rather than converting.

## Fix

`get_resource_content()` now calls `convert_document_async()` and handles its typed outcomes the way the other call sites do:

- **Success** → the converted markdown is returned.
- **Quarantine** (`timeout` / `memory` / `oversize` / `parser_error` / `encrypted` / `unsupported`) → the existing observability warning fires, now carrying `quarantine_reason`, and the call returns the unchanged `[Unable to extract: <name>]` placeholder. User-visible behavior on failure is preserved: an attachment that cannot be converted **degrades, it does not abort the SOP**, and the service never raises into the execution path.
- The caller's `max_file_size_mb` budget is passed through as the sandbox's pre-spawn `max_input_bytes`, so the size limit is enforced on both sides of the boundary.

The extension gate is now `ATTACHMENT_CONVERTIBLE_EXTENSIONS` — the converter's own supported set — rather than a hand-maintained list that could drift from it. Consequences:

- `.doc` / `.ppt` / `.xls` (legacy binary Office) now convert via anydoc (PR #318) instead of failing.
- `.odt` / `.ods` / `.odp`, `.rtf`, `.epub`, `.html` convert for the first time on this path.

## Also removed

`_get_document_processor()` (the MarkItDown holder) and `_get_chunk_manager()`. The latter existed only to populate that dict's `chunk_manager` key and had no other caller in the repo — it is dead once the dict is gone. Flagging it explicitly since it is the one deletion beyond the direct fix.

## Tests

New `tests/unit/test_sops_document_conversion.py`, 21 cases in three layers:

1. **Sandbox routing** — the SOP path awaits `convert_document_async` with the file's raw bytes and name (never a path handle), with a poisoned `markitdown` module installed as a regression tripwire so any future in-process `MarkItDown()` construction fails loudly. Also asserts text and image resources never reach the converter at all.
2. **Graceful degradation** — parametrized over every `QuarantineReason`: placeholder returned, no exception; the observability event carries the reason; an unreadable file degrades before conversion is attempted.
3. **Extension gate** — the gate object *is* the converter's constant; legacy `.doc`/`.ppt`/`.xls` convert; `.odt`/`.rtf`/`.epub`/`.html` convert; genuinely unsupported types (`.zip`) keep the pre-existing `[Unsupported file type: ...]` placeholder.

Affected breadth run green:

```
pytest tests/unit -k "sop or workflow or document_converter"
308 passed, 3908 deselected
```

Lint clean: black (line 100), isort (profile=black), ruff, flake8.

CHANGELOG entry added under `[unreleased]`.